### PR TITLE
Fix: Add input validation for zero wind speed (fixes #314)

### DIFF
--- a/docs/source/inputs/tables/SSss_YYYY_data_tt.csv
+++ b/docs/source/inputs/tables/SSss_YYYY_data_tt.csv
@@ -8,7 +8,7 @@ No.,Use,Column Name,Description
 7,`O`,qe,Latent heat flux [W |m^-2|]
 8,`O`,qs,Storage heat flux [W |m^-2|]
 9,`O`,qf,Anthropogenic heat flux [W |m^-2|]
-10,`MU`,U,Wind speed [m s-1] (measurement height (`z`) is needed in `SUEWS_SiteSelect.txt`)
+10,`MU`,U,Wind speed [m s-1] (measurement height (`z`) is needed in `SUEWS_SiteSelect.txt`). **Minimum: 0.01 m/s** to avoid division by zero errors in atmospheric calculations.
 11,`MU`,RH,Relative Humidity [%] (measurement height (`z`) is needed in `SUEWS_SiteSelect.txt`)
 12,`MU`,Tair,Air temperature [°C] (measurement height (`z`) is needed in `SUEWS_SiteSelect.txt`)
 13,`MU`,pres,Barometric pressure [kPa] (measurement height (`z`) is needed in `SUEWS_SiteSelect.txt`)

--- a/docs/source/inputs/tables/met_input.rst
+++ b/docs/source/inputs/tables/met_input.rst
@@ -195,6 +195,9 @@ Essential checks before using forcing data:
        if (df['RH'] < 0).any() or (df['RH'] > 100).any():
            issues.append("Relative humidity outside 0-100% range")
        
+       if (df['U'] < 0.01).any():
+           issues.append("Wind speed below minimum threshold (0.01 m/s) - causes division by zero errors")
+       
        if (df['kdown'] < 0).any():
            issues.append("Negative incoming shortwave radiation")
        

--- a/src/supy/_check.py
+++ b/src/supy/_check.py
@@ -62,11 +62,17 @@ def check_range(ser_to_check: pd.Series, rule_var: dict) -> Tuple:
         is_accepted_flag = False
         ind = ser_flag.index[ser_flag]
         ind = [ser_flag.index.get_loc(x) for x in ind]
-        description = f"`{var}` should be between [{min_v}, {max_v}] but {n_flag} outliers are found at:\n {ind}"
+        # Special message for wind speed
+        if var == "u":
+            description = f"Wind speed (`U`) must be >= {min_v} m/s to avoid division by zero errors in atmospheric calculations. {n_flag} values below {min_v} m/s found at:\n {ind}"
+            suggestion = f"Set all wind speed values < {min_v} m/s to {min_v} m/s. This is required for numerical stability in SUEWS."
+        else:
+            description = f"`{var}` should be between [{min_v}, {max_v}] but {n_flag} outliers are found at:\n {ind}"
 
     if not is_accepted_flag:
         is_accepted = is_accepted_flag
-        suggestion = "change the parameter to fall into the acceptable range"
+        if var != "u":
+            suggestion = "change the parameter to fall into the acceptable range"
     else:
         is_accepted = is_accepted_flag
         suggestion = ""

--- a/src/supy/checker_rules_indiv.json
+++ b/src/supy/checker_rules_indiv.json
@@ -2024,7 +2024,7 @@
         "optional": false,
         "param": {
             "max": 60,
-            "min": 0.0001
+            "min": 0.01
         },
         "unit": "m s-1"
     },

--- a/test/core/test_wind_speed_validation.py
+++ b/test/core/test_wind_speed_validation.py
@@ -12,166 +12,201 @@ class TestWindSpeedValidation:
 
     def test_wind_speed_minimum_rule(self):
         """Test that wind speed minimum is set to 0.01 m/s in rules."""
-        assert 'u' in dict_rules_indiv
-        assert dict_rules_indiv['u']['param']['min'] == 0.01
-        assert dict_rules_indiv['u']['param']['max'] == 60
-        assert dict_rules_indiv['u']['optional'] is False
+        assert "u" in dict_rules_indiv
+        assert dict_rules_indiv["u"]["param"]["min"] == 0.01
+        assert dict_rules_indiv["u"]["param"]["max"] == 60
+        assert dict_rules_indiv["u"]["optional"] is False
 
     def test_check_forcing_with_zero_wind_speed(self):
         """Test that check_forcing detects zero wind speed."""
         # Create sample forcing data with zero wind speed
