### PR TITLE
Fix forcing path resolution to be relative to config file (#573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
 
 ## 2025
 
+### 15 Aug 2025
+- [bugfix] Fix forcing path resolution to be relative to config file location (#573)
+  - SUEWSSimulation now correctly resolves relative forcing paths relative to the config file
+  - Previously, relative paths were resolved relative to the current working directory
+  - Added comprehensive tests to ensure forcing paths work correctly in all scenarios
+
 ### 14 Aug 2025
 - [bugfix] Fix test failures in CI by using package resources for sample_config.yml access
   - Use importlib.resources for proper package resource handling in tests

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -194,17 +194,28 @@ class SUEWSSimulation:
 
                     # Skip default placeholder value
                     if forcing_value and forcing_value != "forcing.txt":
-                        # Resolve relative paths
-                        if self._config_path and not Path(forcing_value).is_absolute():
+                        # Resolve relative paths relative to config file location
+                        if self._config_path:
                             if isinstance(forcing_value, list):
-                                forcing_value = [
-                                    str(self._config_path.parent / f)
-                                    for f in forcing_value
-                                ]
+                                # Handle list of forcing files
+                                resolved_paths = []
+                                for f in forcing_value:
+                                    if not Path(f).is_absolute():
+                                        # Relative path - resolve relative to config file
+                                        resolved_paths.append(
+                                            str(self._config_path.parent / f)
+                                        )
+                                    else:
+                                        # Absolute path - use as is
+                                        resolved_paths.append(f)
+                                forcing_value = resolved_paths
                             else:
-                                forcing_value = str(
-                                    self._config_path.parent / forcing_value
-                                )
+                                # Single forcing file
+                                if not Path(forcing_value).is_absolute():
+                                    # Relative path - resolve relative to config file
+                                    forcing_value = str(
+                                        self._config_path.parent / forcing_value
+                                    )
 
                         self.update_forcing(forcing_value)
 

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -197,20 +197,22 @@ class SUEWSSimulation:
                         # Resolve paths relative to config file if needed
                         if self._config_path:
                             forcing_value = self._resolve_forcing_paths(forcing_value)
-                        
+
                         self.update_forcing(forcing_value)
 
         except Exception as e:
             warnings.warn(f"Could not load forcing from config: {e}")
-    
-    def _resolve_forcing_paths(self, paths: Union[str, List[str]]) -> Union[str, List[str]]:
+
+    def _resolve_forcing_paths(
+        self, paths: Union[str, List[str]]
+    ) -> Union[str, List[str]]:
         """Resolve forcing paths relative to config file location.
-        
+
         Parameters
         ----------
         paths : str or list of str
             Path(s) to resolve. Relative paths are resolved relative to config file.
-            
+
         Returns
         -------
         str or list of str
@@ -220,15 +222,15 @@ class SUEWSSimulation:
             return [self._resolve_single_path(p) for p in paths]
         else:
             return self._resolve_single_path(paths)
-    
+
     def _resolve_single_path(self, path: str) -> str:
         """Resolve a single path relative to config file if it's relative.
-        
+
         Parameters
         ----------
         path : str
             Path to resolve
-            
+
         Returns
         -------
         str

--- a/test/core/test_forcing_path_resolution.py
+++ b/test/core/test_forcing_path_resolution.py
@@ -18,16 +18,16 @@ from supy.suews_sim import SUEWSSimulation
 def temp_config_setup(config_content, forcing_location="next_to_config"):
     """Helper to set up temporary config and forcing files."""
     sample_forcing = files("supy").joinpath("sample_data/Kc_2012_data_60.txt")
-    
+
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         config_dir = tmpdir / "config"
         config_dir.mkdir(parents=True)
-        
+
         # Write config
         config_path = config_dir / "config.yml"
         config_path.write_text(config_content)
-        
+
         # Place forcing file based on test needs
         if forcing_location == "next_to_config":
             forcing_path = config_dir / "Kc_2012_data_60.txt"
@@ -41,10 +41,10 @@ def temp_config_setup(config_content, forcing_location="next_to_config"):
             (data_dir / "forcing_1.txt").write_bytes(sample_forcing.read_bytes())
         else:
             forcing_path = tmpdir / forcing_location
-            
+
         if forcing_location != "missing":
             forcing_path.write_bytes(sample_forcing.read_bytes())
-        
+
         # Change to tmpdir and yield paths
         original_cwd = os.getcwd()
         try:
@@ -106,15 +106,15 @@ sites:
 def test_absolute_path():
     """Absolute paths should work from anywhere."""
     sample_forcing = files("supy").joinpath("sample_data/Kc_2012_data_60.txt")
-    
+
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create forcing at absolute path
         forcing_path = Path(tmpdir) / "forcing.txt"
         forcing_path.write_bytes(sample_forcing.read_bytes())
-        
+
         # Config with absolute path
         config = get_base_config(str(forcing_path))
-        
+
         with temp_config_setup(config, "missing") as (config_path, _):
             # Even though we're in a different dir, absolute path works
             sim = SUEWSSimulation(str(config_path))

--- a/test/core/test_forcing_path_resolution.py
+++ b/test/core/test_forcing_path_resolution.py
@@ -1,0 +1,217 @@
+"""Test forcing path resolution for issue #573.
+
+Ensures forcing paths in config files are resolved relative to the config file location,
+not the current working directory.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+import pytest
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
+
+from supy.suews_sim import SUEWSSimulation
+
+
+class TestForcingPathResolution:
+    """Test that forcing paths are resolved correctly relative to config file."""
+    
+    def test_relative_forcing_path_next_to_config(self):
+        """Test loading forcing file that's next to the config file."""
+        # Get sample data
+        sample_data_dir = files("supy").joinpath("sample_data")
+        sample_config = sample_data_dir / "sample_config.yml"
+        sample_forcing = sample_data_dir / "Kc_2012_data_60.txt"
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            
+            # Create config directory
+            config_dir = tmpdir / "config"
+            config_dir.mkdir()
+            
+            # Copy config and forcing to same directory
+            config_path = config_dir / "test_config.yml"
+            config_path.write_text(sample_config.read_text())
+            
+            forcing_path = config_dir / "Kc_2012_data_60.txt"
+            forcing_path.write_bytes(sample_forcing.read_bytes())
+            
+            # Change to different directory
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)  # Not in config dir
+                
+                # Load config - should find forcing next to config
+                sim = SUEWSSimulation(str(config_path))
+                
+                assert sim._df_forcing is not None
+                assert len(sim._df_forcing) > 0
+                
+            finally:
+                os.chdir(original_cwd)
+    
+    def test_relative_forcing_path_with_parent_reference(self):
+        """Test loading forcing with '../' relative path in config."""
+        sample_data_dir = files("supy").joinpath("sample_data")
+        sample_config = sample_data_dir / "sample_config.yml"
+        sample_forcing = sample_data_dir / "Kc_2012_data_60.txt"
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            
+            # Create nested structure
+            config_subdir = tmpdir / "config" / "subdir"
+            config_subdir.mkdir(parents=True)
+            
+            # Modify config to use ../forcing.txt
+            config_content = sample_config.read_text()
+            config_content = config_content.replace(
+                "Kc_2012_data_60.txt",
+                "../forcing.txt"
+            )
+            config_path = config_subdir / "test_config.yml"
+            config_path.write_text(config_content)
+            
+            # Put forcing in parent directory
+            forcing_path = tmpdir / "config" / "forcing.txt"
+            forcing_path.write_bytes(sample_forcing.read_bytes())
+            
+            # Run from different directory
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                
+                sim = SUEWSSimulation(str(config_path))
+                
+                assert sim._df_forcing is not None
+                assert len(sim._df_forcing) > 0
+                
+            finally:
+                os.chdir(original_cwd)
+    
+    def test_forcing_list_with_relative_paths(self):
+        """Test config with list of relative forcing paths."""
+        sample_data_dir = files("supy").joinpath("sample_data")
+        sample_forcing = sample_data_dir / "Kc_2012_data_60.txt"
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            
+            # Create structure
+            config_dir = tmpdir / "config"
+            config_dir.mkdir()
+            forcing_dir = config_dir / "data"
+            forcing_dir.mkdir()
+            
+            # Create forcing files
+            for i in range(2):
+                forcing_path = forcing_dir / f"forcing_{i}.txt"
+                forcing_path.write_bytes(sample_forcing.read_bytes())
+            
+            # Create config with list
+            config_content = """
+name: test config
+model:
+  control:
+    forcing_file:
+      - data/forcing_0.txt
+      - data/forcing_1.txt
+sites:
+  - name: test site
+    gridiv: 1
+    properties:
+      lat: {value: 51.5}
+      lng: {value: -0.1}
+"""
+            config_path = config_dir / "config.yml"
+            config_path.write_text(config_content)
+            
+            # Run from different directory
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                
+                sim = SUEWSSimulation(str(config_path))
+                
+                assert sim._df_forcing is not None
+                # Should have concatenated both files
+                assert len(sim._df_forcing) > 200000
+                
+            finally:
+                os.chdir(original_cwd)
+    
+    def test_absolute_forcing_path(self):
+        """Test that absolute paths still work correctly."""
+        sample_data_dir = files("supy").joinpath("sample_data")
+        sample_forcing = sample_data_dir / "Kc_2012_data_60.txt"
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            
+            # Create forcing file
+            forcing_path = tmpdir / "forcing.txt"
+            forcing_path.write_bytes(sample_forcing.read_bytes())
+            
+            # Create config with absolute path
+            config_content = f"""
+name: test config
+model:
+  control:
+    forcing_file: {str(forcing_path)}
+sites:
+  - name: test site
+    gridiv: 1
+    properties:
+      lat: {{value: 51.5}}
+      lng: {{value: -0.1}}
+"""
+            config_dir = tmpdir / "config"
+            config_dir.mkdir()
+            config_path = config_dir / "config.yml"
+            config_path.write_text(config_content)
+            
+            # Run from completely different directory
+            original_cwd = os.getcwd()
+            try:
+                os.chdir("/tmp")
+                
+                sim = SUEWSSimulation(str(config_path))
+                
+                assert sim._df_forcing is not None
+                assert len(sim._df_forcing) > 0
+                
+            finally:
+                os.chdir(original_cwd)
+    
+    def test_forcing_not_found_raises_error(self):
+        """Test that missing forcing file still raises appropriate error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            
+            # Create config referencing non-existent forcing
+            config_content = """
+name: test config
+model:
+  control:
+    forcing_file: nonexistent.txt
+sites:
+  - name: test site
+    gridiv: 1
+    properties:
+      lat: {value: 51.5}
+      lng: {value: -0.1}
+"""
+            config_path = tmpdir / "config.yml"
+            config_path.write_text(config_content)
+            
+            # Should warn but not fail on init
+            with pytest.warns(UserWarning, match="Could not load forcing from config"):
+                sim = SUEWSSimulation(str(config_path))
+            
+            # Forcing should not be loaded
+            assert sim._df_forcing is None

--- a/test/core/test_forcing_path_resolution.py
+++ b/test/core/test_forcing_path_resolution.py
@@ -19,100 +19,99 @@ from supy.suews_sim import SUEWSSimulation
 
 class TestForcingPathResolution:
     """Test that forcing paths are resolved correctly relative to config file."""
-    
+
     def test_relative_forcing_path_next_to_config(self):
         """Test loading forcing file that's next to the config file."""
         # Get sample data
         sample_data_dir = files("supy").joinpath("sample_data")
         sample_config = sample_data_dir / "sample_config.yml"
         sample_forcing = sample_data_dir / "Kc_2012_data_60.txt"
-        
+
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
-            
+
             # Create config directory
             config_dir = tmpdir / "config"
             config_dir.mkdir()
-            
+
             # Copy config and forcing to same directory
             config_path = config_dir / "test_config.yml"
             config_path.write_text(sample_config.read_text())
-            
+
             forcing_path = config_dir / "Kc_2012_data_60.txt"
             forcing_path.write_bytes(sample_forcing.read_bytes())
-            
+
             # Change to different directory
             original_cwd = os.getcwd()
             try:
                 os.chdir(tmpdir)  # Not in config dir
-                
+
                 # Load config - should find forcing next to config
                 sim = SUEWSSimulation(str(config_path))
-                
+
                 assert sim._df_forcing is not None
                 assert len(sim._df_forcing) > 0
-                
+
             finally:
                 os.chdir(original_cwd)
-    
+
     def test_relative_forcing_path_with_parent_reference(self):
         """Test loading forcing with '../' relative path in config."""
         sample_data_dir = files("supy").joinpath("sample_data")
         sample_config = sample_data_dir / "sample_config.yml"
         sample_forcing = sample_data_dir / "Kc_2012_data_60.txt"
-        
+
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
-            
+
             # Create nested structure
             config_subdir = tmpdir / "config" / "subdir"
             config_subdir.mkdir(parents=True)
-            
+
             # Modify config to use ../forcing.txt
             config_content = sample_config.read_text()
             config_content = config_content.replace(
-                "Kc_2012_data_60.txt",
-                "../forcing.txt"
+                "Kc_2012_data_60.txt", "../forcing.txt"
             )
             config_path = config_subdir / "test_config.yml"
             config_path.write_text(config_content)
-            
+
             # Put forcing in parent directory
             forcing_path = tmpdir / "config" / "forcing.txt"
             forcing_path.write_bytes(sample_forcing.read_bytes())
-            
+
             # Run from different directory
             original_cwd = os.getcwd()
             try:
                 os.chdir(tmpdir)
-                
+
                 sim = SUEWSSimulation(str(config_path))
-                
+
                 assert sim._df_forcing is not None
                 assert len(sim._df_forcing) > 0
-                
+
             finally:
                 os.chdir(original_cwd)
-    
+
     def test_forcing_list_with_relative_paths(self):
         """Test config with list of relative forcing paths."""
         sample_data_dir = files("supy").joinpath("sample_data")
         sample_forcing = sample_data_dir / "Kc_2012_data_60.txt"
-        
+
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
-            
+
             # Create structure
             config_dir = tmpdir / "config"
             config_dir.mkdir()
             forcing_dir = config_dir / "data"
             forcing_dir.mkdir()
-            
+
             # Create forcing files
             for i in range(2):
                 forcing_path = forcing_dir / f"forcing_{i}.txt"
                 forcing_path.write_bytes(sample_forcing.read_bytes())
-            
+
             # Create config with list
             config_content = """
 name: test config
@@ -130,33 +129,33 @@ sites:
 """
             config_path = config_dir / "config.yml"
             config_path.write_text(config_content)
-            
+
             # Run from different directory
             original_cwd = os.getcwd()
             try:
                 os.chdir(tmpdir)
-                
+
                 sim = SUEWSSimulation(str(config_path))
-                
+
                 assert sim._df_forcing is not None
                 # Should have concatenated both files
                 assert len(sim._df_forcing) > 200000
-                
+
             finally:
                 os.chdir(original_cwd)
-    
+
     def test_absolute_forcing_path(self):
         """Test that absolute paths still work correctly."""
         sample_data_dir = files("supy").joinpath("sample_data")
         sample_forcing = sample_data_dir / "Kc_2012_data_60.txt"
-        
+
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
-            
+
             # Create forcing file
             forcing_path = tmpdir / "forcing.txt"
             forcing_path.write_bytes(sample_forcing.read_bytes())
-            
+
             # Create config with absolute path
             config_content = f"""
 name: test config
@@ -174,25 +173,25 @@ sites:
             config_dir.mkdir()
             config_path = config_dir / "config.yml"
             config_path.write_text(config_content)
-            
+
             # Run from completely different directory
             original_cwd = os.getcwd()
             try:
                 os.chdir("/tmp")
-                
+
                 sim = SUEWSSimulation(str(config_path))
-                
+
                 assert sim._df_forcing is not None
                 assert len(sim._df_forcing) > 0
-                
+
             finally:
                 os.chdir(original_cwd)
-    
+
     def test_forcing_not_found_raises_error(self):
         """Test that missing forcing file still raises appropriate error."""
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
-            
+
             # Create config referencing non-existent forcing
             config_content = """
 name: test config
@@ -208,10 +207,10 @@ sites:
 """
             config_path = tmpdir / "config.yml"
             config_path.write_text(config_content)
-            
+
             # Should warn but not fail on init
             with pytest.warns(UserWarning, match="Could not load forcing from config"):
                 sim = SUEWSSimulation(str(config_path))
-            
+
             # Forcing should not be loaded
             assert sim._df_forcing is None


### PR DESCRIPTION
## Summary
- Fixes issue #573 where forcing file paths in config files were resolved relative to the current working directory instead of relative to the config file location
- Ensures SUEWSSimulation works correctly when run from different directories

## Changes
- Modified `_try_load_forcing_from_config()` in `suews_sim.py` to properly handle both single files and lists of files
- Relative paths are now resolved relative to the config file's parent directory
- Absolute paths continue to work as before
- Added comprehensive test suite in `test_forcing_path_resolution.py` to prevent regression

## Test Plan
- [x] Added new test file `test/core/test_forcing_path_resolution.py` with 5 test cases:
  - Test relative path next to config file
  - Test relative path with `../` parent reference
  - Test list of relative paths
  - Test absolute paths
  - Test error handling for missing files
- [x] All existing tests still pass
- [x] Manual testing with sample data confirms the fix works

Fixes #573