### PR TITLE
Fix Windows CI builds with setjmp compatibility library for windows-2022 runners

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/build-publish_to_pypi.yml"
       - "test/**"
       - "pyproject.toml"
+      - "meson.build"
 
   pull_request:
     paths: # PR events containing matching files
@@ -17,6 +18,7 @@ on:
       - "src/supy_driver/**"
       - ".github/workflows/build-publish_to_pypi.yml"
       - "pyproject.toml"
+      - "meson.build"
 jobs:
   build_wheels:
     name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
@@ -27,7 +29,7 @@ jobs:
             - [ubuntu-latest, manylinux, x86_64]
             - [macos-13, macosx, x86_64]
             - [macos-latest, macosx, arm64]
-            - [windows-2019, win, AMD64]
+            - [windows-2022, win, AMD64]
 
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
         # exclude:
@@ -46,7 +48,35 @@ jobs:
         brew install gfortran &&
         brew unlink gfortran &&
         brew link gfortran
-      CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel" # Use delvewheel on windows
+      CIBW_BEFORE_ALL_WINDOWS: >
+        C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm" &&
+        C:\msys64\usr\bin\bash.exe -lc "pacman -S --needed --noconfirm mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-gcc-fortran mingw-w64-ucrt-x86_64-binutils mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-openblas"
+      CIBW_ENVIRONMENT_WINDOWS: >
+        PATH="C:\\msys64\\ucrt64\\bin;$PATH"
+        CC=gcc
+        CXX=g++
+        FC=gfortran
+        CFLAGS="-D__USE_MINGW_ANSI_STDIO=1 -mlong-double-64"
+        CXXFLAGS="-D__USE_MINGW_ANSI_STDIO=1 -mlong-double-64"
+        FCFLAGS="-fno-optimize-sibling-calls"
+        LDFLAGS="-lucrt -static-libgcc -static-libgfortran -LC:/msys64/ucrt64/lib -lsetjmp_compat"
+      CIBW_BEFORE_BUILD_WINDOWS: >
+        echo Creating setjmp compatibility library... &&
+        echo int _setjmpex(void* buf) { extern int __intrinsic_setjmpex(void*); return __intrinsic_setjmpex(buf); } > setjmp_compat.c &&
+        C:\msys64\ucrt64\bin\gcc.exe -c setjmp_compat.c -o setjmp_compat.o &&
+        C:\msys64\ucrt64\bin\ar.exe rcs libsetjmp_compat.a setjmp_compat.o &&
+        echo Library created, checking contents: &&
+        C:\msys64\ucrt64\bin\nm.exe libsetjmp_compat.a &&
+        echo Copying to standard locations: &&
+        copy libsetjmp_compat.a C:\msys64\ucrt64\lib\ &&
+        copy libsetjmp_compat.a C:\msys64\ucrt64\x86_64-w64-mingw32\lib\ &&
+        echo Verifying library locations: &&
+        dir C:\msys64\ucrt64\lib\libsetjmp_compat.a &&
+        dir C:\msys64\ucrt64\x86_64-w64-mingw32\lib\libsetjmp_compat.a &&
+        where python &&
+        where gcc &&
+        gcc --version &&
+        pip install delvewheel
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
       CIBW_TEST_REQUIRES: pytest
       CIBW_TEST_COMMAND_MACOS: "python -m pytest '{project}/test'"

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,29 @@ project(
     meson_version: '>=0.64.0',
 )
 
+if host_machine.system() == 'windows'
+  # Link against the modern UCRT
+  # Note: We don't use -D__USE_MINGW_SETJMP_NON_SEH with UCRT64 as it supports SEH properly
+  # Note: recent MinGW-w64 GCC dropped support for the compile-time
+  # "-mcrtdll=..." switch.  We therefore omit it here and rely on
+  # LDFLAGS (set in the CI workflow) to pull in the UCRT at link time.
+  # add_project_arguments('-mcrtdll=ucrtbase', language : ['c','fortran'])
+  add_project_link_arguments('-lucrt', language : ['c','fortran'])
+
+  # Extra safety knobs cribbed from SciPy's build system
+  cc = meson.get_compiler('c')
+  if cc.get_id() == 'gcc'
+    # Force gcc to use 64-bit long double (matches MSVC behaviour)
+    add_project_arguments('-mlong-double-64', language : 'c')
+    # Make fprintf("%zd") work without CRT mismatch warnings
+    add_project_arguments('-D__USE_MINGW_ANSI_STDIO=1', language : 'c')
+    # For gfortran + BLAS string-length quirk on Windows
+    add_project_arguments('-fno-optimize-sibling-calls', language : 'fortran')
+    # Statically link the universal CRT to avoid mixed CRTs at runtime
+    add_project_link_arguments('-lucrt', language : ['c','fortran'])
+  endif
+endif
+
 # find the python installation
 py = import('python').find_installation(pure: false)
 dep_py = py.dependency()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "pytest",
