### PR TITLE
Simplify validation module: consolidate and remove duplicate code

### DIFF
--- a/src/supy/data_model/validation/__init__.py
+++ b/src/supy/data_model/validation/__init__.py
@@ -9,6 +9,10 @@ Structure:
 - pipeline/: Three-phase validation pipeline (Phase A, B, C and orchestrator)
 """
 
+# Re-export package-level utilities for use by submodules
+# This avoids deep relative imports like '...._env' in pipeline modules
+from ..._env import logger_supy
+
 # Core validation exports
 from .core.controller import (
     ValidationController,

--- a/src/supy/data_model/validation/core/yaml_helpers.py
+++ b/src/supy/data_model/validation/core/yaml_helpers.py
@@ -89,7 +89,6 @@ except ImportError:
             return False
 
     trv_supy_module = MockTraversable()
-import os
 
 
 def get_value_safe(param_dict, param_key, default=None):


### PR DESCRIPTION
Consolidates duplicate validation utilities and removes untested standalone mode fallbacks.

Changes:
- Re-export logger_supy at package level to simplify relative imports
- Move DLSCheck, get_value_safe, HAS_TIMEZONE_FINDER to yaml_helpers for single source of truth
- Remove unused standalone fallback code paths (~170 lines) that were never tested or exercised
- Clean up unused imports (BaseModel, pytz) from phase_b

This improves maintainability by eliminating code duplication and dead code paths.