-        dates = pd.date_range('2021-01-01', periods=24, freq='h')
-        df_forcing = pd.DataFrame({
-            'iy': dates.year,
-            'id': dates.dayofyear,
-            'it': dates.hour,
-            'imin': dates.minute,
-            'isec': 0,
-            'kdown': 100,
-            'Tair': 20,
-            'RH': 60,
-            'pres': 101.3,
-            'rain': 0,
-            'U': 0,  # Zero wind speed
-        }, index=dates)
-        
+        dates = pd.date_range("2021-01-01", periods=24, freq="h")
+        df_forcing = pd.DataFrame(
+            {
+                "iy": dates.year,
+                "id": dates.dayofyear,
+                "it": dates.hour,
+                "imin": dates.minute,
+                "isec": 0,
+                "kdown": 100,
+                "Tair": 20,
+                "RH": 60,
+                "pres": 101.3,
+                "rain": 0,
+                "U": 0,  # Zero wind speed
+            },
+            index=dates,
+        )
+
         # Check forcing data without fix
         issues = check_forcing(df_forcing, fix=False)
-        
+
         # Should have at least one issue about wind speed
         assert len(issues) > 0
-        wind_speed_issue = [issue for issue in issues if 'Wind speed' in issue and 'must be >= 0.01' in issue]
+        wind_speed_issue = [
+            issue
+            for issue in issues
+            if "Wind speed" in issue and "must be >= 0.01" in issue
+        ]
         assert len(wind_speed_issue) > 0
 
     def test_check_forcing_with_low_wind_speed(self):
         """Test that check_forcing detects wind speed below 0.01 m/s."""
         # Create sample forcing data with low wind speed
-        dates = pd.date_range('2021-01-01', periods=24, freq='h')
-        df_forcing = pd.DataFrame({
-            'iy': dates.year,
-            'id': dates.dayofyear,
-            'it': dates.hour,
-            'imin': dates.minute,
-            'isec': 0,
-            'kdown': 100,
-            'Tair': 20,
-            'RH': 60,
-            'pres': 101.3,
-            'rain': 0,
-            'U': 0.005,  # Wind speed below minimum
-        }, index=dates)
-        
+        dates = pd.date_range("2021-01-01", periods=24, freq="h")
+        df_forcing = pd.DataFrame(
+            {
+                "iy": dates.year,
+                "id": dates.dayofyear,
+                "it": dates.hour,
+                "imin": dates.minute,
+                "isec": 0,
+                "kdown": 100,
+                "Tair": 20,
+                "RH": 60,
+                "pres": 101.3,
+                "rain": 0,
+                "U": 0.005,  # Wind speed below minimum
+            },
+            index=dates,
+        )
+
         # Check forcing data without fix
         issues = check_forcing(df_forcing, fix=False)
-        
+
         # Should have at least one issue about wind speed
         assert len(issues) > 0
-        wind_speed_issue = [issue for issue in issues if 'Wind speed' in issue and 'must be >= 0.01' in issue]
+        wind_speed_issue = [
+            issue
+            for issue in issues
+            if "Wind speed" in issue and "must be >= 0.01" in issue
+        ]
         assert len(wind_speed_issue) > 0
 
     def test_check_forcing_fixes_low_wind_speed(self):
         """Test that check_forcing can fix low wind speed values."""
         # Create sample forcing data with various wind speeds
-        dates = pd.date_range('2021-01-01', periods=24, freq='h')
-        wind_speeds = np.array([0, 0.001, 0.005, 0.009, 0.01, 0.02, 0.5, 1.0] + [2.0] * 16)
-        df_forcing = pd.DataFrame({
-            'iy': dates.year,
-            'id': dates.dayofyear,
-            'it': dates.hour,
-            'imin': dates.minute,
-            'isec': 0,
-            'kdown': 100,
-            'Tair': 20,
-            'RH': 60,
-            'pres': 101.3,
-            'rain': 0,
-            'U': wind_speeds,
-        }, index=dates)
-        
+        dates = pd.date_range("2021-01-01", periods=24, freq="h")
+        wind_speeds = np.array(
+            [0, 0.001, 0.005, 0.009, 0.01, 0.02, 0.5, 1.0] + [2.0] * 16
+        )
+        df_forcing = pd.DataFrame(
+            {
+                "iy": dates.year,
+                "id": dates.dayofyear,
+                "it": dates.hour,
+                "imin": dates.minute,
+                "isec": 0,
+                "kdown": 100,
+                "Tair": 20,
+                "RH": 60,
+                "pres": 101.3,
+                "rain": 0,
+                "U": wind_speeds,
+            },
+            index=dates,
+        )
+
         # Check forcing data with fix
         df_fixed = check_forcing(df_forcing, fix=True)
