### PR TITLE
Improve docs and fix bugs in YAML validator reports generation

### DIFF
--- a/docs/source/inputs/yaml/validation.rst
+++ b/docs/source/inputs/yaml/validation.rst
@@ -1,7 +1,26 @@
 Validation Tool Reference
 =========================
 
-The ``suews-validate`` command checks and fixes YAML configuration issues automatically.
+The ``suews-validate`` command is a comprehensive three-phase validation system that automatically checks, fixes, and optimises SUEWS YAML configuration files. It ensures your configuration is complete, scientifically valid, and compatible with the SUEWS model.
+
+## What the Validator Does
+
+**Phase A: Completeness & Structure**
+  - Detects missing parameters
+  - Updates deprecated parameter names to current standards
+  - Preserves your custom parameter values while ensuring completeness
+
+**Phase B: Scientific Validation**
+  - Performs automatic scientific corrections
+  - Applies scientific constraints and physical relationships
+  - Initialises temperatures using CRU climatological data based on location and season
+  - Validates physics options compatibility
+
+**Phase C: Model Compatibility**
+  - Validates against Pydantic data models
+  - Applies conditional validation rules based on physics settings
+  - Ensures configuration compatibility with SUEWS computational engine
+  - Performs final consistency checks
 
 Command Reference
 -----------------
@@ -73,26 +92,71 @@ When you run ``suews-validate config.yml``, it creates:
 Understanding Reports
 ---------------------
 
-The report shows all changes made:
+The validation report provides comprehensive details about every change made to your configuration, organised by phase:
 
-::
+**Phase A Report Structure**
 
-    PHASE A - STRUCTURE CHECK
-    ========================
-    Added missing parameters:
-    - soil.soil_depth: [0.1, 0.25, 0.5, 0.75] (default depths)
-    - bldgs.bldgh: 10.0 (default building height)
-    
-    PHASE B - SCIENTIFIC VALIDATION
-    ===============================
-    Automatic corrections:
-    - Surface fractions adjusted from 0.98 to 1.00
-    - Initial temperatures set to 15.2°C (July average for London)
-    
-    PHASE C - COMPATIBILITY CHECK
-    ============================
-    ✓ All physics options compatible
-    ✓ Configuration valid for SUEWS
+.. code-block:: text
+
+    # SUEWS - Phase A (Up-to-date YAML check) Report
+    # ==============================================
+    # Mode: Public
+    # ==============================================
+
+    ## NO ACTION NEEDED
+    - Updated (29) optional missing parameter(s) with null values:
+    -- forcing_file added to the updated YAML and set to null
+    -- output_file added to the updated YAML and set to null
+    -- lat added to the updated YAML and set to null
+    -- lng added to the updated YAML and set to null
+    -- timezone added to the updated YAML and set to null
+    -- physics added to the updated YAML and set to null
+    -- land_cover added to the updated YAML and set to null
+    -- initial_states added to the updated YAML and set to null
+
+    # =================================================
+
+**Phase B Report Structure**
+
+.. code-block:: text
+
+    # SUEWS - Phase B (Scientific Validation) Report
+    # ==================================================
+    # Mode: Public
+    # ==================================================
+
+    ## NO ACTION NEEDED
+    - Updated (24) parameter(s):
+    -- initial_states.paved at site [0]: temperature, tsfc, tin → 4.8°C
+       (Set from CRU data for coordinates (51.51, -0.12) for month 1)
+    -- initial_states.bldgs at site [0]: temperature, tsfc, tin → 4.8°C
+    -- initial_states.grass at site [0]: temperature, tsfc, tin → 4.8°C
+
+    - Revise (2) warnings:
+    -- land_cover.evetr at site [0]: Parameters not checked because 'evetr' surface fraction is 0
+    -- land_cover.bsoil at site [0]: Parameters not checked because 'bsoil' surface fraction is 0
+
+    # =================================================
+
+**Phase C Report Structure**
+
+.. code-block:: text
+
+    # SUEWS - Phase C (Pydantic Validation) Report
+    # ============================================
+    # Mode: Public
+    # ============================================
+
+    Phase C passed
+
+    # ==================================================
+
+**Report Categories Explained**
+
+- **ACTION NEEDED**: Critical issues requiring your attention (missing physics parameters, forbidden locations)
+- **NO ACTION NEEDED**: Informational items automatically handled (optional parameters, allowed customizations)
+- **AUTOMATIC CORRECTIONS**: Scientific adjustments applied (surface fractions, temperatures)
+- **VALIDATION RESULTS**: Final compatibility and consistency checks
 
 Exit Codes
 ----------

