### PR TITLE
docs: Clarify sample data usage and modernise to SUEWSSimulation OOP API

### DIFF
--- a/docs/source/integration/external-interaction.ipynb
+++ b/docs/source/integration/external-interaction.ipynb
@@ -61,66 +61,19 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "**Note**: SUEWS requires site-specific parameters; there are no generic default values. This tutorial uses sample data for demonstration.\n\n### Modern YAML Configuration for Model Coupling\n\n⚠️ **Note**: This tutorial demonstrates external model coupling using low-level SuPy functions and pandas DataFrames. For modern workflows, YAML configurations will provide better integration:\n\n```python\n# Future: Modern YAML-based approach for model coupling\n# coupling_config = sp.load_coupling_config(\"qf_coupling.yml\")\n# external_models = {\n#     'anthropogenic_heat': QF_simple,\n#     'building_energy': BuildingEnergyModel,\n#     'traffic_emissions': TrafficModel\n# }\n# coupled_simulation = sp.run_coupled_simulation(\n#     base_config=\"site_config.yml\",\n#     coupling_config=coupling_config,\n#     external_models=external_models,\n#     timestep_coupling=True\n# )\n```\n\n**Benefits of YAML-based coupling:**\n- **Standardised interfaces**: Consistent data exchange formats\n- **Configuration validation**: Automatic checking of coupling parameters\n- **Metadata preservation**: Scientific references and model documentation\n- **Reproducible workflows**: Version-controlled coupling configurations\n\nThis tutorial demonstrates the principles using the current low-level approach."
+   "source": "**Note**: SUEWS requires site-specific parameters; there are no generic default values. This tutorial uses sample data for demonstration.\n\nThis tutorial uses the modern `SUEWSSimulation` OOP interface where possible. For tight two-way model coupling (demonstrated below), low-level functions are used because single-timestep execution is not exposed in the high-level API.\n\n### Future YAML Configuration for Model Coupling\n\nFor production workflows, YAML-based coupling configurations will provide standardised interfaces:\n\n```python\n# Future: Modern YAML-based approach for model coupling\n# coupling_config = sp.load_coupling_config(\"qf_coupling.yml\")\n# external_models = {\n#     'anthropogenic_heat': QF_simple,\n#     'building_energy': BuildingEnergyModel,\n#     'traffic_emissions': TrafficModel\n# }\n# coupled_simulation = sp.run_coupled_simulation(\n#     base_config=\"site_config.yml\",\n#     coupling_config=coupling_config,\n#     external_models=external_models,\n#     timestep_coupling=True\n# )\n```\n\n**Benefits of YAML-based coupling:**\n- **Standardised interfaces**: Consistent data exchange formats\n- **Configuration validation**: Automatic checking of coupling parameters\n- **Metadata preservation**: Scientific references and model documentation\n- **Reproducible workflows**: Version-controlled coupling configurations"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-06T09:55:20.406837Z",
      "start_time": "2020-07-06T09:54:59.607845Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2025-06-15 23:00:12,607 - SuPy - INFO - Loading config from yaml\n",
