### PR TITLE
feat: Add community publications section (closes #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@
 
 ## 2025
 
+### 15 Aug 2025
+- [feature] Added community publications section for user-submitted SUEWS-related work (#80)
+  - Created new community BibTeX file (refs-community.bib) for community submissions
+  - Added Community Publications page with simple PR submission workflow
+  - Updated main documentation to link to both core and community publications
+  - Included example submission from issue #80
+
 ### 14 Aug 2025
 - [bugfix] Fix test failures in CI by using package resources for sample_config.yml access
   - Use importlib.resources for proper package resource handling in tests

--- a/docs/source/assets/refs/refs-community.bib
+++ b/docs/source/assets/refs/refs-community.bib
@@ -1,0 +1,18 @@
+% Community submissions of SUEWS-related publications
+% To add your publication:
+% 1. Click the "Submit a PR" link on the Community Publications page
+% 2. Add your BibTeX entry below
+% 3. Include a comment above your entry describing how SUEWS was used in your work
+
+% Example entry from issue #80
+% Used SUEWS for urban climate modelling
+@article{empanag2024,
+  title={Urban Climate Modelling with {SUEWS}},
+  author={Empanag},
+  journal={Global Environmental Solutions},
+  volume={1},
+  number={1},
+  pages={0003},
+  year={2024},
+  url={http://www.pivotscipub.com/ges/1/1/0003}
+}

--- a/docs/source/community_publications.rst
+++ b/docs/source/community_publications.rst
@@ -1,0 +1,31 @@
+.. _community_publications:
+
+Community Publications
+======================
+
+Publications and projects using SUEWS from the community.
+
+.. note::
+   **Add your SUEWS publication**
+   
+   `Submit a PR to add your BibTeX entry here <https://github.com/UMEP-dev/SUEWS/edit/master/docs/source/assets/refs/refs-community.bib>`_
+   
+   Please include a comment above your entry describing how SUEWS was used in your work.
+   
+   We welcome all SUEWS-related work including:
+   
+   - Peer-reviewed papers
+   - Conference proceedings
+   - Theses and dissertations
+   - Technical reports
+   - Educational materials
+
+Community Contributions
+-----------------------
+
+The following publications have been submitted by the SUEWS community:
+
+.. bibliography:: assets/refs/refs-community.bib
+   :style: refs_recent
+   :all:
+   :list: bullet

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,7 +84,10 @@ The developers and other users are willing to help you.
 How has SUEWS been used?
 ------------------------------
 
-The scientific details and application examples of SUEWS can be found in `Recent_publications`.
+The scientific details and application examples of SUEWS can be found in:
+
+- `Recent_publications` - Core SUEWS publications from the development team
+- :ref:`community_publications` - Publications from the SUEWS user community
 
 .. _cite_suews:
 
@@ -168,4 +171,5 @@ How to support SUEWS?
    :numbered:
    :hidden:
 
+   community_publications
    GitHub discussion <https://github.com/UMEP-dev/UMEP/discussions>


### PR DESCRIPTION
## Summary
This PR implements a user submission route for SUEWS-related publications, addressing issue #80.

## Changes
- Created `refs-community.bib` for community-submitted publications
- Added Community Publications page with direct GitHub edit link for PR submission
- Updated main documentation to link to both core and community publications
- Included example submission from issue #80

## Implementation Details

### New Files
1. **`docs/source/assets/refs/refs-community.bib`**
   - BibTeX file for community submissions
   - Contains clear instructions in comments
   - Includes example entry from issue #80

2. **`docs/source/community_publications.rst`**
   - New documentation page for community publications
   - Features a direct "Submit a PR" link that opens GitHub's file editor
   - Lists accepted contribution types (papers, theses, reports, etc.)

### Modified Files
1. **`docs/source/index.rst`**
   - Updated "How has SUEWS been used?" section
   - Added link to community publications in toctree

2. **`CHANGELOG.md`**
   - Added entry for this feature

## How It Works
1. Users click the "Submit a PR" link on the Community Publications page
2. GitHub automatically opens the file editor (handles forking if needed)
3. Users add their BibTeX entry with a comment about SUEWS usage
4. Submit PR through GitHub's interface
5. Maintainers review and merge

## Benefits
- ✅ **Simple workflow** - One-click access to submission
- ✅ **Low barrier** - No need to understand Git/GitHub deeply
- ✅ **Self-documenting** - Instructions embedded in the file
- ✅ **Version controlled** - Full history of additions

## Testing
- [x] RST syntax validated
- [x] BibTeX format verified
- [x] Links between pages confirmed working
- [ ] Documentation builds successfully (needs Sphinx environment)

Closes #80