-        
+
         # All wind speeds should now be >= 0.01
-        assert (df_fixed['U'] >= 0.01).all()
+        assert (df_fixed["U"] >= 0.01).all()
         # Values that were already >= 0.01 should be unchanged
-        assert (df_fixed['U'][wind_speeds >= 0.01] == wind_speeds[wind_speeds >= 0.01]).all()
+        assert (
+            df_fixed["U"][wind_speeds >= 0.01] == wind_speeds[wind_speeds >= 0.01]
+        ).all()
         # Values that were < 0.01 should be clipped to 0.01
-        assert (df_fixed['U'][wind_speeds < 0.01] == 0.01).all()
+        assert (df_fixed["U"][wind_speeds < 0.01] == 0.01).all()
 
     def test_check_range_wind_speed_specific_message(self):
         """Test that check_range provides specific message for wind speed."""
         # Create a series with low wind speed
-        ser_wind = pd.Series([0.005, 0.008, 0.012], name='U')
-        
+        ser_wind = pd.Series([0.005, 0.008, 0.012], name="U")
+
         # Check range
-        var, is_accepted, description, suggestion = check_range(ser_wind, dict_rules_indiv)
-        
-        assert var == 'u'  # Note: lowercased
+        var, is_accepted, description, suggestion = check_range(
+            ser_wind, dict_rules_indiv
+        )
+
+        assert var == "u"  # Note: lowercased
         assert not is_accepted
-        assert 'Wind speed' in description
-        assert 'must be >= 0.01 m/s' in description
-        assert 'division by zero errors' in description
-        assert 'numerical stability in SUEWS' in suggestion
+        assert "Wind speed" in description
+        assert "must be >= 0.01 m/s" in description
+        assert "division by zero errors" in description
+        assert "numerical stability in SUEWS" in suggestion
 
     def test_valid_wind_speed_passes_validation(self):
         """Test that valid wind speed passes validation."""
         # Create sample forcing data with valid wind speed
-        dates = pd.date_range('2021-01-01', periods=24, freq='h')
-        df_forcing = pd.DataFrame({
-            'iy': dates.year,
-            'id': dates.dayofyear,
-            'it': dates.hour,
-            'imin': dates.minute,
-            'isec': 0,
-            'kdown': 100,
-            'Tair': 20,
-            'RH': 60,
-            'pres': 101.3,
-            'rain': 0,
-            'U': np.random.uniform(0.01, 10, 24),  # Valid wind speeds
-        }, index=dates)
-        
+        dates = pd.date_range("2021-01-01", periods=24, freq="h")
+        df_forcing = pd.DataFrame(
+            {
+                "iy": dates.year,
+                "id": dates.dayofyear,
+                "it": dates.hour,
+                "imin": dates.minute,
+                "isec": 0,
+                "kdown": 100,
+                "Tair": 20,
+                "RH": 60,
+                "pres": 101.3,
+                "rain": 0,
+                "U": np.random.uniform(0.01, 10, 24),  # Valid wind speeds
+            },
+            index=dates,
+        )
+
         # Check forcing data
         issues = check_forcing(df_forcing, fix=False)
-        
+
         # Should have no issues (or at least no wind speed issues)
         if issues:
-            wind_speed_issues = [issue for issue in issues if 'Wind speed' in issue or 'U' in issue]
+            wind_speed_issues = [
+                issue for issue in issues if "Wind speed" in issue or "U" in issue
+            ]
             assert len(wind_speed_issues) == 0
 
     def test_mixed_wind_speeds_partial_fix(self):
         """Test handling of mixed valid and invalid wind speeds."""
         # Create sample forcing data with mixed wind speeds
