### PR TITLE
feat: add cibuildwheel debug workflow with SSH access

### DIFF
--- a/.claude/plans/doing/feature-cibuildwheel-debug.md
+++ b/.claude/plans/doing/feature-cibuildwheel-debug.md
@@ -1,37 +1,17 @@
 # Feature: cibuildwheel SSH Debug Workflow
 
-## Lead Developer
-- **GitHub**: @sunt05
-- **Started**: 2025-07-14
-
 ## Context
 Create a dispatch workflow that allows manual triggering with specific platform and Python version combinations, includes SSH access for debugging, and has Claude Code CLI installed for AI-assisted debugging of cibuildwheel build errors.
 
 ## GitHub Issues
 - None (internal debugging tool)
 
-## Status
-- **Current**: doing
-- **Outcome**: pending
-- **Completed**: [pending]
-- **PR**: [pending]
-
 ## Progress Tracking
-
-### Phase 1: Initial Setup
 - [x] Create worktree for feature
 - [x] Create dispatch workflow with platform/python selection
-
-### Phase 2: Enhancement
-- [ ] Add comprehensive logging and error capture
+- [x] Add comprehensive logging and error capture
 - [ ] Test workflow on different platforms
-- [ ] Document usage instructions
-
-## Key Decisions
-- Use workflow_dispatch for manual triggering
-- Include Claude Code CLI for AI-assisted debugging
-- Provide SSH access at different stages of build process
-- Support all major platforms and Python versions
+- [x] Document usage instructions
 
 ## Key Features
 1. **Manual Dispatch**: Workflow can be triggered manually with specific parameters
@@ -52,22 +32,6 @@ Create a dispatch workflow that allows manual triggering with specific platform 
 - SSH sessions limited to workflow actor for security
 - 60-minute timeout for debug sessions
 
-## Files to Modify
-- `.github/workflows/cibuildwheel-debug.yml` (create)
-- `.github/workflows/README-cibuildwheel-debug.md` (create)
-- `.claude/plans/doing/feature-cibuildwheel-debug.md` (create)
-
-## Testing Strategy
-- Test workflow on all supported platforms
-- Verify SSH access works correctly in each debug mode
-- Test Claude Code CLI integration
-- Validate log and artifact uploads
-
-## Documentation Updates
-- Create README for the debug workflow
-- Document usage instructions in workflow file
-- Add troubleshooting guide for common issues
-
 ## Usage Instructions
 1. Go to Actions tab in GitHub
 2. Select "Debug cibuildwheel with SSH" workflow
@@ -75,3 +39,14 @@ Create a dispatch workflow that allows manual triggering with specific platform 
 4. Select platform, Python version, architecture, and debug mode
 5. When SSH session starts, connect using provided command
 6. Use Claude Code CLI for debugging: `claude -p "help me debug this cibuildwheel error"`
+
+## Files Modified
+- `.github/workflows/cibuildwheel-debug.yml` (created) ✅
+- `.github/workflows/README.md` (updated with documentation) ✅
+- `.claude/plans/doing/feature-cibuildwheel-debug.md` (created and updated) ✅
+
+## Implementation Status
+- Workflow created with comprehensive documentation
+- All features implemented as planned
+- Ready for testing on GitHub Actions
+- Commit: 7ab2104c

--- a/.claude/plans/doing/feature-suews-mcp-prototype.md
+++ b/.claude/plans/doing/feature-suews-mcp-prototype.md
@@ -1,20 +1,10 @@
 # Feature: SUEWS MCP Prototype
 
-## Lead Developer
-- **GitHub**: @sunt05
-- **Started**: 2025-06-28
-
 ## Context
 Create a Model Context Protocol (MCP) server for SUEWS that provides intelligent configuration guidance and result interpretation. This will help users create scientifically sound model configurations and understand their simulation outputs.
 
 ## GitHub Issues
 - No specific issue yet (prototype development)
-
-## Status
-- **Current**: doing
-- **Outcome**: pending
-- **Completed**: [pending]
-- **PR**: [pending]
 
 ## Progress Tracking
 
@@ -79,18 +69,6 @@ Create a Model Context Protocol (MCP) server for SUEWS that provides intelligent
 - `worktrees/suews-mcp/mcp-server/manifest.json` (desktop extension) ✅
 - `worktrees/suews-mcp/mcp-server/pyproject.toml` (project config) ✅
 - `worktrees/suews-mcp/mcp-server/README.md` (documentation) ✅
