### PR TITLE
fix(ci): update GitHub note callout syntax

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -106,7 +106,8 @@ jobs:
 
             **Preview:** https://suews.io/preview/pr-${prNumber}/
 
-            > **Note:** This preview is ephemeral. It will be lost when:
+            > [!NOTE]
+            > This preview is ephemeral. It will be lost when:
             > - Another PR with \`site/\` changes is pushed
             > - Changes are merged to master
             > - A manual workflow dispatch runs


### PR DESCRIPTION
Use proper GitHub callout syntax `> [!NOTE]` for styled note blocks instead of plain blockquote format in the pages-deploy workflow.

This ensures the note is rendered with GitHub's styled background and icon, improving visibility and consistency with modern GitHub documentation standards.