### PR TITLE
fix: update cibuildwheel to v3.0.0 with manylinux_2_28 to fix Pillow build failures

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -43,6 +43,8 @@ jobs:
       CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}*
       CIBW_ARCHS: ${{ matrix.buildplat[2] }}
       CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
       CIBW_BEFORE_ALL_MACOS: >
         brew install gfortran &&
         brew unlink gfortran &&
@@ -95,7 +97,7 @@ jobs:
             python-version: 3.12
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.0.0
 
       - name: Setup tmate session for debugging
         if: failure()


### PR DESCRIPTION
## Summary
- Upgrade cibuildwheel from v2.23.3 to v3.0.0
- Switch from manylinux2014 to manylinux_2_28 for Linux builds
- Fixes build failures that started on 1 July 2025

## Root Cause Analysis

The CI builds started failing today because:

1. **Pillow 11.3.0 was released on 1 July 2025** with a breaking change - it no longer provides manylinux2014 (manylinux_2_17) wheels
2. Pillow 11.3.0+ only ships wheels for manylinux_2_27 and manylinux_2_28
3. Our CI was using the default manylinux2014 image from cibuildwheel v2.23.3
4. When pip couldn't find a compatible wheel, it tried to build Pillow from source
5. The build failed because the manylinux2014 image doesn't have libjpeg-dev headers installed

## Solution

This PR updates to cibuildwheel v3.0.0 which:
- Uses manylinux_2_28 as the default (though we explicitly set it for clarity)
- Provides better compatibility with modern Python packages
- Aligns with the Python packaging ecosystem's move away from CentOS 7-based images (EOL June 2024)

## Testing

The CI will automatically test all Python versions (3.9-3.13) across all platforms with this change.

## Alternative Approaches Considered

1. Pin Pillow to <11.3.0 - This would work short-term but leaves us on outdated infrastructure
2. Install libjpeg-dev in the build environment - This adds complexity and build time
3. **Update to modern manylinux images (chosen)** - Best long-term solution

Fixes the build failures reported in GitHub Actions runs starting from run ID 16009527322.