### PR TITLE
docs: Direct users to dedicated SUEWS discussion channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -51,7 +51,7 @@ git push origin $VERSION
 
 ## Announce (Optional)
 
-- [ ] [UMEP Discussions](https://github.com/UMEP-dev/UMEP/discussions)
+- [ ] [SUEWS Discussions](https://github.com/UMEP-dev/SUEWS/discussions)
 
 ---
 

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -235,7 +235,7 @@
                 </div>
             </a>
 
-            <a href="https://github.com/UMEP-dev/umep/discussions" class="nav-card">
+            <a href="https://github.com/UMEP-dev/SUEWS/discussions" class="nav-card">
                 <span class="nav-icon">💬</span>
                 <div class="nav-title">Community</div>
                 <div class="nav-description">

--- a/dev-ref/RELEASE_MANUAL.md
+++ b/dev-ref/RELEASE_MANUAL.md
@@ -37,7 +37,7 @@ SUEWS adopts a **rolling release model** that reflects the continuous nature of 
 
    Both deployed to PyPI → GitHub Release → Zenodo DOI
 5. **Verify**: Check [Actions](https://github.com/UMEP-dev/SUEWS/actions), [PyPI](https://pypi.org/project/supy/), [Zenodo dashboard](https://zenodo.org/me/uploads)
-6. **Announce**: [UMEP Discussions](https://github.com/UMEP-dev/UMEP/discussions) (optional)
+6. **Announce**: [SUEWS Discussions](https://github.com/UMEP-dev/SUEWS/discussions) (optional)
 
 **Everything else is automatic.** See below for detailed guidance.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -391,11 +391,11 @@ rst_prolog = rf"""
 
     .. tip::
 
-      1. Need help? Please let us know in the `UMEP Community`_.
+      1. Need help? Please let us know in the `SUEWS Discussion Channel`_.
       2. Please report issues with the manual on `GitHub Issues`_ (or use `Report Issue for This Page`_ for page-specific feedback).
       3. Please cite SUEWS with proper information from our `Zenodo page`_.
 
-.. _UMEP Community: https://github.com/UMEP-dev/UMEP/discussions/
+.. _SUEWS Discussion Channel: https://github.com/UMEP-dev/SUEWS/discussions/
 .. _GitHub Issues: https://github.com/UMEP-dev/SUEWS/issues
 .. _SUEWS download page: https://forms.office.com/r/4qGfYu8LaR
 

--- a/docs/source/contributing/contributing.rst
+++ b/docs/source/contributing/contributing.rst
@@ -14,7 +14,7 @@ We welcome community contributions in the following areas:
 
 - **Bug Reports**: Open an issue on `GitHub Issues <https://github.com/UMEP-dev/SUEWS/issues>`_
 - **Documentation Improvements**: Click the "Suggest an edit" button at the top right of the page (the GitHub icon) and make your changes.
-- **Feature Requests**: Discuss ideas in `GitHub Discussions <https://github.com/UMEP-dev/UMEP/discussions>`_
+- **Feature Requests**: Discuss ideas in `GitHub Discussions <https://github.com/UMEP-dev/SUEWS/discussions>`_
 
 .. note:: If you are interested in contributing to the project, please open a new discussion in the `SUEWS GitHub Issues <https://github.com/UMEP-dev/SUEWS/issues>`_ to share your ideas.
 
@@ -34,6 +34,6 @@ Getting Help
 ------------
 
 - **Issues**: `GitHub Issues <https://github.com/UMEP-dev/SUEWS/issues>`_
-- **Discussions**: `GitHub Discussions <https://github.com/UMEP-dev/UMEP/discussions>`_
+- **Discussions**: `GitHub Discussions <https://github.com/UMEP-dev/SUEWS/discussions>`_
 - **Documentation**: `ReadTheDocs <https://suews.readthedocs.io>`_
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,7 +73,7 @@ Before performing SUEWS simulations, users should understand the :ref:`physical 
 How to get help in using SUEWS?
 ---------------------------------------------
 
-Please let us know in the `UMEP Community`_.
+Please let us know in the `SUEWS Discussion Channel`_.
 The developers and other users are willing to help you.
 
 
@@ -172,4 +172,4 @@ How to support SUEWS?
    :hidden:
 
    community_publications
-   GitHub discussion <https://github.com/UMEP-dev/UMEP/discussions>
+   GitHub discussion <https://github.com/UMEP-dev/SUEWS/discussions>

--- a/docs/source/inputs/yaml/index.rst
+++ b/docs/source/inputs/yaml/index.rst
@@ -271,4 +271,4 @@ Getting Help
 - **Validation issues**: Check the report file (``report_*.txt``)
 - **Parameter documentation**: See the error messages from validation
 - **Examples**: Look in ``sample_data/`` directory
-- **Community support**: `UMEP Community Forum <https://github.com/UMEP-dev/UMEP/discussions>`_
+- **Community support**: `SUEWS Discussion Channel <https://github.com/UMEP-dev/SUEWS/discussions>`_

--- a/docs/source/integration/future-features.rst
+++ b/docs/source/integration/future-features.rst
@@ -44,7 +44,7 @@ The SUEWS community welcomes contributions of integration examples and coupling 
 Please see :doc:`../contributing/contributing` for guidelines on contributing integration code and documentation.
 
 **Discussion and Support:**
-- `GitHub Discussions <https://github.com/UMEP-dev/UMEP/discussions/>`_: Community Q&A and feature requests
+- `GitHub Discussions <https://github.com/UMEP-dev/SUEWS/discussions/>`_: Community Q&A and feature requests
 - `GitHub Issues <https://github.com/UMEP-dev/SUEWS/issues>`_: Bug reports and development tracking
 
 Research Collaboration


### PR DESCRIPTION
## Summary

Updates documentation references to direct users to the new SUEWS discussion channel on GitHub instead of the broader UMEP discussions.

## Changes

- Documentation: Replaced UMEP Community/UMEP Discussions links with SUEWS Discussions
- Release checklists: Updated announcement instructions  
- GitHub Pages: Updated community navigation link

## Test Plan

- [x] All documentation references updated
- [x] Links point to correct SUEWS discussions URL