### PR TITLE
feat: streamlined uv environment setup with Makefile recipes

### DIFF
--- a/.claude/howto/setup-uv-environment.md
+++ b/.claude/howto/setup-uv-environment.md
@@ -1,0 +1,170 @@
+# Setting Up uv Environment for SUEWS Development
+
+This guide provides the best practices for setting up a uv environment for SUEWS development, properly aligned with the project's `pyproject.toml` and `env.yml` files.
+
+## Why uv?
+
+- **10-100x faster** than pip/conda for package installation
+- **Single tool** for all Python needs
+- **Built-in lock file support** for reproducible environments
+- **Automatic dependency resolution** without conda complexity
+
+## Installation
+
+First, install uv if you haven't already:
+
+```bash
+# macOS
+brew install uv
+
+# Or via installer script
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+## Best Practice Setup Method
+
+### Recommended: Using pyproject.toml
+
+This method uses the project's existing `pyproject.toml` which already defines all dependencies:
+
+```bash
+# 1. Create and activate virtual environment
+uv venv
+source .venv/bin/activate  # Required due to Python 3.13 compatibility
+
+# 2. Install SUEWS with development + documentation dependencies (recommended)
+uv pip install -e ".[dev,docs]"
+
+# Or install everything including all optional dependencies
+# uv pip install -e ".[all]"
+
+# 3. Verify installation
+python -c "import supy; print(f'✓ SuPy {supy.__version__} ready')"
+```
+
+### Method 2: Direct Command (If pyproject.toml method fails)
+
+For a quick setup without creating files:
+
+```bash
+# Create and activate environment
+uv venv
+source .venv/bin/activate
+
+# Install all dependencies in one command (aligned with env.yml)
+uv pip install pandas scipy matplotlib matplotlib-inline scikit-learn scikit-image \
+    geopandas rtree openpyxl tables psutil salem==0.3.8 floweaver==2.0.0 \
+    f90nml click pydantic ipykernel jupyter_client jupyter_core \
+    pytest pytest-cov ruff f90wrap==0.2.16 atmosp "meson-python>=0.17.0" \
+    chardet dask seaborn cdsapi xarray multiprocess lmfit numdifftools \
+    pvlib platypus-opt==1.0.4 timezonefinder==6.5.9 pytz pyarrow
+
+# Install SUEWS in development mode
+uv pip install -e . --no-deps
+```
+
+## Working with Git Worktrees
+
+For parallel development using git worktrees:
+
+```bash
+# Set your feature name
+FEATURE="my-feature"
+
+# Create the worktree
+git worktree add worktrees/$FEATURE feature/$FEATURE
+
+# Navigate to the worktree
+cd worktrees/$FEATURE
+
+# Set up uv environment using Method 1 (recommended)
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+
+# Or for full development including docs
+uv pip install -e ".[all]"
+
+# Test your setup
+make test
+```
+
+## Important Notes
+
+### Package Name Differences
+
+When migrating from conda/mamba, note these package name differences:
+- conda: `matplotlib-base` → pip/uv: `matplotlib`
+- conda: `pytables` → pip/uv: `tables`
+
+### Python 3.13 Compatibility
+
+Currently, you need to activate the environment (`source .venv/bin/activate`) rather than using `uv run` due to Python 3.13 compatibility. This is temporary and will be resolved as packages add Python 3.13 support.
+
+### Build System Integration
+
+The Makefile automatically detects and uses uv:
+- `make dev` - Builds SUEWS using uv if available
+- `make test` - Runs tests in the uv environment
+
+## Verification
+
+After setup, verify your environment:
+
+```bash
+# Check SuPy is installed
+python -c "import supy; print(f'SuPy version: {supy.__version__}')"
+
+# Check key dependencies
+python -c "import pandas, scipy, matplotlib, pydantic; print('Core packages: OK')"
+
+# Run tests
+make test
+
+# Or with pytest directly
+pytest test -v --tb=short
+```
+
+## Advantages Over conda/mamba
+
+1. **Speed**: Package installation takes seconds, not minutes
+2. **Simplicity**: No channel management or environment solving issues
+3. **Reproducibility**: Built-in lock file support
+4. **Python-focused**: Designed specifically for Python projects
+5. **Modern resolver**: Better dependency conflict resolution
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. **Check Python version**: uv defaults to Python 3.13
+   ```bash
+   python --version
+   ```
+
+2. **Clear cache if needed**:
+   ```bash
+   uv cache clean
+   ```
+
+3. **For specific Python version**:
+   ```bash
+   uv venv --python 3.12
+   ```
+
+4. **If packages fail to install**, check for Python 3.13 compatibility and consider using Python 3.12:
+   ```bash
+   uv venv --python 3.12
+   source .venv/bin/activate
+   uv pip install -e ".[dev]"
+   ```
+
+## Summary
+
+The recommended approach for SUEWS development with uv:
+
+1. Use `uv pip install -e ".[dev]"` for development work
+2. Use `uv pip install -e ".[all]"` for full setup including documentation
+3. Always activate the environment with `source .venv/bin/activate`
+4. The setup takes seconds compared to minutes with conda/mamba
+5. All dependencies are properly aligned with `pyproject.toml` and `env.yml`

--- a/.claude/howto/setup-worktree.md
+++ b/.claude/howto/setup-worktree.md
@@ -20,16 +20,10 @@ cd worktrees/$FEATURE
 uv venv
 source .venv/bin/activate
 
-# Install core requirements
-# Package list maintained in .claude/reference/core-requirements.txt
-# IMPORTANT: Use 'matplotlib' not 'matplotlib-base', 'tables' not 'pytables'
-uv pip install pandas scipy matplotlib matplotlib-inline scikit-learn scikit-image \
-    geopandas rtree openpyxl tables psutil salem==0.3.8 floweaver==2.0.0 \
-    f90nml click pydantic ipykernel jupyter_client jupyter_core \
-    pytest pytest-cov ruff f90wrap==0.2.16 atmosp "meson-python>=0.17.0"
+# Install SUEWS with development + documentation dependencies (aligned with pyproject.toml)
+uv pip install -e ".[dev,docs]"
 
-# Install SUEWS in development mode
-make dev  # This will auto-detect uv and use it!
+# Alternative: If pyproject.toml method fails, see setup-uv-environment.md
 
 # Create a marker file
 echo "$FEATURE" > .worktree-name
@@ -37,6 +31,8 @@ echo "$FEATURE" > .worktree-name
 # Test your setup
 python -c "import supy; print(f'✓ SuPy {supy.__version__} ready')"
 ```
