### PR TITLE
Fix GH#1031: Separate input and output documentation namespaces

### DIFF
--- a/docs/generate_datamodel_rst.py
+++ b/docs/generate_datamodel_rst.py
@@ -357,8 +357,8 @@ class RSTGenerator:
         # Add index entries
         lines.extend(self._add_field_index_entries(field_name, model_name))
 
-        # Use yaml:option directive for YAML configuration options
-        lines.append(f".. yaml:option:: {field_name}")
+        # Use input:option directive for YAML configuration options
+        lines.append(f".. input:option:: {field_name}")
         lines.append("")
 
         # Add description
@@ -1110,7 +1110,7 @@ class RSTGenerator:
             field_name = field["name"]
             if field_name == "ref":
                 continue
-            lines.append(f"{dropdown_indent}- :yaml:option:`{field_name}`")
+            lines.append(f"{dropdown_indent}- :input:option:`{field_name}`")
         lines.append("")
 
         return lines
@@ -1233,7 +1233,7 @@ class RSTGenerator:
             field_name = field["name"]
             if field_name == "ref":
                 continue
-            lines.append(f"{dropdown_indent}- :yaml:option:`{field_name}`")
+            lines.append(f"{dropdown_indent}- :input:option:`{field_name}`")
         lines.append("")
 
         return lines
@@ -1328,13 +1328,13 @@ class RSTGenerator:
                 field_name = (
                     field.get("name", field) if isinstance(field, dict) else field
                 )
-                lines.append(f"{indent}   * :yaml:option:`{field_name}`")
+                lines.append(f"{indent}   * :input:option:`{field_name}`")
         else:
             for field in filtered_fields:
                 field_name = (
                     field.get("name", field) if isinstance(field, dict) else field
                 )
-                lines.append(f"{indent}* :yaml:option:`{field_name}`")
+                lines.append(f"{indent}* :input:option:`{field_name}`")
 
         return lines
 
@@ -1381,13 +1381,13 @@ class RSTGenerator:
                 field_name = field["name"]
                 if field_name == "ref":
                     continue
-                lines.append(f"{indent}         * :yaml:option:`{field_name}`")
+                lines.append(f"{indent}         * :input:option:`{field_name}`")
         else:
             for field in fields:
                 field_name = field["name"]
                 if field_name == "ref":
                     continue
-                lines.append(f"{indent}      * :yaml:option:`{field_name}`")
+                lines.append(f"{indent}      * :input:option:`{field_name}`")
 
         lines.append("")
         return lines
@@ -1620,13 +1620,13 @@ class RSTGenerator:
                                 for field in tab_content:
                                     if field["name"] != "ref":
                                         lines.append(
-                                            f"{indent}         * :yaml:option:`{field['name']}`"
+                                            f"{indent}         * :input:option:`{field['name']}`"
                                         )
                             else:
                                 for field in tab_content:
                                     if field["name"] != "ref":
                                         lines.append(
-                                            f"{indent}      * :yaml:option:`{field['name']}`"
+                                            f"{indent}      * :input:option:`{field['name']}`"
                                         )
                             lines.append("")
                         else:
@@ -1686,13 +1686,13 @@ class RSTGenerator:
                                             for field in child_fields:
                                                 if field.get("name") != "ref":
                                                     lines.append(
-                                                        f"{indent}{next_level_indent}   - :yaml:option:`{field['name']}`"
+                                                        f"{indent}{next_level_indent}   - :input:option:`{field['name']}`"
                                                     )
                                         else:
                                             for field in child_fields:
                                                 if field.get("name") != "ref":
                                                     lines.append(
-                                                        f"{indent}{next_level_indent}* :yaml:option:`{field['name']}`"
+                                                        f"{indent}{next_level_indent}* :input:option:`{field['name']}`"
                                                     )
                                         lines.append("")
 
@@ -1735,14 +1735,14 @@ class RSTGenerator:
                                             for field in nested_fields:
                                                 if field.get("name") != "ref":
                                                     lines.append(
-                                                        f"{indent}{next_level_indent}     - :yaml:option:`{field['name']}`"
+                                                        f"{indent}{next_level_indent}     - :input:option:`{field['name']}`"
                                                     )
                                             lines.append("")
                                         elif nested_field_count > 0:
                                             for field in nested_fields:
                                                 if field.get("name") != "ref":
                                                     lines.append(
-                                                        f"{indent}{next_level_indent}  - :yaml:option:`{field['name']}`"
+                                                        f"{indent}{next_level_indent}  - :input:option:`{field['name']}`"
                                                     )
                                             lines.append("")
 

--- a/docs/generate_output_variable_rst.py
+++ b/docs/generate_output_variable_rst.py
@@ -152,8 +152,9 @@ class OutputVariableRSTGenerator:
             "",
         ])
 
-        # Use yaml:option directive for consistency with input docs
-        lines.append(f".. yaml:option:: {var.name}")
+        # Use output:variable directive to avoid namespace collisions with input params
+        # See GitHub issue #1031 for context
+        lines.append(f".. output:variable:: {var.name}")
         lines.append("")
 
         # Add description

