### PR TITLE
Removed upper limit of jinja2 package version in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ dev = [
     "sphinx-click",             # CLI documentation
     "sphinx_comments",          # Comments (may be re-enabled)
     "docutils>=0.16,<0.17",     # Version pinned for compatibility
-    "jinja2>=3.0,<3.1",         # Version pinned for compatibility
+    "jinja2>=3.0",         # Version pinned for compatibility - # MP removed upper limit
 ]
 
 [project.scripts]


### PR DESCRIPTION
To resolve full package compatibility with Pandas, an upgraded version of jinja2 is required. Therefore the upper limit of the jinja2 version in the SuPy dependencies has been removed.