### PR TITLE
docs: clarify British English style guidelines with technical term exceptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ This file is protected against accidental truncation or content loss via pre-com
 
 ## Style Guidelines
 
-- **Language**: Use British English for all documentation, code comments, and communication
+- **Language**: Use British English for all documentation, code comments, file names, and communication
+  - **Exception**: Technical terms follow scientific computing conventions (e.g., "analyze" not "analyse", following numpy/scipy/matplotlib standard)
 - **No emoji-like characters** in print/logging functions - use only plain ASCII characters
 
 ## Common Workflow


### PR DESCRIPTION
## Summary
- Expand British English style guideline to explicitly include file names
- Add exception for technical terms that follow scientific computing conventions (e.g., "analyze" following numpy/scipy/matplotlib standard)

## Rationale
This clarifies the documentation style policy to balance British English usage with standard scientific computing terminology conventions.

## Test plan
- [ ] Review updated CLAUDE.md content
- [ ] Verify style guidelines are clear and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)