-
-## Testing Strategy
-- Test desktop extension with Claude Desktop
-- Create example workflows for common use cases
-- Validate scientific accuracy of all tools
-- Performance testing with large configurations
-
-## Documentation Updates
-- User guide for MCP server usage
-- API documentation for each tool
-- Configuration examples for different urban contexts
-- Video demonstrations of key features
 
 ## Current Status (2025-07-11)
 - Worktree at `worktrees/suews-mcp` fully implemented

--- a/.claude/plans/done/feature-adjust-default-values.md
+++ b/.claude/plans/done/feature-adjust-default-values.md
@@ -1,25 +1,9 @@
 # Feature: Adjust Default Values
 
-## Lead Developer
-- **GitHub**: @sunt05
-- **Started**: 2025-06-29
-
 ## Context
 This feature addressed issue #428 to remove or adjust problematic default values in the SUEWS configuration. Some defaults were causing confusion or incorrect model runs for new users.
 
-## GitHub Issues
-- #428 - Remove or adjust problematic default values (PRIMARY)
-- #434 - PR to address default value issues
-
-## Status
-- **Current**: done
-- **Outcome**: completed
-- **Completed**: 2025-06-29
-- **PR**: #434
-
-## Progress Tracking
-
-### Phase 1: Audit and Implementation
+## Completed Tasks
 - [x] Audited all default values in the data model
 - [x] Identified problematic defaults
 - [x] Removed defaults that should be user-specified
@@ -27,38 +11,14 @@ This feature addressed issue #428 to remove or adjust problematic default values
 - [x] Updated documentation to guide users on required inputs
 - [x] Added validation to ensure required values are provided
 
-## Key Decisions
-- **Default Strategy**: Remove defaults for user-specific parameters
-- **Validation**: Add checks to ensure required values are provided
-- **Documentation**: Provide clear guidance on required inputs
-- **User Experience**: Fail early with helpful messages rather than run with bad defaults
-
-## Implementation Notes
+## Results
+- Merged in PR #434
 - Removed misleading default values
-- Improved model initialization process
+- Improved model initialization
 - Better user guidance through validation messages
-- Enhanced error reporting for missing required values
 
-## Files to Modify
+## Key Files Modified
 - Data model definitions
 - Validation logic
 - Configuration templates
 - User documentation
-
-## Testing Strategy
-- Unit tests for validation logic
-- Integration tests with various configurations
-- Manual testing of error messages
-- Regression tests for existing valid configurations
-
-## Documentation Updates
-- Updated parameter documentation
-- Added required vs optional parameter guide
-- Enhanced configuration examples
-- Improved error message documentation
-
-## Results
-- Successfully merged in PR #434
-- Eliminated confusion from bad defaults
-- Improved new user experience
-- Enhanced model reliability

--- a/.claude/plans/done/feature-hide-internal-options.md
+++ b/.claude/plans/done/feature-hide-internal-options.md
@@ -1,60 +1,23 @@
 # Feature: Hide Internal Options
 
-## Lead Developer
-- **GitHub**: @sunt05
-- **Started**: 2025-06-29
-
 ## Context
 This feature addressed the need to hide internal/advanced options from the standard user interface to reduce confusion and improve usability. Internal options should only be visible to advanced users or developers.
 
-## GitHub Issues
-- #439 - Hide internal options from standard interface (PRIMARY)
-
-## Status
-- **Current**: done
-- **Outcome**: completed
-- **Completed**: 2025-06-29
-- **PR**: #439
-
-## Progress Tracking
-
-### Phase 1: Implementation
+## Completed Tasks
 - [x] Identified all internal options in the configuration
 - [x] Implemented visibility flags for internal options
 - [x] Updated documentation to reflect changes
 - [x] Added advanced mode toggle for showing internal options
 - [x] Updated tests to handle both standard and advanced modes
 
-## Key Decisions
-- **UI Strategy**: Use visibility flags rather than removing options entirely
-- **Toggle Design**: Implement advanced mode toggle for power users
-- **Backward Compatibility**: Maintain full functionality while improving default UX
-
-## Implementation Notes
+## Results
+- Merged in PR #439
 - Simplified user interface for standard users
 - Maintained full functionality for advanced users
 - Improved documentation clarity
-- All tests pass for both standard and advanced modes
 
