### PR TITLE
Add ORCID identifiers for Vitor Lavor and Keisuke Nakao

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -24,7 +24,8 @@
     },
     {
       "name": "Lavor, Vitor",
-      "affiliation": "University of Reading"
+      "affiliation": "University of Reading",
+      "orcid": "0000-0001-9346-7694"
     },
     {
       "name": "Lindberg, Fredrik",
@@ -40,7 +41,8 @@
     },
     {
       "name": "Nakao, Keisuke",
-      "affiliation": "Central Research Institute of Electric Power Industry"
+      "affiliation": "Central Research Institute of Electric Power Industry",
+      "orcid": "0000-0002-5260-1110"
     },
     {
       "name": "Paskin, Matthew",


### PR DESCRIPTION
## Summary
- Add ORCID identifier for Vitor Lavor (0000-0001-9346-7694)
- Add ORCID identifier for Keisuke Nakao (0000-0002-5260-1110)

Updates `.zenodo.json` with complete author metadata for proper academic attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)