### PR TITLE
Update the minimum threshold on RSL Lc parameter

### DIFF
--- a/SUEWS-SourceCode/src/suews_ctrl_driver.f95
+++ b/SUEWS-SourceCode/src/suews_ctrl_driver.f95
@@ -973,7 +973,7 @@ CONTAINS
       IF (Diagnose == 1) WRITE (*, *) 'Calling RSLProfile...'
       CALL RSLProfile( &
          zH, z0m, zdm, z0v, &
-         L_MOD, sfr, FAI, StabilityMethod, RA_h, &
+         L_MOD, sfr, FAI, FAIBldg, StabilityMethod, RA_h, &
          avcp, lv_J_kg, avdens, &
          avU1, Temp_C, avRH, Press_hPa, z, qh, qe, &  ! input
          T2_C, q2_gkg, U10_ms, RH2, & !output

--- a/SUEWS-SourceCode/src/suews_phys_rslprof.f95
+++ b/SUEWS-SourceCode/src/suews_phys_rslprof.f95
@@ -836,6 +836,7 @@ CONTAINS
       REAL(KIND(1D0)) ::lc_over_L
       ! real(KIND(1D0)) ::betaHF
       ! real(KIND(1D0)) ::betaNL
+      REAL(KIND(1D0)) ::Lc_min! LB Oct2021 - minimum value of Lc
 
       REAL(KIND(1D0)), PARAMETER::planF_low = 1E-6
       REAL(KIND(1D0)), PARAMETER::kappa = 0.40
@@ -844,7 +845,6 @@ CONTAINS
       REAL(KIND(1D0)), PARAMETER::a1 = 4., a2 = -0.1, a3 = 1.5, a4 = -1.
       REAL(KIND(1D0)), PARAMETER::Zh_min = 0.4! limit for minimum canyon height used in RSL module
       REAL(KIND(1D0)), PARAMETER::Lb_av = 35.! LB Oct2021 - average building dimensions
-      REAL(KIND(1D0)), PARAMETER::Lc_min! LB Oct2021 - minimum value of Lc
 
       ! under stable conditions, set a threshold for L_MOD to avoid numerical issues. TS 28 Oct 2019
       ! L_MOD = merge(L_MOD, 300.d1, L_MOD < 300.)

--- a/SUEWS-SourceCode/src/suews_phys_rslprof.f95
+++ b/SUEWS-SourceCode/src/suews_phys_rslprof.f95
@@ -843,7 +843,8 @@ CONTAINS
       REAL(KIND(1D0)), PARAMETER::r = 0.1
       REAL(KIND(1D0)), PARAMETER::a1 = 4., a2 = -0.1, a3 = 1.5, a4 = -1.
       REAL(KIND(1D0)), PARAMETER::Zh_min = 0.4! limit for minimum canyon height used in RSL module
-      REAL(KIND(1D0)), PARAMETER::Lc_min = 15.
+      REAL(KIND(1D0)), PARAMETER::Lb_av = 35.! LB Oct2021 - average building dimensions
+      REAL(KIND(1D0)), PARAMETER::Lc_min! LB Oct2021 - minimum value of Lc
 
       ! under stable conditions, set a threshold for L_MOD to avoid numerical issues. TS 28 Oct 2019
       ! L_MOD = merge(L_MOD, 300.d1, L_MOD < 300.)
@@ -870,6 +871,7 @@ CONTAINS
       ! set a minimum threshold (of 0.5*Zh_RSL) for Lc to avoid numerical diffulties when FAI is too large (e.g., FAI>10)
       Lc = MERGE(Lc, 0.5*Zh_RSL, Lc > 0.5*Zh_RSL)
       ! LB Oct2021 - set a minimum threshold (of 15 m) based on the Lc required to ensure the horizontal length scale associated with changes in canopy geometry (Lg<3Lc) is greater than a typical street
+      Lc_min = Lb_av*BldgSurf**-0.5/3.
       Lc = MERGE(Lc, Lc_min, Lc > Lc_min)
       
       ! a normalised scale with a physcially valid range between [-2,2] (Harman 2012, BLM)

--- a/SUEWS-SourceCode/src/suews_phys_rslprof.f95
+++ b/SUEWS-SourceCode/src/suews_phys_rslprof.f95
@@ -839,7 +839,7 @@ CONTAINS
       ! real(KIND(1D0)) ::betaHF
       ! real(KIND(1D0)) ::betaNL
       REAL(KIND(1D0)) ::Lc_min! LB Oct2021 - minimum value of Lc
-      REAL(KIND(1D0)), PARAMETER::lb_av! LB Oct2021 - horizontal building dimensions
+      REAL(KIND(1D0)) ::bldg_dim! LB Oct2021 - horizontal building dimensions
 
       REAL(KIND(1D0)), PARAMETER::planF_low = 1E-6
       REAL(KIND(1D0)), PARAMETER::kappa = 0.40
@@ -874,8 +874,8 @@ CONTAINS
       Lc = MERGE(Lc, 0.5*Zh_RSL, Lc > 0.5*Zh_RSL)
       ! LB Oct2021 - set a minimum Lc threshold based on the Lc required to ensure the horizontal length scale associated with changes in canopy geometry (i.e. 3Lc) is greater than a typical street+building unit
       ! Note: the horizontal building size and street+building unit size is calculated assuming a regular array of cuboids with the same x and y dimension but with height that can be different 
-      lb_av = Zh_RSL*sfr(BldgSurf)/FAIBldg
-      Lc_min = lb_av*sfr(BldgSurf)**(-0.5)/3.
+      bldg_dim = Zh_RSL*sfr(BldgSurf)/FAIBldg
+      Lc_min = bldg_dim*sfr(BldgSurf)**(-0.5)/3.
       Lc = MERGE(Lc, Lc_min, Lc > Lc_min)
       
       ! a normalised scale with a physcially valid range between [-2,2] (Harman 2012, BLM)

--- a/SUEWS-SourceCode/src/suews_phys_rslprof.f95
+++ b/SUEWS-SourceCode/src/suews_phys_rslprof.f95
@@ -839,7 +839,7 @@ CONTAINS
       ! real(KIND(1D0)) ::betaHF
       ! real(KIND(1D0)) ::betaNL
       REAL(KIND(1D0)) ::Lc_min! LB Oct2021 - minimum value of Lc
-      REAL(KIND(1D0)), PARAMETER::Lb_av! LB Oct2021 - horizontal building dimensions
+      REAL(KIND(1D0)), PARAMETER::lb_av! LB Oct2021 - horizontal building dimensions
 
       REAL(KIND(1D0)), PARAMETER::planF_low = 1E-6
       REAL(KIND(1D0)), PARAMETER::kappa = 0.40
@@ -874,8 +874,8 @@ CONTAINS
       Lc = MERGE(Lc, 0.5*Zh_RSL, Lc > 0.5*Zh_RSL)
       ! LB Oct2021 - set a minimum Lc threshold based on the Lc required to ensure the horizontal length scale associated with changes in canopy geometry (i.e. 3Lc) is greater than a typical street+building unit
       ! Note: the horizontal building size and street+building unit size is calculated assuming a regular array of cuboids with the same x and y dimension but with height that can be different 
-      Lb_av = Zh_RSL*sfr(BldgSurf)/FAIBldg
-      Lc_min = Lb_av*sfr(BldgSurf)**(-0.5)/3.
+      lb_av = Zh_RSL*sfr(BldgSurf)/FAIBldg
+      Lc_min = lb_av*sfr(BldgSurf)**(-0.5)/3.
       Lc = MERGE(Lc, Lc_min, Lc > Lc_min)
       
       ! a normalised scale with a physcially valid range between [-2,2] (Harman 2012, BLM)

--- a/SUEWS-SourceCode/src/suews_phys_rslprof.f95
+++ b/SUEWS-SourceCode/src/suews_phys_rslprof.f95
@@ -843,6 +843,7 @@ CONTAINS
       REAL(KIND(1D0)), PARAMETER::r = 0.1
       REAL(KIND(1D0)), PARAMETER::a1 = 4., a2 = -0.1, a3 = 1.5, a4 = -1.
       REAL(KIND(1D0)), PARAMETER::Zh_min = 0.4! limit for minimum canyon height used in RSL module
+      REAL(KIND(1D0)), PARAMETER::Lc_min = 15.
 
       ! under stable conditions, set a threshold for L_MOD to avoid numerical issues. TS 28 Oct 2019
       ! L_MOD = merge(L_MOD, 300.d1, L_MOD < 300.)
@@ -869,7 +870,7 @@ CONTAINS
       ! set a minimum threshold (of 0.5*Zh_RSL) for Lc to avoid numerical diffulties when FAI is too large (e.g., FAI>10)
       Lc = MERGE(Lc, 0.5*Zh_RSL, Lc > 0.5*Zh_RSL)
       ! LB Oct2021 - set a minimum threshold (of 15 m) based on the Lc required to ensure the horizontal length scale associated with changes in canopy geometry (Lg<3Lc) is greater than a typical street
-      Lc = MERGE(Lc, 15., Lc > 15.)
+      Lc = MERGE(Lc, Lc_min, Lc > Lc_min)
       
       ! a normalised scale with a physcially valid range between [-2,2] (Harman 2012, BLM)
       lc_over_L = Lc/L_MOD

--- a/SUEWS-SourceCode/src/suews_phys_rslprof.f95
+++ b/SUEWS-SourceCode/src/suews_phys_rslprof.f95
@@ -192,8 +192,8 @@ CONTAINS
 
       ! see Fig 1 of Grimmond and Oke (1999) for the range for 'real cities'
       ! PAI ~ [0.1,.61], FAI ~ [0.05,0.45], zH_RSL > 2 m
-      flag_RSL = (1.-PAI)/FAI <= 18 .AND. (1.-PAI)/FAI > .021 &
-                 .AND. zH_RSL >= 5
+      flag_RSL = (1.-PAI)/FAI <= 18 .AND. zH_RSL >= 5 ! LB Oct2021 - FAI and PAI can be larger than 0.45 and 0.61 respectively -> remove (1.-PAI)/FAI > .021 constraint (note: it seems worng anyway - should be 0.87 not 0.021 based G&O1991 numbers)
+                 
       ! &
       ! .and. PAI>0.1 .and. PAI<0.61
       IF (flag_RSL) THEN
@@ -826,7 +826,7 @@ CONTAINS
       REAL(KIND(1D0)), INTENT(out) ::elm ! length scale used in RSL
       REAL(KIND(1D0)), INTENT(out) ::Scc ! parameter in RSL
       REAL(KIND(1D0)), INTENT(out) ::f ! parameter in RSL
-      REAL(KIND(1D0)), INTENT(out) ::PAI ! plan area index inlcuding area of trees
+      REAL(KIND(1D0)), INTENT(out) ::PAI ! plan area index inlcuding area of trees 
 
       ! internal variables
       ! INTEGER ::it
@@ -865,10 +865,12 @@ CONTAINS
       ! Lc_tree = 1./(cd_tree*a_tree) ! not used? why?
 
       ! height scale for bluff bodies
-      Lc = (1.-PAI)/FAI*Zh_RSL
-      ! set a threshold of Lc to avoid numerical diffulties when FAI is too large (e.g., FAI>10)
+      Lc = (1.-sfr(BldgSurf))/FAI*Zh_RSL ! LB Oct2021 - replaced PAI with sfr(BldgSurf) since the parameter should represent the solid fraction (and trees have negligible solid fraction).
+      ! set a minimum threshold (of 0.5*Zh_RSL) for Lc to avoid numerical diffulties when FAI is too large (e.g., FAI>10)
       Lc = MERGE(Lc, 0.5*Zh_RSL, Lc > 0.5*Zh_RSL)
-
+      ! LB Oct2021 - set a minimum threshold (of 15 m) based on the Lc required to ensure the horizontal length scale associated with changes in canopy geometry (Lg<3Lc) is greater than a typical street
+      Lc = MERGE(Lc, 15., Lc > 15.)
+      
       ! a normalised scale with a physcially valid range between [-2,2] (Harman 2012, BLM)
       lc_over_L = Lc/L_MOD
       ! lc_over_L = lc/L_MOD_RSL_x

--- a/SUEWS-SourceCode/src/suews_phys_rslprof.f95
+++ b/SUEWS-SourceCode/src/suews_phys_rslprof.f95
@@ -871,7 +871,7 @@ CONTAINS
       ! set a minimum threshold (of 0.5*Zh_RSL) for Lc to avoid numerical diffulties when FAI is too large (e.g., FAI>10)
       Lc = MERGE(Lc, 0.5*Zh_RSL, Lc > 0.5*Zh_RSL)
       ! LB Oct2021 - set a minimum threshold (of 15 m) based on the Lc required to ensure the horizontal length scale associated with changes in canopy geometry (Lg<3Lc) is greater than a typical street
-      Lc_min = Lb_av*BldgSurf**-0.5/3.
+      Lc_min = Lb_av*BldgSurf**(-0.5)/3.
       Lc = MERGE(Lc, Lc_min, Lc > Lc_min)
       
       ! a normalised scale with a physcially valid range between [-2,2] (Harman 2012, BLM)

--- a/SUEWS-SourceCode/src/suews_phys_rslprof.f95
+++ b/SUEWS-SourceCode/src/suews_phys_rslprof.f95
@@ -871,7 +871,7 @@ CONTAINS
       ! set a minimum threshold (of 0.5*Zh_RSL) for Lc to avoid numerical diffulties when FAI is too large (e.g., FAI>10)
       Lc = MERGE(Lc, 0.5*Zh_RSL, Lc > 0.5*Zh_RSL)
       ! LB Oct2021 - set a minimum threshold (of 15 m) based on the Lc required to ensure the horizontal length scale associated with changes in canopy geometry (Lg<3Lc) is greater than a typical street
-      Lc_min = Lb_av*BldgSurf**(-0.5)/3.
+      Lc_min = Lb_av*sfr(BldgSurf)**(-0.5)/3.
       Lc = MERGE(Lc, Lc_min, Lc > Lc_min)
       
       ! a normalised scale with a physcially valid range between [-2,2] (Harman 2012, BLM)

--- a/supy-driver/setup.py
+++ b/supy-driver/setup.py
@@ -23,7 +23,8 @@ elif sysname == "Linux":
 
 # change compiler settings
 if sysname == "Windows":
-    shutil.copyfile("win-setup.cfg", "setup.cfg")
+    pfn=Path.cwd()/"setup.cfg"
+    shutil.copyfile("win-setup.cfg", pfn)
 
 # load SUEWS Fortran source files
 dir_f95 = "../SUEWS-SourceCode/src"


### PR DESCRIPTION
The parameter Lc in RSL is a length scale determining the distance it takes flow to adjust to changes in urban canopy geometry. The distance is approximately 3Lc (Coceal and Belcher 2004). Physically it does not makes sense for the distance to be smaller than at least one building plus street unit i.e. the flow cannot adjust over a smaller distance than the minimum size that can be used to define the urban canopy geometry. I assume a regular cube array geometry, and along with lambdap and lambdaf calculate the minimum size of a building plus street unit, and use this to define a minimum Lc value. I have also updated the calculation of Lc. lambdap was being taken to be the building plus tree plan area density, but lambdap in Lc should represent the solid fraction of the canopy. Trees can be approximated as having negligible solid fraction as is done routinely in the vegetation canopy literature. I therefore removed the tree fraction from lambdap. The result of updating the minimum Lc threshold and redefining lambdap is to increase Lc, which in turn increases the velocity in the canopy, and reduces the temperature in the canopy under unstable conditions. SuPy runs have demonstrated that these changes help to alleviate the Tmax overestimation problems that were occurring for the Colombo runs.