### PR TITLE
fix: Add issues:write permission for PR comment posting

### DIFF
--- a/.github/workflows/schema-pr-validation.yml
+++ b/.github/workflows/schema-pr-validation.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
## Problem Analysis

The schema validation workflow still fails to post comments despite PR #870's fix. Deep analysis of the 403 error reveals the root cause:

```
POST /repos/UMEP-dev/SUEWS/issues/868/comments
Response header: 'x-accepted-github-permissions': 'issues=write; pull_requests=write'
Error: Resource not accessible by integration (403)
```

**Key insight**: GitHub's PR comments API uses the `/issues` endpoint, which requires **`issues: write`** permission, not just `pull-requests: write`.

## What Was Missing

PR #870 added:
- ✅ `pull-requests: write` 
- ✅ `continue-on-error: true`

But **didn't add**:
- ❌ `issues: write` ← This is needed for `/issues/{number}/comments` endpoint

## This Fix

Adds the missing `issues: write` permission to the workflow permissions block:

```yaml
permissions:
  contents: read
  issues: write        # ← NEW: Required for PR comment posting
  pull-requests: write
  statuses: write
```

Now the workflow can:
1. Validate schema-only PRs ✓
2. Post validation result comments ✓ (was silently failing before)
3. Set commit statuses ✓

## Testing

After merge, the next bot-created schema PR should successfully post validation comments without 403 errors.

Related: #868, #870