--- a/docs/source/inputs/yaml/validation.rst
+++ b/docs/source/inputs/yaml/validation.rst
@@ -13,11 +13,11 @@ Basic Commands
 
     # Validate and fix (creates corrected file)
     suews-validate config.yml
-    
+
     # Check only (no changes)
     suews-validate validate config.yml
-    
-    # Check without writing files
+
+    # Check without writing files (read-only validation)
     suews-validate --dry-run config.yml
 
 Output Options
@@ -43,14 +43,22 @@ Advanced Usage
 .. code-block:: bash
 
     # Run specific validation phases
-    suews-validate config.yml --phase A    # Structure only
-    suews-validate config.yml --phase B    # Science only
-    suews-validate config.yml --phase C    # Compatibility only
-    suews-validate config.yml --phase AB   # Structure + Science
-    
+    suews-validate --pipeline A config.yml     # Phase A: Structure only
+    suews-validate --pipeline B config.yml     # Phase B: Science only
+    suews-validate --pipeline C config.yml     # Phase C: Compatibility only
+    suews-validate --pipeline AB config.yml    # Phases A+B: Structure + Science
+    suews-validate --pipeline ABC config.yml   # All phases (default)
+
+    # Public mode (default)
+    suews-validate --pipeline ABC config.yml
+    suews-validate --mode public --pipeline ABC config.yml
+
+    # Developer mode (enables experimental features)
+    suews-validate --mode dev --pipeline ABC config.yml
+
     # Migrate old configuration format
     suews-validate migrate old.yml -o new.yml
-    
+
     # Check schema version
     suews-validate version config.yml
 

--- a/src/supy/data_model/validation/pipeline/phase_b_science_check.py
+++ b/src/supy/data_model/validation/pipeline/phase_b_science_check.py
@@ -235,22 +235,27 @@ def extract_simulation_parameters(yaml_data: dict) -> Tuple[int, str, str]:
     start_date = control.get("start_time")
     end_date = control.get("end_time")
 
-    if not isinstance(start_date, str) or "-" not in start_date:
-        raise ValueError(
-            "Missing or invalid 'start_time' in model.control - must be in 'YYYY-MM-DD' format"
-        )
+    # Collect all validation errors instead of failing on first error
+    errors = []
 
-    if not isinstance(end_date, str) or "-" not in end_date:
-        raise ValueError(
-            "Missing or invalid 'end_time' in model.control - must be in 'YYYY-MM-DD' format"
-        )
+    if not isinstance(start_date, str) or "-" not in str(start_date):
+        errors.append("Missing or invalid 'start_time' in model.control - must be in 'YYYY-MM-DD' format")
 
-    try:
-        model_year = int(start_date.split("-")[0])
-    except Exception:
-        raise ValueError(
-            "Could not extract model year from 'start_time' - ensure 'YYYY-MM-DD' format"
-        )
+    if not isinstance(end_date, str) or "-" not in str(end_date):
+        errors.append("Missing or invalid 'end_time' in model.control - must be in 'YYYY-MM-DD' format")
+
+    # Try to extract model year if start_date looks valid
+    model_year = None
+    if isinstance(start_date, str) and "-" in str(start_date):
+        try:
+            model_year = int(start_date.split("-")[0])
+        except Exception:
+            errors.append("Could not extract model year from 'start_time' - ensure 'YYYY-MM-DD' format")
+
+    # If we have errors, combine them into a single error message
+    if errors:
+        error_msg = "; ".join(errors)
+        raise ValueError(error_msg)
 
     return model_year, start_date, end_date
 
