### PR TITLE
test: Fix path resolution in CSV conversion tests to work in CI

### DIFF
--- a/test/cmd/test_df_state_conversion.py
+++ b/test/cmd/test_df_state_conversion.py
@@ -62,12 +62,8 @@ class TestCsvFileConversion:
     @pytest.fixture
     def old_csv_path(self):
         """Path to the provided old format CSV."""
-        # Use the fixture file in the test directory
-        csv_path = Path("test/fixtures/legacy_format/old_df_state.csv")
-        if csv_path.exists():
-            return csv_path
-        else:
-            pytest.skip("Test CSV file not available")
+        # Use __file__-based path to work regardless of CWD
+        return Path(__file__).parent.parent / "fixtures/legacy_format/old_df_state.csv"
 
     def test_load_old_csv(self, old_csv_path):
         """Test loading the provided old CSV file."""


### PR DESCRIPTION
## Summary
Fixes 3 of 4 tests in `TestCsvFileConversion` that were being skipped in CI due to path resolution issues.

## Problem
The `old_csv_path` fixture used a relative path (`test/fixtures/legacy_format/old_df_state.csv`) that assumes pytest runs from the project root. In CI (cibuildwheel), pytest runs with `CWD=test/`, causing the path lookup to fail and all tests to skip silently.

## Solution
- Use `Path(__file__).parent.parent` for working-directory-independent path resolution
- Remove unnecessary `pytest.skip()` condition (committed fixtures shouldn't skip)
- Follow the pattern used throughout the test suite (`test_supy.py`, `test_cli_run.py`, etc.)

## Test Results

### Before (CI):
```
test_load_old_csv SKIPPED
test_detect_old_csv_version SKIPPED
test_convert_old_csv SKIPPED
test_full_yaml_conversion SKIPPED
```

### After (CI):
```
test_load_old_csv PASSED ✓
test_detect_old_csv_version PASSED ✓
test_full_yaml_conversion PASSED ✓
test_convert_old_csv FAILED (reveals existing column count bug)
```

## Notes
- The skip condition dates back to commit `12dbc555` when the test used a machine-specific Conductor upload path
- `test_convert_old_csv` now reveals a pre-existing assertion bug (expects 1424 columns, gets 1423)
- That column count issue should be addressed in a separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)