-        dates = pd.date_range('2021-01-01', periods=100, freq='h')
+        dates = pd.date_range("2021-01-01", periods=100, freq="h")
         wind_speeds = np.random.uniform(0, 5, 100)
         wind_speeds[::10] = 0  # Set every 10th value to 0
-        
-        df_forcing = pd.DataFrame({
-            'iy': dates.year,
-            'id': dates.dayofyear,
-            'it': dates.hour,
-            'imin': dates.minute,
-            'isec': 0,
-            'kdown': 100,
-            'Tair': 20,
-            'RH': 60,
-            'pres': 101.3,
-            'rain': 0,
-            'U': wind_speeds,
-        }, index=dates)
-        
+
+        df_forcing = pd.DataFrame(
+            {
+                "iy": dates.year,
+                "id": dates.dayofyear,
+                "it": dates.hour,
+                "imin": dates.minute,
+                "isec": 0,
+                "kdown": 100,
+                "Tair": 20,
+                "RH": 60,
+                "pres": 101.3,
+                "rain": 0,
+                "U": wind_speeds,
+            },
+            index=dates,
+        )
+
         # Count invalid values
         n_invalid = (wind_speeds < 0.01).sum()
-        
+
         # Check without fix
         issues = check_forcing(df_forcing, fix=False)
-        wind_speed_issue = [issue for issue in issues if 'Wind speed' in issue and 'must be >= 0.01' in issue]
+        wind_speed_issue = [
+            issue
+            for issue in issues
+            if "Wind speed" in issue and "must be >= 0.01" in issue
+        ]
         assert len(wind_speed_issue) > 0
-        
+
         # Check with fix
         df_fixed = check_forcing(df_forcing, fix=True)
-        
+
         # Verify all values are now valid
-        assert (df_fixed['U'] >= 0.01).all()
+        assert (df_fixed["U"] >= 0.01).all()
         # Verify the number of modified values
-        assert (df_fixed['U'] == 0.01).sum() == n_invalid
+        assert (df_fixed["U"] == 0.01).sum() == n_invalid

--- a/test/core/test_wind_speed_validation.py
+++ b/test/core/test_wind_speed_validation.py
@@ -140,30 +140,46 @@ class TestWindSpeedValidation:
         """Test that valid wind speed passes validation."""
         # Create sample forcing data with valid wind speed
         dates = pd.date_range("2021-01-01", periods=24, freq="h")
+
+        # Create forcing data with all required columns in correct order
         df_forcing = pd.DataFrame(
             {
                 "iy": dates.year,
                 "id": dates.dayofyear,
                 "it": dates.hour,
                 "imin": dates.minute,
-                "isec": 0,
-                "kdown": 100,
-                "Tair": 20,
-                "RH": 60,
-                "pres": 101.3,
-                "rain": 0,
+                "qn": -999,  # Optional
+                "qh": -999,  # Optional
+                "qe": -999,  # Optional
+                "qs": -999,  # Optional
+                "qf": -999,  # Optional
                 "U": np.random.uniform(0.01, 10, 24),  # Valid wind speeds
+                "RH": 60,
+                "Tair": 20,
+                "pres": 1013,  # hPa
+                "rain": 0,
+                "kdown": 100,
+                "snow": -999,  # Optional
+                "ldown": -999,  # Optional
+                "fcld": -999,  # Optional
+                "Wuh": -999,  # Optional
+                "xsmd": -999,  # Optional
+                "lai": -999,  # Optional
+                "kdiff": -999,  # Optional
+                "kdir": -999,  # Optional
+                "wdir": -999,  # Optional
             },
             index=dates,
         )
-
         # Check forcing data
         issues = check_forcing(df_forcing, fix=False)
 
         # Should have no issues (or at least no wind speed issues)
         if issues:
             wind_speed_issues = [
-                issue for issue in issues if "Wind speed" in issue or "U" in issue
+                issue
+                for issue in issues
+                if "Wind speed" in issue and "must be >= 0.01" in issue
             ]
             assert len(wind_speed_issues) == 0
 

