### PR TITLE
Add restore_state subroutine for model state management

### DIFF
--- a/src/suews/src/suews_ctrl_driver.f95
+++ b/src/suews/src/suews_ctrl_driver.f95
@@ -5187,28 +5187,27 @@ CONTAINS
       tsfc_C = qh/(dens_air*vcp_air)*RA + temp_C
    END FUNCTION cal_tsfc
 
-    subroutine restore_state(mod_state, mod_state_stepstart)
+   SUBROUTINE restore_state(mod_state, mod_state_stepstart)
       ! restore model state from the beginning of the time step while keeping the surface temperature updated from last iteration
       ! TS, 03 Mar 2025
       IMPLICIT NONE
-      type(SUEWS_STATE), INTENT(INOUT) :: mod_state ! model state being updated during the time step
-      type(SUEWS_STATE), INTENT(IN) :: mod_state_stepstart ! model state saved at the beginning of the time step
+      TYPE(SUEWS_STATE), INTENT(INOUT) :: mod_state ! model state being updated during the time step
+      TYPE(SUEWS_STATE), INTENT(IN) :: mod_state_stepstart ! model state saved at the beginning of the time step
 
-      real(kind(1d0)), dimension(:), allocatable :: tsfc_roof_tmp ! temporary surface temperature of roof saved at the beginning of the time step
-      real(kind(1d0)), dimension(:), allocatable :: tsfc_wall_tmp ! temporary surface temperature of wall saved at the beginning of the time step
-      real(kind(1d0)), dimension(:), allocatable :: tsfc_surf_tmp ! temporary surface temperature saved at the beginning of the time step
-      integer :: nlayer ! number of vertical layers
-      integer :: nsurf ! number of surfaces
+      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_roof_tmp ! temporary surface temperature of roof saved at the beginning of the time step
+      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_wall_tmp ! temporary surface temperature of wall saved at the beginning of the time step
+      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_surf_tmp ! temporary surface temperature saved at the beginning of the time step
+      INTEGER :: nlayer ! number of vertical layers
+      INTEGER :: nsurf ! number of surfaces
 
       ! get dimension information from surface temperature variables
-      nlayer = size(mod_state%heatstate%tsfc_roof)
-      nsurf = size(mod_state%heatstate%tsfc_surf)
-
+      nlayer = SIZE(mod_state%heatstate%tsfc_roof)
+      nsurf = SIZE(mod_state%heatstate%tsfc_surf)
 
       ! allocate temporary surface temperature arrays
-      allocate(tsfc_roof_tmp(nlayer))
-      allocate(tsfc_wall_tmp(nlayer))
-      allocate(tsfc_surf_tmp(nsurf))
+      ALLOCATE (tsfc_roof_tmp(nlayer))
+      ALLOCATE (tsfc_wall_tmp(nlayer))
+      ALLOCATE (tsfc_surf_tmp(nsurf))
 
       ! save surface temperature updated from last iteration and use it as initial surface temperature for the next iteration
       tsfc_roof_tmp = mod_state%heatstate%tsfc_roof
@@ -5224,10 +5223,10 @@ CONTAINS
       mod_state%heatstate%tsfc_surf = tsfc_surf_tmp
 
       ! deallocate temporary surface temperature arrays
-      deallocate(tsfc_roof_tmp)
-      deallocate(tsfc_wall_tmp)
-      deallocate(tsfc_surf_tmp)
+      DEALLOCATE (tsfc_roof_tmp)
+      DEALLOCATE (tsfc_wall_tmp)
+      DEALLOCATE (tsfc_surf_tmp)
 
-   end subroutine restore_state
+   END SUBROUTINE restore_state
 
 END MODULE SUEWS_Driver

--- a/src/suews/src/suews_ctrl_driver.f95
+++ b/src/suews/src/suews_ctrl_driver.f95
@@ -108,7 +108,7 @@ CONTAINS
       TYPE(output_line), INTENT(OUT) :: outputLine
       ! ########################################################################################
 
-      TYPE(SUEWS_STATE) :: modState_init
+      TYPE(SUEWS_STATE) :: modState_tstepstart
 
       ! these local variables are used in iteration
       INTEGER, PARAMETER :: max_iter = 30 ! maximum number of iteration
@@ -135,9 +135,9 @@ CONTAINS
             ev_surf => hydroState%ev_surf, &
             ev0_surf => hydroState%ev0_surf, &
             ! heatState
-            tsfc0_out_surf => heatState%tsfc0_out_surf, &
-            tsfc0_out_roof => heatState%tsfc0_out_roof, &
-            tsfc0_out_wall => heatState%tsfc0_out_wall, &
+            tsfc_surf_stepstart => heatState%tsfc_surf_stepstart, &
+            tsfc_roof_stepstart => heatState%tsfc_roof_stepstart, &
+            tsfc_wall_stepstart => heatState%tsfc_wall_stepstart, &
             tsfc_surf => heatState%tsfc_surf, &
             tsfc_roof => heatState%tsfc_roof, &
             tsfc_wall => heatState%tsfc_wall, &
