### PR TITLE
Add physics method dependency description in docs

### DIFF
--- a/docs/generate_datamodel_rst.py
+++ b/docs/generate_datamodel_rst.py
@@ -346,12 +346,14 @@ class RSTGenerator:
             if depends:
                 refs = ", ".join(f":ref:`{d} <{d}>`" for d in depends)
                 lines.append(f"      **Depends on:** {refs}")
+                lines.append("")
 
             # Add provides_to
             provides = relationships.get("provides_to", [])
             if provides:
                 refs = ", ".join(f":ref:`{p} <{p}>`" for p in provides)
                 lines.append(f"      **Provides to:** {refs}")
+                lines.append("")
 
         return lines
 

--- a/docs/generate_datamodel_rst.py
+++ b/docs/generate_datamodel_rst.py
@@ -182,13 +182,25 @@ class RSTGenerator:
         ]
 
         # Add reference label for physics method fields with relationships
-        # Note: diagmethod→rslmethod, localclimatemethod→rsllevel (legacy rename)
-        if field_name in {
+        # These fields are cross-referenced in documentation describing physics
+        # method dependencies (e.g., "see netradiationmethod_" for SPARTACUS coupling)
+        # Note: diagmethod→rslmethod, localclimatemethod→rsllevel (legacy renames)
+        physics_anchor_fields = {
+            "netradiationmethod",
+            "emissionsmethod",
+            "storageheatmethod",
+            "ohmincqf",
+            "roughlenmommethod",
+            "roughlenheatmethod",
             "stabilitymethod",
             "rslmethod",  # was diagmethod
             "rsllevel",  # was localclimatemethod
             "gsmodel",
-        }:
+            "snowuse",
+            "stebbsmethod",
+            "rcmethod",
+        }
+        if field_name in physics_anchor_fields:
             lines.append(f".. _{field_name}:")
             lines.append("")
 

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -767,7 +767,9 @@ class ModelPhysics(BaseModel):
             if stebbs_enum is None:
                 errors.append("RCMethod>0 requires a valid stebbsmethod value.")
             elif stebbs_enum not in {StebbsMethod.DEFAULT, StebbsMethod.PROVIDED}:
-                errors.append("RCMethod>0 requires stebbsmethod to be DEFAULT or PROVIDED.")
+                errors.append(
+                    "RCMethod>0 requires stebbsmethod to be DEFAULT or PROVIDED."
+                )
 
         # OhmIncQf can only be used with OHM-based storage heat methods
         if ohm_enum == OhmIncQf.INCLUDE:
@@ -789,8 +791,12 @@ class ModelPhysics(BaseModel):
                 raise ValueError(errors[0])
             else:
                 # Format multiple errors with numbered list for clarity
-                formatted_errors = "\n  ".join(f"{i+1}. {err}" for i, err in enumerate(errors))
-                raise ValueError(f"Multiple configuration errors found:\n  {formatted_errors}")
+                formatted_errors = "\n  ".join(
+                    f"{i + 1}. {err}" for i, err in enumerate(errors)
+                )
+                raise ValueError(
+                    f"Multiple configuration errors found:\n  {formatted_errors}"
+                )
 
         return self
 

--- a/test/data_model/test_model_physics.py
+++ b/test/data_model/test_model_physics.py
@@ -39,8 +39,9 @@ def test_spartacus_requires_ehc_storage():
     """SPARTACUS radiation options should only be paired with EHC storage heat."""
 
     # Verify that the test uses a valid SPARTACUS option (>= 1000)
