### PR TITLE
fix(ci): enable determine_matrix for scheduled builds

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -236,6 +236,8 @@ jobs:
     name: Determine build matrix
     runs-on: ubuntu-latest
     needs: [detect-changes]
+    # Always run - detect-changes is skipped for non-PR events, but we still need matrix
+    if: always() && (needs.detect-changes.result == 'success' || needs.detect-changes.result == 'skipped')
     outputs:
       buildplat: ${{ steps.set-matrix.outputs.buildplat }}
       python: ${{ steps.set-matrix.outputs.python }}


### PR DESCRIPTION
## Problem
Nightly scheduled builds were skipping all substantive steps due to job dependency propagation. The `determine_matrix` job depends on `detect-changes`, which only runs for pull requests. When `detect-changes` was skipped, `determine_matrix` was also skipped by default, preventing wheel builds and TestPyPI deployment.

## Solution
Added explicit `if: always()` condition to `determine_matrix` to allow it to run when `detect-changes` is skipped. The job now properly evaluates the build trigger (schedule vs PR vs tag) and sets the appropriate matrix.

## Result
Nightly builds will now execute the full build matrix and deploy to TestPyPI as intended.