### PR TITLE
Fix conductor setup script to hard reset instead of merge

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "git fetch origin && git merge origin/master && for remote in $(git remote | grep -v '^origin$'); do git remote remove \"$remote\"; done && uv venv && source .venv/bin/activate",
+    "setup": "git fetch origin --prune && git reset --hard origin/master && for remote in $(git remote | grep -v '^origin$'); do git remote remove \"$remote\"; done && uv venv && source .venv/bin/activate",
     "run": "source .venv/bin/activate && npx -y browser-sync start --server site --port 3000 --files 'site/**/*' & cd docs && make livehtml",
     "archive": "cd $CONDUCTOR_ROOT_PATH && git fetch origin --prune && git reset --hard origin/master"
   }


### PR DESCRIPTION
## Summary
- Use `git reset --hard origin/master` instead of `git merge origin/master` in setup script
- Ensures workspace starts from a clean state matching remote exactly
- Avoids interactive merge prompts when there are divergent commits

## Test plan
- [ ] Run Conductor setup on a workspace with local changes to verify hard reset behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)