@@ -1621,51 +1626,94 @@ def run_science_check(
         validation_results = run_scientific_validation_pipeline(
             uptodate_data, start_date, model_year
         )
+    except (ValueError, FileNotFoundError, KeyError) as e:
+        # Handle initialization failures and create error report
+        error_message = str(e)
 
-        critical_errors = [r for r in validation_results if r.status == "ERROR"]
-        if not critical_errors:
-            science_checked_data, adjustments = run_scientific_adjustment_pipeline(
-                uptodate_data, start_date, model_year
-            )
+        # Create individual validation results for each error if multiple errors are present
+        validation_results = []
+        if ";" in error_message:
+            # Multiple errors - split them and create separate ValidationResult objects
+            individual_errors = error_message.split("; ")
+            for error in individual_errors:
+                validation_results.append(ValidationResult(
+                    status="ERROR",
+                    category="INITIALIZATION",
+                    parameter="model.control",
+                    message=f"Phase B initialization failed: {error.strip()}",
+                    suggested_value=None
+                ))
         else:
-            science_checked_data = deepcopy(uptodate_data)
-            adjustments = []
+            # Single error
+            validation_results = [ValidationResult(
+                status="ERROR",
+                category="INITIALIZATION",
+                parameter="model.control",
+                message=f"Phase B initialization failed: {error_message}",
+                suggested_value=None
+            )]
 
+        # Create error report
         science_yaml_filename = (
             os.path.basename(science_yaml_file) if science_yaml_file else None
         )
         report_content = create_science_report(
             validation_results,
-            adjustments,
+            [],  # No adjustments since we failed early
             science_yaml_filename,
             phase_a_report_file,
             mode,
             phase,
         )
 
+        # Write error report file
         if science_report_file:
             with open(science_report_file, "w") as f:
                 f.write(report_content)
 
-        if critical_errors:
-            print_critical_halt_message(critical_errors)
-            raise ValueError("Critical scientific errors detected - Phase B halted")
+        # Re-raise the exception so orchestrator knows it failed
+        raise e
 
-        print_science_check_results(validation_results, adjustments)
+    critical_errors = [r for r in validation_results if r.status == "ERROR"]
+    if not critical_errors:
+        science_checked_data, adjustments = run_scientific_adjustment_pipeline(
+            uptodate_data, start_date, model_year
+        )
+    else:
+        science_checked_data = deepcopy(uptodate_data)
+        adjustments = []
 
-        if science_yaml_file and not critical_errors:
-            header = create_science_yaml_header(phase_a_performed)
-            with open(science_yaml_file, "w") as f:
-                f.write(header)
-                yaml.dump(
-                    science_checked_data, f, default_flow_style=False, sort_keys=False
-                )
+    science_yaml_filename = (
+        os.path.basename(science_yaml_file) if science_yaml_file else None
+    )
+    report_content = create_science_report(
+        validation_results,
+        adjustments,
+        science_yaml_filename,
+        phase_a_report_file,
+        mode,
+        phase,
+    )
 
-        return science_checked_data
+    if science_report_file:
+        with open(science_report_file, "w") as f:
+            f.write(report_content)
 
-    except Exception as e:
-        print(f"Phase B Error: {e}")
-        raise
+    if critical_errors:
+        print_critical_halt_message(critical_errors)
+        raise ValueError("Critical scientific errors detected - Phase B halted")
+
+    print_science_check_results(validation_results, adjustments)
+
+    if science_yaml_file and not critical_errors:
+        header = create_science_yaml_header(phase_a_performed)
+        with open(science_yaml_file, "w") as f:
+            f.write(header)
+            yaml.dump(
+                science_checked_data, f, default_flow_style=False, sort_keys=False
+            )
+
+    return science_checked_data
 
 
 def main():


### PR DESCRIPTION
This PR addresses some of the issues in #650 related to report generation and improves/fixes docs descriptions to better user experience.

**Main changes and fix**
- improved description of validator utilities in validation.rst doc file, including --mode dev and --mode public examples
- fix validation.rst doc file to reflect actual usage commands and reports structure
- fix validate_config.py to be able to distinguish between --mode dev and --mode public
- fix validate_config.py and phase_b_science_check.py to produce a report for the user even if phase B fails during initialisation