-    "f90wrap==0.2.15",
+    "f90wrap==0.2.16",
     "numpy>=2.0",
     "meson-python>=0.12.0",
 ]
@@ -27,7 +27,7 @@ dependencies = [
     "chardet",
     "scipy",
     "pydantic",
-    "f90wrap==0.2.15",                             # f90wrap is required for f2py-based supy driver
+    "f90wrap==0.2.16",                             # f90wrap is required for f2py-based supy driver
     "dask",                                        # needs dask for parallel tasks
     "f90nml",                                      # utility for namelist files
     "seaborn",                                     # stat plotting

--- a/src/supy_driver/meson.build
+++ b/src/supy_driver/meson.build
@@ -40,6 +40,13 @@ add_global_arguments(cflags, language: 'c')
 
 # flags for converting f95 to fpp
 fpp_flags = ['-E', '-x', 'f95-cpp-input', '-fPIC']
+
+# Use UCRT for everything when on Windows
+if host_machine.system() == 'windows'
+  # The UCRT64 msys2 environment implicitly handles linking to the UCRT.
+  # Explicitly adding '-mcrtdll=ucrtbase' can fail with older GCC versions.
+  # Note: We don't use -D__USE_MINGW_SETJMP_NON_SEH with UCRT64 as it supports SEH properly
+endif
 ##################################################################
 
 ##################################################################


### PR DESCRIPTION
## Summary

Fix Windows CI builds failing on GitHub Actions `windows-2022` runners with `_setjmpex` symbol errors.

## Problem

Windows wheel builds were failing with undefined reference errors:
```
undefined reference to '_setjmpex'
```

This issue didn't occur on `windows-2019` runners but started appearing on `windows-2022` environments. The migration to `windows-2022` runners became necessary due to GitHub's forthcoming sunset of the `windows-2019` image, making this fix critical for continued Windows support.

## Root Cause Analysis

The issue stems from a symbol name mismatch between:
- **f90wrap generated code**: Calls `_setjmpex` (Windows SEH setjmp)
- **UCRT64 runtime libraries**: Provide `__intrinsic_setjmpex` instead
- **Environment difference**: `windows-2022` has different runtime configurations than `windows-2019`

### Technical Context

This represents a common challenge when mixing:
- **Code generators** (f90wrap) that assume certain runtime symbols
- **Modern Windows runtimes** (UCRT) with different symbol conventions  
- **Cross-compilation toolchains** (MSYS2/MinGW) bridging these environments

## Solution

Created a setjmp compatibility library that provides the missing symbol:

```c
int _setjmpex(void* buf) { 
    extern int __intrinsic_setjmpex(void*); 
    return __intrinsic_setjmpex(buf); 
}
```

### Implementation Details

1. **Library Creation**: Build compatibility library during CI setup using UCRT64 toolchain
2. **Strategic Placement**: Copy to multiple standard library locations
3. **Explicit Linking**: Add library path and link flags to ensure discovery
4. **Verification**: Include debugging output to confirm successful creation

## Changes Made

### `.github/workflows/build-publish_to_pypi.yml`

#### Platform Update
```yaml
# Migrate from deprecated windows-2019 to windows-2022
- [windows-2022, win, AMD64]  # was: windows-2019
```

#### Enhanced UCRT64 Setup
```yaml
CIBW_BEFORE_ALL_WINDOWS: >
  C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm" &&
  C:\msys64\usr\bin\bash.exe -lc "pacman -S --needed --noconfirm mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-gcc-fortran mingw-w64-ucrt-x86_64-binutils mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-openblas"
```

#### Environment Configuration
```yaml
CIBW_ENVIRONMENT_WINDOWS: >
  PATH="C:\\msys64\\ucrt64\\bin;$PATH"
  CC=gcc CXX=g++ FC=gfortran
  CFLAGS="-D__USE_MINGW_ANSI_STDIO=1 -mlong-double-64"
  CXXFLAGS="-D__USE_MINGW_ANSI_STDIO=1 -mlong-double-64"
  FCFLAGS="-fno-optimize-sibling-calls"
  LDFLAGS="-lucrt -static-libgcc -static-libgfortran -LC:/msys64/ucrt64/lib -lsetjmp_compat"
```

#### Compatibility Library Creation
```yaml
CIBW_BEFORE_BUILD_WINDOWS: >
  echo Creating setjmp compatibility library... &&
  echo int _setjmpex(void* buf) { extern int __intrinsic_setjmpex(void*); return __intrinsic_setjmpex(buf); } > setjmp_compat.c &&
  C:\msys64\ucrt64\bin\gcc.exe -c setjmp_compat.c -o setjmp_compat.o &&
  C:\msys64\ucrt64\bin\ar.exe rcs libsetjmp_compat.a setjmp_compat.o &&
  copy libsetjmp_compat.a C:\msys64\ucrt64\lib\ &&
  copy libsetjmp_compat.a C:\msys64\ucrt64\x86_64-w64-mingw32\lib\
```

### `meson.build` (root)

Added Windows-specific UCRT configuration:
```python
if host_machine.system() == 'windows'
  # Link against the modern UCRT
  # Note: We don't use -D__USE_MINGW_SETJMP_NON_SEH with UCRT64 as it supports SEH properly
  add_project_link_arguments('-lucrt', language : ['c','fortran'])
  
  # Extra safety knobs cribbed from SciPy's build system
  cc = meson.get_compiler('c')
  if cc.get_id() == 'gcc'
    add_project_arguments('-mlong-double-64', language : 'c')
    add_project_arguments('-D__USE_MINGW_ANSI_STDIO=1', language : 'c')
    add_project_arguments('-fno-optimize-sibling-calls', language : 'fortran')
    add_project_link_arguments('-lucrt', language : ['c','fortran'])
  endif
endif
```

### `src/supy_driver/meson.build`

Added UCRT compatibility notes:
```python
# Use UCRT for everything when on Windows
if host_machine.system() == 'windows'
  # Note: We don't use -D__USE_MINGW_SETJMP_NON_SEH with UCRT64 as it supports SEH properly
endif
```

### `pyproject.toml`

Updated f90wrap for better Windows compatibility:
```toml
"f90wrap==0.2.16"  # was: 0.2.15
```

## Key Features

- ✅ **Minimal impact**: No changes to core SUEWS/SuPy code
- ✅ **Windows SEH compatible**: Maintains proper exception handling
- ✅ **f90wrap agnostic**: Works with generated code without modification
- ✅ **UCRT64 native**: Uses standard UCRT64 toolchain
- ✅ **Robust library placement**: Multiple locations ensure linker discovery
- ✅ **Future-proof**: Migrates to supported GitHub Actions runners

## Debugging Journey & Lessons Learned

### Initial Challenges
1. **Platform migration**: windows-2019 sunset forced upgrade to windows-2022
2. **Symbol mismatch**: f90wrap generated `_setjmpex` calls vs UCRT64's `__intrinsic_setjmpex`
3. **Runtime conflicts**: Mixed CRT libraries caused multiple definition errors
4. **Library placement**: Ensuring linker could find compatibility library

### Evolution of the Fix
- **Started with**: Platform upgrade investigation
- **Progressed through**: MSVCRT library linking attempts
- **Resolved with**: Custom compatibility library approach

### Debugging Process
Through systematic debugging on the actual CI environment:
- Identified available setjmp symbols in UCRT64 libraries
- Discovered f90wrap's Windows-specific setjmp usage
- Confirmed symbol name mismatch as root cause
- Verified compatibility library approach resolves linking

## Testing

The fix has been thoroughly tested and verified to:
- [x] Successfully build Windows wheels for Python 3.9-3.13
- [x] Pass all CI pipeline stages including tests  
- [x] Resolve all undefined `_setjmpex` symbol errors
- [x] Complete wheel upload to artifacts
- [x] Maintain compatibility with existing functionality
- [x] Work reliably on windows-2022 runners

## Technical Background

### Build Environment
- **Platform**: Windows Server 2022 (GitHub Actions)
- **Build Tool**: cibuildwheel v2.23.3
- **Compiler**: MinGW-w64 UCRT64 toolchain
- **Code Generation**: f90wrap + f2py for Fortran-Python interfaces

### Symbol Analysis
- **f90wrap behavior**: Generates Windows SEH-style setjmp calls
- **UCRT64 symbols**: Provides `__intrinsic_setjmpex` for SEH support
- **Compatibility layer**: Bridges the symbol name gap

## Impact

- 🔧 **Fixes**: Windows CI builds and wheel generation
- 📦 **Enables**: PyPI publication for Windows users  
- 🚀 **Restores**: Complete multi-platform CI functionality
- 🛡️ **Maintains**: All existing functionality and compatibility
- 📚 **Future-proofs**: Migration to supported GitHub Actions infrastructure
- 🎯 **Addresses**: GitHub's windows-2019 sunset requirements

This fix ensures that Windows wheel builds work reliably on modern GitHub Actions runners and provides a robust foundation for future Windows builds, while addressing the mandatory migration from deprecated windows-2019 images.