### PR TITLE
including calculation of psihat at building height level

### DIFF
--- a/src/suews/src/suews_phys_rslprof.f95
+++ b/src/suews/src/suews_phys_rslprof.f95
@@ -1063,7 +1063,7 @@ CONTAINS
                CALL RSL_cal_prms( &
                   StabilityMethod, & !input
                   !nz_above, zarray(nz_can + 1:nz), & !input
-                  nz_above+1, zarray(nz_can:nz), & !input
+                  nz_above + 1, zarray(nz_can:nz), & !input
                   zh, L_MOD, sfr_surf, FAI, PAI, & !input
                   !psihatm_z(nz_can + 1:nz), psihath_z(nz_can + 1:nz), & !output
                   psihatm_z(nz_can:nz), psihath_z(nz_can:nz), & !output

--- a/src/suews/src/suews_phys_rslprof.f95
+++ b/src/suews/src/suews_phys_rslprof.f95
@@ -1062,9 +1062,11 @@ CONTAINS
                ! Step 0: Calculate grid-cell dependent constants and Beta (crucial for H&F method)
                CALL RSL_cal_prms( &
                   StabilityMethod, & !input
-                  nz_above, zarray(nz_can + 1:nz), & !input
+                  !nz_above, zarray(nz_can + 1:nz), & !input
+                  nz_above+1, zarray(nz_can:nz), & !input
                   zh, L_MOD, sfr_surf, FAI, PAI, & !input
-                  psihatm_z(nz_can + 1:nz), psihath_z(nz_can + 1:nz), & !output
+                  !psihatm_z(nz_can + 1:nz), psihath_z(nz_can + 1:nz), & !output
+                  psihatm_z(nz_can:nz), psihath_z(nz_can:nz), & !output
                   zH_RSL, L_MOD_RSL, & ! output
                   Lc, beta, zd_RSL, z0_RSL, elm, Scc, fx)
 


### PR DESCRIPTION
I spotted the master branch was not calculating psihat at the building height level in RSLProfile_DTS routine. This changes includes the calculation at building height level as result of the proposed issue 1 in Issue #296.

![Screenshot 2025-02-04 at 11 34 12](https://github.com/user-attachments/assets/41c93d45-b758-4d88-a179-b141a437fac4)
