### PR TITLE
fix: Schema PR validation permissions and error handling

### DIFF
--- a/.github/workflows/schema-pr-validation.yml
+++ b/.github/workflows/schema-pr-validation.yml
@@ -18,7 +18,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   statuses: write
 
 jobs:
@@ -116,6 +116,7 @@ jobs:
 
       - name: Post validation comment
         if: always() && github.event_name == 'pull_request_target'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Problem

Bot-created schema PRs are failing CI with 403 errors when the validation workflow tries to post comments. This is because:

1. The workflow has `pull-requests: read` permission but needs `write` to post comments
2. With `pull_request_target` trigger, workflows use files from the base branch (master), creating a chicken-and-egg problem where fixes in PRs don't apply to themselves

## Solution

Two changes to `.github/workflows/schema-pr-validation.yml`:

1. **Grant `pull-requests: write` permission** - Allows the workflow to post validation result comments
2. **Add `continue-on-error: true`** - Makes comment posting non-critical, so validation passes even if commenting fails

This is a hotfix to unblock PR #868 and future bot-created schema PRs.

## Testing

After merging, PR #868's validation should pass when re-run.

Fixes #868