### PR TITLE
chore: update deprecated macos-13 runner to macos-15-intel

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -3,7 +3,7 @@ description: 'Build SUEWS wheels with cibuildwheel (standard or UMEP variant)'
 
 inputs:
   buildplat:
-    description: 'Build platform (e.g., ubuntu-latest, macos-13, windows-2025)'
+    description: 'Build platform (e.g., ubuntu-latest, macos-15-intel, windows-2025)'
     required: true
   buildplat_name:
     description: 'Platform name for wheel (e.g., manylinux, macosx, win)'
@@ -167,7 +167,7 @@ runs:
               inputs.test_tier == 'cfg' && '-m "smoke or cfg"' ||
               inputs.test_tier == 'standard' && '-m "not slow"' ||
               '--durations=10' }}
-        MACOSX_DEPLOYMENT_TARGET: ${{ inputs.buildplat == 'macos-13' && '13.0' || '15.0' }}
+        MACOSX_DEPLOYMENT_TARGET: '15.0'
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -271,7 +271,7 @@ jobs:
         id: set-matrix
         run: |
           # Platform matrix
-          FULL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-13", "macosx", "x86_64"], ["macos-latest", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
+          FULL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-15-intel", "macosx", "x86_64"], ["macos-latest", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
           PR_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-latest", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
           MINIMAL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"]]'
 

--- a/.github/workflows/cibuildwheel-debug.yml
+++ b/.github/workflows/cibuildwheel-debug.yml
@@ -36,7 +36,7 @@ on:
         type: choice
         options:
           - ubuntu-latest-x86_64    # Linux 64-bit
-          - macos-13-x86_64         # macOS Intel
+          - macos-15-intel-x86_64   # macOS Intel
           - macos-latest-arm64      # macOS Apple Silicon
           - windows-2025           # Windows 64-bit
       python_version:
@@ -66,7 +66,7 @@ jobs:
     name: Debug ${{ inputs.python_version || 'cp311' }}-${{ inputs.platform_arch || 'macos-latest-arm64' }}
     runs-on: ${{
       (inputs.platform_arch || 'macos-latest-arm64') == 'ubuntu-latest-x86_64' && 'ubuntu-latest' ||
-      (inputs.platform_arch || 'macos-latest-arm64') == 'macos-13-x86_64' && 'macos-13' ||
+      (inputs.platform_arch || 'macos-latest-arm64') == 'macos-15-intel-x86_64' && 'macos-15-intel' ||
       (inputs.platform_arch || 'macos-latest-arm64') == 'macos-latest-arm64' && 'macos-latest' ||
       (inputs.platform_arch || 'macos-latest-arm64') == 'windows-2025' && 'windows-2025' }}
 
@@ -75,13 +75,13 @@ jobs:
       # Extract platform and architecture from combined input
       PLATFORM: ${{
         (inputs.platform_arch || 'macos-latest-arm64') == 'ubuntu-latest-x86_64' && 'ubuntu-latest' ||
-        (inputs.platform_arch || 'macos-latest-arm64') == 'macos-13-x86_64' && 'macos-13' ||
+        (inputs.platform_arch || 'macos-latest-arm64') == 'macos-15-intel-x86_64' && 'macos-15-intel' ||
         (inputs.platform_arch || 'macos-latest-arm64') == 'macos-latest-arm64' && 'macos-latest' ||
         (inputs.platform_arch || 'macos-latest-arm64') == 'windows-2025' && 'windows-2025' }}
 
       ARCHITECTURE: ${{
         (inputs.platform_arch || 'macos-latest-arm64') == 'ubuntu-latest-x86_64' && 'x86_64' ||
-        (inputs.platform_arch || 'macos-latest-arm64') == 'macos-13-x86_64' && 'x86_64' ||
+        (inputs.platform_arch || 'macos-latest-arm64') == 'macos-15-intel-x86_64' && 'x86_64' ||
         (inputs.platform_arch || 'macos-latest-arm64') == 'macos-latest-arm64' && 'arm64' ||
         (inputs.platform_arch || 'macos-latest-arm64') == 'windows-2025' && 'AMD64' }}
 
@@ -95,7 +95,7 @@ jobs:
       CIBW_BUILD: ${{ inputs.python_version || 'cp311' }}-*
       CIBW_ARCHS: ${{
         (inputs.platform_arch || 'macos-latest-arm64') == 'ubuntu-latest-x86_64' && 'x86_64' ||
-        (inputs.platform_arch || 'macos-latest-arm64') == 'macos-13-x86_64' && 'x86_64' ||
+        (inputs.platform_arch || 'macos-latest-arm64') == 'macos-15-intel-x86_64' && 'x86_64' ||
         (inputs.platform_arch || 'macos-latest-arm64') == 'macos-latest-arm64' && 'arm64' ||
         (inputs.platform_arch || 'macos-latest-arm64') == 'windows-2025' && 'AMD64' }}
       CIBW_BUILD_VERBOSITY: 3  # Maximum verbosity for debugging
@@ -168,7 +168,7 @@ jobs:
       CIBW_TEST_COMMAND_WINDOWS: "python -m pytest {project}\\test"
 
       # macOS deployment target
-      MACOSX_DEPLOYMENT_TARGET: ${{ contains(inputs.platform_arch || 'macos-latest-arm64', 'macos-13') && '13.0' || '15.0' }}
+      MACOSX_DEPLOYMENT_TARGET: '15.0'
 
       # Debug mode for SSH sessions
       DEBUG_MODE: ${{ inputs.debug_mode || 'after-failure' }}


### PR DESCRIPTION
## Summary

Replace deprecated `macos-13` runner with `macos-15-intel` to maintain Intel x86_64 build support. Updates deployment target to 15.0 across build workflows and composite actions.

## Changes

- Build workflows: `build-publish_to_pypi.yml`, `cibuildwheel-debug.yml`
- Composite action: `build-suews/action.yml`
- Deployment target: Simplified to `15.0` (was conditional on runner type)

## Test Plan

- Verify macOS Intel wheel builds pass on next workflow run
- Confirm ARM and Linux builds remain unchanged