### PR TITLE
docs(claude): add CI rules for fork PR handling

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -17,8 +17,10 @@ This directory contains all Claude Code-specific documentation, plans, and confi
 │   │   └── conventions.md          # When editing docs/**/*
 │   ├── tests/
 │   │   └── patterns.md             # When editing test*/**/*.py
-│   └── changelog/
-│       └── format.md               # When editing CHANGELOG.md
+│   ├── changelog/
+│   │   └── format.md               # When editing CHANGELOG.md
+│   └── ci/
+│       └── conventions.md          # When editing .github/workflows/**/*
 │
 ├── skills/                # Action-oriented workflows (invoked via /skill-name)
 │   ├── audit-pr/          # PR review orchestrator
@@ -106,6 +108,7 @@ audit-pr ────────────┬── lint-code (style review)
 - **"Fortran conventions"** -> `.claude/rules/fortran/`
 - **"Python conventions"** -> `.claude/rules/python/`
 - **"Test patterns"** -> `.claude/rules/tests/`
+- **"CI/GitHub Actions"** -> `.claude/rules/ci/`
 
 ## Git Policy
 

--- a/.claude/rules/00-project-essentials.md
+++ b/.claude/rules/00-project-essentials.md
@@ -62,3 +62,4 @@ For full setup options, use `/setup-dev` command.
 | `src/supy/` | Python wrapper (see `rules/python/`) |
 | `docs/` | Documentation (see `rules/docs/`) |
 | `test/` | Tests (see `rules/tests/`) |
+| `.github/workflows/` | CI/Actions (see `rules/ci/`) |

--- a/.claude/rules/ci/conventions.md
+++ b/.claude/rules/ci/conventions.md
@@ -1,0 +1,113 @@
+---
+paths:
+  - .github/workflows/**/*.yml
+  - .github/workflows/**/*.yaml
+---
+
+# CI/GitHub Actions Conventions
+
+Patterns and guidelines for GitHub Actions workflows in this repository.
+
+---
+
+## Fork PR Security
+
+GitHub's security model prevents forks from obtaining OIDC tokens for `pull_request` events. This affects deployment actions like `actions/deploy-pages@v4`.
+
+**Fork Detection Pattern:**
+
+```yaml
+- name: Check if PR is from fork
+  id: fork-check
+  if: github.event_name == 'pull_request'
+  run: |
+    if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+      echo "is_fork=true" >> $GITHUB_OUTPUT
+      echo "::notice::PR from fork detected - deployment will be skipped"
+    else
+      echo "is_fork=false" >> $GITHUB_OUTPUT
+    fi
+```
+
+**Conditional Step Execution:**
+
+```yaml
+- name: Deploy to GitHub Pages
+  if: steps.fork-check.outputs.is_fork != 'true'
+  uses: actions/deploy-pages@v4
+```
+
+---
+
+## Workflow Re-run Behaviour
+
+Re-running a GitHub Actions workflow uses the **same workflow file version** from the original run. To apply updated workflow logic:
+
+- Rebase the PR branch onto the target branch
+- Push a new commit
+- Close and reopen the PR
+
+**Avoid**: Assuming re-runs pick up latest workflow changes from master.
+
+---
+
+## Fork PR Feedback
+
+When deployment is skipped for fork PRs, provide clear feedback via PR comments:
+
+```yaml
+- name: Comment on fork PR
+  if: steps.fork-check.outputs.is_fork == 'true'
+  uses: actions/github-script@v7
+  continue-on-error: true  # Token limitations on fork PRs
+  with:
+    script: |
+      github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+        body: '**Note:** GitHub Pages deployment was skipped because this PR is from a fork. This is a GitHub security restriction. You can test the docs locally with `make docs`.'
+      })
+```
+
+Use `continue-on-error: true` due to potential token limitations on fork PRs.
+
+---
+
+## Maintainer Workflow Patterns
+
+### Handling Contributor PRs
+
+When `maintainerCanModify` is enabled on a PR, maintainers can directly rebase or push changes to the contributor's fork branch.
+
+**Maintainer Actions:**
+- Rebase to trigger fresh CI with updated workflows
+- Push fixes directly to the contributor's branch
+- Merge master changes before re-triggering CI
+
+### PR Management Strategy
+
+When fixing CI issues that affect existing PRs:
+
+1. Create a separate PR for the workflow fix
+2. Merge the fix PR first
+3. Rebase the original problematic PR to trigger fresh CI
+4. The rebased PR will use the corrected workflow
+
+---
+
+## Best Practices
+
+- **Explicit fork detection**: Always check for fork PRs in workflows involving authenticated operations
+- **Informative feedback**: Explain why actions are skipped (GitHub security, token limitations)
+- **Avoid hardcoded assumptions**: Don't assume all PRs have the same permissions
+- **Test locally first**: Fork contributors should test locally before relying on CI
+
+---
+
+## Anti-Patterns to Avoid
+
+- Assuming `id-token: write` works for fork PRs
+- Re-running workflows expecting new logic to apply
+- Silent failures without user feedback
+- Blocking fork PRs entirely when only deployment is affected

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Full setup: `/setup-dev` | Style check: `/lint-code` | Build check: `/verify-bui
 | `src/supy/` | Python | `.claude/rules/python/` |
 | `docs/` | Documentation | `.claude/rules/docs/` |
 | `test/` | Tests | `.claude/rules/tests/` |
+| `.github/workflows/` | CI/Actions | `.claude/rules/ci/` |
 
 ## Skills
 


### PR DESCRIPTION
Documents GitHub Actions patterns and conventions for handling fork PRs:

- Fork PR OIDC token limitations and security model
- Fork detection pattern with conditional step execution
- Workflow re-run behaviour (uses original file version)
- Maintainer workflow patterns for handling contributor PRs
- PR comment feedback for fork contributors

Adds .claude/rules/ci/conventions.md with reusable patterns and updates documentation.