### PR TITLE
chore: add British English instructions to Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -94,6 +94,12 @@ jobs:
           # Use Claude Opus 4 for better code review quality
           model: claude-opus-4-20250514
 
+          # Custom instructions for British English
+          custom_instructions: |
+            IMPORTANT: Always use British English spelling and grammar in all your responses, reviews, and written content.
+            This project follows British English conventions throughout its documentation and codebase.
+            Examples: use "organisation" not "organization", "colour" not "color", "centre" not "center", etc.
+
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide structured feedback using collapsible HTML sections for better organization.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -107,6 +107,8 @@ jobs:
           
           # Custom instructions based on CLAUDE.md and project standards
           custom_instructions: |
+            IMPORTANT: Always use British English spelling and grammar in all your responses and written content.
+            
             You are working on SUEWS (Surface Urban Energy and Water Balance Scheme), a Fortran/Python urban climate model.
             
             Key project information:


### PR DESCRIPTION
## Summary

This PR adds explicit British English instructions to both Claude workflow files to ensure consistent language usage across all Claude interactions.

## Changes

- **claude-code-review.yml**: Added `custom_instructions` section with clear British English requirements
- **claude.yml**: Made the existing British English instruction more prominent by placing it at the top of `custom_instructions`

## Details

Added the following instruction to both workflows:
```yaml
custom_instructions: |
  IMPORTANT: Always use British English spelling and grammar in all your responses and written content.
```

This ensures Claude will use British English spelling and grammar in all interactions when triggered from GitHub Actions, matching the project's documentation standards.

## Examples
- "organisation" not "organization"
- "colour" not "color"  
- "centre" not "center"
- "authorised" not "authorized"

## Testing
- Verified YAML syntax is valid
- Confirmed instructions are properly formatted
- Tested that custom_instructions parameter is supported by claude-code-action@beta