-      "📊 Sample data loaded using modern load_sample_data() API\n",
-      "✅ Ready for external model coupling\n",
-      "2025-06-15 23:00:14,320 - SuPy - INFO - ====================\n",
-      "2025-06-15 23:00:14,320 - SuPy - INFO - SUEWS version: 2025.6.2.dev99\n",
-      "2025-06-15 23:00:14,321 - SuPy - INFO - Simulation period:\n",
-      "2025-06-15 23:00:14,321 - SuPy - INFO -   Start: 2012-01-01 00:10:00\n",
-      "2025-06-15 23:00:14,321 - SuPy - INFO -   End: 2012-12-31 23:55:00\n",
-      "2025-06-15 23:00:14,322 - SuPy - INFO - \n",
-      "2025-06-15 23:00:14,322 - SuPy - INFO - No. of grids: 1\n",
-      "2025-06-15 23:00:14,322 - SuPy - INFO - SUEWS is running in serial mode\n",
-      "2025-06-15 23:00:20,246 - SuPy - INFO - Execution time: 5.9 s\n",
-      "2025-06-15 23:00:20,247 - SuPy - INFO - ====================\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Load sample run dataset using modern API\n",
-    "df_state_init, df_forcing = sp.load_sample_data()\n",
-    "\n",
-    "print(\"📊 Sample data loaded using modern load_sample_data() API\")\n",
-    "print(\"✅ Ready for external model coupling\")\n",
-    "\n",
-    "# turn off the snow module as unnecessary at the sample site\n",
-    "df_state_init.loc[:, \"snowuse\"] = 0\n",
-    "\n",
-    "# copy `df_state_init` as the basis for later simulations\n",
-    "df_state_init_def = df_state_init.copy()\n",
-    "\n",
-    "# by default, two years of forcing data are included;\n",
-    "# to save running time for demonstration, we only use one year in this demo\n",
-    "df_forcing = df_forcing.loc[\"2012\"].iloc[1:]\n",
-    "\n",
-    "# set QF as zero for later comparison\n",
-    "df_forcing_def = df_forcing.copy()\n",
-    "grid = df_state_init_def.index[0]\n",
-    "df_state_init_def.loc[:, \"emissionsmethod\"] = 0\n",
-    "df_forcing_def[\"qf\"] = 0\n",
-    "\n",
-    "# run supy\n",
-    "df_output, df_state = sp.run_supy(df_forcing_def, df_state_init_def)\n",
-    "df_output_def = df_output.loc[grid, \"SUEWS\"]"
-   ]
+   "outputs": [],
+   "source": "# Load sample simulation using modern OOP API\nsim = sp.SUEWSSimulation.from_sample_data()\n\nprint(\"📊 Sample simulation loaded using modern SUEWSSimulation API\")\nprint(\"✅ Ready for external model coupling\")\n\n# Extract initial state and forcing for demonstration\ndf_state_init = sim.df_state.copy()\ndf_forcing = sim.df_forcing.copy()\n\n# turn off the snow module as unnecessary at the sample site\ndf_state_init.loc[:, \"snowuse\"] = 0\n\n# copy for later simulations\ndf_state_init_def = df_state_init.copy()\n\n# by default, two years of forcing data are included;\n# to save running time for demonstration, we only use one year in this demo\ndf_forcing = df_forcing.loc[\"2012\"].iloc[1:]\n\n# set QF as zero for later comparison\ndf_forcing_def = df_forcing.copy()\ngrid = df_state_init_def.index[0]\ndf_state_init_def.loc[:, \"emissionsmethod\"] = 0\ndf_forcing_def[\"qf\"] = 0\n\n# run simulation using modern API\nsim_def = sp.SUEWSSimulation(df_forcing=df_forcing_def, df_state=df_state_init_def)\ndf_output_def = sim_def.run().df_output.loc[grid, \"SUEWS\"]"
   },
   {
    "cell_type": "markdown",
@@ -322,9 +275,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "The coupling between the simple $Q_F$ model and SuPy is done via the low-level function `suews_cal_tstep`, which is an interface function in charge of communications between SuPy frontend and the calculation kernel. By setting SuPy to receive external $Q_F$ as forcing, at each timestep, the simple $Q_F$ model is driven by the SuPy output $T_2$ and provides SuPy with $Q_F$, which thus forms a two-way coupled loop."
-   ]
+   "source": "**Note**: The coupling function below uses low-level functions because tight two-way coupling requires single-timestep execution, which is not exposed in the high-level `SUEWSSimulation` API. For production coupling workflows, future YAML-based coupling configurations (shown above) will provide standardised interfaces.\n\nThe coupling between the simple $Q_F$ model and SuPy is done via the low-level function `suews_cal_tstep`, which is an interface function in charge of communications between SuPy frontend and the calculation kernel. By setting SuPy to receive external $Q_F$ as forcing, at each timestep, the simple $Q_F$ model is driven by the SuPy output $T_2$ and provides SuPy with $Q_F$, which thus forms a two-way coupled loop."
   },
   {
    "cell_type": "code",
@@ -453,35 +404,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-06T09:55:27.170991Z",
      "start_time": "2020-07-06T09:55:20.902346Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2025-06-15 23:10:57,852 - SuPy - INFO - ====================\n",
-      "2025-06-15 23:10:57,853 - SuPy - INFO - SUEWS version: 2025.6.2.dev99\n",
-      "2025-06-15 23:10:57,853 - SuPy - INFO - Simulation period:\n",
-      "2025-06-15 23:10:57,854 - SuPy - INFO -   Start: 2012-01-01 00:10:00\n",
-      "2025-06-15 23:10:57,854 - SuPy - INFO -   End: 2012-06-30 23:55:00\n",
-      "2025-06-15 23:10:57,854 - SuPy - INFO - \n",
-      "2025-06-15 23:10:57,855 - SuPy - INFO - No. of grids: 1\n",
-      "2025-06-15 23:10:57,855 - SuPy - INFO - SUEWS is running in serial mode\n",
-      "2025-06-15 23:11:00,957 - SuPy - INFO - Execution time: 3.1 s\n",
-      "2025-06-15 23:11:00,958 - SuPy - INFO - ====================\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df_output_june, df_state_jul = sp.run_supy(df_forcing.loc[:\"2012 6\"], df_state_init)"
-   ]
+   "outputs": [],
+   "source": "# spin-up run using modern OOP API\nsim_june = sp.SUEWSSimulation(df_forcing=df_forcing.loc[:\"2012 6\"], df_state=df_state_init)\nsim_june.run()\ndf_output_june = sim_june.df_output\ndf_state_jul = sim_june.df_state"
   },
   {
    "cell_type": "markdown",
@@ -492,37 +423,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-06T09:55:33.142183Z",
      "start_time": "2020-07-06T09:55:27.174782Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2025-06-15 23:14:31,011 - SuPy - INFO - ====================\n",
-      "2025-06-15 23:14:31,012 - SuPy - INFO - SUEWS version: 2025.6.2.dev99\n",
-      "2025-06-15 23:14:31,012 - SuPy - INFO - Simulation period:\n",
-      "2025-06-15 23:14:31,013 - SuPy - INFO -   Start: 2012-07-01 00:00:00\n",
-      "2025-06-15 23:14:31,013 - SuPy - INFO -   End: 2012-11-30 23:55:00\n",
-      "2025-06-15 23:14:31,014 - SuPy - INFO - \n",
-      "2025-06-15 23:14:31,014 - SuPy - INFO - No. of grids: 1\n",
-      "2025-06-15 23:14:31,015 - SuPy - INFO - SUEWS is running in serial mode\n",
-      "2025-06-15 23:14:33,960 - SuPy - INFO - Execution time: 2.9 s\n",
-      "2025-06-15 23:14:33,971 - SuPy - INFO - ====================\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df_output_oct, df_state_dec = sp.run_supy(\n",
-    "    df_forcing.loc[\"2012 7\":\"2012 11\"], df_state_jul\n",
-    ")"
-   ]
+   "outputs": [],
+   "source": "# spin-up run using modern OOP API\nsim_oct = sp.SUEWSSimulation(df_forcing=df_forcing.loc[\"2012 7\":\"2012 11\"], df_state=df_state_jul)\nsim_oct.run()\ndf_output_oct = sim_oct.df_output\ndf_state_dec = sim_oct.df_state"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Clarified heading from "run SUEWS with default settings" to "run SUEWS with sample data"
- Added note explaining that SUEWS requires site-specific parameters with no generic defaults
- Modernised tutorial to use `SUEWSSimulation` OOP interface throughout

## Context
Fixes #856

Sue correctly identified two issues:
1. **Misleading heading**: Tutorial suggested "default settings" when it actually uses sample data for a specific location
2. **Outdated API**: Tutorial used legacy `sp.run_supy()` function instead of modern OOP interface

## Changes

### Clarification of sample data usage
- Changed heading to "run SUEWS with sample data"
- Added explicit note: "SUEWS requires site-specific parameters; there are no generic default values. This tutorial uses sample data for demonstration."

### Modernisation to OOP interface
- **Cell 7**: Now uses `SUEWSSimulation.from_sample_data()` to load sample simulation
- **Cell 7**: Updated to use `SUEWSSimulation` class and `.run()` method
- **Cells 24, 26**: Updated spin-up runs to use `SUEWSSimulation` class
- **Cell 19**: Added note explaining why low-level API is still needed for tight coupling
- **Cell 20**: Kept coupling function with low-level API (single-timestep execution not exposed in high-level interface)

The tutorial now demonstrates the modern recommended approach while still showing advanced coupling techniques where necessary.

## Test plan
- [x] Documentation changes only, no functional code changes
- [ ] Verify rendered documentation shows corrected text and modern API usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)