### PR TITLE
fix: include missing Python modules in wheel

### DIFF
--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -13,6 +13,7 @@ py.install_sources(
         '_version.py',
         '_version_scm.py',
         'suews_sim.py',
+        'validation.py',
         'code2file.json',
         'checker_rules_indiv.json',
         'checker_rules_joint.json',
@@ -20,6 +21,7 @@ py.install_sources(
         [
             'cmd/__init__.py',
             'cmd/SUEWS.py',
+            'cmd/json_output.py',
             'cmd/table_converter.py',
             'cmd/to_yaml.py',
             'cmd/validate_config.py',


### PR DESCRIPTION
## Summary

Add two missing Python modules to meson.build:

- `cmd/json_output.py`: Provides structured JSON output for CLI commands (required by `suews-validate`)
- `validation.py`: Conditional validation framework for physics parameter interdependencies

These modules were present in the source tree but not included in wheel installations, causing `ImportError` when `suews-validate` or conditional validation features were invoked.

## Test plan

- [x] Build succeeds with meson
- [x] Python files are present in filesystem
- [x] meson.build correctly lists all modules