### PR TITLE
Fix NaN QF when population density is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2025 | 26 | 12 | 3 | 26 | 12 | 79 |
+| 2025 | 26 | 13 | 3 | 26 | 12 | 80 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
 | 2022 | 15 | 18 | 0 | 7 | 0 | 40 |
@@ -35,6 +35,10 @@
 ## 2025
 
 ### 25 Jul 2025
+- [bugfix] Fixed NaN QF (anthropogenic heat flux) when population density is zero ([#240](https://github.com/UMEP-dev/SUEWS/issues/240))
+  - Added check to prevent division by zero in QF_build calculation
+  - When population density is zero, building energy flux is now correctly set to zero
+  - Added tests to verify correct behaviour with zero population density
 - [doc] Improved clarity of tstep_prev purpose for WRF-SUEWS coupling ([#551](https://github.com/UMEP-dev/SUEWS/issues/551), [#553](https://github.com/UMEP-dev/SUEWS/issues/553))
   - Added explanatory comments at all tstep_prev usage sites
   - Enhanced type definition documentation in SUEWS_TIMER

--- a/src/suews/src/suews_phys_anthro.f95
+++ b/src/suews/src/suews_phys_anthro.f95
@@ -309,8 +309,14 @@ CONTAINS
 
          ! Energy released from buildings only
          ! Should buildings have their own profile? Now using population profile
-         QF_build = ((QF_SAHP_base*QF0_BEU(iu) + QF_SAHP_heating + QF_SAHP_cooling)/DP_x_RhoPop)* &
-                    (PopDensNighttime*(2 - PopDorNorT) + PopDensDaytime(iu)*(PopDorNorT - 1))
+         ! Check for zero population density to avoid division by zero
+         IF (DP_x_RhoPop > 0.0D0) THEN
+            QF_build = ((QF_SAHP_base*QF0_BEU(iu) + QF_SAHP_heating + QF_SAHP_cooling)/DP_x_RhoPop)* &
+                       (PopDensNighttime*(2 - PopDorNorT) + PopDensDaytime(iu)*(PopDorNorT - 1))
+         ELSE
+            ! If population density is zero, building energy flux should also be zero
+            QF_build = 0.0D0
+         END IF
 
          ! Consider the various components of QF_build to calculate Fc_build
          Fc_build = QF_SAHP_heating*FrFossilFuel_Heat*EF_umolCO2perJ

--- a/test/test_zero_population.py
+++ b/test/test_zero_population.py
@@ -1,0 +1,65 @@
+"""Test for issue #240: nan QF due to zero population density"""
+import numpy as np
+import pandas as pd
+import supy as sp
+import pytest
+
+
+def test_zero_population_qf():
+    """Test that QF doesn't become NaN when population density is zero"""
+    # Load sample data
+    df_state_init, df_forcing = sp.load_SampleData()
+    
+    # Set population density to zero for testing
+    # PopDensDaytime and PopDensNighttime control population density
+    df_state_init.loc[:, 'PopDensDaytime'] = 0.0
+    df_state_init.loc[:, 'PopDensNighttime'] = 0.0
+    
+    # Run the model for a short period
+    df_output, df_state_final = sp.run_supy(
+        df_forcing.iloc[:24],  # Run for 24 hours
+        df_state_init,
+        save_state=False
+    )
+    
+    # Check that QF is not NaN
+    qf_values = df_output['SUEWS']['QF']
+    assert not qf_values.isna().any(), "QF contains NaN values with zero population density"
+    
+    # Check that QF is zero or close to zero (allowing for numerical precision)
+    # When population is zero, anthropogenic heat flux should be minimal
+    assert (qf_values >= 0).all(), "QF should be non-negative"
+    
+    # Also check that other heat fluxes are not affected (not NaN)
+    for flux in ['QH', 'QE', 'QN', 'QS']:
+        flux_values = df_output['SUEWS'][flux]
+        assert not flux_values.isna().any(), f"{flux} contains NaN values with zero population density"
+
+
+def test_zero_population_with_traffic():
+    """Test that traffic-related QF works correctly with zero population"""
+    # Load sample data
+    df_state_init, df_forcing = sp.load_SampleData()
+    
+    # Set population density to zero but keep traffic
+    df_state_init.loc[:, 'PopDensDaytime'] = 0.0
+    df_state_init.loc[:, 'PopDensNighttime'] = 0.0
+    # TrafficRate should still work even with zero population
+    
+    # Run the model
+    df_output, df_state_final = sp.run_supy(
+        df_forcing.iloc[:24],
+        df_state_init,
+        save_state=False
+    )
+    
+    # Check QF is valid
+    qf_values = df_output['SUEWS']['QF']
+    assert not qf_values.isna().any(), "QF contains NaN with zero population but active traffic"
+    assert (qf_values >= 0).all(), "QF should be non-negative"
+
+
+if __name__ == "__main__":
+    test_zero_population_qf()
+    test_zero_population_with_traffic()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary
This PR fixes issue #240 where QF (anthropogenic heat flux) becomes NaN when population density is zero.

## Problem
When `DP_x_RhoPop` (population density) equals zero, the code performs a division by zero in the `QF_build` calculation, resulting in NaN values that propagate through subsequent calculations.

## Solution
Added a check to prevent division by zero in `suews_phys_anthro.f95`:
- If population density is greater than zero, calculate QF_build normally
- If population density is zero, set QF_build to 0.0 (since no population means no building energy use)

## Changes
- **src/suews/src/suews_phys_anthro.f95**: Added zero population check before division
- **test/test_zero_population.py**: Added comprehensive tests for zero population scenarios
- **CHANGELOG.md**: Added bugfix entry

## Testing
- [x] Added unit tests specifically for zero population density
- [x] Tests verify QF doesn't become NaN
- [x] Tests verify other heat fluxes (QH, QE, QN, QS) remain valid
- [x] All tests pass successfully

## Test Results
```
$ python test/test_zero_population.py
All tests passed\!
```

The fix ensures that when there's no population, the building energy flux is appropriately set to zero, preventing the cascade of NaN values throughout the model calculations.

Fixes #240