-    assert NetRadiationMethod.LDOWN_SS_OBSERVED.value >= 1000, \
+    assert NetRadiationMethod.LDOWN_SS_OBSERVED.value >= 1000, (
         f"NetRadiationMethod.LDOWN_SS_OBSERVED should be >= 1000, got {NetRadiationMethod.LDOWN_SS_OBSERVED.value}"
+    )
 
     with pytest.raises(ValueError, match="must be coupled with StorageHeatMethod=5"):
         ModelPhysics(
@@ -77,8 +78,9 @@ def test_valid_combinations_pass():
     """A configuration satisfying all constraints should instantiate cleanly."""
 
     # Verify that the test uses a valid SPARTACUS option (>= 1000) for EHC
-    assert NetRadiationMethod.LDOWN_SS_CLOUD.value >= 1000, \
+    assert NetRadiationMethod.LDOWN_SS_CLOUD.value >= 1000, (
         f"NetRadiationMethod.LDOWN_SS_CLOUD should be >= 1000, got {NetRadiationMethod.LDOWN_SS_CLOUD.value}"
+    )
 
     config = ModelPhysics(
         storageheatmethod=StorageHeatMethod.EHC,

--- a/test/data_model/test_model_physics.py
+++ b/test/data_model/test_model_physics.py
@@ -1,27 +1,12 @@
-from pathlib import Path
-import sys
-import types
-
 import pytest
-
-SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
-if str(SRC_ROOT) not in sys.path:
-    sys.path.insert(0, str(SRC_ROOT))
-
-try:
-    import supy  # type: ignore
-except ImportError:  # pragma: no cover
-    supy = types.ModuleType("supy")
-    supy.__path__ = [str(SRC_ROOT / "supy")]
-    sys.modules["supy"] = supy
 
 from supy.data_model.core.model import (
     ModelPhysics,
     NetRadiationMethod,
-    StorageHeatMethod,
-    StebbsMethod,
-    RCMethod,
     OhmIncQf,
+    RCMethod,
+    StebbsMethod,
+    StorageHeatMethod,
 )
 
 

--- a/test/data_model/test_model_physics.py
+++ b/test/data_model/test_model_physics.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+try:
+    import supy  # type: ignore
+except ImportError:  # pragma: no cover
+    supy = types.ModuleType("supy")
+    supy.__path__ = [str(SRC_ROOT / "supy")]
+    sys.modules["supy"] = supy
+
+from supy.data_model.core.model import (
+    ModelPhysics,
+    NetRadiationMethod,
+    StorageHeatMethod,
+    StebbsMethod,
+    RCMethod,
+    OhmIncQf,
+)
+
+
+def test_ehc_requires_spartacus_netrad():
+    """EHC storage heat must use a SPARTACUS net radiation option."""
+
+    with pytest.raises(ValueError, match="requires NetRadiationMethod >= 1000"):
+        ModelPhysics(
+            storageheatmethod=StorageHeatMethod.EHC,
+            netradiationmethod=NetRadiationMethod.LDOWN_AIR,
+        )
+
+
+def test_spartacus_requires_ehc_storage():
+    """SPARTACUS radiation options should only be paired with EHC storage heat."""
+
+    # Verify that the test uses a valid SPARTACUS option (>= 1000)
+    assert NetRadiationMethod.LDOWN_SS_OBSERVED.value >= 1000, \
+        f"NetRadiationMethod.LDOWN_SS_OBSERVED should be >= 1000, got {NetRadiationMethod.LDOWN_SS_OBSERVED.value}"
+
+    with pytest.raises(ValueError, match="must be coupled with StorageHeatMethod=5"):
+        ModelPhysics(
+            storageheatmethod=StorageHeatMethod.OHM_WITHOUT_QF,
+            netradiationmethod=NetRadiationMethod.LDOWN_SS_OBSERVED,
+        )
+
+
+def test_stebbs_storage_requires_stebbs_method():
+    with pytest.raises(ValueError, match="requires stebbsmethod"):
+        ModelPhysics(
+            storageheatmethod=StorageHeatMethod.STEBBS,
+            stebbsmethod=StebbsMethod.NONE,
+        )
+
+
+def test_rcmethod_requires_active_stebbs():
+    with pytest.raises(ValueError, match="RCMethod>0 requires stebbsmethod"):
+        ModelPhysics(
+            rcmethod=RCMethod.PROVIDED,
+            stebbsmethod=StebbsMethod.NONE,
+        )
+
+
+def test_ohmincqf_include_only_for_ohm_methods():
+    with pytest.raises(ValueError, match="ohmIncQf=1"):
+        ModelPhysics(
+            storageheatmethod=StorageHeatMethod.OBSERVED,
+            ohmincqf=OhmIncQf.INCLUDE,
+        )
+
+
+def test_valid_combinations_pass():
+    """A configuration satisfying all constraints should instantiate cleanly."""
+
+    # Verify that the test uses a valid SPARTACUS option (>= 1000) for EHC
+    assert NetRadiationMethod.LDOWN_SS_CLOUD.value >= 1000, \
+        f"NetRadiationMethod.LDOWN_SS_CLOUD should be >= 1000, got {NetRadiationMethod.LDOWN_SS_CLOUD.value}"
+
+    config = ModelPhysics(
+        storageheatmethod=StorageHeatMethod.EHC,
+        netradiationmethod=NetRadiationMethod.LDOWN_SS_CLOUD,
+        stebbsmethod=StebbsMethod.DEFAULT,
+        rcmethod=RCMethod.NONE,
+        ohmincqf=OhmIncQf.EXCLUDE,
+    )
+
+    assert config.storageheatmethod == StorageHeatMethod.EHC
+    assert config.netradiationmethod == NetRadiationMethod.LDOWN_SS_CLOUD


### PR DESCRIPTION
Add comprehensive validation for physics method configurations to enforce critical compatibility rules between methods. Includes:

- EHC storage heat requires SPARTACUS net radiation (≥1000)
- SPARTACUS requires EHC storage heat pairing
- STEBBS storage heat requires active stebbsmethod
- RC method requires active STEBBS
- OhmIncQf inclusion requires OHM-based storage methods

Validation includes explicit None checks, improved error formatting with numbered lists for multiple errors, and full test coverage. Documentation enhanced with depends_on/provides_to metadata and proper cross-reference links.