### PR TITLE
Sort MultiIndex columns to fix lexsort warnings

### DIFF
--- a/src/supy/data_model/core/site.py
+++ b/src/supy/data_model/core/site.py
@@ -690,6 +690,9 @@ class EvetrProperties(VegetatedSurfaceProperties):  # TODO: Move waterdist VWD h
             self.alb_max.value if isinstance(self.alb_max, RefValue) else self.alb_max
         )
 
+        # Sort the MultiIndex columns to avoid performance warnings
+        df_state = df_state.sort_index(axis=1)
+
         return df_state
 
     @classmethod
@@ -804,6 +807,9 @@ class DectrProperties(VegetatedSurfaceProperties):
         df_state.loc[grid_id, ("albmax_dectr", "0")] = (
             self.alb_max.value if isinstance(self.alb_max, RefValue) else self.alb_max
         )
+
+        # Sort the MultiIndex columns to avoid performance warnings
+        df_state = df_state.sort_index(axis=1)
 
         return df_state
 


### PR DESCRIPTION
Adds `df.sort_index(axis=1)` before returning DataFrames in `EvetrProperties` and `DectrProperties` `to_df_state()` methods. This ensures MultiIndex columns are lexicographically sorted for efficient binary search when accessing via `.loc` operations, eliminating ~3,000 performance warnings per CI run.

All 538 tests pass with no regressions.