### PR TITLE
chore: add .conductor/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -645,3 +645,6 @@ docs/source/api/_autosummary/
 # Exclude large test data but track structure
 test/fixtures/gh846/*.zip
 
+
+# Conductor worktree workspaces
+.conductor/


### PR DESCRIPTION
## Summary
- Add `.conductor/` directory to `.gitignore`
- This directory contains Conductor worktree workspaces and should not be tracked

## Test plan
- [x] Verify `.conductor/` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)