### PR TITLE
Fix Sphinx version display to use git tags instead of outdated RST files

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -198,19 +198,11 @@ def gen_csv_suews(path_csv):
     return list_csv_suews
 
 
-# determine latest version and release
-path_source = Path(".").resolve()
-list_ver = sorted([
-    x.stem
-    for x in list((path_source / "version-history").glob("v*rst"))
-    if "version" not in x.stem
-])
-
-
-# The short X.Y version
-version = list_ver[-1]
-# The full version, including alpha/beta/rc tags
-release = list_ver[-1]
+# Use git version for both version and release
+# This ensures the displayed version matches the actual codebase version
+# Previously used RST filenames from version-history/, which was outdated
+version = git_version_string
+release = git_version_string
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
## Summary

Fixes incorrect version display in ReadTheDocs documentation by using git-based versioning instead of outdated RST filenames.

### Problem
- Sphinx configuration was reading version from `version-history/*.rst` files
- Displayed version: `v2020a` (5 years outdated)
- Actual git version: `2025.10.15.dev1`
- Users couldn't tell which codebase version they were reading

### Solution
Modified `docs/source/conf.py` to use `git_version_string` (computed earlier in config via `get_ver_git.py`) for both `version` and `release` variables.

### Impact
- ✅ ReadTheDocs "stable" now shows correct release version (e.g., `2025.10.15`)
- ✅ ReadTheDocs "latest" now shows correct dev version (e.g., `2025.10.15.dev1`)
- ✅ Version displayed matches actual codebase
- ✅ No breaking changes to existing functionality

### Testing
```bash
cd docs/source
python3 -c "import conf; print(f'Version: {conf.version}')"
# Output: Version: 2025.10.15.dev1 ✅
```

### Related
- Aligns with CalVer tagging strategy documented in `get_ver_git.py`
- Improves ReadTheDocs user experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)