### PR TITLE
inlcude recent RSL revisions

### DIFF
--- a/src/suews/src/suews_phys_atmmoiststab.f95
+++ b/src/suews/src/suews_phys_atmmoiststab.f95
@@ -1,7 +1,7 @@
 MODULE AtmMoistStab_module
    USE SUEWS_DEF_DTS, ONLY: atm_state, SUEWS_FORCING, SUEWS_TIMER, SUEWS_STATE
    IMPLICIT NONE
-   REAL(KIND(1D0)), PARAMETER :: neut_limit = 1.E-2 !Limit for neutral stability
+   REAL(KIND(1D0)), PARAMETER :: neut_limit = 1.E-4 !Limit for neutral stability
    REAL(KIND(1D0)), PARAMETER :: k = 0.4 !Von Karman's contant
    REAL(KIND(1D0)), PARAMETER :: grav = 9.80665 !g - gravity - physics today august 1987
 

--- a/src/suews/src/suews_phys_rslprof.f95
+++ b/src/suews/src/suews_phys_rslprof.f95
@@ -1062,9 +1062,11 @@ CONTAINS
                ! Step 0: Calculate grid-cell dependent constants and Beta (crucial for H&F method)
                CALL RSL_cal_prms( &
                   StabilityMethod, & !input
-                  nz_above, zarray(nz_can + 1:nz), & !input
+                  !nz_above, zarray(nz_can + 1:nz), & !input
+                  nz_above + 1, zarray(nz_can:nz), & !input
                   zh, L_MOD, sfr_surf, FAI, PAI, & !input
-                  psihatm_z(nz_can + 1:nz), psihath_z(nz_can + 1:nz), & !output
+                  !psihatm_z(nz_can + 1:nz), psihath_z(nz_can + 1:nz), & !output
+                  psihatm_z(nz_can:nz), psihath_z(nz_can:nz), & !output
                   zH_RSL, L_MOD_RSL, & ! output
                   Lc, beta, zd_RSL, z0_RSL, elm, Scc, fx)
 


### PR DESCRIPTION
changes to calc psihat in DTS subroutine and set neut_limit = 1.E-4