### PR TITLE
fix: add --clear flag to uv venv in setup script

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "git fetch origin --prune && git reset --hard origin/master && for remote in $(git remote | grep -v '^origin$'); do git remote remove \"$remote\"; done && uv venv && source .venv/bin/activate",
+    "setup": "git fetch origin --prune && git reset --hard origin/master && for remote in $(git remote | grep -v '^origin$'); do git remote remove \"$remote\"; done && uv venv --clear && source .venv/bin/activate",
     "run": "source .venv/bin/activate && npx -y browser-sync start --server site --port 3000 --files 'site/**/*' & cd docs && make livehtml",
     "archive": "cd $CONDUCTOR_ROOT_PATH && git fetch origin --prune && git reset --hard origin/master"
   }


### PR DESCRIPTION
Use '--clear' when creating virtual environment to ensure a clean environment is created, preventing issues with stale cached packages.