### PR TITLE
fix(build): add suews_util_datetime.f95 to meson source list

### DIFF
--- a/src/supy_driver/meson.build
+++ b/src/supy_driver/meson.build
@@ -103,6 +103,7 @@ src_f95_all = [
   'suews_ctrl_input.f95',
   'suews_util_time.f95',
   'suews_util_meteo.f95',
+  'suews_util_datetime.f95',
   'suews_phys_waterdist.f95',
   'suews_phys_narp.f95',
   'suews_phys_beers.f95',


### PR DESCRIPTION
## Summary

Fixes runtime symbol errors caused by missing datetime module in meson build. The module was present in the Makefile but omitted from meson.build, causing successful builds with undefined symbols at import time.

## Test plan

- [x] Clean build succeeds
- [x] `import supy` works without symbol errors  
- [x] All 9 smoke tests pass

Fixes #885