### PR TITLE
feat: add archive script to update parent repo

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "setup": "git fetch origin && git merge origin/master && git remote | grep -v '^origin$' | xargs -r -n 1 git remote remove && uv venv && source .venv/bin/activate && make dev && make docs",
-    "run": "cd docs && make livehtml"
+    "setup": "git fetch origin && git merge origin/master && for remote in $(git remote | grep -v '^origin$'); do git remote remove \"$remote\"; done && uv venv && source .venv/bin/activate && make dev && make docs",
+    "run": "cd docs && make livehtml",
+    "archive": "cd $CONDUCTOR_ROOT_PATH && git fetch origin && git pull origin master"
   }
 }


### PR DESCRIPTION
## Summary
- Add archive script to `conductor.json` that updates the parent repository when archiving Conductor worktrees
- Fix setup script to use macOS-compatible remote cleanup (replace `xargs -r` with for loop)

## Changes
- Archive script uses `CONDUCTOR_ROOT_PATH` to navigate to parent repo and pull latest from master
- Setup script now works on both macOS (BSD) and Linux (GNU)

## Test plan
- [ ] Archive a Conductor workspace and verify parent repo is updated
- [ ] Verify setup script removes non-origin remotes successfully on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)