### PR TITLE
perf: streamline Conductor setup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "git fetch origin && git merge origin/master && for remote in $(git remote | grep -v '^origin$'); do git remote remove \"$remote\"; done && uv venv && source .venv/bin/activate && make dev && make docs",
+    "setup": "git fetch origin && git merge origin/master && for remote in $(git remote | grep -v '^origin$'); do git remote remove \"$remote\"; done && uv venv && source .venv/bin/activate",
     "run": "source .venv/bin/activate && cd docs && make livehtml",
     "archive": "cd $CONDUCTOR_ROOT_PATH && git fetch origin && git pull origin master"
   }


### PR DESCRIPTION
## Summary
- Removes `make dev` and `make docs` from Conductor setup script
- Significantly reduces workspace initialization time
- Build and docs can still be run manually when needed

## Test plan
- [x] Verify conductor.json syntax is valid
- [ ] Test setup script runs successfully without make commands
- [ ] Confirm workspace can still run docs server via run script

🤖 Generated with [Claude Code](https://claude.com/claude-code)