### PR TITLE
docs: API reference structure refinements

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,11 +3,10 @@
 Python API Reference
 =====================
 
-The Python interface (SuPy) provides the complete API for SUEWS with comprehensive functionality for urban climate modelling, data analysis, and integration with the scientific Python ecosystem.
+The Python interface provides the complete API for SUEWS with comprehensive functionality for urban climate modelling, data analysis, and integration with the scientific Python ecosystem.
 
 .. toctree::
    :maxdepth: 2
-   :numbered:
    :hidden:
 
    api/simulation
@@ -20,9 +19,6 @@ The Python interface (SuPy) provides the complete API for SUEWS with comprehensi
 **Object-Oriented Interface**
     The :class:`~supy.SUEWSSimulation` class provides a modern interface for running simulations. See :doc:`api/simulation`.
 
-**Configuration Converter**
-    Python functions for converting between SUEWS formats and versions. See :doc:`api/converter`.
-
 **Core Functions**
     Functional API for SUEWS simulations (init, run, save). See :doc:`api/core-functions`.
 
@@ -34,4 +30,7 @@ The Python interface (SuPy) provides the complete API for SUEWS with comprehensi
 
 **Data Structures**
     DataFrame structures for model inputs and outputs. See :doc:`api/data-structures`.
+
+**Configuration Converter**
+    Python functions for converting between SUEWS formats and versions. See :doc:`api/converter`.
 

--- a/docs/source/api/converter.rst
+++ b/docs/source/api/converter.rst
@@ -17,8 +17,8 @@ Key Features
 
 For CLI usage, see :doc:`/inputs/converter`.
 
-Core Functions
---------------
+Functions
+---------
 
 Table to YAML Conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Minor refinements to the API reference structure following the merged #726.

## Changes

### `docs/source/api.rst`
- Remove `:numbered:` directive from toctree for cleaner navigation
- Simplify intro text (remove redundant 'SuPy' mention)
- Move "Configuration Converter" section to end for better logical ordering

### `docs/source/api/converter.rst`
- Simplify section heading: "Core Functions" → "Functions"

## Rationale

These changes improve readability and logical flow:
- Numbered sections aren't necessary in the API reference toctree
- "Configuration Converter" fits better at the end (after core API components)
- Simpler headings reduce visual clutter

## Related

Follow-up to #726 (merged)

## Checklist

- [x] Documentation builds successfully
- [x] Changes are backwards compatible
- [x] No functional changes (documentation only)
- [x] British English conventions maintained