### PR TITLE
Fix pandas FutureWarning and DataFrame fragmentation warnings

### DIFF
--- a/src/supy/util/_io.py
+++ b/src/supy/util/_io.py
@@ -56,7 +56,7 @@ def read_forcing(path_suews_file: str, tstep_mod=300) -> pd.DataFrame:
     str_pattern = path_suews_file.name
 
     df_forcing_raw = load_SUEWS_Forcing_met_df_pattern(path_input, str_pattern)
-    tstep_met_in = df_forcing_raw.index.to_series().diff()[-1] / pd.Timedelta("1s")
+    tstep_met_in = df_forcing_raw.index.to_series().diff().iloc[-1] / pd.Timedelta("1s")
     df_forcing_raw = df_forcing_raw.asfreq(f"{tstep_met_in:.0f}s")
 
     df_forcing = df_forcing_raw


### PR DESCRIPTION
## Summary

- Use `.iloc[-1]` instead of `[-1]` for Series positional indexing in `util/_io.py` to fix FutureWarning for pandas 3.0 compatibility
- Refactor `convert_df_state_format()` in `converter/df_state.py` to build all column data in a dictionary before creating DataFrame, avoiding fragmentation from repeated column insertions

## Test plan

- [x] All existing tests pass (538 tests)
- [ ] Verify no FutureWarning from `util/_io.py`
- [ ] Verify no PerformanceWarning from `df_state.py`
- [ ] CI passes

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)