### PR TITLE
fix(ci): prevent format-master from running on forks

### DIFF
--- a/.github/workflows/format-master.yml
+++ b/.github/workflows/format-master.yml
@@ -16,6 +16,10 @@ permissions:
 
 jobs:
   format:
+    # Only run on upstream repo, not on forks
+    # Forks inherit this workflow but should not auto-format and push commits
+    # as this prevents PR build validation checks from running on the new commits
+    if: github.repository == 'UMEP-dev/SUEWS'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Prevent the format-master workflow from running on contributor forks
- This fixes the issue where fork pushes created format commits that blocked PR merges

## Problem
When contributors push to their fork's master branch, the inherited `format-master.yml` workflow runs and creates a format commit. This commit is included in the PR but doesn't trigger the upstream's build workflow, causing the "PR build validation" check to be missing on the latest commit and blocking auto-merge.

## Solution
Add `if: github.repository == 'UMEP-dev/SUEWS'` condition to ensure the workflow only runs on the upstream repository.

## Related
- Unblocks GH#1105

🤖 Generated with [Claude Code](https://claude.ai/code)