### PR TITLE
feat: enable forcing_file to accept list of files in YAML

### DIFF
--- a/docs/source/inputs/yaml/examples/forcing_multiple_files.yml
+++ b/docs/source/inputs/yaml/examples/forcing_multiple_files.yml
@@ -1,0 +1,34 @@
+# Example: YAML configuration with multiple forcing files
+# This example shows how to specify a list of forcing files
+# The files will be automatically concatenated in chronological order
+
+model:
+  control:
+    tstep: 3600
+    forcing_file:   # List of forcing files
+      - "forcing_2020.txt"
+      - "forcing_2021.txt"
+      - "forcing_2022.txt"
+    output_file: "output_2020_2022.txt"
+  physics:
+    netradiationmethod: 3
+    emissionsmethod: 2
+
+sites:
+  - name: "London_KCL"
+    latitude: 51.5115
+    longitude: -0.1160
+    altitude: 31.0
+    land_cover:
+      paved: 0.38
+      bldgs: 0.37
+      evetr: 0.02
+      dectr: 0.04
+      grass: 0.14
+      bsoil: 0.01
+      water: 0.04
+
+# Notes:
+# - Files must have consistent column structure
+# - Files will be concatenated based on their timestamps
+# - Ensure no gaps or overlaps in time periods between files

--- a/docs/source/inputs/yaml/examples/forcing_single_file.yml
+++ b/docs/source/inputs/yaml/examples/forcing_single_file.yml
@@ -1,0 +1,25 @@
+# Example: YAML configuration with single forcing file
+# This example shows how to specify a single forcing file
+
+model:
+  control:
+    tstep: 3600
+    forcing_file: "forcing_2020.txt"  # Single forcing file
+    output_file: "output_2020.txt"
+  physics:
+    netradiationmethod: 3
+    emissionsmethod: 2
+
+sites:
+  - name: "London_KCL"
+    latitude: 51.5115
+    longitude: -0.1160
+    altitude: 31.0
+    land_cover:
+      paved: 0.38
+      bldgs: 0.37
+      evetr: 0.02
+      dectr: 0.04
+      grass: 0.14
+      bsoil: 0.01
+      water: 0.04

--- a/docs/source/inputs/yaml/index.rst
+++ b/docs/source/inputs/yaml/index.rst
@@ -43,7 +43,30 @@ Data Files
 In addition to the YAML configuration file, SUEWS works with input and output data files:
 
 **Input Data:**
-- **Forcing data**: Meteorological time-series data file specified by :ref:`model.control.forcing_file <modelcontrol>`
+- **Forcing data**: Meteorological time-series data specified by :ref:`model.control.forcing_file <modelcontrol>`
+
+  The ``forcing_file`` parameter supports two modes:
+  
+  1. **Single file**: Specify a path to a single forcing file
+     
+     .. code-block:: yaml
+     
+        model:
+          control:
+            forcing_file: "forcing_2020.txt"
+     
+  2. **Multiple files**: Specify a list of file paths
+     
+     .. code-block:: yaml
+     
+        model:
+          control:
+            forcing_file: 
+              - "forcing_2020.txt"
+              - "forcing_2021.txt"
+              - "forcing_2022.txt"
+     
+     When multiple files are provided, they will be automatically loaded and concatenated in chronological order.
 
 **Output Data:**
 - **Model results**: Time-series output files specified by :ref:`model.control.output_file <modelcontrol>`

