### PR TITLE
Fix mobile stats bar overlap with badges

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -406,7 +406,10 @@
         }
 
         @media (max-width: 900px) {
-            .badges { justify-content: center; }
+            .badges {
+                justify-content: center;
+                padding-bottom: 160px; /* Space for stats bar */
+            }
         }
 
         .badges a {


### PR DESCRIPTION
## Summary
Fixes overlapping stats section on mobile devices by adding padding-bottom to badges container on screens ≤900px wide.

## Changes
- Added 160px bottom padding to `.badges` in mobile media query
- This provides clearance for the absolutely positioned stats bar

🤖 Generated with Claude Code