### PR TITLE
docs: clarify pip-only and UMEP installation guide

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -136,38 +136,55 @@ To deactivate when finished::
 Alternative: pip-only Approach
 ******************************
 
-If you cannot use ``uv`` (e.g., in managed Python environments like OSGeo4W/QGIS, or corporate environments), use this two-step pip approach:
-
-1. **Check latest version** at https://test.pypi.org/project/supy/
-
-2. **Download and install** (two steps)::
-
-    # Download supy only (no dependencies) from test.pypi.org
-    # Replace VERSION with the latest from step 1 (e.g., 2025.11.25.dev0)
-    pip download --no-deps -i https://test.pypi.org/simple/ supy==VERSION
-
-    # Install from the downloaded wheel - pip will resolve dependencies from regular PyPI
-    pip install --find-links=. supy==VERSION
-
-3. **Verify installation**::
-
-    python -c "import supy; print(f'SUEWS version: {supy.__version__}')"
+If you cannot use ``uv`` (e.g., in managed Python environments like OSGeo4W/QGIS, or corporate environments), use this two-step approach.
 
 .. note::
 
-   **Why the two-step approach?**
+   **Why two steps?** Using ``pip install --extra-index-url https://test.pypi.org/simple/`` can cause dependency issues where pip pulls source tarballs from test.pypi.org instead of pre-built wheels from PyPI. The two-step approach ensures only ``supy`` comes from test.pypi.org while all dependencies come from regular PyPI.
 
-   Using ``pip install --extra-index-url https://test.pypi.org/simple/`` can cause dependency resolution issues where pip pulls source tarballs from test.pypi.org instead of pre-built wheels from PyPI. The two-step approach ensures only ``supy`` comes from test.pypi.org while all dependencies are fetched from regular PyPI.
+**Steps:**
+
+1. **Check available versions** at https://test.pypi.org/project/supy/#history
+
+   .. warning::
+
+      TestPyPI regularly removes old packages to free up space, so version numbers in examples below may no longer exist. Always use a version currently listed on the page above.
+
+2. **Download the wheel from test.pypi.org** (supy only, no dependencies)::
+
+    # Replace 2025.11.25.dev0 with an available version from step 1
+    pip download --no-deps -i https://test.pypi.org/simple/ supy==2025.11.25.dev0
+
+3. **Install from the downloaded wheel** (dependencies from regular PyPI)::
+
+    pip install --find-links=. supy==2025.11.25.dev0
+
+4. **Verify installation**::
+
+    python -c "import supy; print(f'SUEWS version: {supy.__version__}')"
 
 
 OSGeo4W / UMEP Users
 ********************
 
-If you are using SUEWS via `UMEP <https://umep-docs.readthedocs.io/>`_ in QGIS, use the **pip-only approach** above from the **OSGeo4W Shell** (not PowerShell or CMD).
+If you use SUEWS via `UMEP <https://umep-docs.readthedocs.io/>`_ in QGIS, use the **pip-only approach** above with these UMEP-specific requirements:
 
-.. warning::
+.. important::
 
-   ``uv`` does not work with OSGeo4W because OSGeo4W's Python requires environment variables (``PYTHONHOME``, ``PYTHONPATH``, etc.) that are only set in the OSGeo4W Shell.
+   **Use dev1 versions only.** UMEP users should install versions ending in ``dev1`` (e.g., ``2025.11.25.dev1``), which include UMEP-specific compatibility fixes. Do not use ``dev0`` versions.
+
+.. important::
+
+   **Use the OSGeo4W Shell** (not PowerShell or CMD). OSGeo4W's Python requires environment variables that are only set in this shell. Find it via Start menu → "OSGeo4W Shell".
+
+**UMEP-specific notes:**
+
+- No virtual environment is needed — OSGeo4W manages QGIS's Python environment
+- The development version will replace any existing ``supy`` installation in QGIS
+- After installation, **restart QGIS** before using the new version
+- To verify, open the QGIS Python Console and run::
+
+    import supy; print(supy.__version__)
 
 
 Development build


### PR DESCRIPTION
## Summary
- Clarify TestPyPI installation instructions for pip-only and UMEP users
- Add warning that TestPyPI regularly removes old packages (version examples may not exist)
- Specify that UMEP users should use **dev1 versions** (include UMEP-specific compatibility fixes)
- Streamline UMEP section to reference pip-only approach instead of duplicating steps

Related to #1035 - addresses installation confusion mentioned in [this comment](https://github.com/UMEP-dev/SUEWS/issues/1035#issuecomment-2905814888).

## Test plan
- [ ] Review rendered RST in docs build
- [ ] Verify links to TestPyPI version history work

🤖 Generated with [Claude Code](https://claude.com/claude-code)