### PR TITLE
Fixes bad imports resulting in cmd module conflicts

### DIFF
--- a/src/supy/data_model/yaml_processor/phase_b_science_check.py
+++ b/src/supy/data_model/yaml_processor/phase_b_science_check.py
@@ -30,6 +30,7 @@ import pytz
 
 from supy._env import logger_supy, trv_supy_module
 
+
 @dataclass
 class ValidationResult:
     """Structured result from scientific validation checks."""


### PR DESCRIPTION
Resolves issue #601 

I have removed that full try except as this code does nothing. The try will fail 100% of the time due to incorrect relative import. The inclusion to the system path is not used either as using supy._env is already using an absolute path so the addition to sys.path is redundant. This  then stops Python from thinking the standard cmd library is in the supy package.