### PR TITLE
Remove hardcoded Claude model specification

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -91,9 +91,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Use Claude Opus 4 for better code review quality
-          model: claude-opus-4-20250514
-
           # Custom instructions for British English and project standards
           custom_instructions: |
             IMPORTANT: Always use British English spelling and grammar in all your responses, reviews, and written content.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -83,10 +83,7 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Use Claude Opus 4 by default for better performance
-          model: claude-opus-4-20250514
-          
+
           # Enhanced allowed tools for SUEWS development
           allowed_tools: |
             Bash(make dev),


### PR DESCRIPTION
## Summary
- Remove explicit `model: claude-opus-4-20250514` from Claude Code GitHub Actions
- Allow workflows to use the default model provided by the action

## Changes
- **claude-code-review.yml**: Removed model specification
- **claude.yml**: Removed model specification

## Rationale
Using the default model allows the Claude Code action to automatically select the most appropriate model, keeping the configuration simpler and more maintainable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)