### PR TITLE
Make dev target self-healing after clean

### DIFF
--- a/.claude/reference/quick-start.md
+++ b/.claude/reference/quick-start.md
@@ -53,10 +53,23 @@ make test
 ## Makefile Commands
 
 - `make setup` - Create virtual environment with uv (if available)
-- `make dev` - Install SUEWS in editable mode
+- `make dev` - Install SUEWS in editable mode (self-healing, works after clean)
 - `make test` - Run test suite
 - `make clean` - Smart clean (keeps .venv if active)
 - `make format` - Format Python and Fortran code
+
+## Common Workflows
+
+```bash
+# Fresh start (most common for troubleshooting)
+make clean && make dev
+
+# Update code and rebuild
+git pull && make dev
+
+# Build and test changes
+make dev && make test
+```
 
 ## Package Name Differences
 

--- a/README.md
+++ b/README.md
@@ -116,12 +116,13 @@ For local development without containerisation, follow these steps:
 
 5. **Build SUEWS**:
    ```bash
-   # Quick development build (recommended)
+   # Fast editable install (recommended)
    make dev
 
-   # Or full build with tests
-   make
+   # Optional: run tests
+   make test
    ```
+   *Running `make` with no target just prints the help summary.*
 
 6. **Verify installation**:
    ```bash
@@ -133,13 +134,19 @@ For local development without containerisation, follow these steps:
 
 * **Build commands**:
   ```bash
-  make dev          # Fast development build
-  make              # Full build with tests
+  make dev          # Install in editable mode (self-healing, works after clean)
   make test         # Run test suite only
-  make clean        # Clean build artifacts
-  make wheel        # Build distribution wheels
+  make clean        # Clean build artifacts (smart - keeps .venv if active)
   make docs         # Build documentation
   make livehtml     # Live documentation preview
+  make              # Show help summary (default target)
+  ```
+
+* **Common workflows**:
+  ```bash
+  make clean && make dev    # Fresh start (most common for troubleshooting)
+  git pull && make dev      # Update code and rebuild
+  make dev && make test     # Build and test changes
   ```
 
 * **Environment management**:
@@ -149,7 +156,7 @@ For local development without containerisation, follow these steps:
   ```
 
 * **Common issues**:
-  - **Build conflicts**: Run `make clean` before rebuilding
+  - **Build conflicts**: Run `make clean && make dev` (most reliable)
   - **Import errors**: Ensure you're in the `suews-dev` environment
   - **Permission errors on Windows**: Right-click project folder → Properties → Security → Edit → Everyone → Allow
 

--- a/dev-ref/building-locally.md
+++ b/dev-ref/building-locally.md
@@ -47,8 +47,7 @@ pip install -e .
 
 ### Development
 - `make setup` - Create virtual environment (requires `uv`)
-- `make dev` - Install SUEWS in editable mode
-- `make reinstall` - Fix stale editable install (uninstall + reinstall)
+- `make dev` - Install SUEWS in editable mode (self-healing, works after clean)
 
 ### Testing
 - `make test` - Run test suite (excludes slow tests ~3-4 min)
@@ -62,6 +61,19 @@ pip install -e .
 - `make clean` - Smart clean (preserves active `.venv`)
 - `make format` - Format Python (ruff) and Fortran (fprettify)
 - `make help` - Show all available commands
+
+### Common Workflows
+
+```bash
+# Fresh start (most common for troubleshooting)
+make clean && make dev
+
+# Update code and rebuild
+git pull && make dev
+
+# Build and test changes
+make dev && make test
+```
 
 ## Additional Notes
 


### PR DESCRIPTION
## Summary
Make `make dev` automatically detect and fix stale builds after `make clean`, eliminating the need for a separate `make reinstall` command. Add clear workflow documentation with practical examples for common development tasks.

## Changes
- Detect missing build directory in `dev` target and perform automatic reinstall
- Deprecate `make reinstall` with migration guidance
- Add "Common Workflows" sections to all documentation (Makefile, README, quick-start, building-locally)
- Simplify user mental model: one command for all build scenarios

## Benefits
Reduces user confusion by providing self-healing builds and clear guidance on recommended workflows.