### PR TITLE
feat(ci): Add limited testing for draft PRs

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -52,6 +52,12 @@ on:
     - cron: '0 2 * * *'
 
   workflow_dispatch:
+
+# Cancel in-progress runs when new commits are pushed to the same PR/branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Determine if we should run limited or full matrix
   determine_matrix:

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -36,6 +36,7 @@ on:
       - "Makefile"
 
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths: # PR events containing matching files
       - "src/suews/**"
       - "src/supy/**"
@@ -52,18 +53,35 @@ on:
 
   workflow_dispatch:
 jobs:
+  # Determine if we should run limited or full matrix
+  determine_matrix:
+    name: Determine build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      buildplat: ${{ steps.set-matrix.outputs.buildplat }}
+      python: ${{ steps.set-matrix.outputs.python }}
+    steps:
+      - name: Set matrix based on draft status
+        id: set-matrix
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            echo "Running limited matrix for draft PR"
+            echo 'buildplat=[["ubuntu-latest", "manylinux", "x86_64"]]' >> $GITHUB_OUTPUT
+            echo 'python=["cp39", "cp313"]' >> $GITHUB_OUTPUT
+          else
+            echo "Running full matrix"
+            echo 'buildplat=[["ubuntu-latest", "manylinux", "x86_64"], ["macos-13", "macosx", "x86_64"], ["macos-latest", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]' >> $GITHUB_OUTPUT
+            echo 'python=["cp39", "cp310", "cp311", "cp312", "cp313"]' >> $GITHUB_OUTPUT
+          fi
+
   build_wheels:
     name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
     runs-on: ${{ matrix.buildplat[0] }}
+    needs: determine_matrix
     strategy:
       matrix:
-        buildplat:
-            - [ubuntu-latest, manylinux, x86_64]
-            - [macos-13, macosx, x86_64]
-            - [macos-latest, macosx, arm64]
-            - [windows-2025, win, AMD64]
-
-        python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
+        buildplat: ${{ fromJson(needs.determine_matrix.outputs.buildplat) }}
+        python: ${{ fromJson(needs.determine_matrix.outputs.python) }}
 
       fail-fast: false
     env:
@@ -136,7 +154,7 @@ jobs:
   create_nightly_tag:
     name: Create nightly tag after successful builds
     runs-on: ubuntu-latest
-    needs: [build_wheels]
+    needs: [determine_matrix, build_wheels]
     if: github.event_name == 'schedule' && success()
     permissions:
       contents: write
@@ -176,6 +194,7 @@ jobs:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
     needs:
+      - determine_matrix
       - build_wheels
       - create_nightly_tag  # Will be skipped for non-nightly builds
     # Only run TestPyPI deployment for: scheduled (nightly) or tagged releases WITH 'dev'
@@ -209,6 +228,7 @@ jobs:
     name: Publish all wheels to PyPI
     runs-on: ubuntu-latest
     needs:
+      - determine_matrix
       - build_wheels
       - create_nightly_tag  # Will be skipped for non-nightly builds
     # Only run for tagged releases WITHOUT 'dev' in the tag name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
   - Modified main CI workflow to dynamically adjust build matrix based on draft status
   - Draft PRs: Only test Linux + Python 3.9 and 3.13 (2 configurations)
   - Ready PRs: Full testing across all platforms and Python versions (20 configurations)
+  - Added auto-cancellation of in-progress CI runs when new commits are pushed
   - Provides 10x faster feedback during development while ensuring full coverage when ready
 
 ### 5 Aug 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2025 | 26 | 12 | 3 | 26 | 12 | 79 |
+| 2025 | 26 | 12 | 3 | 27 | 12 | 80 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
 | 2022 | 15 | 18 | 0 | 7 | 0 | 40 |
@@ -33,6 +33,13 @@
 
 
 ## 2025
+
+### 6 Aug 2025
+- [maintenance] Integrated limited CI testing for draft PRs to speed up development feedback
+  - Modified main CI workflow to dynamically adjust build matrix based on draft status
+  - Draft PRs: Only test Linux + Python 3.9 and 3.13 (2 configurations)
+  - Ready PRs: Full testing across all platforms and Python versions (20 configurations)
+  - Provides 10x faster feedback during development while ensuring full coverage when ready
 
 ### 5 Aug 2025
 - [doc] Fixed FAIMethod option descriptions inconsistency ([#578](https://github.com/UMEP-dev/SUEWS/issues/578))


### PR DESCRIPTION
## Summary
- Implements dynamic CI matrix adjustment based on PR draft status
- Significantly speeds up feedback during development while maintaining full coverage for review-ready code

## Changes
- Modified `.github/workflows/build-publish_to_pypi.yml` to dynamically adjust build matrix
- Added `ready_for_review` trigger to handle draft → ready transitions
- Updated CHANGELOG.md

## Performance Impact
**Draft PRs:**
- Only Linux + Python 3.9 and 3.13
- 2 configurations (vs 20)
- ~10x faster feedback

**Ready PRs:**
- Full matrix: all platforms and Python versions
- 20 configurations as before
- Complete coverage maintained

## Workflow
1. Create draft PR → limited tests run automatically
2. Work on code → push commits → get fast feedback
3. Mark as "Ready for review" → full tests trigger automatically
4. No manual intervention needed

This change improves developer experience by providing faster feedback during active development while ensuring comprehensive testing when code is ready for review.