### PR TITLE
ci: add docs build validation and preview for PRs

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -96,10 +96,12 @@ jobs:
 
             # Rewrite absolute paths for preview context
             # /brand/ → /preview/pr-N/brand/ so links work within preview
+            # https://docs.suews.io → /preview/pr-N/docs/ so docs links use preview
             echo "Rewriting absolute paths for preview..."
             find "_site/${PR_DIR}" -name "*.html" -type f -not -path "*/${PR_DIR}/docs/*" | while read -r f; do
               sed -i "s|href=\"/brand/|href=\"/${PR_DIR}/brand/|g" "$f"
               sed -i "s|href=\"/\"|href=\"/${PR_DIR}/\"|g" "$f"
+              sed -i "s|href=\"https://docs.suews.io[/]*\"|href=\"/${PR_DIR}/docs/\"|g" "$f"
             done
 
             # Inject preview banner into site pages


### PR DESCRIPTION
## Summary

Extends `pages-deploy.yml` to build Sphinx documentation and provide live preview for PRs, addressing #1010.

**What this PR does:**
- Validates Sphinx docs build on PRs (catches syntax errors, missing refs, broken toctrees before merge)
- Provides live preview at `suews.io/preview/pr-N/docs/` for human inspection
- Adds preview banner with links to production docs and the PR

**Changes to `pages-deploy.yml`:**
- Add `docs/**` and `src/supy/data_model/**` to trigger paths
- Add Python 3.13, uv, and `make docs` build steps
- Add `fetch-depth: 0` for `sphinx-last-updated-by-git` extension
- Copy built docs to `preview/pr-N/docs/` for PRs
- Inject preview banner into Sphinx pages (with theme-specific CSS adjustments)
- Update PR comment to include docs preview link

## Test plan

- [ ] Verify workflow triggers on docs changes
- [ ] Verify Sphinx build completes successfully
- [ ] Verify docs preview is accessible at expected URL
- [ ] Verify preview banner displays correctly with working links

Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)