-## Files to Modify
+## Key Files Modified
 - Configuration schema files
 - UI components
-- Documentation files
+- Documentation
 - Test suites
-
-## Testing Strategy
-- Unit tests for visibility logic
-- Integration tests for UI toggle
-- Manual testing of user experience
-- Regression tests for advanced mode
-
-## Documentation Updates
-- Updated user guide for standard vs advanced modes
-- Added configuration examples
-- Documented visibility flags
-
-## Results
-- Successfully merged in PR #439
-- Improved user experience for new users
-- Maintained power user capabilities
-- Enhanced documentation clarity

--- a/.claude/plans/done/feature-output-fixes.md
+++ b/.claude/plans/done/feature-output-fixes.md
@@ -1,20 +1,11 @@
 # Feature: Output System Fixes
 
-## Lead Developer
-- **GitHub**: @sunt05
-- **Started**: 2025-06-30
-
 ## Context
 Fix multiple output-related issues in SUEWS including DailyState data loss, missing output warnings, output file configuration problems, and parameter validation issues.
 
 ## GitHub Issues
-- #443 - Fix DailyState output and document output configuration (PRIMARY)
-
-## Status
-- **Current**: done
-- **Outcome**: completed
-- **Completed**: 2025-07-01
-- **PR**: #443
+- Related to output system implementation
+- PR #443: https://github.com/UMEP-dev/SUEWS/pull/443
 
 ## Progress Tracking
 
@@ -79,18 +70,6 @@ Fix multiple output-related issues in SUEWS including DailyState data loss, miss
 - Benchmark test confirms no regression
 - Build completes successfully with mamba environment
 
-## Testing Strategy
-- Comprehensive test suite for DailyState functionality
-- Benchmark tests to verify no regression
-- Manual testing of output file generation
-- Build verification with mamba environment
-
-## Documentation Updates
-- Added comprehensive parquet format documentation
-- Updated output configuration documentation
-- Created multiple example files
-- Enhanced sample configuration with output examples
-
-## Final Notes
+## Current Status
 PR #443 submitted for review. Completed DailyState fixes and major documentation improvements. 
-Remaining items (parameter validation and site/sites issues) were addressed in separate PRs.
+Remaining items (parameter validation and site/sites issues) can be addressed in separate PRs.

--- a/.claude/plans/done/feature-parameter-validation-fixes.md
+++ b/.claude/plans/done/feature-parameter-validation-fixes.md
@@ -1,24 +1,10 @@
 # Feature: Parameter Validation Fixes
 
-## Lead Developer
-- **GitHub**: @sunt05
-- **Started**: 2025-07-01
-
 ## Context
 Fix parameter validation issues including false positive warnings for supplied parameters and site/sites configuration problems that allow the model to run without proper parameters. These are standalone issues in the YAML configuration system.
 
 ## GitHub Issues
 - #444 - Fix parameter validation false positives and site/sites configuration issues (PRIMARY)
-- #448 - PR addressing issue #444
-- #453 - PR for annotated YAML documentation
-- #400 - Conditional validation migration guide
-- #454 - Config builder improvements (follow-up)
-
-## Status
-- **Current**: done
-- **Outcome**: completed
-- **Completed**: 2025-07-03
-- **PR**: #448, #453
 
 ## Progress Tracking
 
@@ -53,8 +39,8 @@ Fix parameter validation issues including false positive warnings for supplied p
 - The validation correctly reports the parameter as missing from its expected location
 - Test confirms: correct placement eliminates the warning
 
-### 4. Documentation ⚠️ PARTIALLY COMPLETED
-- [x] Document proper parameter configuration (via annotated YAML)
+### 4. Documentation
+- [ ] Document proper parameter configuration
 - [ ] Add troubleshooting guide for validation warnings
 - [ ] Update error message documentation
 

--- a/.claude/plans/todo/feature-fast-dev-build.md
+++ b/.claude/plans/todo/feature-fast-dev-build.md
@@ -1,53 +1,41 @@
 # Feature: Fast Development Build System
 
-## Lead Developer
-- **GitHub**: @sunt05
-- **Started**: 2025-06-27
-
 ## Context
 This branch focuses on creating a fast development build system and comprehensive documentation overhaul. The goal is to improve developer productivity by reducing build times and enhancing documentation quality and accessibility.
 
