### PR TITLE
Fix: Correct grass albedo LAI-albedo relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ EXAMPLES:
 - [bugfix] `2017b` could not be converted at all -- an orphan in the converter version graph crashed with a cryptic `TypeError`; its table format is byte-identical to `2017a`, so it now joins the graph via a zero-delta equivalence edge (#1522)
 - [bugfix] Converter rule matching collected rows where *either* version-graph endpoint matched, which was wrong once two edges shared an endpoint; it now requires both endpoints (#1522)
 - [feature][experimental] Opt-in `SUEWSConfig.strict_initial_state_bounds` (default `True`, strict behaviour unchanged) lets a faithfully-converted legacy config whose initial albedo sits outside the modern seasonal range load with a warning instead of a hard validation error; `suews-convert` sets it for legacy conversions (#1522)
+- [bugfix] Corrected the grass albedo LAI relationship in the daily-state update (#1134)
+  - `update_Veg` applied the tree formula to grass, so grass albedo rose with LAI through the growing season; grass has the reversed relationship (a denser canopy is less reflective than the bright soil/litter it replaces), so increasing LAI must lower albedo
+  - Brings the Fortran daily-state update in line with the phenology albedo auto-initialisation (#1133) and the `alb_min`/`alb_max` field definitions, which already encode the reversed grass convention
 
 ### 11 Jun 2026
 

--- a/src/suews/src/suews_phys_dailystate.f95
+++ b/src/suews/src/suews_phys_dailystate.f95
@@ -508,7 +508,9 @@ CONTAINS
       iv = ivGrass
       IF ((LAI_id(iv) - LAI_id_prev(iv)) /= 0) THEN
          deltaLAIGrass = (LAI_id(iv) - LAI_id_prev(iv))/(LAImax(iv) - LAIMin(iv))
-         albChangeGrass = (AlbMax_Grass - AlbMin_Grass)*deltaLAIGrass
+         ! Grass has reversed LAI-albedo relationship: higher LAI -> lower albedo
+         ! (bright soil/litter background replaced by absorbing canopy)
+         albChangeGrass = (AlbMin_Grass - AlbMax_Grass)*deltaLAIGrass
       END IF
 
       iv = ivDecid


### PR DESCRIPTION
## Summary

Corrects the grass albedo update formula in the daily state module. Grass has a reversed LAI-albedo relationship compared to trees: increasing LAI should **decrease** albedo, not increase it.

## Problem

The Fortran code in `update_Veg` (`suews_phys_dailystate.f95`) was using the same albedo update formula for all vegetation types:
```fortran
albChangeGrass = (AlbMax_Grass - AlbMin_Grass)*deltaLAIGrass
```

This incorrectly increases grass albedo during the growing season, contradicting the physics (a dense grass canopy is less reflective than the bright soil/litter background it replaces). It was also inconsistent with the Python phenology albedo auto-initialisation (#1133) and the `alb_min`/`alb_max` field definitions, which already encode the reversed grass convention (`alb_max` = sparse/senesced, `alb_min` = full-leaf).

## Solution

Reversed the formula for grass to correctly model the negative LAI-albedo relationship:
```fortran
albChangeGrass = (AlbMin_Grass - AlbMax_Grass)*deltaLAIGrass
```

This is the only grass-albedo formula site in the codebase; the tree formulas and the albedo clamp are unchanged. Rebased onto current `master`; the regression fixture `sample_output.csv.gz` is regenerated against `master` + this fix (the per-timestep deltas below exceed the regression tolerance, so the reference fixture must move with the change). `test_sample_output` and `make test-smoke` both pass.

## Impact

Effect isolated as a fixed-vs-unfixed comparison (same config/forcing/obs; only the grass line differs).

- **Bulk albedo** (sample site, grass fraction 0.03): summer (JJA) mean −0.0009, winter (DJF) mean +0.0003; max |Δ| 0.0009 (= grass fraction × albedo range).
- **Fluxes** peak in the high-LAI, high-radiation summer. Per-timestep max |Δ| at the sample site: QS 2.2, QH 1.9, QE 0.6, QN 0.8 W/m² (annual *means* an order of magnitude smaller: QN +0.065, QS +0.037, QH +0.027 W/m²). T2 max |Δ| 0.011 °C.
- **Energy balance** closure (QN + QF = QH + QE + QS) is unchanged to machine precision (residual ~2e-13 W/m² before and after) — the fix repartitions reflected shortwave, it does not open or close the balance.

Canonical KCL/Ward energy-balance benchmark (2011–2013, real observations), grass fix isolated — **neutral-to-slightly-positive** on this dense-urban site (3% grass):

- **Kup** (reflected shortwave, the variable albedo directly controls): full-year MAE 2.443 vs 2.456 (better); summer MAE 2.733 vs 2.772 (better) with summer bias |MBE| 0.062 vs 0.106 — roughly halved and pulled toward zero. The old formula over-predicted summer reflected shortwave; the fix removes that bias.
- **QN / QH / QE / Lup**: MAE changes ≤ ~0.02 W/m² — no regression.

The effect scales with grass fraction × albedo range, so grassy / non-urban sites (the Omidvar et al. 2022 context) see a proportionally larger — and correct — change.

Closes #1134
