### PR TITLE
Fix yaml validator counter issuer

### DIFF
--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -166,7 +166,12 @@ def detect_pydantic_defaults(
                 for i, (orig_item, proc_item) in enumerate(
                     zip(original_value, processed_value)
                 ):
-                    list_path = f"{current_path}[{i}]"
+                    # Use GRIDID for sites array instead of numeric index
+                    if current_path == "sites" and isinstance(orig_item, dict) and "gridiv" in orig_item:
+                        gridid = orig_item["gridiv"]
+                        list_path = f"{current_path}.{gridid}"
+                    else:
+                        list_path = f"{current_path}[{i}]"
                     nested_critical, nested_defaults = detect_pydantic_defaults(
                         orig_item, proc_item, list_path, standard_data
                     )

--- a/src/supy/data_model/validation/pipeline/phase_c_pydantic_report.py
+++ b/src/supy/data_model/validation/pipeline/phase_c_pydantic_report.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import yaml
 
 PHASE_TITLES = {
     "A": "SUEWS - Phase A (Up-to-date YAML check) Report",
@@ -12,6 +13,58 @@ PHASE_TITLES = {
     "BC": "SUEWS - Phase BC (Scientific Validation and Pydantic Validation) Report",
     "ABC": "SUEWS - Phase ABC (Up-to-date YAML check, Scientific Validation and Pydantic Validation) Report",
 }
+
+
+def convert_pydantic_location_to_gridid_path(loc_tuple, input_yaml_file):
+    """Convert Pydantic error location tuple to user-friendly GRIDID path.
+
+    Args:
+        loc_tuple: Tuple of location elements from Pydantic error (e.g., ('sites', 0, 'properties', 'lat'))
+        input_yaml_file: Path to original YAML file to extract GRIDID values
+
+    Returns:
+        str: User-friendly path with GRIDID (e.g., "sites.123.properties.lat")
+    """
+    if not loc_tuple:
+        return ""
+
+    path_parts = []
+
+    for i, part in enumerate(loc_tuple):
+        if part == "sites" and i + 1 < len(loc_tuple) and isinstance(loc_tuple[i + 1], int):
+            # This is the sites array, next element is numeric index
+            site_index = loc_tuple[i + 1]
+            try:
+                # Load YAML to get the actual GRIDID
+                with open(input_yaml_file, 'r') as f:
+                    yaml_data = yaml.safe_load(f)
+
+                if ('sites' in yaml_data and
+                    isinstance(yaml_data['sites'], list) and
+                    site_index < len(yaml_data['sites']) and
+                    isinstance(yaml_data['sites'][site_index], dict) and
+                    'gridiv' in yaml_data['sites'][site_index]):
+
+                    gridid = yaml_data['sites'][site_index]['gridiv']
+                    path_parts.append(f"sites.{gridid}")
+                    # Skip the numeric index in next iteration
+                    continue
+                else:
+                    # Fallback to original format if GRIDID not found
+                    path_parts.append(f"sites.{site_index}")
+                    continue
+            except Exception:
+                # Fallback to original format on any error
+                path_parts.append(f"sites.{site_index}")
+                continue
+        elif isinstance(part, int) and i > 0 and loc_tuple[i-1] == "sites":
+            # Skip numeric indices that follow "sites" (already handled above)
+            continue
+        else:
+            # Regular path component
+            path_parts.append(str(part))
+
+    return ".".join(path_parts)
 
 
 def _parse_previous_phase_report(report_content: str):
@@ -108,7 +161,9 @@ def generate_phase_c_report(
     if pydantic_errors:
         for error in pydantic_errors:
             error_type = error.get("type", "unknown")
-            field_path = ".".join(str(loc) for loc in error.get("loc", []))
+            # Convert Pydantic location to GRIDID-friendly path
+            error_loc = error.get("loc", [])
+            field_path = convert_pydantic_location_to_gridid_path(error_loc, input_yaml_file)
             error_msg = error.get("msg", "Unknown error")
 
             if not field_path:
@@ -118,7 +173,21 @@ def generate_phase_c_report(
                 if field_match:
                     field_name = field_match.group(1)
                     if field_name in ["lat", "lon", "alt"]:
-                        field_path = f"sites[0].properties.{field_name}"
+                        # Try to get GRIDID for first site as fallback
+                        try:
+                            with open(input_yaml_file, 'r') as f:
+                                yaml_data = yaml.safe_load(f)
+                            if ('sites' in yaml_data and
+                                isinstance(yaml_data['sites'], list) and
+                                len(yaml_data['sites']) > 0 and
+                                isinstance(yaml_data['sites'][0], dict) and
+                                'gridiv' in yaml_data['sites'][0]):
+                                gridid = yaml_data['sites'][0]['gridiv']
+                                field_path = f"sites.{gridid}.properties.{field_name}"
+                            else:
+                                field_path = f"sites.0.properties.{field_name}"
+                        except Exception:
+                            field_path = f"sites.0.properties.{field_name}"
                     else:
                         field_path = f"model.{field_name}"
                 else:


### PR DESCRIPTION
This PR addresses issue #703 by changing terminal outputs and report messages to be in line with grid-id number rather than the internal site index counter.

**Main changes**

- Edited orchestrator.py to use `gridiv` for sites array instead of numeric index
- Edited phase_b_science_check.py to use `gridiv` for site identification instead of numeric index in report messages
- Edited phase_c_pydantic_report.py to use `gridiv` for site identification instead of numeric index in report messages
- Edited config.py to show `gridiv` number in terminal outputs from Pydantic model error messages