### PR TITLE
Fix bug in validator standard config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 
 ## 2025
 
+### 26 Sep 2025
+- [bugfix] Fixed path resolution bug in `suews-validate` CLI command that prevented validation from working when run from subdirectories
+
 ### 23 Sep 2025
 - [bugfix] Fixed missing ANOHM parameter mappings in validation system (chanohm→ch_anohm, cpanohm→rho_cp_anohm, kkanohm→k_anohm)
 - [doc] Updated Phase A documentation (PHASE_A_DETAILED.md, README.md) to reflect complete ANOHM parameter mappings

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -720,8 +720,12 @@ def _execute_pipeline(file, pipeline, mode):
 
     # Fix: Make standard file path absolute to work from any directory
     current_file = os.path.abspath(__file__)
-    suews_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_file))))
-    standard_yaml_file = os.path.join(suews_root, "src/supy/sample_data/sample_config.yml")
+    suews_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(current_file)))
+    )
+    standard_yaml_file = os.path.join(
+        suews_root, "src/supy/sample_data/sample_config.yml"
+    )
 
     (
         uptodate_file,

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -721,7 +721,9 @@ def _execute_pipeline(file, pipeline, mode):
 
     # Use importlib.resources for robust package resource access
     sample_data_files = importlib.resources.files(supy) / "sample_data"
-    with importlib.resources.as_file(sample_data_files / "sample_config.yml") as standard_yaml_path:
+    with importlib.resources.as_file(
+        sample_data_files / "sample_config.yml"
+    ) as standard_yaml_path:
         standard_yaml_file = str(standard_yaml_path)
 
     (

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 import importlib.resources
 from typing import Optional, List
+import supy
 import jsonschema
 from rich.console import Console
 from rich.table import Table
@@ -719,7 +720,9 @@ def _execute_pipeline(file, pipeline, mode):
         return 1
 
     # Use importlib.resources for robust package resource access
-    standard_yaml_file = str(importlib.resources.files('supy.sample_data') / 'sample_config.yml')
+    sample_data_files = importlib.resources.files(supy) / "sample_data"
+    with importlib.resources.as_file(sample_data_files / "sample_config.yml") as standard_yaml_path:
+        standard_yaml_file = str(standard_yaml_path)
 
     (
         uptodate_file,

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -9,6 +9,7 @@ import click
 import yaml
 import json
 import sys
+import os
 from pathlib import Path
 from typing import Optional, List
 import jsonschema

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -9,8 +9,8 @@ import click
 import yaml
 import json
 import sys
-import os
 from pathlib import Path
+import importlib.resources
 from typing import Optional, List
 import jsonschema
 from rich.console import Console
@@ -718,14 +718,8 @@ def _execute_pipeline(file, pipeline, mode):
         console.print(f"[red]✗ {e}[/red]")
         return 1
 
-    # Fix: Make standard file path absolute to work from any directory
-    current_file = os.path.abspath(__file__)
-    suews_root = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.dirname(current_file)))
-    )
-    standard_yaml_file = os.path.join(
-        suews_root, "src/supy/sample_data/sample_config.yml"
-    )
+    # Use importlib.resources for robust package resource access
+    standard_yaml_file = str(importlib.resources.files('supy.sample_data') / 'sample_config.yml')
 
     (
         uptodate_file,

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -717,7 +717,10 @@ def _execute_pipeline(file, pipeline, mode):
         console.print(f"[red]✗ {e}[/red]")
         return 1
 
-    standard_yaml_file = "src/supy/sample_data/sample_config.yml"
+    # Fix: Make standard file path absolute to work from any directory
+    current_file = os.path.abspath(__file__)
+    suews_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_file))))
+    standard_yaml_file = os.path.join(suews_root, "src/supy/sample_data/sample_config.yml")
 
     (
         uptodate_file,

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -17,6 +17,7 @@ import importlib.resources
 import shutil
 import io
 from contextlib import redirect_stdout, redirect_stderr
+import supy
 
 # Import Phase A and B functions
 try:
@@ -464,8 +465,10 @@ def run_phase_c(
                 # Load standard config for comparison
                 try:
                     # Use importlib.resources for robust package resource access
-                    with importlib.resources.open_text('supy.sample_data', 'sample_config.yml') as f:
-                        standard_data = yaml.safe_load(f)
+                    sample_data_files = importlib.resources.files(supy) / "sample_data"
+                    with importlib.resources.as_file(sample_data_files / "sample_config.yml") as standard_yaml_path:
+                        with open(standard_yaml_path, 'r') as f:
+                            standard_data = yaml.safe_load(f)
                 except FileNotFoundError:
                     print(
                         "Warning: Standard config file not found, reporting all defaults"
@@ -843,7 +846,9 @@ Modes:
 
         # Step 2: Setup paths
         # Use importlib.resources for robust package resource access
-        standard_yaml_file = str(importlib.resources.files('supy.sample_data') / 'sample_config.yml')
+        sample_data_files = importlib.resources.files(supy) / "sample_data"
+        with importlib.resources.as_file(sample_data_files / "sample_config.yml") as standard_yaml_path:
+            standard_yaml_file = str(standard_yaml_path)
 
         # Print workflow header (after variables are defined)
         phase_desc = {

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -13,6 +13,7 @@ import os
 import argparse
 import yaml
 from typing import Tuple, Optional
+import importlib.resources
 import shutil
 import io
 from contextlib import redirect_stdout, redirect_stderr
@@ -462,15 +463,8 @@ def run_phase_c(
 
                 # Load standard config for comparison
                 try:
-                    # Fix: Make standard file path absolute to work from any directory
-                    current_file = os.path.abspath(__file__)
-                    suews_root = os.path.dirname(
-                        os.path.dirname(os.path.dirname(os.path.dirname(current_file)))
-                    )
-                    standard_yaml_file = os.path.join(
-                        suews_root, "src/supy/sample_data/sample_config.yml"
-                    )
-                    with open(standard_yaml_file, "r") as f:
+                    # Use importlib.resources for robust package resource access
+                    with importlib.resources.open_text('supy.sample_data', 'sample_config.yml') as f:
                         standard_data = yaml.safe_load(f)
                 except FileNotFoundError:
                     print(
@@ -848,14 +842,8 @@ Modes:
         user_yaml_file = validate_input_file(user_yaml_file)
 
         # Step 2: Setup paths
-        # Fix: Make standard file path absolute to work from any directory
-        current_file = os.path.abspath(__file__)
-        suews_root = os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.dirname(current_file)))
-        )
-        standard_yaml_file = os.path.join(
-            suews_root, "src/supy/sample_data/sample_config.yml"
-        )
+        # Use importlib.resources for robust package resource access
+        standard_yaml_file = str(importlib.resources.files('supy.sample_data') / 'sample_config.yml')
 
         # Print workflow header (after variables are defined)
         phase_desc = {

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -464,8 +464,12 @@ def run_phase_c(
                 try:
                     # Fix: Make standard file path absolute to work from any directory
                     current_file = os.path.abspath(__file__)
-                    suews_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_file))))
-                    standard_yaml_file = os.path.join(suews_root, "src/supy/sample_data/sample_config.yml")
+                    suews_root = os.path.dirname(
+                        os.path.dirname(os.path.dirname(os.path.dirname(current_file)))
+                    )
+                    standard_yaml_file = os.path.join(
+                        suews_root, "src/supy/sample_data/sample_config.yml"
+                    )
                     with open(standard_yaml_file, "r") as f:
                         standard_data = yaml.safe_load(f)
                 except FileNotFoundError:
@@ -846,8 +850,12 @@ Modes:
         # Step 2: Setup paths
         # Fix: Make standard file path absolute to work from any directory
         current_file = os.path.abspath(__file__)
-        suews_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_file))))
-        standard_yaml_file = os.path.join(suews_root, "src/supy/sample_data/sample_config.yml")
+        suews_root = os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.dirname(current_file)))
+        )
+        standard_yaml_file = os.path.join(
+            suews_root, "src/supy/sample_data/sample_config.yml"
+        )
 
         # Print workflow header (after variables are defined)
         phase_desc = {

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -466,8 +466,10 @@ def run_phase_c(
                 try:
                     # Use importlib.resources for robust package resource access
                     sample_data_files = importlib.resources.files(supy) / "sample_data"
-                    with importlib.resources.as_file(sample_data_files / "sample_config.yml") as standard_yaml_path:
-                        with open(standard_yaml_path, 'r') as f:
+                    with importlib.resources.as_file(
+                        sample_data_files / "sample_config.yml"
+                    ) as standard_yaml_path:
+                        with open(standard_yaml_path, "r") as f:
                             standard_data = yaml.safe_load(f)
                 except FileNotFoundError:
                     print(
@@ -847,7 +849,9 @@ Modes:
         # Step 2: Setup paths
         # Use importlib.resources for robust package resource access
         sample_data_files = importlib.resources.files(supy) / "sample_data"
-        with importlib.resources.as_file(sample_data_files / "sample_config.yml") as standard_yaml_path:
+        with importlib.resources.as_file(
+            sample_data_files / "sample_config.yml"
+        ) as standard_yaml_path:
             standard_yaml_file = str(standard_yaml_path)
 
         # Print workflow header (after variables are defined)

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -214,6 +214,9 @@ def setup_output_paths(
     """Generate output file paths based on input file and phase."""
     basename = os.path.basename(user_yaml_file)
     dirname = os.path.dirname(user_yaml_file)
+    # Fix path resolution bug: handle empty dirname
+    if not dirname:
+        dirname = "."
     name_without_ext = os.path.splitext(basename)[0]
 
     uptodate_file = None
@@ -459,7 +462,11 @@ def run_phase_c(
 
                 # Load standard config for comparison
                 try:
-                    with open("src/supy/sample_data/sample_config.yml", "r") as f:
+                    # Fix: Make standard file path absolute to work from any directory
+                    current_file = os.path.abspath(__file__)
+                    suews_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_file))))
+                    standard_yaml_file = os.path.join(suews_root, "src/supy/sample_data/sample_config.yml")
+                    with open(standard_yaml_file, "r") as f:
                         standard_data = yaml.safe_load(f)
                 except FileNotFoundError:
                     print(
@@ -837,7 +844,10 @@ Modes:
         user_yaml_file = validate_input_file(user_yaml_file)
 
         # Step 2: Setup paths
-        standard_yaml_file = "src/supy/sample_data/sample_config.yml"
+        # Fix: Make standard file path absolute to work from any directory
+        current_file = os.path.abspath(__file__)
+        suews_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_file))))
+        standard_yaml_file = os.path.join(suews_root, "src/supy/sample_data/sample_config.yml")
 
         # Print workflow header (after variables are defined)
         phase_desc = {


### PR DESCRIPTION
This PR address the problem in issue #701 by replacing the relative path to standard config with an absolute path that allow suews-validate to be called from any subdir.

**Main changes**
- Updated validate_config.py to avoid a hardcoded relative path to standard sample_config.yml
- Updated orchestrator.py to avoid a hardcoded relative path to standard sample_config.yml

Changes have been reported in the CHANGELOG.md.
No additional test has been added to the test suite for this specific bug.