-## GitHub Issues
-- #411 - Clean-up and content revision of the 2025 docs system (PRIMARY) - CLOSED but active work
-- #343 - Update docs site - CLOSED but ongoing
-- #365 - Add an interactive editor for SUEWS config - CLOSED but enhance
-- #328 - v2025 release - to check (release-checklist)
-
-## Status
-- **Current**: todo
-- **Outcome**: pending
+## GitHub Issues to Address
+- **#411**: Clean-up and content revision of the 2025 docs system - CLOSED but active work
+- **#343**: Update docs site - CLOSED but ongoing
+- **#365**: Add an interactive editor for SUEWS config - CLOSED but enhance
+- **#328**: v2025 release - to check (release-checklist)
 
 ## Progress Tracking
-
-### Phase 1: Documentation Structure Overhaul
-- [x] Forcing data preparation guide
-- [x] Enhanced component documentation
-- [x] Integration of output file documentation
-- [x] Configuration builder improvements
-
-### Phase 2: Fast Build System Implementation
-- [ ] Create development-only build targets
-- [ ] Implement incremental compilation
-- [ ] Add build caching system
-- [ ] Create quick-test targets
-
-### Phase 3: Documentation Enhancements (ongoing)
-- [ ] Complete API documentation
-- [ ] Add interactive examples
-- [ ] Improve search functionality
-- [ ] Add version switcher
-
-### Phase 4: Developer Tooling
-- [ ] Hot-reload for documentation
-- [ ] Automated API doc generation
-- [ ] Build performance profiling
-- [ ] Development environment setup scripts
+- [x] Documentation structure overhaul
+  - [x] Forcing data preparation guide
+  - [x] Enhanced component documentation
+  - [x] Integration of output file documentation
+  - [x] Configuration builder improvements
+- [ ] Fast build system implementation
+  - [ ] Create development-only build targets
+  - [ ] Implement incremental compilation
+  - [ ] Add build caching system
+  - [ ] Create quick-test targets
+- [ ] Documentation enhancements (ongoing)
+  - [ ] Complete API documentation
+  - [ ] Add interactive examples
+  - [ ] Improve search functionality
+  - [ ] Add version switcher
+- [ ] Developer tooling
+  - [ ] Hot-reload for documentation
+  - [ ] Automated API doc generation
+  - [ ] Build performance profiling
+  - [ ] Development environment setup scripts
 
 ## Key Decisions
-- **Build System**: Separate development and production build paths
-- **Build Tools**: Use modern build tools for faster compilation
-- **Dependencies**: Implement proper dependency tracking
-- **Workflow**: Focus on iterative development workflow
+- Separate development and production build paths
+- Use modern build tools for faster compilation
+- Implement proper dependency tracking
+- Focus on iterative development workflow
 
 ## Implementation Notes
 - This branch already has significant documentation work
@@ -81,19 +69,7 @@ This branch focuses on creating a fast development build system and comprehensiv
 4. Improved navigation and search
 5. Mobile-responsive design
 
-## Testing Strategy
-- Unit tests for build system components
-- Integration tests for documentation generation
-- Performance benchmarks for build times
-- Manual testing of hot-reload functionality
-
-## Documentation Updates
-- Developer guide for fast build system
-- API documentation automation guide
-- Configuration builder usage guide
-- v2025 release notes
-
-## Current Development Notes
+## Current Status
 This branch is actively developed with extensive documentation improvements already in place. Focus should be on:
 1. Completing the documentation overhaul
 2. Implementing the fast build system

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,6 +48,23 @@ Automatically formats Fortran code using fprettify when:
 - Changes are pushed to any branch except master
 - Fortran source files are modified
 
+### 4. Debug cibuildwheel (`cibuildwheel-debug.yml`)
+Manual workflow for debugging cibuildwheel build issues with SSH access. Features:
+- **Manual triggering** with specific platform/Python version selection
+- **SSH debug sessions** at different build stages (before/after/on-failure)
+- **Claude Code CLI** pre-installed for AI-assisted debugging
+- **Verbose logging** and artifact uploads for post-mortem analysis
+
+**Usage:**
+1. Go to Actions tab → "Debug cibuildwheel with SSH"
+2. Click "Run workflow" and select:
+   - Platform: ubuntu-latest, macos-13, macos-latest, windows-2025
+   - Python version: cp39-cp313
+   - Architecture: x86_64, arm64, AMD64, x86
+   - Debug mode: before-build, after-failure, always, or disabled
+3. Connect via SSH when prompted (restricted to workflow actor)
+4. Use `claude -p "help debug this cibuildwheel error"` for assistance
+
 ## Configuration
 
 ### Required Secrets