+
+**Note**: For detailed uv setup options and alignment with `env.yml`, see `.claude/howto/setup-uv-environment.md`
 
 ## Working Without Environment Activation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,19 @@
   - Extended 1-question label from 'User question/support' to 'User question/support/dev query'
   - Updated issue triage documentation and decision tree to reflect this change
 
+### 24 Jul 2025
+- [maintenance] Enhanced uv environment setup documentation and best practices
+  - Created comprehensive `.claude/howto/setup-uv-environment.md` guide aligned with `pyproject.toml` and `env.yml`
+  - Updated worktree setup guide to use `uv pip install -e ".[dev]"` for proper dependency management
+  - Documented package name differences between conda and pip (e.g., `matplotlib-base` → `matplotlib`, `pytables` → `tables`)
+  - Emphasised uv's 10-100x speed improvement over pip/conda for package installation
+- [feature] Added minimal Makefile recipes for uv environment management
+  - Added `make uv-dev` - one-stop setup with both dev and docs dependencies
+  - Added `make uv-clean` - remove virtual environment
+  - Streamlined recipes to avoid Makefile bloat while maintaining essential functionality
+  - Includes documentation dependencies by default for complete development environment
+  - Properly aligned with `pyproject.toml` dependency groups
+
 ### 23 Jul 2025
 - [maintenance] Added `/log-changes` slash command for automated documentation updates
   - Created custom slash command in `.claude/commands/log-changes.md`

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SUEWS Makefile - read the README file before editing
 
-.PHONY: main clean test pip supy docs dev dev-clean dev-fast livehtml schema proc-csv config-ui check-dev-install mamba-dev help deactivate format lint
+.PHONY: main clean test pip supy docs dev dev-clean dev-fast livehtml schema proc-csv config-ui check-dev-install mamba-dev help deactivate format lint uv-dev uv-clean
 
 # OS-specific configurations
 ifeq ($(OS),Windows_NT)
@@ -74,6 +74,10 @@ help:
 	@echo ""
 	@echo "Environment Management:"
 	@echo "  deactivate      - Show command to deactivate current environment"
+	@echo ""
+	@echo "UV Environment Setup (Ultra-fast):"
+	@echo "  uv-dev          - Setup uv environment with dev + docs dependencies (recommended)"
+	@echo "  uv-clean        - Remove uv virtual environment"
 	@echo ""
 	@echo "Testing and Quality:"
 	@echo "  test            - Run test suite"
@@ -331,5 +335,32 @@ lint:
 		fi \
 	else \
 		echo "WARNING: fprettify not found. Install with: pip install fprettify"; \
+	fi
+
+# UV Environment Setup - Minimal and Essential
+
+# Setup uv environment with dev + docs dependencies (one-stop recipe)
+uv-dev:
+	@if ! command -v uv >/dev/null 2>&1; then \
+		echo "ERROR: uv not installed. Install with: brew install uv"; \
+		exit 1; \
+	fi
+	@if [ ! -d ".venv" ]; then \
+		echo "Creating uv environment..."; \
+		uv venv; \
+	fi
+	@echo "Installing SUEWS with dev + docs dependencies..."
+	@. .venv/bin/activate 2>/dev/null || source .venv/Scripts/activate 2>/dev/null || true; \
+	uv pip install -e ".[dev,docs]"
+	@echo ""
+	@echo "✓ Ready! Activate with: source .venv/bin/activate"
+
+# Clean uv virtual environment
+uv-clean:
+	@if [ -d ".venv" ]; then \
+		rm -rf .venv; \
+		echo "✓ Virtual environment removed"; \
+	else \
+		echo "No .venv found"; \
 	fi
 


### PR DESCRIPTION
## Summary
- Added streamlined uv environment setup for 10-100x faster dependency installation
- Created minimal Makefile recipes for one-command setup
- Comprehensive documentation for best practices

## Changes
- **New documentation**: `.claude/howto/setup-uv-environment.md` - comprehensive guide for uv setup
- **Makefile recipes**: 
  - `make uv-dev` - one-stop setup with dev + docs dependencies
  - `make uv-clean` - remove virtual environment
- **Updated guides**: Modified worktree setup to use `pyproject.toml`-based installation
- **Removed redundancy**: No separate requirements-dev.txt needed - uses pyproject.toml as single source of truth

## Benefits
- **Ultra-fast setup**: 10-100x faster than pip/conda
- **Single command**: `make uv-dev` sets up complete environment
- **Minimal bloat**: Only 2 essential Makefile recipes
- **DRY principle**: Dependencies defined once in pyproject.toml
- **Complete environment**: Includes both dev and docs dependencies by default

## Test plan
- [ ] Run `make uv-dev` to verify environment setup
- [ ] Activate environment with `source .venv/bin/activate`
- [ ] Run `make test` to verify tests work
- [ ] Run `make docs` to verify documentation builds
- [ ] Run `make uv-clean` to verify cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)