@@ -160,10 +160,10 @@ CONTAINS
             ! IF (Diagnose == 1) WRITE (*, *) 'dectime', dectime
 
             ! ############# memory allocation for DTS variables (start) #############
-            CALL modState_init%ALLOCATE(nlayer, ndepth)
+            CALL modState_tstepstart%ALLOCATE(nlayer, ndepth)
             CALL debugState%init(nlayer, ndepth)
             ! save initial values of model states
-            modState_init = modState
+            modState_tstepstart = modState
 
             ! ########################################3
             ! set initial values for output arrays
@@ -215,11 +215,11 @@ CONTAINS
             flag_converge = .FALSE.
 
             ! save surface temperature at the beginning of the time step
-            tsfc0_out_surf = tsfc_surf
+            tsfc_surf_stepstart = tsfc_surf
             ! ! TODO: ESTM work: to allow heterogeneous surface temperatures
             IF (config%StorageHeatMethod == 5 .OR. config%NetRadiationMethod > 1000) THEN
-               tsfc0_out_roof = tsfc_roof
-               tsfc0_out_wall = tsfc_wall
+               tsfc_roof_stepstart = tsfc_roof
+               tsfc_wall_stepstart = tsfc_wall
             END IF
 
             !==============surface roughness calculation=======================
@@ -260,7 +260,9 @@ CONTAINS
                ! IMPORTANT: restore initial states as they SHOULD NOT be changed during iterations
                ! #316: restore initial hydroState as hydrostate should not be changed during iterations
                ! IF (config%flag_test) THEN
-               hydroState = modState_init%hydroState
+               ! restore all initial states but surface temperatures
+               CALL restore_state(modState, modState_tstepstart)
+               ! hydroState = modState_init%hydroState
                ! #369: restore initial phenState as phenState should not be changed during iterations
                ! phenState = modState_init%phenState
                ! ========================================================================================
@@ -510,7 +512,7 @@ CONTAINS
             ! here we may still use the original output array but another derived type can be used for enriched debugging info
             CALL update_debug_info( &
                timer, config, forcing, siteInfo, & ! input
-               modState_init, & ! input
+               modState_tstepstart, & ! input
                modState, & ! inout
                dataoutlineDebug) ! output
 
