### PR TITLE
Fix: implemented tolerance-based logic for land cover fraction sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
 
 ## 2025
 
+### 4 Nov 2025
+- [bugfix] Fixed land cover fraction validation to use floating-point tolerance
+  - Changed from exact equality check (`total_fraction != 1.0`) to tolerance-based check (`abs(total_fraction - 1.0) > 1e-6`)
+  - Uses same tolerance (1e-6) as Phase B fraction normalisation
+  - Improved error messages to show tolerance level and actual difference from 1.0
+
 ### 31 Oct 2025
 - [bugfix] Added `rcmethod` to required physics options in validation system
   - Updated validation pipelines: Phase A (`PHYSICS_OPTIONS`), Phase B (`required_physics_params`), orchestrator (`CRITICAL_PHYSICS_PARAMS`)

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -309,7 +309,7 @@ def test_validate_land_cover_fractions_sum_too_high():
     assert cfg._validation_summary["total_warnings"] >= 1
     assert "Land cover fraction validation" in cfg._validation_summary["issue_types"]
     assert any(
-        "must sum to 1.0 (got 1.400000)" in msg
+        "must sum to 1.0 within tolerance" in msg and "got 1.400000" in msg
         for msg in cfg._validation_summary["detailed_messages"]
     )
 
@@ -333,7 +333,7 @@ def test_validate_land_cover_fractions_sum_too_low():
     assert cfg._validation_summary["total_warnings"] >= 1
     assert "Land cover fraction validation" in cfg._validation_summary["issue_types"]
     assert any(
-        "must sum to 1.0 (got 0.600000)" in msg
+        "must sum to 1.0 within tolerance" in msg and "got 0.600000" in msg
         for msg in cfg._validation_summary["detailed_messages"]
     )
 


### PR DESCRIPTION
This PR addresses Issue #817 by allowing the code to accept sums of land cover fractions within a specific tolerance of 1e-6. This behaviour mimics what is already implemented in the Phase B land cover fraction update mechanism (with the same tolerance level).

**Main changes**
- Changed config.py to have a floating-point tolerance logic (with tolerance value matching Phase B normalisation logic)
- Improved error message to include the value of tolerance 
- Updated tests in test_validation.py to account for the revised error message

**Benefits**
  - No more spurious warnings for fractions with tiny floating-point errors
  - Consistent with Phase B fraction normalisation logic