### PR TITLE
refactor: Replace incremental DataFrame assignment with batch creation

### DIFF
--- a/src/supy/data_model/core/human_activity.py
+++ b/src/supy/data_model/core/human_activity.py
@@ -3,9 +3,8 @@ from pydantic_core import PydanticUndefined
 from typing import Optional, Union
 import pandas as pd
 import warnings
-from .type import RefValue, Reference, FlexibleRefValue
+from .type import RefValue, Reference, FlexibleRefValue, df_from_cols
 from .profile import HourlyProfile, WeeklyProfile, DayProfile
-from .type import init_df_state
 from ..validation.core.utils import (
     warn_missing_params,
     check_missing_params,
@@ -92,39 +91,41 @@ class IrrigationParams(
             pd.DataFrame: DataFrame containing irrigation parameters
         """
 
-        df_state = init_df_state(grid_id)
-
-        df_state.loc[grid_id, ("h_maintain", "0")] = (
-            self.h_maintain.value
-            if isinstance(self.h_maintain, RefValue)
-            else self.h_maintain
-            if self.h_maintain is not None
-            else 0.0
-        )
-        df_state.loc[grid_id, ("faut", "0")] = (
-            self.faut.value if isinstance(self.faut, RefValue) else self.faut
-        )
-        df_state.loc[grid_id, ("ie_start", "0")] = (
-            self.ie_start.value
-            if isinstance(self.ie_start, RefValue)
-            else self.ie_start
-            if self.ie_start is not None
-            else 0.0
-        )
-        df_state.loc[grid_id, ("ie_end", "0")] = (
-            self.ie_end.value
-            if isinstance(self.ie_end, RefValue)
-            else self.ie_end
-            if self.ie_end is not None
-            else 0.0
-        )
-        df_state.loc[grid_id, ("internalwateruse_h", "0")] = (
-            self.internalwateruse_h.value
-            if isinstance(self.internalwateruse_h, RefValue)
-            else self.internalwateruse_h
-            if self.internalwateruse_h is not None
-            else 0.0
-        )
+        cols = {
+            ("gridiv", "0"): grid_id,
+            ("h_maintain", "0"): (
+                self.h_maintain.value
+                if isinstance(self.h_maintain, RefValue)
+                else self.h_maintain
+                if self.h_maintain is not None
+                else 0.0
+            ),
+            ("faut", "0"): (
+                self.faut.value if isinstance(self.faut, RefValue) else self.faut
+            ),
+            ("ie_start", "0"): (
+                self.ie_start.value
+                if isinstance(self.ie_start, RefValue)
+                else self.ie_start
+                if self.ie_start is not None
+                else 0.0
+            ),
+            ("ie_end", "0"): (
+                self.ie_end.value
+                if isinstance(self.ie_end, RefValue)
+                else self.ie_end
+                if self.ie_end is not None
+                else 0.0
+            ),
+            ("internalwateruse_h", "0"): (
+                self.internalwateruse_h.value
+                if isinstance(self.internalwateruse_h, RefValue)
+                else self.internalwateruse_h
+                if self.internalwateruse_h is not None
+                else 0.0
+            ),
+        }
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         df_daywatper = self.daywatper.to_df_state(grid_id, "daywatper")
         df_daywat = self.daywat.to_df_state(grid_id, "daywat")
@@ -297,7 +298,11 @@ class AnthropogenicHeat(
             pd.DataFrame: DataFrame containing anthropogenic heat parameters.
         """
 
-        df_state = init_df_state(grid_id)
+        cols = {
+            ("gridiv", "0"): grid_id,
+            ("popdensnighttime", "0"): self.popdensnighttime,
+        }
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         day_profiles = {
             "qf0_beu": self.qf0_beu,
@@ -322,8 +327,6 @@ class AnthropogenicHeat(
         for param_name, profile in hourly_profiles.items():
             df_hourly_profile = profile.to_df_state(grid_id, param_name)
             df_state = df_state.combine_first(df_hourly_profile)
-
-        df_state.loc[grid_id, ("popdensnighttime", "0")] = self.popdensnighttime
 
         return df_state
 
@@ -517,8 +520,6 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
             pd.DataFrame: DataFrame containing CO2 parameters.
         """
 
-        df_state = init_df_state(grid_id)
-
         scalar_params = {
             "co2pointsource": self.co2pointsource.value
             if isinstance(self.co2pointsource, RefValue)
@@ -571,8 +572,10 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
             if self.trafficunits is not None
             else 0.0,
         }
+        cols = {("gridiv", "0"): grid_id}
         for param_name, value in scalar_params.items():
-            df_state.loc[grid_id, (param_name, "0")] = value
+            cols[(param_name, "0")] = value
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         day_profiles = {
             "fcef_v_kgkm": self.fcef_v_kgkm,
@@ -686,31 +689,33 @@ class AnthropogenicEmissions(BaseModel):
         Returns:
             pd.DataFrame: DataFrame containing anthropogenic emissions parameters.
         """
-        df_state = init_df_state(grid_id)
-
         # Set start and end daylight saving times
-        df_state.loc[grid_id, ("startdls", "0")] = (
-            self.startdls.value
-            if isinstance(self.startdls, RefValue)
-            else self.startdls
-            if self.startdls is not None
-            else 0.0
-        )
-        df_state.loc[grid_id, ("enddls", "0")] = (
-            self.enddls.value
-            if isinstance(self.enddls, RefValue)
-            else self.enddls
-            if self.enddls is not None
-            else 0.0
-        )
+        cols = {
+            ("gridiv", "0"): grid_id,
+            ("startdls", "0"): (
+                self.startdls.value
+                if isinstance(self.startdls, RefValue)
+                else self.startdls
+                if self.startdls is not None
+                else 0.0
+            ),
+            ("enddls", "0"): (
+                self.enddls.value
+                if isinstance(self.enddls, RefValue)
+                else self.enddls
+                if self.enddls is not None
+                else 0.0
+            ),
+        }
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         # Add heat parameters
         df_heat = self.heat.to_df_state(grid_id)
-        df_state = pd.concat([df_state, df_heat], axis=1)
 
         # Add CO2 parameters
         df_co2 = self.co2.to_df_state(grid_id)
-        df_state = pd.concat([df_state, df_co2], axis=1)
+
+        df_state = pd.concat([df_state, df_heat, df_co2], axis=1)
 
         # Drop duplicate columns if necessary
         df_state = df_state.loc[:, ~df_state.columns.duplicated()]

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -6,8 +6,7 @@ import pandas as pd
 from enum import Enum
 import inspect
 
-from .type import RefValue, Reference, FlexibleRefValue
-from .type import init_df_state
+from .type import RefValue, Reference, FlexibleRefValue, df_from_cols
 
 
 def _enum_description(enum_class: type[Enum]) -> str:
@@ -662,17 +661,7 @@ class ModelPhysics(BaseModel):
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert model physics properties to DataFrame state format."""
-        df_state = init_df_state(grid_id)
-
-        # Helper function to set values in DataFrame
-        def set_df_value(col_name: str, value: float):
-            idx_str = "0"
-            if (col_name, idx_str) not in df_state.columns:
-                # df_state[(col_name, idx_str)] = np.nan
-                df_state[(col_name, idx_str)] = None
-            val = value.value if isinstance(value, RefValue) else value
-            df_state.at[grid_id, (col_name, idx_str)] = int(val)
-
+        cols = {("gridiv", "0"): grid_id}
         list_attr = [
             "netradiationmethod",
             "emissionsmethod",
@@ -692,8 +681,10 @@ class ModelPhysics(BaseModel):
             "rcmethod",
         ]
         for attr in list_attr:
-            set_df_value(attr, getattr(self, attr))
-        return df_state
+            value = getattr(self, attr)
+            val = value.value if isinstance(value, RefValue) else value
+            cols[(attr, "0")] = int(val)
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "ModelPhysics":
@@ -834,23 +825,14 @@ class ModelControl(BaseModel):
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert model control properties to DataFrame state format."""
-        df_state = init_df_state(grid_id)
-
-        # Helper function to set values in DataFrame
-        def set_df_value(col_name: str, value: float):
-            idx_str = "0"
-            if (col_name, idx_str) not in df_state.columns:
-                # df_state[(col_name, idx_str)] = np.nan
-                df_state[(col_name, idx_str)] = None
-            df_state.at[grid_id, (col_name, idx_str)] = value
-
+        cols = {("gridiv", "0"): grid_id}
         list_attr = ["tstep", "diagnose"]
         for attr in list_attr:
             value = getattr(self, attr)
             # Extract value from RefValue if needed
             val = value.value if isinstance(value, RefValue) else value
-            set_df_value(attr, val)
-        return df_state
+            cols[(attr, "0")] = val
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "ModelControl":
@@ -880,7 +862,9 @@ class Model(BaseModel):
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert model to DataFrame state format"""
-        df_state = init_df_state(grid_id)
+        df_state = df_from_cols(
+            {("gridiv", "0"): grid_id}, index=pd.Index([grid_id], name="grid")
+        )
         df_control = self.control.to_df_state(grid_id)
         df_physics = self.physics.to_df_state(grid_id)
         df_state = pd.concat([df_state, df_control, df_physics], axis=1)

--- a/src/supy/data_model/core/site.py
+++ b/src/supy/data_model/core/site.py
@@ -1,8 +1,7 @@
 from typing import Optional
 from pydantic import ConfigDict, BaseModel, Field, model_validator
-from .type import RefValue, Reference, FlexibleRefValue
+from .type import RefValue, Reference, FlexibleRefValue, df_from_cols
 from .profile import HourlyProfile, DayProfile, WeeklyProfile, TenMinuteProfile
-from .type import init_df_state
 from .timezone_enum import TimezoneOffset
 from ..._env import logger_supy
 from ..validation.core.utils import (
@@ -184,8 +183,6 @@ class Conductance(BaseModel):
             pd.DataFrame: DataFrame containing conductance parameters.
         """
 
-        df_state = init_df_state(grid_id)
-
         scalar_params = {
             "g_max": self.g_max,
             "g_k": self.g_k,
@@ -200,14 +197,15 @@ class Conductance(BaseModel):
             "th": self.th,
         }
 
+        cols = {("gridiv", "0"): grid_id}
         for param_name, value in scalar_params.items():
             if value is not None:
                 val = value.value if isinstance(value, RefValue) else value
             else:
                 val = 0.0  # Default to 0.0 for DataFrame compatibility
-            df_state.loc[grid_id, (param_name, "0")] = val
+            cols[(param_name, "0")] = val
 
-        return df_state
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "Conductance":
@@ -300,22 +298,13 @@ class LAIPowerCoefficients(BaseModel):
         Returns:
             pd.DataFrame: DataFrame containing LAI power coefficients
         """
-        df_state = init_df_state(grid_id)
-
-        # Helper function to set values in DataFrame
-        def set_df_value(col_name: str, indices: Tuple, value: float):
-            idx_str = str(indices)
-            if (col_name, idx_str) not in df_state.columns:
-                # df_state[(col_name, idx_str)] = np.nan
-                df_state[(col_name, idx_str)] = None
-            df_state.at[grid_id, (col_name, idx_str)] = value
-
         # Set power coefficients in order
+        cols = {("gridiv", "0"): grid_id}
         for i, value in enumerate(self.to_list()):
             val = value.value if isinstance(value, RefValue) else value
-            set_df_value("laipower", (i, veg_idx), val)
+            cols[("laipower", f"({i}, {veg_idx})")] = val
 
-        return df_state
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(
@@ -419,18 +408,8 @@ class LAIParams(BaseModel):
         Returns:
             pd.DataFrame: DataFrame containing LAI parameters
         """
-        df_state = init_df_state(grid_id)
-
         # Adjust index for vegetation surfaces (surface index - 2)
         veg_idx = surf_idx - 2
-
-        # Helper function to set values in DataFrame
-        def set_df_value(col_name: str, indices: Union[Tuple, int], value: float):
-            idx_str = str(indices) if isinstance(indices, int) else str(indices)
-            if (col_name, idx_str) not in df_state.columns:
-                # df_state[(col_name, idx_str)] = np.nan
-                df_state[(col_name, idx_str)] = None
-            df_state.at[grid_id, (col_name, idx_str)] = value
 
         # Set basic LAI parameters
         lai_params = {
@@ -443,6 +422,7 @@ class LAIParams(BaseModel):
             "laitype": self.laitype,
         }
 
+        cols = {("gridiv", "0"): grid_id}
         for param, value in lai_params.items():
             if value is not None:
                 val = value.value if isinstance(value, RefValue) else value
@@ -457,15 +437,16 @@ class LAIParams(BaseModel):
                     "laitype": 0,
                 }
                 val = defaults.get(param, 0.0)
-            set_df_value(param, (veg_idx,), val)
+            cols[(param, f"({veg_idx},)")] = val
+
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         # Add LAI power coefficients using the LAIPowerCoefficients to_df_state method
         if self.laipower:
             df_power = self.laipower.to_df_state(grid_id, veg_idx)
-            # Merge power coefficients into main DataFrame
-            for col in df_power.columns:
-                if col[0] != "grid_iv":  # Skip the grid_iv column
-                    df_state[col] = df_power[col]
+            if ("gridiv", "0") in df_power.columns:
+                df_power = df_power.drop(columns=[("gridiv", "0")])
+            df_state = pd.concat([df_state, df_power], axis=1)
 
         return df_state
 
@@ -623,14 +604,8 @@ class VegetatedSurfaceProperties(SurfaceProperties):
         # Add vegetation-specific properties
         surf_idx = self.get_surface_index()
 
-        # Helper function to set values in DataFrame
-        def set_df_value(col_name: str, idx_str: str, value: float):
-            if (col_name, idx_str) not in df_state.columns:
-                # df_state[(col_name, idx_str)] = np.nan
-                df_state[(col_name, idx_str)] = None
-            df_state.loc[grid_id, (col_name, idx_str)] = value
-
         # add ordinary float properties
+        cols = {}
         for attr in [
             "beta_bioco2",
             "beta_enh_bioco2",
@@ -657,10 +632,11 @@ class VegetatedSurfaceProperties(SurfaceProperties):
                     "theta_bioco2": 1.2,
                 }
                 val = defaults.get(attr, 0.0)
-            set_df_value(attr, f"({surf_idx - 2},)", val)
+            cols[(attr, f"({surf_idx - 2},)")] = val
 
+        df_veg = df_from_cols(cols, index=df_state.index)
         df_lai = self.lai.to_df_state(grid_id, surf_idx)
-        df_state = pd.concat([df_state, df_lai], axis=1).sort_index(axis=1)
+        df_state = pd.concat([df_state, df_veg, df_lai], axis=1).sort_index(axis=1)
 
         return df_state
 
@@ -1090,8 +1066,6 @@ class SnowParams(BaseModel):
             pd.DataFrame: DataFrame containing snow parameters.
         """
 
-        df_state = init_df_state(grid_id)
-
         scalar_params = {
             "crwmax": self.crwmax,
             "crwmin": self.crwmin,
@@ -1110,6 +1084,7 @@ class SnowParams(BaseModel):
             "tempmeltfact": self.tempmeltfact,
             "radmeltfact": self.radmeltfact,
         }
+        cols = {("gridiv", "0"): grid_id}
         for param_name, value in scalar_params.items():
             if value is not None:
                 val = value.value if isinstance(value, RefValue) else value
@@ -1121,7 +1096,9 @@ class SnowParams(BaseModel):
                     "snowdensmax": 400.0,
                 }
                 val = defaults.get(param_name, 0.0)
-            df_state.loc[grid_id, (param_name, "0")] = val
+            cols[(param_name, "0")] = val
+
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         df_hourly_profile = self.snowprof_24hr.to_df_state(grid_id, "snowprof_24hr")
         df_state = df_state.combine_first(df_hourly_profile)
@@ -1768,22 +1745,27 @@ class ArchetypeProperties(BaseModel):
     ref: Optional[Reference] = None
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
-        df_state = init_df_state(grid_id)
-
         string_fields = {"BuildingType", "BuildingName"}
-        ten_minute_profile_fields = {"HeatingSetpointTemperature", "CoolingSetpointTemperature", "OccupantsProfile"}
+        ten_minute_profile_fields = {
+            "HeatingSetpointTemperature",
+            "CoolingSetpointTemperature",
+            "OccupantsProfile",
+        }
         excluded_fields = string_fields | ten_minute_profile_fields | {"ref"}
 
+        cols = {("gridiv", "0"): grid_id}
         for field_name in self.model_fields:
             if field_name in excluded_fields:
                 continue
             field_val = getattr(self, field_name)
             value = field_val.value if isinstance(field_val, RefValue) else field_val
-            df_state.loc[grid_id, (field_name.lower(), "0")] = value
+            cols[(field_name.lower(), "0")] = value
 
         for field_name in string_fields:
             value = getattr(self, field_name)
-            df_state.loc[grid_id, (field_name.lower(), "0")] = value
+            cols[(field_name.lower(), "0")] = value
+
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         for field_name in ten_minute_profile_fields:
             profile = getattr(self, field_name)
@@ -2269,18 +2251,19 @@ class StebbsProperties(BaseModel):
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert StebbsProperties to DataFrame state format."""
-        df_state = init_df_state(grid_id)
-
         tenmin_profile_fields = {"ApplianceProfile", "HotWaterFlowProfile"}
         excluded_fields = tenmin_profile_fields | {"ref"}
 
         # scalar fields
+        cols = {("gridiv", "0"): grid_id}
         for field_name in self.model_fields:
             if field_name in excluded_fields:
                 continue
             field_val = getattr(self, field_name)
             value = field_val.value if isinstance(field_val, RefValue) else field_val
-            df_state.loc[grid_id, (field_name.lower(), "0")] = value
+            cols[(field_name.lower(), "0")] = value
+
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         # 10-minute profile fields
         for field_name in tenmin_profile_fields:
@@ -2451,9 +2434,6 @@ class SPARTACUSParams(BaseModel):
         Returns:
             pd.DataFrame: DataFrame containing SPARTACUS parameters
         """
-        # Initialize DataFrame with grid index
-        df_state = init_df_state(grid_id)
-
         # Map SPARTACUS parameters to DataFrame columns
         spartacus_params = {
             "air_ext_lw": self.air_ext_lw,
@@ -2473,11 +2453,12 @@ class SPARTACUSParams(BaseModel):
         }
 
         # Assign each parameter to its corresponding column in the DataFrame
+        cols = {("gridiv", "0"): grid_id}
         for param_name, value in spartacus_params.items():
             val = value.value if isinstance(value, RefValue) else value
-            df_state[(param_name, "0")] = val
+            cols[(param_name, "0")] = val
 
-        return df_state
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "SPARTACUSParams":
@@ -2572,14 +2553,13 @@ class SoilObservationConfig(BaseModel):
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert soil observation config to DataFrame state format."""
-        df_state = init_df_state(grid_id)
-
+        cols = {("gridiv", "0"): grid_id}
         for attr, col_name in self._FIELD_TO_COLUMN.items():
             field_val = getattr(self, attr)
             val = field_val.value if isinstance(field_val, RefValue) else field_val
-            df_state[(col_name, "0")] = val
+            cols[(col_name, "0")] = val
 
-        return df_state
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "SoilObservationConfig":
@@ -2650,15 +2630,14 @@ class LUMPSParams(BaseModel):
         Returns:
             pd.DataFrame: DataFrame containing LUMPS parameters
         """
-        df_state = init_df_state(grid_id)
-
         # Add all attributes
+        cols = {("gridiv", "0"): grid_id}
         for attr in ["raincover", "rainmaxres", "drainrt", "veg_type"]:
             field_val = getattr(self, attr)
             val = field_val.value if isinstance(field_val, RefValue) else field_val
-            df_state[(attr, "0")] = val
+            cols[(attr, "0")] = val
 
-        return df_state
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "LUMPSParams":
@@ -2873,9 +2852,8 @@ class SiteProperties(BaseModel):
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert site properties to DataFrame state format"""
-        df_state = init_df_state(grid_id)
-
         # simple attributes
+        cols = {("gridiv", "0"): grid_id}
         for var in [
             "lat",
             "lng",
@@ -2899,7 +2877,9 @@ class SiteProperties(BaseModel):
             if var == "timezone" and isinstance(val, TimezoneOffset):
                 val = val.value  # Get the float value from the enum
 
-            df_state.loc[grid_id, (f"{var}", "0")] = val
+            cols[(f"{var}", "0")] = val
+
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         # complex attributes
         df_lumps = self.lumps.to_df_state(grid_id)
@@ -3023,8 +3003,12 @@ class Site(BaseModel):
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert site to DataFrame state format"""
-        df_state = init_df_state(grid_id)
+        df_state = df_from_cols(
+            {("gridiv", "0"): grid_id}, index=pd.Index([grid_id], name="grid")
+        )
         df_site_properties = self.properties.to_df_state(grid_id)
         df_initial_states = self.initial_states.to_df_state(grid_id)
         df_state = pd.concat([df_state, df_site_properties, df_initial_states], axis=1)
+        # Drop duplicate columns while preserving first occurrence
+        df_state = df_state.loc[:, ~df_state.columns.duplicated(keep="first")]
         return df_state

--- a/src/supy/data_model/core/state.py
+++ b/src/supy/data_model/core/state.py
@@ -9,7 +9,13 @@ from pydantic import (
     PrivateAttr,
 )
 
-from .type import RefValue, Reference, FlexibleRefValue, init_df_state, SurfaceType
+from .type import (
+    RefValue,
+    Reference,
+    FlexibleRefValue,
+    df_from_cols,
+    SurfaceType,
+)
 from ..._env import logger_supy
 
 
@@ -118,52 +124,53 @@ class SurfaceInitialState(BaseModel):
         Returns:
             pd.DataFrame: DataFrame containing initial state parameters
         """
-        df_state = init_df_state(grid_id)
-
         # Get surface index
         if vert_idx is None:
-            idx = self.get_surface_index()
+            surf_idx = self.get_surface_index()
             str_type = "surf"
         else:
-            idx = vert_idx
+            surf_idx = vert_idx
             str_type = "roof" if is_roof else "wall"
         # Set basic state parameters
-        df_state[(f"state_{str_type}", f"({idx},)")] = (
-            self.state.value if isinstance(self.state, RefValue) else self.state
-        )
-        df_state[(f"soilstore_{str_type}", f"({idx},)")] = (
-            self.soilstore.value
-            if isinstance(self.soilstore, RefValue)
-            else self.soilstore
-        )
+        cols = {
+            ("gridiv", "0"): grid_id,
+            (f"state_{str_type}", f"({surf_idx},)"): (
+                self.state.value if isinstance(self.state, RefValue) else self.state
+            ),
+            (f"soilstore_{str_type}", f"({surf_idx},)"): (
+                self.soilstore.value
+                if isinstance(self.soilstore, RefValue)
+                else self.soilstore
+            ),
+        }
 
         # Set snow/ice parameters if present
         if self.snowfrac is not None:
-            df_state[(f"snowfrac", f"({idx},)")] = (
+            cols[(f"snowfrac", f"({surf_idx},)")] = (
                 self.snowfrac.value
                 if isinstance(self.snowfrac, RefValue)
                 else self.snowfrac
             )
         if self.snowpack is not None:
-            df_state[(f"snowpack", f"({idx},)")] = (
+            cols[(f"snowpack", f"({surf_idx},)")] = (
                 self.snowpack.value
                 if isinstance(self.snowpack, RefValue)
                 else self.snowpack
             )
         if self.icefrac is not None:
-            df_state[(f"icefrac", f"({idx},)")] = (
+            cols[(f"icefrac", f"({surf_idx},)")] = (
                 self.icefrac.value
                 if isinstance(self.icefrac, RefValue)
                 else self.icefrac
             )
         if self.snowwater is not None:
-            df_state[(f"snowwater", f"({idx},)")] = (
+            cols[(f"snowwater", f"({surf_idx},)")] = (
                 self.snowwater.value
                 if isinstance(self.snowwater, RefValue)
                 else self.snowwater
             )
         if self.snowdens is not None:
-            df_state[(f"snowdens", f"({idx},)")] = (
+            cols[(f"snowdens", f"({surf_idx},)")] = (
                 self.snowdens.value
                 if isinstance(self.snowdens, RefValue)
                 else self.snowdens
@@ -176,18 +183,18 @@ class SurfaceInitialState(BaseModel):
             else self.temperature
         )
         for i, temp in enumerate(temp_values):
-            df_state[(f"temp_{str_type}", f"({idx}, {i})")] = temp
+            cols[(f"temp_{str_type}", f"({surf_idx}, {i})")] = temp
 
         if self.tsfc is not None:
-            df_state[(f"tsfc_{str_type}", f"({idx},)")] = (
+            cols[(f"tsfc_{str_type}", f"({surf_idx},)")] = (
                 self.tsfc.value if isinstance(self.tsfc, RefValue) else self.tsfc
             )
         if self.tin is not None:
-            df_state[(f"tin_{str_type}", f"({idx},)")] = (
+            cols[(f"tin_{str_type}", f"({surf_idx},)")] = (
                 self.tin.value if isinstance(self.tin, RefValue) else self.tin
             )
 
-        return df_state
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(
@@ -310,21 +317,25 @@ class WaterUse(BaseModel):
 
     def to_df_state(self, veg_idx: int, grid_id: int) -> pd.DataFrame:
         """Convert water use to DataFrame state format."""
-        df_state = init_df_state(grid_id)
-        df_state.loc[grid_id, ("wuday_id", f"({veg_idx * 3 + 0},)")] = (
-            self.wu_total.value
-            if isinstance(self.wu_total, RefValue)
-            else self.wu_total
-        )
-        df_state.loc[grid_id, ("wuday_id", f"({veg_idx * 3 + 1},)")] = (
-            self.wu_auto.value if isinstance(self.wu_auto, RefValue) else self.wu_auto
-        )
-        df_state.loc[grid_id, ("wuday_id", f"({veg_idx * 3 + 2},)")] = (
-            self.wu_manual.value
-            if isinstance(self.wu_manual, RefValue)
-            else self.wu_manual
-        )
-        return df_state
+        cols = {
+            ("gridiv", "0"): grid_id,
+            ("wuday_id", f"({veg_idx * 3 + 0},)"): (
+                self.wu_total.value
+                if isinstance(self.wu_total, RefValue)
+                else self.wu_total
+            ),
+            ("wuday_id", f"({veg_idx * 3 + 1},)"): (
+                self.wu_auto.value
+                if isinstance(self.wu_auto, RefValue)
+                else self.wu_auto
+            ),
+            ("wuday_id", f"({veg_idx * 3 + 2},)"): (
+                self.wu_manual.value
+                if isinstance(self.wu_manual, RefValue)
+                else self.wu_manual
+            ),
+        }
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, veg_idx: int, grid_id: int) -> "WaterUse":
@@ -420,23 +431,33 @@ class InitialStateVeg(SurfaceInitialState):
 
         # Add vegetated surface specific parameters
         # alb is universal so use surf_idx
-        df_state[("alb", f"({surf_idx},)")] = (
-            self.alb_id.value if isinstance(self.alb_id, RefValue) else self.alb_id
-        )
-        # others are aligned with veg_idx
-        df_state[("lai_id", f"({veg_idx},)")] = (
-            self.lai_id.value if isinstance(self.lai_id, RefValue) else self.lai_id
-        )
-        df_state[("gdd_id", f"({veg_idx},)")] = (
-            self.gdd_id.value if isinstance(self.gdd_id, RefValue) else self.gdd_id
-        )
-        df_state[("sdd_id", f"({veg_idx},)")] = (
-            self.sdd_id.value if isinstance(self.sdd_id, RefValue) else self.sdd_id
-        )
+        cols = {
+            ("alb", f"({surf_idx},)"): (
+                self.alb_id.value
+                if isinstance(self.alb_id, RefValue)
+                else self.alb_id
+            ),
+            ("lai_id", f"({veg_idx},)"): (
+                self.lai_id.value
+                if isinstance(self.lai_id, RefValue)
+                else self.lai_id
+            ),
+            ("gdd_id", f"({veg_idx},)"): (
+                self.gdd_id.value
+                if isinstance(self.gdd_id, RefValue)
+                else self.gdd_id
+            ),
+            ("sdd_id", f"({veg_idx},)"): (
+                self.sdd_id.value
+                if isinstance(self.sdd_id, RefValue)
+                else self.sdd_id
+            ),
+        }
+        df_veg = df_from_cols(cols, index=df_state.index)
 
         # Add water use parameters
         df_wu = self.wu.to_df_state(veg_idx, grid_id)
-        df_state = pd.concat([df_state, df_wu], axis=1)
+        df_state = pd.concat([df_state, df_veg, df_wu], axis=1)
 
         # Drop any duplicate columns
         df_state = df_state.loc[:, ~df_state.columns.duplicated()]
@@ -492,10 +513,13 @@ class InitialStateEvetr(InitialStateVeg):
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert evergreen tree initial state to DataFrame state format."""
         df_state = super().to_df_state(grid_id)
-        df_state[("albevetr_id", "0")] = (
-            self.alb_id.value if isinstance(self.alb_id, RefValue) else self.alb_id
-        )
-        return df_state
+        cols = {
+            ("albevetr_id", "0"): (
+                self.alb_id.value if isinstance(self.alb_id, RefValue) else self.alb_id
+            )
+        }
+        df_evetr = df_from_cols(cols, index=df_state.index)
+        return pd.concat([df_state, df_evetr], axis=1)
 
     @classmethod
     def from_df_state(
@@ -561,21 +585,23 @@ class InitialStateDectr(InitialStateVeg):
         df_state = super().to_df_state(grid_id)
 
         # Add deciduous tree specific parameters
-        df_state[("porosity_id", "0")] = (
-            self.porosity_id.value
-            if isinstance(self.porosity_id, RefValue)
-            else self.porosity_id
-        )
-        df_state[("decidcap_id", "0")] = (
-            self.decidcap_id.value
-            if isinstance(self.decidcap_id, RefValue)
-            else self.decidcap_id
-        )
-        df_state[("albdectr_id", "0")] = (
-            self.alb_id.value if isinstance(self.alb_id, RefValue) else self.alb_id
-        )
-
-        return df_state
+        cols = {
+            ("porosity_id", "0"): (
+                self.porosity_id.value
+                if isinstance(self.porosity_id, RefValue)
+                else self.porosity_id
+            ),
+            ("decidcap_id", "0"): (
+                self.decidcap_id.value
+                if isinstance(self.decidcap_id, RefValue)
+                else self.decidcap_id
+            ),
+            ("albdectr_id", "0"): (
+                self.alb_id.value if isinstance(self.alb_id, RefValue) else self.alb_id
+            ),
+        }
+        df_dectr = df_from_cols(cols, index=df_state.index)
+        return pd.concat([df_state, df_dectr], axis=1)
 
     @classmethod
     def from_df_state(
@@ -623,10 +649,13 @@ class InitialStateGrass(InitialStateVeg):
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert grass initial state to DataFrame state format."""
         df_state = super().to_df_state(grid_id)
-        df_state[("albgrass_id", "0")] = (
-            self.alb_id.value if isinstance(self.alb_id, RefValue) else self.alb_id
-        )
-        return df_state
+        cols = {
+            ("albgrass_id", "0"): (
+                self.alb_id.value if isinstance(self.alb_id, RefValue) else self.alb_id
+            )
+        }
+        df_grass = df_from_cols(cols, index=df_state.index)
+        return pd.concat([df_state, df_grass], axis=1)
 
     @classmethod
     def from_df_state(
@@ -1052,12 +1081,42 @@ class InitialStates(BaseModel):
     )
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert initial states to DataFrame state format."""
-        df_state = init_df_state(grid_id)
+        index = pd.Index([grid_id], name="grid")
 
-        # Add snowalb
-        df_state[("snowalb", "0")] = (
-            self.snowalb.value if isinstance(self.snowalb, RefValue) else self.snowalb
-        )
+        cols = {
+            ("gridiv", "0"): grid_id,
+            ("snowalb", "0"): (
+                self.snowalb.value
+                if isinstance(self.snowalb, RefValue)
+                else self.snowalb
+            ),
+            ("dqndt", "0"): self.dqndt,
+            ("dqnsdt", "0"): self.dqnsdt,
+            ("dt_since_start", "0"): self.dt_since_start,
+            ("lenday_id", "0"): self.lenday_id,
+            ("qn_av", "0"): self.qn_av,
+            ("qn_s_av", "0"): self.qn_s_av,
+            ("tair_av", "0"): self.tair_av,
+            ("tmax_id", "0"): self.tmax_id,
+            ("tmin_id", "0"): self.tmin_id,
+            ("tstep_prev", "0"): self.tstep_prev,
+            ("snowfallcum", "0"): self.snowfallcum,
+        }
+
+        # qn_surfs (7)
+        for i, val in enumerate(self.qn_surfs):
+            cols[("qn_surfs", f"({i},)")] = val
+
+        # dqndt_surf (7)
+        for i, val in enumerate(self.dqndt_surf):
+            cols[("dqndt_surf", f"({i},)")] = val
+
+        # special treatment for hdd_id - convert to list format for legacy compatibility
+        hdd_list = self.hdd_id.to_list()
+        for i, hdd in enumerate(hdd_list):
+            cols[(f"hdd_id", f"({i},)")] = hdd
+
+        frames = [df_from_cols(cols, index=index)]
 
         # Add surface states
         surfaces = {
@@ -1071,46 +1130,17 @@ class InitialStates(BaseModel):
         }
         # Add surface states
         for surface in surfaces.values():
-            df_surface = surface.to_df_state(grid_id)
-            df_state = pd.concat([df_state, df_surface], axis=1)
+            frames.append(surface.to_df_state(grid_id))
 
         # Add roof and wall states
         for facet_list, facet_type in [(self.roofs, "roof"), (self.walls, "wall")]:
             if facet_list is not None:  # Check for None explicitly
                 for i, facet in enumerate(facet_list):
                     is_roof = facet_type == "roof"
-                    df_facet = facet.to_df_state(grid_id, i, is_roof)
-                    df_state = pd.concat([df_state, df_facet], axis=1)
-                    df_state = df_state.sort_index(axis=1)
+                    frames.append(facet.to_df_state(grid_id, i, is_roof))
 
-        # Add these attributes to the DataFrame
-        df_state[("dqndt", "0")] = self.dqndt
-        df_state[("dqnsdt", "0")] = self.dqnsdt
-        df_state[("dt_since_start", "0")] = self.dt_since_start
-        df_state[("lenday_id", "0")] = self.lenday_id
-        df_state[("qn_av", "0")] = self.qn_av
-        df_state[("qn_s_av", "0")] = self.qn_s_av
-        df_state[("tair_av", "0")] = self.tair_av
-        df_state[("tmax_id", "0")] = self.tmax_id
-        df_state[("tmin_id", "0")] = self.tmin_id
-        df_state[("tstep_prev", "0")] = self.tstep_prev
-        df_state[("snowfallcum", "0")] = self.snowfallcum
-
-        # qn_surfs (7)
-        for i, val in enumerate(self.qn_surfs):
-            df_state[("qn_surfs", f"({i},)")] = val
-
-        # dqndt_surf (7)
-        for i, val in enumerate(self.dqndt_surf):
-            df_state[("dqndt_surf", f"({i},)")] = val
-            
+        df_state = pd.concat(frames, axis=1)
         df_state = df_state.sort_index(axis=1)
-        # special treatment for hdd_id - convert to list format for legacy compatibility
-        hdd_list = self.hdd_id.to_list()
-        for i, hdd in enumerate(hdd_list):
-            df_state[(f"hdd_id", f"({i},)")] = hdd
-        df_state = df_state.sort_index(axis=1)
-
         # Drop duplicate columns while preserving first occurrence
         df_state = df_state.loc[:, ~df_state.columns.duplicated(keep="first")]
 

--- a/src/supy/data_model/core/surface.py
+++ b/src/supy/data_model/core/surface.py
@@ -10,11 +10,9 @@ from pydantic import (
 from typing import Optional, Literal, List, Union
 import pandas as pd
 import warnings
-from .type import RefValue, Reference, FlexibleRefValue
+from .type import RefValue, Reference, FlexibleRefValue, df_from_cols
 from ..validation.core.utils import warn_missing_params, validate_only_when_complete
 from ..._env import logger_supy
-
-from .type import init_df_state
 
 from .ohm import OHM_Coefficient_season_wetness
 
@@ -76,8 +74,6 @@ class ThermalLayers(BaseModel):
         Returns:
             pd.DataFrame: DataFrame containing thermal layer parameters
         """
-        df_state = init_df_state(grid_id)
-
         if surf_type == "roof":
             suffix = "roof"
         elif surf_type == "wall":
@@ -86,20 +82,21 @@ class ThermalLayers(BaseModel):
             suffix = "surf"
 
         # Add thermal layer parameters
+        cols = {("gridiv", "0"): grid_id}
         for i in range(5):
             if self.dz is not None:
                 dz_val = self.dz.value if isinstance(self.dz, RefValue) else self.dz
-                df_state[(f"dz_{suffix}", f"({idx}, {i})")] = dz_val[i]
+                cols[(f"dz_{suffix}", f"({idx}, {i})")] = dz_val[i]
             else:
-                df_state[(f"dz_{suffix}", f"({idx}, {i})")] = 0.1 * (
+                cols[(f"dz_{suffix}", f"({idx}, {i})")] = 0.1 * (
                     i + 1
                 )  # Default layer thickness
 
             if self.k is not None:
                 k_val = self.k.value if isinstance(self.k, RefValue) else self.k
-                df_state[(f"k_{suffix}", f"({idx}, {i})")] = k_val[i]
+                cols[(f"k_{suffix}", f"({idx}, {i})")] = k_val[i]
             else:
-                df_state[(f"k_{suffix}", f"({idx}, {i})")] = (
+                cols[(f"k_{suffix}", f"({idx}, {i})")] = (
                     1.0  # Default thermal conductivity
                 )
 
@@ -109,14 +106,14 @@ class ThermalLayers(BaseModel):
                     if isinstance(self.rho_cp, RefValue)
                     else self.rho_cp
                 )
-                df_state[(f"cp_{suffix}", f"({idx}, {i})")] = rho_cp_val[i]
+                cols[(f"cp_{suffix}", f"({idx}, {i})")] = rho_cp_val[i]
             else:
-                df_state[(f"cp_{suffix}", f"({idx}, {i})")] = (
+                cols[(f"cp_{suffix}", f"({idx}, {i})")] = (
                     1000.0  # Default heat capacity
                 )
             # TODO: Change df_state to use rho_cp instead of cp
 
-        return df_state
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(
@@ -324,21 +321,13 @@ class SurfaceProperties(BaseModel):
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert surface properties to DataFrame state format.
         This is the base implementation that handles common surface properties."""
-        df_state = init_df_state(grid_id)
-
         # Get surface index
         surf_idx = self.get_surface_index()
 
         # Get surface name
         surf_name = self.get_surface_name()
 
-        # Helper function to set values in DataFrame
-        def set_df_value(col_name: str, value: float):
-            idx_str = f"({surf_idx},)"
-            if (col_name, idx_str) not in df_state.columns:
-                # df_state[(col_name, idx_str)] = np.nan
-                df_state[(col_name, idx_str)] = None
-            df_state.loc[grid_id, (col_name, idx_str)] = value
+        cols = {("gridiv", "0"): grid_id}
 
         # Get all properties of this class using introspection
         properties = [
@@ -368,7 +357,7 @@ class SurfaceProperties(BaseModel):
         ]
 
         # Process each property
-        dfs = [df_state]  # List to collect all DataFrames
+        dfs = []
 
         for property in properties:
             # Handle nested properties with their own to_df_state methods
@@ -390,7 +379,7 @@ class SurfaceProperties(BaseModel):
             elif property == "irrfrac":
                 value = getattr(self, property)
                 value = value.value if isinstance(value, RefValue) else value
-                df_state.loc[grid_id, (f"{property}{surf_name}", "0")] = value
+                cols[(f"{property}{surf_name}", "0")] = value
             elif property in ["sfr", "soilstorecap", "statelimit", "wetthresh"]:
                 value = getattr(self, property)
                 if value is not None:
@@ -401,19 +390,19 @@ class SurfaceProperties(BaseModel):
                         "soilstorecap": 150.0,
                     }
                     value = defaults.get(property, 0.0)
-                set_df_value(f"{property}_surf", value)
+                cols[(f"{property}_surf", f"({surf_idx},)")] = value
             elif property == "rho_cp_anohm":  # Moved to cp in df_state
                 value = getattr(self, property)
                 value = value.value if isinstance(value, RefValue) else value
-                set_df_value("cpanohm", value)
+                cols[("cpanohm", f"({surf_idx},)")] = value
             elif property == "ch_anohm":  # Moved to ch in df_state
                 value = getattr(self, property)
                 value = value.value if isinstance(value, RefValue) else value
-                set_df_value("chanohm", value)
+                cols[("chanohm", f"({surf_idx},)")] = value
             elif property == "k_anohm":  # Moved to k in df_state
                 value = getattr(self, property)
                 value = value.value if isinstance(value, RefValue) else value
-                set_df_value("kkanohm", value)
+                cols[("kkanohm", f"({surf_idx},)")] = value
             else:
                 value = getattr(self, property)
                 if value is not None:
@@ -426,7 +415,7 @@ class SurfaceProperties(BaseModel):
                         "soildensity": -999.0,
                     }
                     value = defaults.get(property, 0.0)
-                set_df_value(property, value)
+                cols[(property, f"({surf_idx},)")] = value
             # except Exception as e:
             #     print(f"Warning: Could not set property {property}: {str(e)}")
             #     continue
@@ -437,10 +426,11 @@ class SurfaceProperties(BaseModel):
             "ohm_threshwd",
         ]
         for col in list_cols:
-            df_state[(col, "(7,)")] = 0
+            cols[(col, "(7,)")] = 0
 
         # Merge all DataFrames
-        df_final = pd.concat(dfs, axis=1).sort_index(axis=1)
+        df_base = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
+        df_final = pd.concat([df_base, *dfs], axis=1).sort_index(axis=1)
         return df_final
 
     @classmethod
@@ -569,17 +559,20 @@ class NonVegetatedSurfaceProperties(SurfaceProperties):
 
         surf_idx = self.get_surface_index()
 
+        frames = [df_base]
+
         if self.waterdist is not None:
             df_waterdist = self.waterdist.to_df_state(grid_id, surf_idx)
-            df_base = pd.concat([df_base, df_waterdist], axis=1).sort_index(axis=1)
+            frames.append(df_waterdist)
 
-        for attr in ["alb"]:
-            field_val = getattr(self, attr)
-            val = field_val.value if isinstance(field_val, RefValue) else field_val
-            df_base.loc[grid_id, (attr, f"({surf_idx},)")] = val
-            df_base = df_base.sort_index(axis=1)
+        field_val = self.alb
+        val = field_val.value if isinstance(field_val, RefValue) else field_val
+        df_alb = df_from_cols(
+            {("alb", f"({surf_idx},)"): val}, index=df_base.index
+        )
+        frames.append(df_alb)
 
-        return df_base
+        return pd.concat(frames, axis=1).sort_index(axis=1)
 
     @classmethod
     def from_df_state(
@@ -752,45 +745,46 @@ class BuildingLayer(
         Returns:
             pd.DataFrame: DataFrame containing building layer parameters
         """
-        df_state = init_df_state(grid_id)
-
         # Add basic parameters
-        df_state[(f"alb_{facet_type}", f"({layer_idx},)")] = (
-            self.alb.value if isinstance(self.alb, RefValue) else self.alb
-        )
-        df_state[(f"emis_{facet_type}", f"({layer_idx},)")] = (
-            self.emis.value if isinstance(self.emis, RefValue) else self.emis
-        )
-        df_state[(f"statelimit_{facet_type}", f"({layer_idx},)")] = (
-            self.statelimit.value
-            if isinstance(self.statelimit, RefValue)
-            else self.statelimit
-        )
-        df_state[(f"soilstorecap_{facet_type}", f"({layer_idx},)")] = (
-            self.soilstorecap.value
-            if isinstance(self.soilstorecap, RefValue)
-            else self.soilstorecap
-            if self.soilstorecap is not None
-            else 150.0
-        )
-        df_state[(f"wetthresh_{facet_type}", f"({layer_idx},)")] = (
-            self.wetthresh.value
-            if isinstance(self.wetthresh, RefValue)
-            else self.wetthresh
-        )
+        cols = {
+            ("gridiv", "0"): grid_id,
+            (f"alb_{facet_type}", f"({layer_idx},)"): (
+                self.alb.value if isinstance(self.alb, RefValue) else self.alb
+            ),
+            (f"emis_{facet_type}", f"({layer_idx},)"): (
+                self.emis.value if isinstance(self.emis, RefValue) else self.emis
+            ),
+            (f"statelimit_{facet_type}", f"({layer_idx},)"): (
+                self.statelimit.value
+                if isinstance(self.statelimit, RefValue)
+                else self.statelimit
+            ),
+            (f"soilstorecap_{facet_type}", f"({layer_idx},)"): (
+                self.soilstorecap.value
+                if isinstance(self.soilstorecap, RefValue)
+                else self.soilstorecap
+                if self.soilstorecap is not None
+                else 150.0
+            ),
+            (f"wetthresh_{facet_type}", f"({layer_idx},)"): (
+                self.wetthresh.value
+                if isinstance(self.wetthresh, RefValue)
+                else self.wetthresh
+            ),
+        }
 
         # Determine prefix based on layer type
         prefix = facet_type
 
         # Add layer-specific parameters
         if facet_type == "roof" and self.roof_albedo_dir_mult_fact is not None:
-            df_state[(f"{prefix}_albedo_dir_mult_fact", f"(0, {layer_idx})")] = (
+            cols[(f"{prefix}_albedo_dir_mult_fact", f"(0, {layer_idx})")] = (
                 self.roof_albedo_dir_mult_fact.value
                 if isinstance(self.roof_albedo_dir_mult_fact, RefValue)
                 else self.roof_albedo_dir_mult_fact
             )
         elif facet_type == "wall" and self.wall_specular_frac is not None:
-            df_state[(f"{prefix}_specular_frac", f"(0, {layer_idx})")] = (
+            cols[(f"{prefix}_specular_frac", f"(0, {layer_idx})")] = (
                 self.wall_specular_frac.value
                 if isinstance(self.wall_specular_frac, RefValue)
                 else self.wall_specular_frac
@@ -798,6 +792,7 @@ class BuildingLayer(
 
         # Add thermal layers
         df_thermal = self.thermal_layers.to_df_state(grid_id, layer_idx, facet_type)
+        df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
         df_state = pd.concat([df_state, df_thermal], axis=1)
 
         return df_state
@@ -933,25 +928,27 @@ class BldgsProperties(
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert building properties to DataFrame state format."""
-        df_state = super().to_df_state(grid_id).sort_index(axis=1)
+        df_state = super().to_df_state(grid_id)
 
-        df_state.loc[grid_id, ("faibldg", "0")] = (
-            self.faibldg.value
-            if isinstance(self.faibldg, RefValue)
-            else self.faibldg
-            if self.faibldg is not None
-            else 0.3
-        )
-        df_state = df_state.sort_index(axis=1)
-        df_state.loc[grid_id, ("bldgh", "0")] = (
-            self.bldgh.value
-            if isinstance(self.bldgh, RefValue)
-            else self.bldgh
-            if self.bldgh is not None
-            else 10.0
-        )
+        cols = {
+            ("faibldg", "0"): (
+                self.faibldg.value
+                if isinstance(self.faibldg, RefValue)
+                else self.faibldg
+                if self.faibldg is not None
+                else 0.3
+            ),
+            ("bldgh", "0"): (
+                self.bldgh.value
+                if isinstance(self.bldgh, RefValue)
+                else self.bldgh
+                if self.bldgh is not None
+                else 10.0
+            ),
+        }
+        df_bldgs = df_from_cols(cols, index=df_state.index)
 
-        return df_state
+        return pd.concat([df_state, df_bldgs], axis=1).sort_index(axis=1)
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "BldgsProperties":
@@ -1014,26 +1011,18 @@ class WaterProperties(NonVegetatedSurfaceProperties):
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert water surface properties to DataFrame state format."""
         df_state = super().to_df_state(grid_id)
-        surf_idx = self.get_surface_index()
-
-        # Helper function to set values in DataFrame
-        def set_df_value(col_name: str, value: float):
-            idx_str = f"({surf_idx},)"
-            if (col_name, idx_str) not in df_state.columns:
-                # df_state[(col_name, idx_str)] = np.nan
-                df_state[(col_name, idx_str)] = None
-            df_state.loc[grid_id, (col_name, idx_str)] = value
-
-        list_attr = ["flowchange"]
-
-        # Add all non-inherited properties
-        df_state.loc[grid_id, ("flowchange", "0")] = (
-            self.flowchange.value
-            if isinstance(self.flowchange, RefValue)
-            else self.flowchange
+        df_flow = df_from_cols(
+            {
+                ("flowchange", "0"): (
+                    self.flowchange.value
+                    if isinstance(self.flowchange, RefValue)
+                    else self.flowchange
+                )
+            },
+            index=df_state.index,
         )
 
-        return df_state
+        return pd.concat([df_state, df_flow], axis=1)
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "WaterProperties":
@@ -1108,21 +1097,21 @@ class VerticalLayers(BaseModel):
 
     def to_df_state(self, grid_id: int) -> pd.DataFrame:
         """Convert vertical layers to DataFrame state format."""
-        # Initialize empty DataFrame with grid_id index
-        df_state = init_df_state(grid_id)
-
         # Set number of vertical layers
         nlayer_val = (
             self.nlayer.value if isinstance(self.nlayer, RefValue) else self.nlayer
         )
-        df_state[(f"nlayer", "0")] = nlayer_val
+        cols = {
+            ("gridiv", "0"): grid_id,
+            ("nlayer", "0"): nlayer_val,
+        }
 
         # Set heights for each layer boundary (nlayer + 1 heights needed)
         height_val = (
             self.height.value if isinstance(self.height, RefValue) else self.height
         )
         for i in range(nlayer_val + 1):
-            df_state[("height", f"({i},)")] = height_val[i]
+            cols[("height", f"({i},)")] = height_val[i]
 
         # Set vegetation and building parameters for each layer
         for var in ["veg_frac", "veg_scale", "building_frac", "building_scale"]:
@@ -1131,22 +1120,17 @@ class VerticalLayers(BaseModel):
                 field_val.value if isinstance(field_val, RefValue) else field_val
             )
             for i in range(nlayer_val):
-                df_state[(f"{var}", f"({i},)")] = var_values[i]
+                cols[(f"{var}", f"({i},)")] = var_values[i]
+
+        frames = [df_from_cols(cols, index=pd.Index([grid_id], name="grid"))]
 
         # Convert roof and wall properties to DataFrame format for each layer
-        df_roofs = pd.concat(
-            [self.roofs[i].to_df_state(grid_id, i, "roof") for i in range(nlayer_val)],
-            axis=1,
-        )
-        df_walls = pd.concat(
-            [self.walls[i].to_df_state(grid_id, i, "wall") for i in range(nlayer_val)],
-            axis=1,
-        )
+        for i in range(nlayer_val):
+            frames.append(self.roofs[i].to_df_state(grid_id, i, "roof"))
+            frames.append(self.walls[i].to_df_state(grid_id, i, "wall"))
 
         # Combine all DataFrames
-        df_state = pd.concat([df_state, df_roofs, df_walls], axis=1)
-
-        return df_state
+        return pd.concat(frames, axis=1)
 
     @classmethod
     def from_df_state(cls, df: pd.DataFrame, grid_id: int) -> "VerticalLayers":

--- a/src/supy/data_model/core/type.py
+++ b/src/supy/data_model/core/type.py
@@ -169,6 +169,14 @@ def FlexibleRefValue(type_param):
     return Union[RefValue[type_param], type_param]
 
 
+def df_from_cols(cols: dict, index: pd.Index) -> pd.DataFrame:
+    df_state = pd.DataFrame(cols, index=index)
+    df_state.columns = pd.MultiIndex.from_tuples(
+        df_state.columns, names=["var", "ind_dim"]
+    )
+    return df_state
+
+
 def init_df_state(grid_id: int) -> pd.DataFrame:
     idx = pd.Index([grid_id], name="grid")
     col = pd.MultiIndex.from_tuples([("gridiv", "0")], names=["var", "ind_dim"])


### PR DESCRIPTION
## Summary

Refactors the data model to use `df_from_cols()` for efficient DataFrame construction instead of incremental column assignment. This eliminates pandas `PerformanceWarning` about DataFrame fragmentation.

## Key improvements

- Introduces `df_from_cols()` utility function for batch column creation
- Eliminates repeated "DataFrame is highly fragmented" performance warnings
- Consolidates multiple `pd.concat()` calls into single operations
- Deduplicates gridiv columns in Site.to_df_state() (reduces from 50 to 1)
- Removes unused `init_df_state()` imports where possible
- All smoke tests pass with no functional changes

## Test plan

- [x] Run smoke tests (13 passed, 2 skipped)
- [x] Verify data model roundtrip conversions work
- [x] Confirm no DataFrame fragmentation warnings
- [x] Check that Site.to_df_state() now has only 1 gridiv column

🤖 Generated with [Claude Code](https://claude.com/claude-code)