### PR TITLE
fix: Skip expensive builds for schema-only PRs

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -194,7 +194,8 @@ jobs:
               - '.github/actions/build-suews/**'
               - 'test/**'
               - 'scripts/**'
-              - 'schemas/**'
+              # NOTE: schemas/** excluded - JSON metadata files don't require builds
+              # Bot-created schema PRs use schema-pr-validation.yml instead
               - 'pyproject.toml'
               - 'meson.build'
               - 'meson_options.txt'


### PR DESCRIPTION
Remove schemas/** from detect-changes path filter to prevent bot-created schema update PRs from triggering the full build matrix. Schema files are JSON metadata already validated and deployed by schema-management.yml, so the lightweight schema-pr-validation.yml provides sufficient PR checks whilst avoiding unnecessary compilation costs.