--- a/test/core/test_wind_speed_validation.py
+++ b/test/core/test_wind_speed_validation.py
@@ -1,0 +1,177 @@
+"""Test wind speed validation in forcing data."""
+
+import pytest
+import pandas as pd
+import numpy as np
+from supy._check import check_forcing, check_range
+from supy._check import dict_rules_indiv
+
+
+class TestWindSpeedValidation:
+    """Test class for wind speed validation."""
+
+    def test_wind_speed_minimum_rule(self):
+        """Test that wind speed minimum is set to 0.01 m/s in rules."""
+        assert 'u' in dict_rules_indiv
+        assert dict_rules_indiv['u']['param']['min'] == 0.01
+        assert dict_rules_indiv['u']['param']['max'] == 60
+        assert dict_rules_indiv['u']['optional'] is False
+
+    def test_check_forcing_with_zero_wind_speed(self):
+        """Test that check_forcing detects zero wind speed."""
+        # Create sample forcing data with zero wind speed
+        dates = pd.date_range('2021-01-01', periods=24, freq='h')
+        df_forcing = pd.DataFrame({
+            'iy': dates.year,
+            'id': dates.dayofyear,
+            'it': dates.hour,
+            'imin': dates.minute,
+            'isec': 0,
+            'kdown': 100,
+            'Tair': 20,
+            'RH': 60,
+            'pres': 101.3,
+            'rain': 0,
+            'U': 0,  # Zero wind speed
+        }, index=dates)
+        
+        # Check forcing data without fix
+        issues = check_forcing(df_forcing, fix=False)
+        
+        # Should have at least one issue about wind speed
+        assert len(issues) > 0
+        wind_speed_issue = [issue for issue in issues if 'Wind speed' in issue and 'must be >= 0.01' in issue]
+        assert len(wind_speed_issue) > 0
+
+    def test_check_forcing_with_low_wind_speed(self):
+        """Test that check_forcing detects wind speed below 0.01 m/s."""
+        # Create sample forcing data with low wind speed
+        dates = pd.date_range('2021-01-01', periods=24, freq='h')
+        df_forcing = pd.DataFrame({
+            'iy': dates.year,
+            'id': dates.dayofyear,
+            'it': dates.hour,
+            'imin': dates.minute,
+            'isec': 0,
+            'kdown': 100,
+            'Tair': 20,
+            'RH': 60,
+            'pres': 101.3,
+            'rain': 0,
+            'U': 0.005,  # Wind speed below minimum
+        }, index=dates)
+        
+        # Check forcing data without fix
+        issues = check_forcing(df_forcing, fix=False)
+        
+        # Should have at least one issue about wind speed
+        assert len(issues) > 0
+        wind_speed_issue = [issue for issue in issues if 'Wind speed' in issue and 'must be >= 0.01' in issue]
+        assert len(wind_speed_issue) > 0
+
+    def test_check_forcing_fixes_low_wind_speed(self):
+        """Test that check_forcing can fix low wind speed values."""
+        # Create sample forcing data with various wind speeds
+        dates = pd.date_range('2021-01-01', periods=24, freq='h')
+        wind_speeds = np.array([0, 0.001, 0.005, 0.009, 0.01, 0.02, 0.5, 1.0] + [2.0] * 16)
+        df_forcing = pd.DataFrame({
+            'iy': dates.year,
+            'id': dates.dayofyear,
+            'it': dates.hour,
+            'imin': dates.minute,
+            'isec': 0,
+            'kdown': 100,
+            'Tair': 20,
+            'RH': 60,
+            'pres': 101.3,
+            'rain': 0,
+            'U': wind_speeds,
+        }, index=dates)
+        
+        # Check forcing data with fix
+        df_fixed = check_forcing(df_forcing, fix=True)
+        
+        # All wind speeds should now be >= 0.01
+        assert (df_fixed['U'] >= 0.01).all()
+        # Values that were already >= 0.01 should be unchanged
+        assert (df_fixed['U'][wind_speeds >= 0.01] == wind_speeds[wind_speeds >= 0.01]).all()
+        # Values that were < 0.01 should be clipped to 0.01
+        assert (df_fixed['U'][wind_speeds < 0.01] == 0.01).all()
+
+    def test_check_range_wind_speed_specific_message(self):
+        """Test that check_range provides specific message for wind speed."""
+        # Create a series with low wind speed
+        ser_wind = pd.Series([0.005, 0.008, 0.012], name='U')
+        
+        # Check range
+        var, is_accepted, description, suggestion = check_range(ser_wind, dict_rules_indiv)
+        
+        assert var == 'u'  # Note: lowercased
+        assert not is_accepted
+        assert 'Wind speed' in description
+        assert 'must be >= 0.01 m/s' in description
+        assert 'division by zero errors' in description
+        assert 'numerical stability in SUEWS' in suggestion
+
+    def test_valid_wind_speed_passes_validation(self):
+        """Test that valid wind speed passes validation."""
+        # Create sample forcing data with valid wind speed
+        dates = pd.date_range('2021-01-01', periods=24, freq='h')
+        df_forcing = pd.DataFrame({
+            'iy': dates.year,
+            'id': dates.dayofyear,
+            'it': dates.hour,
+            'imin': dates.minute,
+            'isec': 0,
+            'kdown': 100,
+            'Tair': 20,
+            'RH': 60,
+            'pres': 101.3,
+            'rain': 0,
+            'U': np.random.uniform(0.01, 10, 24),  # Valid wind speeds
+        }, index=dates)
+        
+        # Check forcing data
+        issues = check_forcing(df_forcing, fix=False)
+        
+        # Should have no issues (or at least no wind speed issues)
+        if issues:
+            wind_speed_issues = [issue for issue in issues if 'Wind speed' in issue or 'U' in issue]
+            assert len(wind_speed_issues) == 0
+
+    def test_mixed_wind_speeds_partial_fix(self):
+        """Test handling of mixed valid and invalid wind speeds."""
+        # Create sample forcing data with mixed wind speeds
+        dates = pd.date_range('2021-01-01', periods=100, freq='h')
+        wind_speeds = np.random.uniform(0, 5, 100)
+        wind_speeds[::10] = 0  # Set every 10th value to 0
+        
+        df_forcing = pd.DataFrame({
+            'iy': dates.year,
+            'id': dates.dayofyear,
+            'it': dates.hour,
+            'imin': dates.minute,
+            'isec': 0,
+            'kdown': 100,
+            'Tair': 20,
+            'RH': 60,
+            'pres': 101.3,
+            'rain': 0,
+            'U': wind_speeds,
+        }, index=dates)
+        
+        # Count invalid values
+        n_invalid = (wind_speeds < 0.01).sum()
+        
+        # Check without fix
+        issues = check_forcing(df_forcing, fix=False)
+        wind_speed_issue = [issue for issue in issues if 'Wind speed' in issue and 'must be >= 0.01' in issue]
+        assert len(wind_speed_issue) > 0
+        
+        # Check with fix
+        df_fixed = check_forcing(df_forcing, fix=True)
+        
+        # Verify all values are now valid
+        assert (df_fixed['U'] >= 0.01).all()
+        # Verify the number of modified values
+        assert (df_fixed['U'] == 0.01).sum() == n_invalid