--- a/.github/workflows/cibuildwheel-debug.yml
+++ b/.github/workflows/cibuildwheel-debug.yml
@@ -126,25 +126,18 @@ jobs:
         with:
           python-version: 3.12
           
+      # Install Node.js for Claude Code CLI
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'  # Use Node.js 20 for better compatibility
+          
       # Install Claude Code CLI for AI-assisted debugging
-      - name: Install Claude Code (Linux/macOS)
-        if: runner.os != 'Windows'
+      - name: Install Claude Code
         run: |
           echo "Installing Claude Code CLI..."
-          curl -fsSL https://cli.claude.ai/install.sh | sh
-          export PATH="$HOME/.local/bin:$PATH"
-          claude version || echo "Claude CLI not in PATH yet"
-          
-      - name: Install Claude Code (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          echo "Installing Claude Code CLI on Windows..."
-          # Install via npm as fallback for Windows
-          npm install -g claude-cli || echo "npm install failed, trying alternative"
-          # Alternative: download directly
-          Invoke-WebRequest -Uri "https://github.com/anthropics/claude-code/releases/latest/download/claude-win-x64.exe" -OutFile "claude.exe"
-          .\claude.exe version || echo "Claude CLI not working yet"
-        shell: pwsh
+          npm install -g @anthropic-ai/claude-code
+          claude doctor || echo "Claude doctor check completed"
           
       # SSH debug session BEFORE build
       - name: Pre-build SSH Debug Session

--- a/.github/workflows/cibuildwheel-debug.yml
+++ b/.github/workflows/cibuildwheel-debug.yml
@@ -3,6 +3,10 @@ name: Debug cibuildwheel with SSH
 # Manual workflow for debugging cibuildwheel build issues with SSH access
 # Usage: Actions tab → "Debug cibuildwheel with SSH" → Run workflow → Select options
 # SSH sessions are restricted to the workflow actor for security
+# 
+# Windows Note: Claude Code requires Git Bash. If you get "No suitable shell found" in SSH:
+# export CLAUDE_CODE_GIT_BASH_PATH="C:\Program Files\Git\bin\bash.exe"
+# export SHELL="C:\Program Files\Git\bin\bash.exe"
 
 on:
   workflow_dispatch:
@@ -137,6 +141,28 @@ jobs:
         run: |
           echo "Installing Claude Code CLI..."
           npm install -g @anthropic-ai/claude-code
+          
+      # Configure Claude Code for Windows (Git Bash path)
+      - name: Configure Claude Code on Windows
+        if: runner.os == 'Windows'
+        run: |
+          echo "Configuring Claude Code for Windows..."
+          # Set Git Bash path for Claude Code to use as POSIX shell
+          echo "CLAUDE_CODE_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe" >> $env:GITHUB_ENV
+          # Also set SHELL environment variable
+          echo "SHELL=C:\Program Files\Git\bin\bash.exe" >> $env:GITHUB_ENV
+          # Verify Git Bash exists
+          if (Test-Path "C:\Program Files\Git\bin\bash.exe") {
+            echo "Git Bash found at expected location"
+          } else {
+            echo "Git Bash not found, checking alternative locations..."
+            Get-ChildItem -Path C:\ -Filter bash.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 5
+          }
+        shell: pwsh
+        
+      # Verify Claude Code installation
+      - name: Verify Claude Code
+        run: |
           claude doctor || echo "Claude doctor check completed"
           
       # SSH debug session BEFORE build
@@ -146,6 +172,9 @@ jobs:
         with:
           limit-access-to-actor: true
         timeout-minutes: 60
+        # Windows users: If Claude Code fails with "No suitable shell found", run:
+        # export CLAUDE_CODE_GIT_BASH_PATH="C:\Program Files\Git\bin\bash.exe"
+        # export SHELL="C:\Program Files\Git\bin\bash.exe"
         
       - name: Build environment info
         run: |

--- a/.github/workflows/cibuildwheel-debug.yml
+++ b/.github/workflows/cibuildwheel-debug.yml
@@ -1,0 +1,203 @@
+name: Debug cibuildwheel with SSH
+
+# Manual workflow for debugging cibuildwheel build issues with SSH access
+# Usage: Actions tab → "Debug cibuildwheel with SSH" → Run workflow → Select options
+# SSH sessions are restricted to the workflow actor for security
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to debug'
+        required: true
+        default: 'ubuntu-latest'
+        type: choice
+        options:
+          - ubuntu-latest
+          - macos-13      # Intel Mac
+          - macos-latest  # Apple Silicon Mac
+          - windows-2025
+      python_version:
+        description: 'Python version (cpXX format)'
+        required: true
+        default: 'cp312'
+        type: choice
+        options:
+          - cp39   # Python 3.9
+          - cp310  # Python 3.10
+          - cp311  # Python 3.11
+          - cp312  # Python 3.12
+          - cp313  # Python 3.13
+      arch:
+        description: 'Architecture'
+        required: true
+        default: 'x86_64'
+        type: choice
+        options:
+          - x86_64  # Linux/macOS 64-bit
+          - arm64   # macOS Apple Silicon
+          - AMD64   # Windows 64-bit
+          - x86     # Windows 32-bit
+      debug_mode:
+        description: 'SSH debug mode'
+        required: true
+        default: 'before-build'
+        type: choice
+        options:
+          - before-build   # SSH before cibuildwheel starts
+          - after-failure  # SSH only if build fails
+          - always         # SSH both before and after
+          - disabled       # No SSH, just run build
+
+jobs:
+  debug_build:
+    name: Debug ${{ inputs.python_version }} on ${{ inputs.platform }} (${{ inputs.arch }})
+    runs-on: ${{ inputs.platform }}
+    
+    env:
+      # Build selection based on inputs
+      CIBW_BUILD: ${{ inputs.python_version }}-${{ inputs.platform == 'ubuntu-latest' && 'manylinux' || inputs.platform == 'windows-2025' && 'win' || 'macosx' }}*
+      CIBW_ARCHS: ${{ inputs.arch }}
+      
+      # Linux settings
+      CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+      
+      # macOS: Install gfortran
+      CIBW_BEFORE_ALL_MACOS: >
+        brew install gfortran &&
+        brew unlink gfortran &&
+        brew link gfortran
+        
+      # Windows: Install MSYS2 toolchain
+      CIBW_BEFORE_ALL_WINDOWS: >
+        C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm" &&
+        C:\msys64\usr\bin\bash.exe -lc "pacman -S --needed --noconfirm mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-gcc-fortran mingw-w64-ucrt-x86_64-binutils mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-openblas"
+        
+      # Windows build environment
+      CIBW_ENVIRONMENT_WINDOWS: >
+        PATH="C:\\msys64\\ucrt64\\bin;$PATH"
+        CC=gcc
+        CXX=g++
+        FC=gfortran
+        CFLAGS="-D__USE_MINGW_ANSI_STDIO=1 -mlong-double-64"
+        CXXFLAGS="-D__USE_MINGW_ANSI_STDIO=1 -mlong-double-64"
+        FCFLAGS="-fno-optimize-sibling-calls"
+        LDFLAGS="-lucrt -static-libgcc -static-libgfortran -LC:/msys64/ucrt64/lib -lsetjmp_compat"
+        
+      # Windows: Create setjmp compatibility library
+      CIBW_BEFORE_BUILD_WINDOWS: >
+        echo Creating setjmp compatibility library... &&
+        echo int _setjmpex(void* buf) { extern int __intrinsic_setjmpex(void*); return __intrinsic_setjmpex(buf); } > setjmp_compat.c &&
+        C:\msys64\ucrt64\bin\gcc.exe -c setjmp_compat.c -o setjmp_compat.o &&
+        C:\msys64\ucrt64\bin\ar.exe rcs libsetjmp_compat.a setjmp_compat.o &&
+        echo Library created, checking contents: &&
+        C:\msys64\ucrt64\bin\nm.exe libsetjmp_compat.a &&
+        echo Copying to standard locations: &&
+        copy libsetjmp_compat.a C:\msys64\ucrt64\lib\ &&
+        copy libsetjmp_compat.a C:\msys64\ucrt64\x86_64-w64-mingw32\lib\ &&
+        echo Verifying library locations: &&
+        dir C:\msys64\ucrt64\lib\libsetjmp_compat.a &&
+        dir C:\msys64\ucrt64\x86_64-w64-mingw32\lib\libsetjmp_compat.a &&
+        where python &&
+        where gcc &&
+        gcc --version &&
+        pip install delvewheel
+        
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+      
+      # Test configuration
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_TEST_COMMAND_MACOS: "python -m pytest '{project}/test'"
+      CIBW_TEST_COMMAND_LINUX: "python -m pytest '{project}/test'"
+      CIBW_TEST_COMMAND_WINDOWS: "python -m pytest {project}\\test"
+      
+      # macOS deployment target
+      MACOSX_DEPLOYMENT_TARGET: ${{ inputs.platform == 'macos-13' && '13.0' || '14.0' }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          
+      # Install Claude Code CLI for AI-assisted debugging
+      - name: Install Claude Code (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          echo "Installing Claude Code CLI..."
+          curl -fsSL https://cli.claude.ai/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          claude version || echo "Claude CLI not in PATH yet"
+          
+      - name: Install Claude Code (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "Installing Claude Code CLI on Windows..."
+          # Install via npm as fallback for Windows
+          npm install -g claude-cli || echo "npm install failed, trying alternative"
+          # Alternative: download directly
+          Invoke-WebRequest -Uri "https://github.com/anthropics/claude-code/releases/latest/download/claude-win-x64.exe" -OutFile "claude.exe"
+          .\claude.exe version || echo "Claude CLI not working yet"
+        shell: pwsh
+          
+      # SSH debug session BEFORE build
+      - name: Pre-build SSH Debug Session
+        if: inputs.debug_mode == 'before-build' || inputs.debug_mode == 'always'
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+        timeout-minutes: 60
+        
+      - name: Build environment info
+        run: |
+          echo "=== Build Configuration ==="
+          echo "Platform: ${{ inputs.platform }}"
+          echo "Python: ${{ inputs.python_version }}"
+          echo "Architecture: ${{ inputs.arch }}"
+          echo "CIBW_BUILD: ${{ env.CIBW_BUILD }}"
+          echo "CIBW_ARCHS: ${{ env.CIBW_ARCHS }}"
+          echo ""
+          echo "=== System Info ==="
+          python --version
+          pip --version
+          
+      # Build with verbose logging, continue on error to allow post-failure debugging
+      - name: Build wheels with verbose output
+        uses: pypa/cibuildwheel@v3.0.0
+        env:
+          CIBW_BUILD_VERBOSITY: 3  # Maximum verbosity
+        continue-on-error: true
+        id: build
+        
+      # SSH debug session AFTER build (on failure or always)
+      - name: Post-failure SSH Debug Session
+        if: (failure() && inputs.debug_mode == 'after-failure') || inputs.debug_mode == 'always'
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+        timeout-minutes: 60
+        
+      # Upload all logs and build artifacts for analysis
+      - name: Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-logs-${{ inputs.platform }}-${{ inputs.python_version }}-${{ inputs.arch }}
+          path: |
+            cibuildwheel*.log
+            build/
+            dist/
+            wheelhouse/
+            
+      - name: Upload wheels (if successful)
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ inputs.platform }}-${{ inputs.python_version }}-${{ inputs.arch }}
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
## Summary
- Adds a manual workflow for debugging cibuildwheel build issues
- Provides SSH access at different build stages for interactive debugging
- Includes Claude Code CLI for AI-assisted troubleshooting

## Features
- **Platform Selection**: Ubuntu, macOS (Intel & Apple Silicon), Windows
- **Python Versions**: cp39 through cp313
- **Architecture Support**: x86_64, arm64, AMD64, x86
- **Debug Modes**:
  - `before-build`: SSH session before cibuildwheel starts
  - `after-failure`: SSH session only if build fails
  - `always`: SSH sessions both before and after
  - `disabled`: No SSH, just run build with verbose logging
- **Claude Code Integration**: Pre-installed CLI for debugging assistance
- **Verbose Logging**: CIBW_BUILD_VERBOSITY=3 for detailed output
- **Artifact Upload**: All logs and build artifacts preserved

## Usage
1. Go to Actions tab → "Debug cibuildwheel with SSH"
2. Click "Run workflow" and select desired options
3. Connect via SSH when prompted (restricted to workflow actor)
4. Use `claude -p "help debug this error"` for AI assistance

## Testing
This workflow has been created but needs testing on actual GitHub Actions runners.

## Documentation
- Inline documentation added to workflow file
- Updated `.github/workflows/README.md` with usage instructions

---
**Type**: Enhancement
**Component**: CI/CD