### PR TITLE
docs: add documentation for annotated YAML feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 <!-- [doc]: Documentation updates -->
 <!-- [change]: Changes exposed to users -->
 
+- 02 Jul 2025:
+  - [feature] Added automatic annotated YAML generation for parameter validation errors
+    - Generates helpful annotated YAML files when configuration validation fails
+    - Marks missing parameters with [ERROR] MISSING: and provides [TIP] ADD HERE: suggestions
+    - Includes parameter descriptions and expected types for each missing field
+    - Significantly improves user experience when creating configuration files
+  - [change] Replaced emoji markers with text markers in annotated YAML files
+    - Changed from emoji (🔴, 💡) to text markers ([ERROR], [TIP]) for Windows compatibility
+    - Ensures consistent display across all platforms without Unicode encoding issues
+  - [bugfix] Fixed parameter validation false positives and improved validation messages (#448)
+    - Resolved spurious warnings during normal operations
+    - Made validation messages clearer and more actionable
+    - Fixed platform-specific test failures on Windows, Linux, and macOS
+
 - 28 Jun 2025:
   - [feature] Streamlined worktree workflow for Claude Code development
     - Created automated scripts for worktree management: worktree-setup.sh and worktree-cleanup.sh

--- a/docs/source/inputs/yaml/index.rst
+++ b/docs/source/inputs/yaml/index.rst
@@ -36,6 +36,23 @@ Here's a minimal example of the YAML structure:
 
 For a complete working example, please refer to the `sample configuration file <https://github.com/UMEP-dev/SUEWS/blob/master/src/supy/sample_run/sample_config.yml>`_ provided with SuPy.
 
+Validation and Error Handling
+-----------------------------
+
+When loading a YAML configuration file, SUEWS performs comprehensive validation to ensure all required parameters are present and valid. If validation errors occur:
+
+1. **Clear error messages** are displayed in the log, listing all missing or invalid parameters
+2. **An annotated YAML file** is automatically generated to help you fix the issues
+
+The annotated YAML file includes:
+
+- **Location**: ``{config_file}_annotated_{timestamp}.yml`` in the same directory as your config
+- **Error markers**: Missing parameters marked with ``[ERROR] MISSING:``
+- **Help tips**: Suggested fixes marked with ``[TIP] ADD HERE:``
+- **Parameter descriptions**: Each error includes the parameter description and expected type
+
+This feature significantly simplifies the process of creating valid configuration files, especially for new users or when using advanced physics options that require additional parameters.
+
 
 Data Files
 ----------

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -188,3 +188,51 @@ Please check the following:
 A general rule of thumb is to use the `load_SampleData` to generate the initial model states from the sample data shipped by SuPy.
 
 
+YAML Configuration Validation Errors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When your YAML configuration has missing or invalid parameters, SUEWS will:
+
+1. Display clear error messages in the log indicating which parameters are missing
+2. Generate an annotated YAML file with helpful guidance
+
+The annotated YAML file features:
+   
+   - File location: ``{config_file}_annotated_{timestamp}.yml``
+   - Missing parameters are marked with ``[ERROR] MISSING:``
+   - Helpful tips are marked with ``[TIP] ADD HERE:``
+   - Each error includes the expected type and description
+
+Example of annotated output::
+
+    sites:
+      - name: "London_KCL"
+        properties:
+          lat: {value: 51.5115}
+          lng: {value: -0.1160}
+          # [ERROR] MISSING: alt (Site altitude above sea level [m])
+          # [TIP] ADD HERE:
+          alt: {value: 10.0}  # Example: 10.0 meters above sea level
+          
+          land_cover:
+            bldgs:
+              sfr: {value: 0.45}
+              # [ERROR] MISSING: bldgh (Mean building height [m])
+              # [TIP] ADD HERE:
+              bldgh: {value: 20.0}  # Example: 20.0 meters
+
+To fix validation errors:
+
+1. Look for the generated annotated YAML file in the same directory as your config
+2. Search for ``[ERROR]`` markers to find missing parameters
+3. Add the missing parameters with appropriate values
+4. Re-run your simulation with the corrected configuration
+
+Common validation errors:
+
+- Missing building height (``bldgh``) when buildings are present
+- Missing thermal properties when using advanced storage heat methods
+- Missing surface fractions that don't sum to 1.0
+- Missing vegetation parameters when vegetation surfaces are present
+
+

--- a/docs/source/version-history/dev.rst
+++ b/docs/source/version-history/dev.rst
@@ -10,11 +10,13 @@ Version 2021a (in development)
   1. Added a new `RoughLenMomMethod` (``4``) to calculate roughness and displacement height as a function of plan area index and effective height of roughness elements following the ensemble mean of Fig 1a in :cite:`GO99`
   2. Coupled `SPARCATUS <https://github.com/Urban-Meteorology-Reading/spartacus-surface>`_ into SUEWS for detailed modelling of radiation balance.
   3. Added a new option `DiagMethod` in `RunControl` to control the output of radiation balance.
+  4. Added automatic generation of annotated YAML files when parameter validation fails, providing clear guidance on missing parameters and how to fix them.
+  5. Improved validation error messages with more descriptive information about missing parameters and their expected values.
 
 
 - **Changes**
 
-  1. TO ADD
+  1. Replaced emoji markers with text markers ([ERROR], [TIP]) in annotated YAML files for better cross-platform compatibility, particularly on Windows systems.
 
 
 - **Fix**


### PR DESCRIPTION
## Summary
- Added documentation for the new annotated YAML validation feature
- Updated YAML configuration guide to explain validation and error handling
- Added troubleshooting section for YAML configuration validation errors

## Purpose
This PR documents the annotated YAML feature that was implemented in #448. When YAML validation errors occur, SUEWS now generates an annotated YAML file with helpful error markers and tips to guide users in fixing configuration issues.

## Changes
- Added "Validation and Error Handling" section to `docs/source/inputs/yaml/index.rst`
- Added "YAML Configuration Validation Errors" section to `docs/source/troubleshooting.rst`
- Includes examples of annotated YAML output with error markers

## Related Issues
- Follows up on #448 which implemented the validation improvements
- Part of ongoing parameter validation documentation work

🤖 Generated with [Claude Code](https://claude.ai/code)