### PR TITLE
Fix conductor archive script to force reset to origin/master

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -2,6 +2,6 @@
   "scripts": {
     "setup": "git fetch origin && git merge origin/master && for remote in $(git remote | grep -v '^origin$'); do git remote remove \"$remote\"; done && uv venv && source .venv/bin/activate",
     "run": "source .venv/bin/activate && npx -y browser-sync start --server site --port 3000 --files 'site/**/*' & cd docs && make livehtml",
-    "archive": "cd $CONDUCTOR_ROOT_PATH && git fetch origin && git pull origin master"
+    "archive": "cd $CONDUCTOR_ROOT_PATH && git fetch origin --prune && git reset --hard origin/master"
   }
 }


### PR DESCRIPTION
## Summary
- Changes archive script from `git pull` to `git reset --hard origin/master`
- Ensures workspace is completely reset to match remote, discarding local changes
- Adds `--prune` flag to remove deleted remote branches

## Test plan
- [x] Verify script syntax is valid JSON
- [ ] Test archive script manually in a Conductor workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)