### PR TITLE
Re-enable AnOHM with rolling buffer forcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,12 @@
   - Same functionality, lighter dependencies
   - Consolidates all parallel processing to one library
 
+### 16 Nov 2025
+- [feature] Re-enabled AnOHM without requiring future forcing data
+  - Added rolling 24-hour forcing buffers to `OHM_STATE` and `SUEWS_cal_Qs` so StorageHeatMethod 3 now diagnoses coefficients from the most recently completed day
+  - Refactored `module_phys_anohm` to consume buffered shortwave, meteorology, and anthropogenic heat series directly (removed the legacy `MetForcingData_grid` dependency)
+  - Updated StorageHeatMethod documentation to clarify the trailing-day workflow and avoid confusion about forcing requirements
+
 ### 14 Nov 2025
 - [feature] Added `SUEWSSimulation.from_sample_data()` factory method and comprehensive OOP enhancements (#779)
   - New factory method for cleaner OOP workflow: `sim = SUEWSSimulation.from_sample_data()`

--- a/docs/source/inputs/tables/RunControl/csv-table/StorageHeatMethod.csv
+++ b/docs/source/inputs/tables/RunControl/csv-table/StorageHeatMethod.csv
@@ -1,5 +1,5 @@
 "Value","Comments"
 0,"Uses observed values of ΔQS supplied in meteorological forcing file."
 1,"ΔQS modelled using the objective hysteresis model (OHM) :cite:`G91` using parameters specified for each surface type."
-3,"ΔQS modelled using AnOHM :cite:`S17`. |NotRecmd|"
+3,"ΔQS modelled using AnOHM :cite:`S17` with coefficients diagnosed from the most recent completed day of forcing (no future data required). |NotRecmd|"
 4,"ΔQS modelled using the Element Surface Temperature Method (ESTM) :cite:`O05`. |NotRecmd|"

--- a/docs/source/parameterisations-and-sub-models.rst
+++ b/docs/source/parameterisations-and-sub-models.rst
@@ -99,6 +99,7 @@ Storage heat flux, ΔQ\ :sub:`S`
 
    -  **OHM** (Objective Hysteresis Model) :cite:`G91,GO99,GO02`. Storage heat heat flux is calculated using empirically-fitted relations with net all-wave radiation and the rate of change in net all-wave radiation.
    -  **AnOHM** (Analytical Objective Hysteresis Model) :cite:`S17`. OHM approach using analytically-derived coefficients. |NotRecmd|
+      -  Coefficients are now updated using the most recently completed 24 h of observed forcing, so coupling no longer requires access to future meteorological data.
    -  **ESTM** (Element Surface Temperature Method) :cite:`O05`. Heat transfer through urban facets (roof, wall, road, interior) is calculated from surface temperature measurements and knowledge of material properties. |NotRecmd|
    -  **EHC** (Explicit Heat Conduction). Calculates storage heat flux using explicit heat conduction through urban facets with separate roof/wall/ground temperature calculations. Provides detailed surface temperature outputs for each urban element.
    -  **DyOHM** (Dynamic Objective Hysteresis Model) (Liu et al., in prep.). Extends OHM by calculating coefficients dynamically based on material thermal properties (thermal conductivity) and meteorological conditions. Requires vertical wall layer configuration.

--- a/src/suews/src/suews_ctrl_type.f95
+++ b/src/suews/src/suews_ctrl_type.f95
@@ -51,6 +51,8 @@ MODULE module_ctrl_type
       solar_State, atm_state
 
    IMPLICIT NONE
+   INTEGER, PARAMETER, PUBLIC :: ANOHM_MAX_SAMPLES = 48
+   INTEGER, PARAMETER, PUBLIC :: ANOHM_MIN_VALID_SAMPLES = 6
    ! in the following, the type definitions starting with `SUEWS_` are used in the main program
 
    ! ********** SUEWS_parameters schema (basic) **********

--- a/src/suews/src/suews_type_surface.f95
+++ b/src/suews/src/suews_type_surface.f95
@@ -1,6 +1,8 @@
 module module_type_surface
+   use module_ctrl_const_allocate, only: nsurf
 
    implicit none
+   INTEGER, PARAMETER, PUBLIC :: ANOHM_MAX_SAMPLES = 48
 
    TYPE, PUBLIC :: LUMPS_PRM
       REAL(KIND(1D0)) :: raincover = 0.0D0 ! limit when surface totally covered with water for LUMPS [mm]
@@ -59,6 +61,28 @@ module module_type_surface
       REAL(KIND(1D0)) :: a1_water = 0.0D0! Dynamic OHM coefficients of water
       REAL(KIND(1D0)) :: a2_water = 0.0D0! Dynamic OHM coefficients of water
       REAL(KIND(1D0)) :: a3_water = 0.0D0! Dynamic OHM coefficients of water
+      INTEGER :: anohm_working_day = -999
+      INTEGER :: anohm_working_count = 0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_working_tHr = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_working_sd = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_working_ta = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_working_rh = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_working_pres = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_working_ws = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_working_ah = -999.0D0
+      INTEGER :: anohm_coeff_day = -999
+      INTEGER :: anohm_coeff_count = 0
+      LOGICAL :: anohm_coeff_ready = .FALSE.
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_coeff_tHr = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_coeff_sd = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_coeff_ta = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_coeff_rh = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_coeff_pres = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_coeff_ws = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(ANOHM_MAX_SAMPLES) :: anohm_coeff_ah = -999.0D0
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: anohm_a1_surf = 0.0D0
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: anohm_a2_surf = 0.0D0
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: anohm_a3_surf = 0.0D0
       ! flag for iteration safety - YES
       LOGICAL :: iter_safe = .TRUE.
    END TYPE OHM_STATE


### PR DESCRIPTION
## Summary

Re-enables AnOHM (Analytical Objective Hysteresis Model) without requiring access to future meteorological forcing data. Introduces a double-buffering system that accumulates hourly forcing observations in a working buffer and commits them to a coefficient buffer when the day completes.

## Changes

- Added rolling 24-hour forcing buffers to `OHM_STATE` structure for managing daily forcing series
- Refactored `module_phys_anohm` to consume pre-buffered forcing arrays instead of legacy `MetForcingData_grid` dependency
- Implemented day-rollover management with graceful OHM fallback during AnOHM spin-up
- Updated documentation to clarify the trailing-day workflow

## Notes

- See review feedback on critical index calculation and magic number thresholds
- Requires clarification on `timer%it` semantics for sub-hourly timestep support