### PR TITLE
Add warning when surface fractions are auto-normalised

### DIFF
--- a/src/supy/_load.py
+++ b/src/supy/_load.py
@@ -18,7 +18,7 @@ from . import supy_driver as sd
 
 
 from ._env import logger_supy, trv_supy_module
-from ._misc import path_insensitive
+from ._misc import path_insensitive, normalise_sfr_surf
 
 # choose different second representation to accommodate different pandas versions
 # pandas version <1.5
@@ -2149,28 +2149,7 @@ def load_InitialCond_grid_df(path_runcontrol, force_reload=True):
     # print('localclimatemethod is not in df_init')
 
     # normalise surface fractions to prevent non-1 sums
-    df_sfr_surf = df_init.sfr_surf.copy()
-    sfr_sums = df_sfr_surf.sum(axis=1)
-
-    # warn if any grid has surface fractions significantly different from 1.0
-    tolerance = 0.0001
-    deviations = (sfr_sums - 1.0).abs()
-    problematic_grids = deviations[deviations > tolerance]
-
-    if not problematic_grids.empty:
-        grid_details = ", ".join(
-            f"grid {idx}: {sfr_sums[idx]:.4f}"
-            for idx in problematic_grids.index
-        )
-        logger_supy.warning(
-            f"Surface fractions do not sum to 1.0 (tolerance {tolerance}). "
-            f"Values will be normalised automatically. "
-            f"Affected grids: {grid_details}. "
-            f"For strict validation, use the YAML validator workflow."
-        )
-
-    df_sfr_surf = df_sfr_surf.div(sfr_sums, axis=0)
-    df_init.sfr_surf = df_sfr_surf
+    df_init = normalise_sfr_surf(df_init)
     return df_init
 
 

--- a/src/supy/_misc.py
+++ b/src/supy/_misc.py
@@ -1,7 +1,9 @@
 import urllib
 import os
 
-# from pathlib import Path
+import pandas as pd
+
+from ._env import logger_supy
 
 
 ##############################################################################
@@ -93,3 +95,50 @@ def url_is_alive(url):
         return True
     except urllib.request.HTTPError:
         return False
+
+
+##############################################################################
+# normalise surface fractions in DataFrame
+def normalise_sfr_surf(df: pd.DataFrame, tolerance: float = 0.0001) -> pd.DataFrame:
+    """Normalise surface fractions to sum to 1.0 with warning.
+
+    Checks if surface fractions in df.sfr_surf sum to 1.0 within tolerance.
+    If not, logs a warning and normalises the fractions.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing sfr_surf columns (MultiIndex with 'sfr_surf' at level 0)
+    tolerance : float, optional
+        Tolerance for deviation from 1.0 (default: 0.0001)
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with normalised surface fractions
+    """
+    if "sfr_surf" not in df.columns.get_level_values(0):
+        return df
+
+    df_sfr_surf = df.sfr_surf.copy()
+    sfr_sums = df_sfr_surf.sum(axis=1)
+
+    # warn if any grid has surface fractions significantly different from 1.0
+    deviations = (sfr_sums - 1.0).abs()
+    problematic_grids = deviations[deviations > tolerance]
+
+    if not problematic_grids.empty:
+        grid_details = ", ".join(
+            f"grid {idx}: {sfr_sums[idx]:.4f}" for idx in problematic_grids.index
+        )
+        logger_supy.warning(
+            f"Surface fractions do not sum to 1.0 (tolerance {tolerance}). "
+            f"Values will be normalised automatically. "
+            f"Affected grids: {grid_details}. "
+            f"For strict validation, use the YAML validator workflow."
+        )
+
+    df_sfr_surf = df_sfr_surf.div(sfr_sums, axis=0)
+    df["sfr_surf"] = df_sfr_surf
+
+    return df

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -56,6 +56,8 @@ except ImportError:
         )
         logger_supy.addHandler(handler)
         logger_supy.setLevel(logging.INFO)
+
+from ..._misc import normalise_sfr_surf
 from ..validation.pipeline.yaml_annotator import YAMLAnnotator
 
 _validation_available = False
@@ -2591,29 +2593,7 @@ class SUEWSConfig(BaseModel):
         df.index.name = "grid"
 
         # normalise surface fractions to prevent non-1 sums
-        if "sfr_surf" in df.columns.get_level_values(0):
-            df_sfr_surf = df.sfr_surf.copy()
-            sfr_sums = df_sfr_surf.sum(axis=1)
-
-            # warn if any grid has surface fractions significantly different from 1.0
-            tolerance = 0.0001
-            deviations = (sfr_sums - 1.0).abs()
-            problematic_grids = deviations[deviations > tolerance]
-
-            if not problematic_grids.empty:
-                grid_details = ", ".join(
-                    f"grid {idx}: {sfr_sums[idx]:.4f}"
-                    for idx in problematic_grids.index
-                )
-                logger_supy.warning(
-                    f"Surface fractions do not sum to 1.0 (tolerance {tolerance}). "
-                    f"Values will be normalised automatically. "
-                    f"Affected grids: {grid_details}. "
-                    f"For strict validation, use the YAML validator workflow."
-                )
-
-            df_sfr_surf = df_sfr_surf.div(sfr_sums, axis=0)
-            df["sfr_surf"] = df_sfr_surf
+        df = normalise_sfr_surf(df)
 
         return df
 


### PR DESCRIPTION
## Summary

- Add warning in legacy SuPy loading path when surface fractions don't sum to 1.0 (tolerance: 0.0001)
- Shows affected grids and their actual sums
- Points users to YAML validator workflow for strict validation

Fixes #1064

## Test plan

- [x] `make test-smoke` passes
- [x] Manually verify warning appears when loading data with fractions summing to e.g. 1.04

🤖 Generated with [Claude Code](https://claude.ai/code)