### PR TITLE
Fix naming convention between data model and YAML parameter names

### DIFF
--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -3192,6 +3192,153 @@ class TestPhaseAUptoDateYaml(TestProcessorFixtures):
             assert old_name in uptodate_yaml.RENAMED_PARAMS
             assert uptodate_yaml.RENAMED_PARAMS[old_name] == new_name
 
+    def test_anohm_parameter_equivalence_fix(self):
+        """
+        Regression test for AnOHM parameter naming equivalence fix.
+
+        This test ensures that ch_anohm/chanohm, rho_cp_anohm/cpanohm,
+        and k_anohm/kkanohm are treated as equivalent parameters,
+        preventing parameter duplication in validation reports.
+
+        GitHub Issue: Parameter naming inconsistency causing validation errors
+        """
+        if not has_uptodate_yaml:
+            pytest.skip("uptodate_yaml module not available")
+
+        # Create test config with old AnOHM naming convention (from sample data)
+        user_config_old_naming = {
+            "model": {
+                "physics": {
+                    "netradiationmethod": {"value": 1}
+                }
+            },
+            "sites": [
+                {
+                    "name": "TestSite",
+                    "properties": {
+                        "land_cover": {
+                            "paved": {
+                                "ohm_coef": {
+                                    "summer_wet": {
+                                        "chanohm": {"value": 0.15},    # OLD naming
+                                        "cpanohm": {"value": 1200000}, # OLD naming
+                                        "kkanohm": {"value": 0.18}     # OLD naming
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+
+        # Create standard config with new AnOHM naming convention (from data model)
+        standard_config_new_naming = {
+            "model": {
+                "physics": {
+                    "netradiationmethod": {"value": 1}
+                }
+            },
+            "sites": [
+                {
+                    "name": "StandardSite",
+                    "properties": {
+                        "land_cover": {
+                            "paved": {
+                                "ohm_coef": {
+                                    "summer_wet": {
+                                        "ch_anohm": {"value": 0.15},      # NEW naming
+                                        "rho_cp_anohm": {"value": 1200000}, # NEW naming
+                                        "k_anohm": {"value": 0.18}        # NEW naming
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+
+        # Test 1: User has old naming, standard has new naming
+        # Should NOT report AnOHM parameters as missing
+        missing_params = uptodate_yaml.find_missing_parameters(
+            user_config_old_naming, standard_config_new_naming
+        )
+
+        missing_paths = [path for path, _, _ in missing_params]
+
+        # These should NOT be in missing parameters (equivalence should prevent them)
+        anohm_new_naming_paths = [
+            "sites[0].properties.land_cover.paved.ohm_coef.summer_wet.ch_anohm",
+            "sites[0].properties.land_cover.paved.ohm_coef.summer_wet.rho_cp_anohm",
+            "sites[0].properties.land_cover.paved.ohm_coef.summer_wet.k_anohm"
+        ]
+
+        for path in anohm_new_naming_paths:
+            assert path not in missing_paths, f"Parameter {path} incorrectly reported as missing when user has equivalent old naming"
+
+        # Test 2: User has new naming, check that old naming is not reported as extra
+        extra_params = uptodate_yaml.find_extra_parameters(
+            standard_config_new_naming, user_config_old_naming
+        )
+
+        extra_paths = [path for path, _ in extra_params]
+
+        # These should NOT be in extra parameters
+        anohm_new_naming_in_extra = [
+            "sites[0].properties.land_cover.paved.ohm_coef.summer_wet.ch_anohm",
+            "sites[0].properties.land_cover.paved.ohm_coef.summer_wet.rho_cp_anohm",
+            "sites[0].properties.land_cover.paved.ohm_coef.summer_wet.k_anohm"
+        ]
+
+        for path in anohm_new_naming_in_extra:
+            assert path not in extra_paths, f"Parameter {path} incorrectly reported as extra when standard has equivalent old naming"
+
+        # Test 3: Verify parameter equivalence function directly
+        # Test that the has_equivalent_parameter function works correctly
+        test_cases = [
+            ("chanohm", "ch_anohm", True),
+            ("ch_anohm", "chanohm", True),
+            ("cpanohm", "rho_cp_anohm", True),
+            ("rho_cp_anohm", "cpanohm", True),
+            ("kkanohm", "k_anohm", True),
+            ("k_anohm", "kkanohm", True),
+            ("unrelated_param1", "unrelated_param2", False),
+            ("chanohm", "cpanohm", False),  # Different AnOHM parameters
+        ]
+
+        for param1, param2, expected_equivalent in test_cases:
+            actual_equivalent = uptodate_yaml.has_equivalent_parameter(param1, param2)
+            assert actual_equivalent == expected_equivalent, \
+                f"Expected {param1} <-> {param2} equivalence to be {expected_equivalent}, got {actual_equivalent}"
+
+        # Test 4: Verify RENAMED_PARAMS contains AnOHM mappings
+        expected_anohm_renames = {
+            "chanohm": "ch_anohm",
+            "cpanohm": "rho_cp_anohm",
+            "kkanohm": "k_anohm",
+        }
+
+        for old_name, new_name in expected_anohm_renames.items():
+            assert old_name in uptodate_yaml.RENAMED_PARAMS, \
+                f"AnOHM parameter {old_name} missing from RENAMED_PARAMS"
+            assert uptodate_yaml.RENAMED_PARAMS[old_name] == new_name, \
+                f"AnOHM parameter {old_name} should map to {new_name}, got {uptodate_yaml.RENAMED_PARAMS[old_name]}"
+
+        # Test 5: Verify PARAMETER_EQUIVALENCE bidirectional mapping
+        for old_name, new_name in expected_anohm_renames.items():
+            # Forward mapping (old -> new)
+            assert old_name in uptodate_yaml.PARAMETER_EQUIVALENCE, \
+                f"Forward equivalence mapping missing for {old_name}"
+            assert uptodate_yaml.PARAMETER_EQUIVALENCE[old_name] == new_name, \
+                f"Forward equivalence {old_name} should map to {new_name}"
+
+            # Reverse mapping (new -> old)
+            assert new_name in uptodate_yaml.PARAMETER_EQUIVALENCE, \
+                f"Reverse equivalence mapping missing for {new_name}"
+            assert uptodate_yaml.PARAMETER_EQUIVALENCE[new_name] == old_name, \
+                f"Reverse equivalence {new_name} should map to {old_name}"
+
 
 class TestPhaseBScienceCheck(TestProcessorFixtures):
     """Test suite for Phase B (science check) functionality."""


### PR DESCRIPTION
This PR solves one of the issues found in validating the config.yml (issue #650 ) related to a mismatch between the naming convention of some parameters in sample_config.yml (used as standard by the validator) and the data model. 

**Fix**
- The validation system is now equipped with a map that links the two naming conventions 
- This avoids duplications of the same parameter in the updated user yaml when running Phase A

**Test**
- Tests have been added to test_yaml_processing.py specific to this issue