--- a/docs/source/_ext/output_domain.py
+++ b/docs/source/_ext/output_domain.py
@@ -1,0 +1,153 @@
+"""
+Sphinx extension for SUEWS output variables.
+
+This creates a separate namespace for output variables,
+preventing collisions with YAML configuration options in the documentation.
+
+See GitHub issue #1031 for context.
+"""
+
+from sphinx import addnodes
+from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain, Index, ObjType
+from sphinx.roles import XRefRole
+from sphinx.util.nodes import make_refnode
+from typing import Any
+
+
+class OutputVariable(ObjectDescription):
+    """Directive for SUEWS output variables."""
+
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+
+    def handle_signature(self, sig, signode):
+        """Handle the signature (variable name)."""
+        signode += addnodes.desc_name(sig, sig)
+        return sig
+
+    def add_target_and_index(self, name, sig, signode):
+        """Add target and index entries."""
+        targetname = f"output-variable-{sig}"
+        if targetname not in self.state.document.ids:
+            signode["ids"].append(targetname)
+            self.state.document.note_explicit_target(signode)
+
+            # Add to domain data
+            domain = self.env.get_domain("output")
+            domain.add_variable(sig, self.env.docname)
+
+            # Add index entry
+            indextext = f"{sig} (output variable)"
+            inode = addnodes.index(
+                entries=[("single", indextext, targetname, "", None)]
+            )
+            return [inode, signode]
+        return []
+
+
+class OutputVariableIndex(Index):
+    """Index for output variables."""
+
+    name = "variable"
+    localname = "Output Variable Index"
+    shortname = "Output variables"
+
+    def generate(self, docnames=None):
+        """Generate the index."""
+        content = {}
+        variables = self.domain.data["variables"]
+
+        for name, docname in variables.items():
+            letter = name[0].upper()
+            entries = content.setdefault(letter, [])
+            entries.append((
+                name,  # name
+                0,  # subtype
+                docname,  # docname
+                f"output-variable-{name}",  # target
+                "",  # extra
+                "",  # qualifier
+                "",  # description
+            ))
+
+        # Sort entries
+        for letter in content:
+            content[letter].sort(key=lambda x: x[0].lower())
+
+        # Return content and collapse flag (True = collapse same sub-entries)
+        return sorted(content.items()), True
+
+
+class OutputDomain(Domain):
+    """Domain for SUEWS output variables."""
+
+    name = "output"
+    label = "Output Variables"
+
+    object_types = {
+        "variable": ObjType("variable", "variable"),
+    }
+
+    directives = {
+        "variable": OutputVariable,
+    }
+
+    roles = {
+        "variable": XRefRole(),
+    }
+
+    indices = [OutputVariableIndex]
+
+    initial_data: dict[str, Any] = {
+        "variables": {},  # name -> docname
+    }
+
+    def add_variable(self, name, docname):
+        """Add a variable to the domain."""
+        self.data["variables"][name] = docname
+
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+        """Resolve cross-references."""
+        if typ == "variable":
+            docname = self.data["variables"].get(target)
+            if docname:
+                targetid = f"output-variable-{target}"
+                return make_refnode(
+                    builder, fromdocname, docname, targetid, contnode, target
+                )
+        return None
+
+    def resolve_any_xref(self, env, fromdocname, builder, target, node, contnode):
+        """Resolve any cross-references.
+
+        Returns empty list to prevent conflicts with other directives.
+        Output variables should be referenced explicitly using :output:variable:`name`
+        rather than bare backticks.
+        """
+        return []
+
+    def clear_doc(self, docname):
+        """Clear all variables from a document."""
+        for name, doc in list(self.data["variables"].items()):
+            if doc == docname:
+                del self.data["variables"][name]
+
+    def merge_domaindata(self, docnames, otherdata):
+        """Merge data from parallel builds."""
+        for name, docname in otherdata["variables"].items():
+            if docname in docnames:
+                self.data["variables"][name] = docname
+
+
+def setup(app):
+    """Setup the extension."""
+    app.add_domain(OutputDomain)
+
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -277,7 +277,8 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
     "sphinx_comments",
-    "yaml_domain",  # Custom domain for YAML configuration options
+    "input_domain",  # Custom domain for input configuration options (see GH#1031)
+    "output_domain",  # Custom domain for output variables (see GH#1031)
     "recommonmark",
     "nbsphinx",
     "sphinx_design",  # For collapsible sections, tabs, and dropdowns in YAML config reference

--- a/docs/source/inputs/forcing-data.rst
+++ b/docs/source/inputs/forcing-data.rst
@@ -28,7 +28,7 @@ SUEWS requires continuous meteorological data representative of the neighbourhoo
           properties:
             z: 50.0  # Forcing height in metres
 
-   See :yaml:option:`z` for full documentation, and :ref:`rsl_mod` in :doc:`/parameterisations-and-sub-models` for details on profile calculations.
+   See :input:option:`z` for full documentation, and :ref:`rsl_mod` in :doc:`/parameterisations-and-sub-models` for details on profile calculations.
 
 Data Requirements
 -----------------


### PR DESCRIPTION
## Summary
Fixes #1031

Resolves namespace collision between input parameters and output variables in documentation. Replaces unified `yaml:option` domain with explicit `input:option` and `output:variable` domains to enable proper cross-reference separation.

## Changes
- Create dedicated `input_domain.py` for input configuration options  
- Create dedicated `output_domain.py` for output variables
- Update all generators and references to use domain-specific directives
- Build tested: docs compile successfully with both indices generated

## Testing
- Docs build passes (412 warnings - all pre-existing)
- Smoke tests pass (9/9)
- Manual verification: `emis` input parameter and output variable now have separate cross-reference targets