### PR TITLE
Fix GH-239: Initialise NumCapita to prevent NaN in CO2 flux

### DIFF
--- a/src/suews/src/suews_phys_anthro.f95
+++ b/src/suews/src/suews_phys_anthro.f95
@@ -121,6 +121,7 @@ CONTAINS
       QF_traff = 0
       QF_SAHP_heating = 0
       QF_SAHP_cooling = 0
+      NumCapita = 0.0D0
 
       ! Transfer HDD/CDD values to local explict variables
       HDD_daily = HDD_id(7)


### PR DESCRIPTION
When population density conditions aren't met (PopDensNighttime < 0), the NumCapita array remained uninitialised, causing garbage values to propagate through DP_x_RhoPop and QF_SAHP calculations, producing NaN outputs.

This fix initialises NumCapita to zero in the declarations block, ensuring safe fallback behaviour when population density data is missing or invalid.

Affects emissions methods 2, 5, 12, 15, 22, 25, 32, 35, 42, 45 (SAHP_2 approach).

Tests: smoke tests passed