### PR TITLE
fix(rtd): use pip instead of uv --system for virtualenv

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,10 +23,9 @@ build:
       - git fetch --tags || true
       - git update-index --assume-unchanged docs/source/conf.py
     post_create_environment:
-      # Install uv for faster package management
-      - python -m pip install uv
       # Pre-install Sphinx with upper bound (Sphinx 9.0 breaks sphinx_click)
-      - uv pip install --system "sphinx>=4.0,<8.2"
+      # Use pip to install to RTD virtualenv (not system Python)
+      - python -m pip install "sphinx>=4.0,<8.2"
       # Detect version type and install (source preferred, wheel fallback)
       - |
         SUPY_VERSION=$(python get_ver_git.py 2>/dev/null || echo "unknown")
@@ -35,7 +34,7 @@ build:
 
         # Try building from source first (ensures docs match exact code)
         echo "Attempting to build from source..."
-        if uv pip install --system ".[dev]"; then
+        if python -m pip install ".[dev]"; then
           INSTALLED=1
         fi
 
@@ -47,11 +46,11 @@ build:
               # Normalize dev version: Test PyPI daily builds use .dev0
               PYPI_VERSION=$(echo "$SUPY_VERSION" | sed 's/\.dev[0-9]*/\.dev0/')
               echo "Trying Test PyPI wheel: $PYPI_VERSION"
-              uv pip install --system --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "supy[dev]==$PYPI_VERSION" || true
+              python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "supy[dev]==$PYPI_VERSION" || true
               ;;
             *)
               echo "Trying PyPI wheel: $SUPY_VERSION"
-              uv pip install --system "supy[dev]==$SUPY_VERSION" || true
+              python -m pip install "supy[dev]==$SUPY_VERSION" || true
               ;;
           esac
         fi


### PR DESCRIPTION
## Summary
- Fixes RTD documentation build failure where `ModuleNotFoundError: No module named 'supy'` was thrown during `make generate-rst`
- The issue was that `uv pip install --system` installs to the ASDF system Python, not the RTD virtualenv
- Switched to standard `python -m pip install` which correctly targets the RTD virtualenv

## Test plan
- RTD builds should complete successfully on the latest branch
- Documentation generation should no longer fail when generating RST files

🤖 Generated with [Claude Code](https://claude.com/claude-code)