### PR TITLE
Fix: soilstore description

### DIFF
--- a/src/supy/data_model/core/state.py
+++ b/src/supy/data_model/core/state.py
@@ -25,7 +25,7 @@ class SurfaceInitialState(BaseModel):
         ge=0,
     )  # Default set to 0.0 means dry surface.
     soilstore: FlexibleRefValue(float) = Field(
-        description="Initial soil store (inverted to become Soil Moisture Deficit in the model)",
+        description="Initial soil store. Related to Soil Moisture Deficit (SMD) as SMD = soilstorecap - soilstore.",
         json_schema_extra={"unit": "mm", "display_name": "Soilstore"},
         default=150.0,
         ge=10,


### PR DESCRIPTION
This PR updates the `soilstore` description in state.py to help users understand how Soilstore is linked to Soil Moisture Deficit (SMD) in the model.

**Main changes**

- Edited `soilstore` description in state.py