### PR DESCRIPTION
## Summary
- Prevents division by zero errors when wind speed is zero or near-zero
- Updates minimum wind speed validation from 0.0001 to 0.01 m/s
- Addresses issue where zero wind speed caused NaN/-600 values in SUEWS output with SPARTACUS

## Changes
1. **Updated validation rules** (`src/supy/checker_rules_indiv.json`):
   - Changed minimum wind speed from 0.0001 to 0.01 m/s
   
2. **Enhanced error messages** (`src/supy/_check.py`):
   - Added specific error message for wind speed validation
   - Explains why minimum is required (division by zero prevention)
   - Provides clear fix guidance

3. **Documentation updates**:
   - `SSss_YYYY_data_tt.csv`: Added note about 0.01 m/s minimum
   - `met_input.rst`: Added wind speed check to quality control example

4. **Test suite** (`test/core/test_wind_speed_validation.py`):
   - Tests for zero wind speed detection
   - Tests for automatic fixing with `fix=True`
   - Tests for specific error messages

## Test plan
- [x] Run new test suite: `pytest test/core/test_wind_speed_validation.py`
- [ ] Test with forcing data containing zero wind speeds
- [ ] Verify SPARTACUS runs without NaN/-600 errors
- [ ] Check that existing simulations with valid wind speeds are unaffected

Fixes #314

🤖 Generated with [Claude Code](https://claude.ai/code)