### PR TITLE
fix(ci): skip pages deployment for fork PRs

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -11,6 +11,7 @@ name: GitHub Pages Deploy
 # No wget required; repo content is the single source of truth.
 #
 # NOTE: Schema hosting removed - validation handled by Pydantic at runtime
+# NOTE: Fork PRs cannot deploy (no OIDC tokens) but still build docs for validation
 
 on:
   push:
@@ -131,15 +132,70 @@ jobs:
           touch _site/.nojekyll
           echo "Site ready: $(find _site -type f | wc -l) files"
 
+      # Fork PRs cannot deploy - they lack OIDC tokens required by deploy-pages
+      # Detect fork: compare PR head repo with base repo
+      - name: Check if fork PR
+        id: fork-check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+            BASE_REPO="${{ github.repository }}"
+            if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+              echo "is_fork=true" >> $GITHUB_OUTPUT
+              echo "::notice::Fork PR detected ($HEAD_REPO) - skipping deployment"
+            else
+              echo "is_fork=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/configure-pages@v5
+        if: steps.fork-check.outputs.is_fork != 'true'
+
       - uses: actions/upload-pages-artifact@v3
+        if: steps.fork-check.outputs.is_fork != 'true'
         with:
           path: _site
+
       - uses: actions/deploy-pages@v4
+        if: steps.fork-check.outputs.is_fork != 'true'
         id: deployment
 
+      - name: Comment fork PR status
+        if: github.event_name == 'pull_request' && steps.fork-check.outputs.is_fork == 'true'
+        continue-on-error: true  # Token may lack permission for fork PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const body = `## Docs Build Validated ✓
+
+            Documentation built successfully. Preview deployment is not available for fork PRs (GitHub security restriction).
+
+            A maintainer can test the preview locally with \`make docs\`.`;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const botComment = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Docs Build Validated')
+            );
+
+            if (!botComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+            }
+
       - name: Comment preview URL
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.fork-check.outputs.is_fork != 'true'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

- Fix CI failure on fork PRs (like #1105) caused by missing OIDC tokens
- Fork PRs now skip deployment but still validate docs build
- Same-repo PRs continue to get full preview deployment

## Root Cause

GitHub doesn't provide OIDC tokens to `pull_request` events from forks (security restriction). The `actions/deploy-pages@v4` action requires OIDC authentication, causing:
```
Error: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Ensure GITHUB_TOKEN has permission "id-token: write"
```

## Changes

- Add fork detection step comparing head/base repository names
- Skip `configure-pages`, `upload-pages-artifact`, `deploy-pages` for fork PRs
- Add informative comment for fork contributors (with `continue-on-error`)
- Update workflow header documentation

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger CI on #1105 - should now pass with "Fork PR detected" notice
- [ ] Verify same-repo PRs still get preview deployment

🤖 Generated with [Claude Code](https://claude.ai/code)