### PR TITLE
Fix: Limit snow warning to only show once per simulation

### DIFF
--- a/src/suews/src/suews_ctrl_driver.f95
+++ b/src/suews/src/suews_ctrl_driver.f95
@@ -65,6 +65,9 @@ MODULE SUEWS_Driver
 
    IMPLICIT NONE
 
+   ! Module-level variable to track if snow warning has been shown
+   LOGICAL, SAVE :: snow_warning_shown = .FALSE.
+
 CONTAINS
 
 ! ===================MAIN CALCULATION WRAPPER FOR ENERGY AND WATER FLUX===========
@@ -399,7 +402,11 @@ CONTAINS
                !===================Calculate surface hydrology and related soil water=======================
                ! MP: Until Snow has been fixed this should not be used (TODO)
                IF (config%SnowUse == 1) THEN
-                  WRITE (*, *) "WARNING SNOW ON! Not recommended at the moment"
+                  ! Only show warning once per simulation run
+                  IF (.NOT. snow_warning_shown) THEN
+                     WRITE (*, *) "WARNING SNOW ON! Not recommended at the moment"
+                     snow_warning_shown = .TRUE.
+                  END IF
                   ! ===================Calculate snow related hydrology=======================
                   ! #234 the snow parts needs more work to be done
                   ! TS 18 Oct 2023: snow is temporarily turned off for easier implementation of other functionalities


### PR DESCRIPTION
## Summary
This PR fixes issue #528 by limiting the snow warning message to only appear once per simulation run, preventing console spam when `SnowUse=1` is enabled.

## Changes
- Added a module-level variable (`snow_warning_shown`) to track whether the warning has been displayed
- Modified the warning logic to check this flag before displaying the warning
- The warning now only appears once per SUEWS simulation run, regardless of timesteps

## Technical Details
- **File modified**: `src/suews/src/suews_ctrl_driver.f95`
- **Implementation**: Uses Fortran `SAVE` attribute to persist the flag across subroutine calls
- **Behaviour**: Warning appears once at the first timestep when snow module is enabled

## Testing
- [x] Built the project successfully with `make dev`
- [x] Ran full test suite with `make test` - all tests pass
- [x] Verified the fix addresses the reported issue

## Example
Before this fix:
```
WARNING SNOW ON\! Not recommended at the moment
WARNING SNOW ON\! Not recommended at the moment
WARNING SNOW ON\! Not recommended at the moment
... (repeated thousands of times)
```

After this fix:
```
WARNING SNOW ON\! Not recommended at the moment
(appears only once)
```

Fixes #528