### PR TITLE
Add default_description and range_description in data model json_schema_extra 

### DIFF
--- a/docs/generate_datamodel_rst.py
+++ b/docs/generate_datamodel_rst.py
@@ -296,6 +296,16 @@ class RSTGenerator:
         if default_label is not None and default_value is not None:
             lines.append(f"   :{default_label}: {default_value}")
 
+        # Add default description if available
+        default_desc = field_doc.get("default_description")
+        if default_desc:
+            lines.append(f"   :Default Description: {default_desc}")
+
+        # Add range description if available
+        range_desc = field_doc.get("range_description")
+        if range_desc:
+            lines.append(f"   :Range Description: {range_desc}")
+
         # Add reference field for RefValue types
         if type_info.get("is_ref_value"):
             lines.append(

--- a/src/supy/data_model/core/site.py
+++ b/src/supy/data_model/core/site.py
@@ -1845,7 +1845,7 @@ class StebbsProperties(BaseModel):
     DHWWaterVolume: Optional[FlexibleRefValue(float)] = Field(
         default=0.0,
         description="Volume of water held in use in building [m3]",
-        json_schema_extra={"unit": "m^3", "display_name": "Dhwwatervolume"},
+        json_schema_extra={"unit": "m^3", "display_name": "Dhwwatervolume", "default_description" : "Missing default explanation.", "range_description": "Missing range explanation."},
     )
     DHWSurfaceArea: Optional[FlexibleRefValue(float)] = Field(
         default=0.0,

--- a/src/supy/data_model/core/site.py
+++ b/src/supy/data_model/core/site.py
@@ -1544,6 +1544,8 @@ class StebbsProperties(BaseModel):
         json_schema_extra={
             "unit": "W m^-2 K^-1",
             "display_name": "Wallinternalconvectioncoefficient",
+            "default_description": "Default value calculated from the CIBSE GUIDE A, Table 3.47, Page 176",
+            "range_description": "Vaue must be greater than zero."
         },
         gt=0.0,
     )

--- a/src/supy/data_model/doc_utils.py
+++ b/src/supy/data_model/doc_utils.py
@@ -173,11 +173,19 @@ class ModelDocExtractor:
         if constraints:
             field_doc["constraints"] = constraints
 
-        # Extract unit
+        # Extract unit and default description
         if isinstance(field_info.json_schema_extra, dict):
             unit = field_info.json_schema_extra.get("unit")
             if unit:
                 field_doc["unit"] = unit
+
+            default_description = field_info.json_schema_extra.get("default_description")
+            if default_description:
+                field_doc["default_description"] = default_description
+
+            range_description = field_info.json_schema_extra.get("range_description")
+            if range_description:
+                field_doc["range_description"] = range_description
 
         # Extract enum options
         enum_class = self._get_enum_class(field_info, field_type)


### PR DESCRIPTION
Proposal for adding code for default_description and range_description fields in documentation generation. This enables contextual documentation for parameter defaults and valid ranges helpful to users.

**Examples**
- site.py: Add default_description and range_description to WallInternalConvectionCoefficient field metadata
- site.py: Add default_description "Missing default explanation." and range_description "Missing range explanation." to DHWWaterVolume field metadata

**Changes**
- generate_datamodel_rst.py: Extract and render both description types in generated RST documentation
- doc_utils.py: Extract new metadata fields from json_schema_extra

**What next?**
If the proposal is approved, default_description and range_description will be added to all parameters in data model. 
  

