### PR TITLE
fix: ensure NumPy version consistency in UMEP variant builds

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -80,7 +80,13 @@ runs:
           ${{ inputs.is_umep_variant == 'true' && 'BUILD_UMEP_VARIANT=true' || '' }}
         CIBW_BEFORE_ALL_LINUX: >
           pip install --upgrade pip setuptools wheel &&
-          pip install oldest-supported-numpy &&
+          if [[ "${{ inputs.is_umep_variant }}" == "true" ]]; then
+            echo "Installing oldest-supported-numpy for UMEP variant build" &&
+            pip install oldest-supported-numpy;
+          else
+            echo "Installing numpy>=2.0 for standard build" &&
+            pip install 'numpy>=2.0';
+          fi &&
           if [[ "${{ inputs.python }}" == "cp313" ]]; then
             echo "Installing numpy for Python 3.13 f90wrap build" &&
             pip install numpy;
@@ -120,7 +126,7 @@ runs:
           gcc --version &&
           pip install delvewheel
         CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
-        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_REQUIRES: ${{ inputs.is_umep_variant == 'true' && 'pytest numpy<2.0' || 'pytest' }}
         CIBW_TEST_COMMAND: "python -m pytest {project}/test -v --tb=short --durations=10"
         MACOSX_DEPLOYMENT_TARGET: ${{ inputs.buildplat == 'macos-13' && '13.0' || '15.0' }}
 


### PR DESCRIPTION
## Summary
- Fix NumPy version mismatch between build and test environments for UMEP variant wheels
- Ensure UMEP wheels built with NumPy 1.x are tested with NumPy 1.x
- Standard builds continue using NumPy 2.x for both build and test

## Problem
UMEP variant wheels were failing CI tests with:
```
ImportError: numpy.core.multiarray failed to import
AttributeError: _ARRAY_API not found

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.2 as it may crash.
```

This occurred because:
- UMEP wheels were built with `oldest-supported-numpy` (NumPy 1.x) for QGIS compatibility
- Test environment installed `numpy>=2.0` from pyproject.toml
- NumPy 1.x compiled extensions cannot run in NumPy 2.x

## Solution
Modified `.github/actions/build-suews/action.yml`:
1. **Build time**: Conditionally install NumPy based on variant
   - UMEP variant: `oldest-supported-numpy` (NumPy 1.x)
   - Standard builds: `numpy>=2.0`
2. **Test time**: Add NumPy version constraint to test requirements
   - UMEP variant: `pytest numpy<2.0`
   - Standard builds: `pytest` (uses default from dependencies)

## Test plan
- [ ] Verify UMEP variant builds pass tests with NumPy 1.x
- [ ] Verify standard builds pass tests with NumPy 2.x
- [ ] Check wheel compatibility in target environments (QGIS for UMEP, general Python for standard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)