### PR TITLE
Fix: Handle heterogeneous site structures in multi-site configs (#716)

### DIFF
--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -2290,6 +2290,9 @@ class SUEWSConfig(BaseModel):
                 df_site = self.sites[i].to_df_state(grid_id)
                 df_model = self.model.to_df_state(grid_id)
                 df_site = pd.concat([df_site, df_model], axis=1)
+                # Remove duplicate columns immediately after combining site+model
+                # This prevents InvalidIndexError when concatenating multiple sites (axis=0)
+                df_site = df_site.loc[:, ~df_site.columns.duplicated()]
                 list_df_site.append(df_site)
 
             df = pd.concat(list_df_site, axis=0)
@@ -2297,9 +2300,6 @@ class SUEWSConfig(BaseModel):
             # Add metadata columns directly to maintain MultiIndex structure
             df[("config", "0")] = self.name
             df[("description", "0")] = self.description
-
-            # remove duplicate columns
-            df = df.loc[:, ~df.columns.duplicated()]
         except Exception as e:
             if use_conditional_validation and not strict:
                 warnings.warn(


### PR DESCRIPTION
# PR: Fix: Handle heterogeneous site structures in multi-site configs (#716)

**Title**: Fix: Handle heterogeneous site structures in multi-site configs (#716)

**Branch**: `fix-duplicate-columns-716`

**Target**: `master`

---

## Summary

Fixes #716 - `InvalidIndexError` when processing UMEP-generated multi-site configurations with heterogeneous building thermal structures.

## Problem

User reported crash when running SUEWS with 500 sites from UMEP Database Prepare:

```python
pandas.errors.InvalidIndexError: Reindexing only valid with uniquely valued Index objects
```

Error occurred in `SUEWSConfig.to_df_state()` during multi-site DataFrame concatenation.

## Root Cause

UMEP-generated sites have **heterogeneous building thermal structures** with varying vertical layer counts:

| Site Type | Vertical Layers | Total Params | Sites | % | DataFrame Cols |
|-----------|----------------|--------------|-------|---|----------------|
| Baseline | 66 | 1102 | 452 | 90.4% | 1613 |
| Medium | 86 | 1122 | 28 | 5.6% | 1682 (+69) |
| High | 106 | 1142 | 5 | 1.0% | 1751 (+138) |
| Very High | 126 | 1162 | 15 | 3.0% | 1820 (+207) |

**Analysis of all 500 UMEP sites** revealed:
- Only **1 property** varies: `vertical_layers` (building thermal layers)
- All other 23 properties are homogeneous across sites
- Heterogeneity is **physics-driven**: different buildings require different thermal resolutions
- Distribution is realistic: 90.4% baseline residential, 9.6% enhanced commercial/industrial

The error requires **both** conditions:
1. **Heterogeneous column counts**: Different sites create DataFrames with different widths (1613, 1682, 1751, 1820)
2. **Duplicate column names**: 217 duplicates from `site.to_df_state()` + `model.to_df_state()` concatenation

When pandas attempts `pd.concat(list_df_site, axis=0)` with varying widths AND non-unique column indices, column alignment becomes ambiguous → `InvalidIndexError`.

### Why Programmatic Test Data Didn't Trigger This

`Site(gridiv=X)` creates sites with:
- Uniform default structure (all 1613 columns)
- Identical thermal layers (66 parameters)
- Homogeneous concatenation succeeds even with 217 duplicates

Real-world UMEP data has structural variation that test data doesn't capture.

## The Fix

**One-line code change** in `src/supy/data_model/core/config.py:2293-2295`:

Move duplicate column removal from AFTER multi-site concatenation to INSIDE the loop (after each site+model concatenation).

### Before (buggy)
```python
for i in range(len(self.sites)):
    grid_id = self.sites[i].gridiv
    df_site = self.sites[i].to_df_state(grid_id)
    df_model = self.model.to_df_state(grid_id)
    df_site = pd.concat([df_site, df_model], axis=1)  # 217 duplicates
    list_df_site.append(df_site)

df = pd.concat(list_df_site, axis=0)  # ← FAILS with heterogeneity + duplicates

# Never reached:
df = df.loc[:, ~df.columns.duplicated()]
```

### After (fixed)
```python
for i in range(len(self.sites)):
    grid_id = self.sites[i].gridiv
    df_site = self.sites[i].to_df_state(grid_id)
    df_model = self.model.to_df_state(grid_id)
    df_site = pd.concat([df_site, df_model], axis=1)
    # Remove duplicate columns immediately after combining site+model
    # This prevents InvalidIndexError when concatenating multiple sites (axis=0)
    df_site = df_site.loc[:, ~df_site.columns.duplicated()]  # ← MOVED HERE
    list_df_site.append(df_site)

df = pd.concat(list_df_site, axis=0)  # ✓ Now succeeds
```

**Why this works**:
1. Each site's DataFrame gets deduplicated immediately (1613 → 1396 unique columns)
2. All DataFrames in `list_df_site` have unique column MultiIndex
3. Pandas can handle varying column counts when indices are unique
4. Concat performs outer join on columns, filling NaN for missing properties

## Verification

Tested with user's version (SuPy 2025.7.9.dev) at isolated environment:

| Test Scenario | Without Fix | With Fix |
|--------------|-------------|----------|
| 1-6 UMEP sites | ✓ Success | ✓ Success |
| 7 UMEP sites | ✗ InvalidIndexError | ✓ Success |
| 10 UMEP sites (863 KB) | ✗ InvalidIndexError | ✓ Success |
| 500 UMEP sites (42 MB) | ✗ InvalidIndexError | ✓ Success (207s) |
| Current test suite (11 tests) | N/A | ✓ All pass |

**Threshold**: Error occurs at 7 sites because:
- Sites 0-5: All baseline (1613 cols)
- Site 6: First heterogeneous site (grid 405, 1682 cols)
- Site 7: First concat with mixed structures → crash

Not about site count—about first structural variation.

## Impact

### Before Fix
- ✗ UMEP multi-site configs fail at 7+ sites (when heterogeneity first appears)
- ✗ Real-world workflows blocked
- ✗ Users must manually split large configurations

### After Fix
- ✓ UMEP multi-site configs work (tested 500 sites)
- ✓ Real-world workflows enabled
- ✓ Heterogeneous site structures supported
- ✓ Backwards compatible with uniform structures

## Design Implications

**Heterogeneity is a feature, not a bug**:

UMEP generates sites with realistic architectural diversity:
- Different building types → different thermal requirements
- Urban core vs suburbs → different modelling resolution
- Site-specific physics → site-specific parameter sets

**This is the correct behaviour**. SUEWS must support real-world urban heterogeneity.

The fix enables SUEWS to do what it **should have been able to do all along**: model real cities with buildings of varying complexity.

## Investigation Details

Full investigation documented in `.investigation/`:
- **ISSUE-716-COMPLETE-ANALYSIS.md**: Comprehensive technical analysis
- **GRID-HETEROGENEITY-REPORT.md**: Complete 500-site heterogeneity analysis
- **DEBRIEF.md**: Executive summary

Key findings:
- Reproduced error with user's exact environment (SuPy 2025.7.9.dev)
- Analysed all 500 UMEP sites to identify heterogeneity sources
- Verified fix with incremental testing (7, 10, 15, 500 sites)
- Confirmed only `vertical_layers` varies (physics-driven)

## Future Recommendations

1. Add heterogeneous multi-site test case to test suite (prevent regression)
2. Document heterogeneous structure support in user docs
3. Consider logging heterogeneity statistics for debugging (optional)

## References

- Issue: #716
- Test environment: `/tmp/suews_test_716/` (verified with user version)
- User data: 500 UMEP-generated sites (42 MB YAML)
