### PR TITLE
Fix: Update macOS deployment target to 15.0 for GCC 15.1.0 compatibility

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -211,7 +211,7 @@ jobs:
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
       CIBW_TEST_REQUIRES: pytest
       CIBW_TEST_COMMAND: "python -m pytest {project}/test -v --tb=short --durations=10"
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.buildplat[0] == 'macos-13' && '13.0' || '14.0' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.buildplat[0] == 'macos-13' && '13.0' || '15.0' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cibuildwheel-debug.yml
+++ b/.github/workflows/cibuildwheel-debug.yml
@@ -153,7 +153,7 @@ jobs:
       CIBW_TEST_COMMAND_WINDOWS: "python -m pytest {project}\\test"
 
       # macOS deployment target
-      MACOSX_DEPLOYMENT_TARGET: ${{ contains(inputs.platform_arch || 'macos-latest-arm64', 'macos-13') && '13.0' || '14.0' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ contains(inputs.platform_arch || 'macos-latest-arm64', 'macos-13') && '13.0' || '15.0' }}
 
       # Debug mode for SSH sessions
       DEBUG_MODE: ${{ inputs.debug_mode || 'after-failure' }}


### PR DESCRIPTION
## Summary
- Fixes CI build failures on macOS with Python 3.12 and 3.13
- Updates MACOSX_DEPLOYMENT_TARGET from 14.0 to 15.0 for macOS-latest runners

## Problem
The CI builds were failing during the wheel repair step with:
```
delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 14.0:
/private/var/folders/.../libquadmath.0.dylib has a minimum target of 15.0
/private/var/folders/.../libgfortran.5.dylib has a minimum target of 15.0
```

## Root Cause
- macOS-latest runners use GCC 15.1.0 installed via Homebrew
- GCC 15.1.0 libraries require macOS 15.0 as minimum deployment target
- Our wheels were targeting macOS 14.0, causing incompatibility

## Solution
Updated MACOSX_DEPLOYMENT_TARGET to 15.0 in:
- `.github/workflows/build-publish_to_pypi.yml`
- `.github/workflows/cibuildwheel-debug.yml`

## Testing
- This should fix the failing CI builds for macOS ARM64 and x86_64 with Python 3.12/3.13
- macOS 13 runners continue to use deployment target 13.0 (unchanged)

Fixes CI run #2270