### PR TITLE
Fix duplicate RST target warnings in documentation build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -421,7 +421,7 @@ rst_prolog = rf"""
     .. tip::
 
       1. Need help? Please let us know in the `UMEP Community`_.
-      2. Please report issues with the manual on the `GitHub Issues`_.
+      2. Please report issues with the manual on `GitHub Issues`_ (or use `Report Issue for This Page`_ for page-specific feedback).
       3. Please cite SUEWS with proper information from our `Zenodo page`_.
 
 .. _UMEP Community: https://github.com/UMEP-dev/UMEP/discussions/
@@ -683,8 +683,9 @@ def source_read_handler(app, docname, source):
 """
     str_query_body = urllib.parse.urlencode({"body": str_body})
     str_url = f"https://github.com/UMEP-dev/SUEWS/issues/new?assignees=&labels=docs&template=docs-issue-report.md&{str_query_body}&title=[Docs]{docname}"
+    # Use unique link name to avoid conflict with global "GitHub Issues" in rst_prolog
     str_GHPage = f"""
-.. _GitHub Issues: {str_url}
+.. _Report Issue for This Page: {str_url}
 """
     rendered = "\n".join([str_GHPage, deprecation_warning, src])
     source[0] = rendered.rstrip("\n")


### PR DESCRIPTION
## Summary
- Fixes duplicate RST target name warnings when building documentation
- Renamed page-specific "GitHub Issues" link to "Report Issue for This Page"
- Updated tip box to reference both general issues link and page-specific link

## Problem
When running `make docs`, Sphinx produced multiple duplicate target warnings:
```
<rst_prolog>:39: ERROR: Duplicate target name, cannot be used as a unique reference: "github issues".
```

This affected all auto-generated YAML configuration reference files.

## Root Cause
Two link definitions with the same name "GitHub Issues":
1. Global definition in `rst_prolog` pointing to general issues page
2. Page-specific definition in `source_read_handler` with pre-filled issue template

Both were being prepended to every RST file, causing Sphinx to complain about duplicate targets.

## Solution
- Renamed page-specific link from "GitHub Issues" to "Report Issue for This Page"
- Updated tip box text to mention both options clearly
- Verified fix by building docs - no more duplicate warnings

## Testing
- ✅ `make docs` completes successfully with no duplicate target warnings
- ✅ Build produces 397 warnings (down from many more with duplicates)
- ✅ Page-specific "Report Issue for This Page" link appears in generated HTML

Fixes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)