### PR TITLE
Fix: Add development version warning banner to documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,9 @@ build:
     python: "mambaforge-latest"
   jobs:
     pre_install:
+      # Fetch all tags for proper version detection
+      - git fetch --unshallow || true
+      - git fetch --tags || true
       - git update-index --assume-unchanged env.yml docs/source/conf.py
       - make dev
     # pre_build:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,8 +56,21 @@ try:
     git_version_string = get_version_from_git()
     is_dev_version = ".dev" in git_version_string
     git_commit_short, git_commit_full = get_commit_info()
-except ImportError:
+    
+    # Debug output for ReadTheDocs
+    print(f"DEBUG: git_version_string = {git_version_string}")
+    print(f"DEBUG: is_dev_version = {is_dev_version}")
+    
+except ImportError as e:
     # Fallback if functions not available
+    print(f"WARNING: Failed to import get_ver_git: {e}")
+    git_version_string = "unknown"
+    is_dev_version = False
+    git_commit_short = "unknown"
+    git_commit_full = "unknown"
+except Exception as e:
+    # Catch any other errors
+    print(f"ERROR: Failed to get version info: {e}")
     git_version_string = "unknown"
     is_dev_version = False
     git_commit_short = "unknown"
@@ -81,6 +94,18 @@ sys.path.insert(0, os.path.abspath("_ext"))
 print(r"this build is made by:", "\n", sys.version)
 # determine if in RTD environment
 read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "unknown")
+rtd_version_type = os.environ.get("READTHEDOCS_VERSION_TYPE", "unknown")
+
+if read_the_docs_build:
+    print(f"DEBUG: RTD Version = {rtd_version}")
+    print(f"DEBUG: RTD Version Type = {rtd_version_type}")
+    
+    # If we're on RTD and building 'latest', assume it's development
+    if rtd_version == "latest" and not is_dev_version:
+        print("DEBUG: Forcing dev version for RTD 'latest' build")
+        is_dev_version = True
+
 if read_the_docs_build:
     # update `today`
     dt_today = datetime.today()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,11 +56,11 @@ try:
     git_version_string = get_version_from_git()
     is_dev_version = ".dev" in git_version_string
     git_commit_short, git_commit_full = get_commit_info()
-    
+
     # Debug output for ReadTheDocs
     print(f"DEBUG: git_version_string = {git_version_string}")
     print(f"DEBUG: is_dev_version = {is_dev_version}")
-    
+
 except ImportError as e:
     # Fallback if functions not available
     print(f"WARNING: Failed to import get_ver_git: {e}")
@@ -100,7 +100,7 @@ rtd_version_type = os.environ.get("READTHEDOCS_VERSION_TYPE", "unknown")
 if read_the_docs_build:
     print(f"DEBUG: RTD Version = {rtd_version}")
     print(f"DEBUG: RTD Version Type = {rtd_version_type}")
-    
+
     # If we're on RTD and building 'latest', assume it's development
     if rtd_version == "latest" and not is_dev_version:
         print("DEBUG: Forcing dev version for RTD 'latest' build")


### PR DESCRIPTION
## Problem
The development version warning banner was not appearing on the SUEWS documentation at https://suews.readthedocs.io/latest despite being configured in the rst_prolog. The warning appears correctly in local builds but not on ReadTheDocs.

## Root Cause Analysis
1. ReadTheDocs likely uses a shallow clone by default, which may not have all git tags
2. Without tags, the version detection script cannot determine if it's a development version
3. The rst_prolog warning (which works locally) isn't showing on ReadTheDocs

## Solution
This PR implements multiple fixes to ensure the warning appears:

1. **Ensure git tags are available on ReadTheDocs**:
   - Added `git fetch --unshallow` to fetch full history
   - Added `git fetch --tags` to ensure all tags are available

2. **Improved error handling and debugging**:
   - Added debug output to understand what's happening on ReadTheDocs
   - Added exception handling for version detection failures
   - Added fallback to RTD environment variables

3. **Force dev version for 'latest' builds**:
   - When building on ReadTheDocs with version='latest', force is_dev_version=True
   - This ensures the warning appears even if git version detection fails

## Testing
- The existing rst_prolog warning works correctly in local builds (as shown in screenshot)
- With these changes, the warning should also appear on ReadTheDocs 'latest' builds
- Debug output will help diagnose any remaining issues

## Notes
This is currently a draft PR for testing. Once confirmed working on ReadTheDocs, the debug output can be removed.