@@ -572,7 +574,7 @@ CONTAINS
 
          ASSOCIATE ( &
             flag_test => config%flag_test, &
-            tsfc0_out_surf => heatState%tsfc0_out_surf, &
+            tsfc0_out_surf => heatState%tsfc_surf_stepstart, &
             qn_surf => heatState%qn_surf, &
             qs_surf => heatState%qs_surf, &
             qe0_surf => heatState%qe0_surf, &
@@ -667,9 +669,9 @@ CONTAINS
             QH_roof => heatState%QH_roof, &
             QH_wall => heatState%QH_wall, &
             qh => heatState%qh, &
-            tsfc0_out_surf => heatState%tsfc0_out_surf, &
-            tsfc0_out_roof => heatState%tsfc0_out_roof, &
-            tsfc0_out_wall => heatState%tsfc0_out_wall, &
+            tsfc0_out_surf => heatState%tsfc_surf_stepstart, &
+            tsfc0_out_roof => heatState%tsfc_roof_stepstart, &
+            tsfc0_out_wall => heatState%tsfc_wall_stepstart, &
             tsfc_surf => heatState%tsfc_surf, &
             tsfc_roof => heatState%tsfc_roof, &
             tsfc_wall => heatState%tsfc_wall, &
@@ -5184,5 +5186,48 @@ CONTAINS
 
       tsfc_C = qh/(dens_air*vcp_air)*RA + temp_C
    END FUNCTION cal_tsfc
+
+    subroutine restore_state(mod_state, mod_state_stepstart)
+      ! restore model state from the beginning of the time step while keeping the surface temperature updated from last iteration
+      ! TS, 03 Mar 2025
+      IMPLICIT NONE
+      type(SUEWS_STATE), INTENT(INOUT) :: mod_state ! model state being updated during the time step
+      type(SUEWS_STATE), INTENT(IN) :: mod_state_stepstart ! model state saved at the beginning of the time step
+
+      real(kind(1d0)), dimension(:), allocatable :: tsfc_roof_tmp ! temporary surface temperature of roof saved at the beginning of the time step
+      real(kind(1d0)), dimension(:), allocatable :: tsfc_wall_tmp ! temporary surface temperature of wall saved at the beginning of the time step
+      real(kind(1d0)), dimension(:), allocatable :: tsfc_surf_tmp ! temporary surface temperature saved at the beginning of the time step
+      integer :: nlayer ! number of vertical layers
+      integer :: nsurf ! number of surfaces
+
+      ! get dimension information from surface temperature variables
+      nlayer = size(mod_state%heatstate%tsfc_roof)
+      nsurf = size(mod_state%heatstate%tsfc_surf)
+
+
+      ! allocate temporary surface temperature arrays
+      allocate(tsfc_roof_tmp(nlayer))
+      allocate(tsfc_wall_tmp(nlayer))
+      allocate(tsfc_surf_tmp(nsurf))
+
+      ! save surface temperature updated from last iteration and use it as initial surface temperature for the next iteration
+      tsfc_roof_tmp = mod_state%heatstate%tsfc_roof
+      tsfc_wall_tmp = mod_state%heatstate%tsfc_wall
+      tsfc_surf_tmp = mod_state%heatstate%tsfc_surf
+
+      ! restore model state from the beginning of the time step
+      mod_state = mod_state_stepstart
+
+      ! restore surface temperature
+      mod_state%heatstate%tsfc_roof = tsfc_roof_tmp
+      mod_state%heatstate%tsfc_wall = tsfc_wall_tmp
+      mod_state%heatstate%tsfc_surf = tsfc_surf_tmp
+
+      ! deallocate temporary surface temperature arrays
+      deallocate(tsfc_roof_tmp)
+      deallocate(tsfc_wall_tmp)
+      deallocate(tsfc_surf_tmp)
+
+   end subroutine restore_state
 
 END MODULE SUEWS_Driver

--- a/src/suews/src/suews_ctrl_type.f95
+++ b/src/suews/src/suews_ctrl_type.f95
@@ -792,9 +792,10 @@ MODULE SUEWS_DEF_DTS
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_wall ! wall surface temperature [degC]
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_surf ! surface temperature [degC]
 
-      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc0_out_roof !surface temperature of roof[degC]
-      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc0_out_wall !surface temperature of wall[degC]
-      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc0_out_surf !surface temperature [degC]
+      ! surface temperature saved at the beginning of the time step - not updated during the time step
+      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_roof_stepstart !surface temperature of roof saved at the beginning of the time step [degC]
+      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_wall_stepstart !surface temperature of wall saved at the beginning of the time step [degC]
+      REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_surf_stepstart !surface temperature saved at the beginning of the time step [degC]
 
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: QS_roof ! heat storage flux for roof component [W m-2]
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: QN_roof ! net all-wave radiation of roof surface [W m-2]
@@ -1225,9 +1226,9 @@ CONTAINS
       ALLOCATE (self%tsfc_wall(num_layer))
       ALLOCATE (self%tsfc_surf(num_surf))
 
-      ALLOCATE (self%tsfc0_out_roof(num_layer))
-      ALLOCATE (self%tsfc0_out_wall(num_layer))
-      ALLOCATE (self%tsfc0_out_surf(num_surf))
+      ALLOCATE (self%tsfc_roof_stepstart(num_layer))
+      ALLOCATE (self%tsfc_wall_stepstart(num_layer))
+      ALLOCATE (self%tsfc_surf_stepstart(num_surf))
 
       ALLOCATE (self%QS_roof(num_layer))
       ALLOCATE (self%QN_roof(num_layer))
@@ -1252,9 +1253,9 @@ CONTAINS
       IF (ALLOCATED(self%tsfc_roof)) DEALLOCATE (self%tsfc_roof)
       IF (ALLOCATED(self%tsfc_wall)) DEALLOCATE (self%tsfc_wall)
       IF (ALLOCATED(self%tsfc_surf)) DEALLOCATE (self%tsfc_surf)
-      IF (ALLOCATED(self%tsfc0_out_roof)) DEALLOCATE (self%tsfc0_out_roof)
-      IF (ALLOCATED(self%tsfc0_out_wall)) DEALLOCATE (self%tsfc0_out_wall)
-      IF (ALLOCATED(self%tsfc0_out_surf)) DEALLOCATE (self%tsfc0_out_surf)
+      IF (ALLOCATED(self%tsfc_roof_stepstart)) DEALLOCATE (self%tsfc_roof_stepstart)
+      IF (ALLOCATED(self%tsfc_wall_stepstart)) DEALLOCATE (self%tsfc_wall_stepstart)
+      IF (ALLOCATED(self%tsfc_surf_stepstart)) DEALLOCATE (self%tsfc_surf_stepstart)
       IF (ALLOCATED(self%temp_surf)) DEALLOCATE (self%temp_surf)
       IF (ALLOCATED(self%QS_roof)) DEALLOCATE (self%QS_roof)
       IF (ALLOCATED(self%QN_roof)) DEALLOCATE (self%QN_roof)


### PR DESCRIPTION
- Implemented `restore_state` subroutine to manage model state during time step iterations
- Preserves surface temperature variables while restoring other model state components
- Allows for more flexible and controlled state restoration during computational iterations
- Supports handling of surface temperatures across different surfaces (roof, wall, ground)