### PR TITLE
Fix: reset error flag before kernel call to prevent stale errors (GH#1103)

### DIFF
--- a/src/supy/_run.py
+++ b/src/supy/_run.py
@@ -284,7 +284,9 @@ def suews_cal_tstep_multi(dict_state_start, df_forcing_block, debug_mode=False):
     # No kernel lock needed - state-based error handling is thread-safe
     # Each call has its own block_mod_state for error capture
     try:
-        # Reset module-level warning state before kernel call
+        # Reset module-level error and warning state before kernel call
+        # GH#1103: Must reset error flag to prevent stale errors from previous runs
+        _reset_supy_error()
         _reset_supy_warnings()
 
         # Create and initialize block_mod_state for state-based error handling


### PR DESCRIPTION
## Summary
Fixes issue where SUEWS runs would fail with stale errors from previous failed runs. When a run failed with Error 32, the module-level error flag remained set, causing all subsequent runs to fail even with valid parameters.

## Changes
- Call `_reset_supy_error()` at the start of each kernel call in `suews_cal_tstep_multi()`
- Matches existing `_reset_supy_warnings()` pattern for consistency
- Ensures only errors from the current run are reported

## Verification
- Smoke tests pass (3/3)
- Specific test: sequential runs with error then valid parameters now work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1103