--- a/src/supy/_supy_module.py
+++ b/src/supy/_supy_module.py
@@ -221,7 +221,13 @@ def load_forcing_grid(
             if config is None:
                 config = init_config_from_yaml(path=path_init)
             path_site = path_init.parent
-            path_input = path_site / config.model.control.forcing_file.value
+            forcing_file_val = config.model.control.forcing_file.value if hasattr(config.model.control.forcing_file, 'value') else config.model.control.forcing_file
+            if isinstance(forcing_file_val, list):
+                # Handle list of files
+                path_input = [path_site / f for f in forcing_file_val]
+            else:
+                # Handle single file
+                path_input = path_site / forcing_file_val
 
         tstep_mod, lat, lon, alt, timezone = df_state_init.loc[
             grid, [(x, "0") for x in ["tstep", "lat", "lng", "alt", "timezone"]]

--- a/src/supy/data_model/model.py
+++ b/src/supy/data_model/model.py
@@ -1,5 +1,5 @@
 import yaml
-from typing import Optional
+from typing import Optional, Union, List
 import numpy as np
 from pydantic import ConfigDict, BaseModel, Field, field_validator, model_validator
 import pandas as pd
@@ -570,9 +570,9 @@ class ModelControl(BaseModel):
     tstep: int = Field(
         default=300, description="Time step in seconds for model calculations"
     )
-    forcing_file: FlexibleRefValue(str) = Field(
+    forcing_file: Union[FlexibleRefValue(str), List[str]] = Field(
         default="forcing.txt",
-        description="Path to meteorological forcing data file. The forcing file contains time-series meteorological data that drives SUEWS simulations. For detailed information about required variables, file format, and data preparation guidelines, see :ref:`met_input`.",
+        description="Path(s) to meteorological forcing data file(s). This can be either: (1) A single file path as a string (e.g., 'forcing.txt'), or (2) A list of file paths (e.g., ['forcing_2020.txt', 'forcing_2021.txt', 'forcing_2022.txt']). When multiple files are provided, they will be automatically concatenated in chronological order. The forcing data contains time-series meteorological measurements that drive SUEWS simulations. For detailed information about required variables, file format, and data preparation guidelines, see :ref:`met_input`.",
     )
     kdownzen: Optional[FlexibleRefValue(int)] = Field(
         default=None,

--- a/test/test_forcing_file_list.py
+++ b/test/test_forcing_file_list.py
@@ -1,0 +1,55 @@
+"""Test that forcing_file parameter accepts both string and list of strings"""
+
+import pytest
+from supy.data_model.model import ModelControl
+
+
+def test_forcing_file_single_string():
+    """Test that forcing_file accepts a single string"""
+    control = ModelControl(forcing_file="forcing_2020.txt")
+    assert control.forcing_file == "forcing_2020.txt"
+
+
+def test_forcing_file_list_of_strings():
+    """Test that forcing_file accepts a list of strings"""
+    files = ["forcing_2020.txt", "forcing_2021.txt", "forcing_2022.txt"]
+    control = ModelControl(forcing_file=files)
+    assert control.forcing_file == files
+    assert isinstance(control.forcing_file, list)
+    assert len(control.forcing_file) == 3
+
+
+def test_forcing_file_with_ref_value():
+    """Test that forcing_file works with RefValue wrapper"""
+    from supy.data_model.type import RefValue
+    
+    # Single file with RefValue
+    control = ModelControl(forcing_file=RefValue("forcing_with_ref.txt"))
+    assert hasattr(control.forcing_file, 'value')
+    assert control.forcing_file.value == "forcing_with_ref.txt"
+
+
+def test_yaml_loading_with_list():
+    """Test loading a YAML config with forcing file list"""
+    import yaml
+    from supy.data_model.core import SUEWSConfig
+    
+    yaml_content = """
+model:
+  control:
+    forcing_file:
+      - "forcing_2020.txt" 
+      - "forcing_2021.txt"
+      - "forcing_2022.txt"
+sites:
+  - name: "TestSite"
+    latitude: 51.5
+    longitude: -0.1
+"""
+    
+    config_dict = yaml.safe_load(yaml_content)
+    config = SUEWSConfig(**config_dict)
+    
+    assert isinstance(config.model.control.forcing_file, list)
+    assert len(config.model.control.forcing_file) == 3
+    assert config.model.control.forcing_file[0] == "forcing_2020.txt"


### PR DESCRIPTION
## Summary

This PR enables the `forcing_file` parameter in YAML configuration to accept either a single file path or a list of file paths, making it easier to work with multi-year datasets split across multiple files.

## Changes

- Updated `ModelControl.forcing_file` field to accept `Union[str, List[str]]`
- Modified `load_forcing_grid()` to handle both single files and lists of files
- Updated documentation to clearly explain both usage modes
- Added example YAML configurations for both single and multiple files
- Added tests to verify the functionality

## Usage

### Single file (existing behavior):
```yaml
model:
  control:
    forcing_file: "forcing_2020.txt"
```

### Multiple files (new feature):
```yaml
model:
  control:
    forcing_file:
      - "forcing_2020.txt"
      - "forcing_2021.txt" 
      - "forcing_2022.txt"
```

When multiple files are provided, they are automatically concatenated in chronological order.

## Notes

- Directory paths are NOT supported - only explicit file paths
- The existing single-string behavior remains unchanged for backwards compatibility
- Files must have consistent column structure for concatenation to work properly

## Testing

- All existing tests pass
- Added new tests specifically for list support
- Verified both YAML loading and programmatic usage work correctly