### PR TITLE
feat: Discourse-to-GitHub issue sync pipeline

### DIFF
--- a/.github/workflows/discourse-to-issue.yml
+++ b/.github/workflows/discourse-to-issue.yml
@@ -1,0 +1,168 @@
+name: Discourse → GitHub Issue
+
+on:
+  repository_dispatch:
+    types: [discourse-topic]
+  workflow_dispatch:
+    inputs:
+      topic_id:
+        description: "Discourse topic ID"
+        required: true
+        type: number
+      target_repo:
+        description: "Target repo (owner/name)"
+        required: false
+        default: "UMEP-dev/SUEWS"
+        type: string
+
+env:
+  DISCOURSE_HOST: https://community.suews.io
+  DISCOURSE_USERNAME: sunt05
+  DEFAULT_REPO: UMEP-dev/SUEWS
+
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "topic_id=${{ github.event.client_payload.topic_id }}" >> "$GITHUB_OUTPUT"
+            echo "target_repo=${{ env.DEFAULT_REPO }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "topic_id=${{ github.event.inputs.topic_id }}" >> "$GITHUB_OUTPUT"
+            echo "target_repo=${{ github.event.inputs.target_repo || env.DEFAULT_REPO }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch Discourse topic
+        id: discourse
+        env:
+          DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_SUEWS_ADMIN_KEY }}
+        run: |
+          TOPIC_ID="${{ steps.inputs.outputs.topic_id }}"
+
+          RESPONSE=$(curl -s -f \
+            -H "Api-Key: ${DISCOURSE_API_KEY}" \
+            -H "Api-Username: ${DISCOURSE_USERNAME}" \
+            "${DISCOURSE_HOST}/t/${TOPIC_ID}.json")
+
+          TITLE=$(echo "$RESPONSE" | jq -r '.title')
+          SLUG=$(echo "$RESPONSE" | jq -r '.slug')
+          TOPIC_URL="${DISCOURSE_HOST}/t/${SLUG}/${TOPIC_ID}"
+
+          # Get the first post (OP)
+          FIRST_POST_RAW=$(echo "$RESPONSE" | jq -r '.post_stream.posts[0].cooked')
+          AUTHOR=$(echo "$RESPONSE" | jq -r '.post_stream.posts[0].username')
+
+          # Convert HTML to plain-ish markdown (basic cleanup)
+          FIRST_POST=$(echo "$FIRST_POST_RAW" \
+            | sed 's/<br>/\n/g' \
+            | sed 's/<\/p>/\n\n/g' \
+            | sed 's/<[^>]*>//g' \
+            | sed 's/&amp;/\&/g; s/&lt;/</g; s/&gt;/>/g; s/&quot;/"/g; s/&#39;/'"'"'/g')
+
+          # Write outputs (use files for multiline)
+          echo "title=${TITLE}" >> "$GITHUB_OUTPUT"
+          echo "topic_url=${TOPIC_URL}" >> "$GITHUB_OUTPUT"
+          echo "author=${AUTHOR}" >> "$GITHUB_OUTPUT"
+          echo "topic_id=${TOPIC_ID}" >> "$GITHUB_OUTPUT"
+
+          # Use delimiter for multiline body
+          {
+            echo "body<<DISCOURSE_EOF"
+            echo "$FIRST_POST"
+            echo "DISCOURSE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build issue body
+        id: body
+        shell: bash
+        run: |
+          TOPIC_URL="${{ steps.discourse.outputs.topic_url }}"
+          AUTHOR="${{ steps.discourse.outputs.author }}"
+          TOPIC_ID="${{ steps.discourse.outputs.topic_id }}"
+
+          {
+            echo "**Reported on**: [SUEWS Community Forum](${TOPIC_URL})"
+            echo "**Reporter**: @${AUTHOR} (Discourse)"
+            echo ""
+            echo "---"
+            echo ""
+            echo "${{ steps.discourse.outputs.body }}"
+            echo ""
+            echo "---"
+            echo ""
+            echo "*Created from [Discourse topic #${TOPIC_ID}](${TOPIC_URL})*"
+          } > /tmp/issue-body.md
+
+      - name: Create GitHub issue
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_URL=$(gh issue create \
+            --repo "${{ steps.inputs.outputs.target_repo }}" \
+            --title "${{ steps.discourse.outputs.title }}" \
+            --body-file /tmp/issue-body.md \
+            --label "user-report" \
+            2>&1)
+
+          echo "issue_url=${ISSUE_URL}" >> "$GITHUB_OUTPUT"
+          echo "Created issue: ${ISSUE_URL}"
+
+      - name: Reply on Discourse
+        env:
+          DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_SUEWS_ADMIN_KEY }}
+        run: |
+          TOPIC_ID="${{ steps.discourse.outputs.topic_id }}"
+          ISSUE_URL="${{ steps.issue.outputs.issue_url }}"
+
+          REPLY_RAW="This topic has been tracked as a GitHub issue for the development team.\n\n**GitHub issue**: ${ISSUE_URL}\n\nThe team will follow up there. Updates will be posted in the GitHub issue."
+
+          # Build JSON payload with jq
+          PAYLOAD=$(jq -n \
+            --argjson tid "$TOPIC_ID" \
+            --arg raw "$(printf '%b' "$REPLY_RAW")" \
+            '{topic_id: $tid, raw: $raw}')
+
+          curl -s -f -X POST \
+            -H "Api-Key: ${DISCOURSE_API_KEY}" \
+            -H "Api-Username: ${DISCOURSE_USERNAME}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "${DISCOURSE_HOST}/posts.json"
+
+      - name: Tag Discourse topic
+        env:
+          DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_SUEWS_ADMIN_KEY }}
+        run: |
+          TOPIC_ID="${{ steps.discourse.outputs.topic_id }}"
+
+          # Fetch current tags
+          CURRENT_TAGS=$(curl -s -f \
+            -H "Api-Key: ${DISCOURSE_API_KEY}" \
+            -H "Api-Username: ${DISCOURSE_USERNAME}" \
+            "${DISCOURSE_HOST}/t/${TOPIC_ID}.json" \
+            | jq -r '[.tags[]?] | join(",")')
+
+          # Add github-issue-created tag
+          if [ -n "$CURRENT_TAGS" ]; then
+            ALL_TAGS="${CURRENT_TAGS},github-issue-created"
+          else
+            ALL_TAGS="github-issue-created"
+          fi
+
+          # Convert to JSON array
+          TAGS_JSON=$(echo "$ALL_TAGS" | tr ',' '\n' | jq -R . | jq -s .)
+
+          curl -s -f -X PUT \
+            -H "Api-Key: ${DISCOURSE_API_KEY}" \
+            -H "Api-Username: ${DISCOURSE_USERNAME}" \
+            -H "Content-Type: application/json" \
+            -d "{\"tags\": ${TAGS_JSON}}" \
+            "${DISCOURSE_HOST}/t/-/${TOPIC_ID}.json"
+
+          echo "Tagged topic ${TOPIC_ID} with github-issue-created"

--- a/scripts/cloudflare-worker/worker.js
+++ b/scripts/cloudflare-worker/worker.js
@@ -1,0 +1,83 @@
+/**
+ * Discourse → GitHub Dispatch Worker
+ *
+ * Bridges Discourse webhook events to GitHub repository_dispatch.
+ * Discourse can't customise webhook payload format or add Authorization headers,
+ * so this worker translates the payload and authenticates with GitHub.
+ *
+ * Secrets (set via `wrangler secret put`):
+ *   DISCOURSE_WEBHOOK_SECRET - shared secret for HMAC-SHA256 verification
+ *   GITHUB_PAT              - GitHub PAT with repo scope
+ */
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    const body = await request.text();
+
+    // 1. Verify Discourse webhook signature
+    const signature = request.headers.get("X-Discourse-Event-Signature");
+    if (!signature) {
+      return new Response("Missing signature", { status: 401 });
+    }
+
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(env.DISCOURSE_WEBHOOK_SECRET),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    const expected = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+    const expectedHex = "sha256=" + [...new Uint8Array(expected)]
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    if (signature !== expectedHex) {
+      return new Response("Invalid signature", { status: 403 });
+    }
+
+    // 2. Parse payload and extract topic info
+    const payload = JSON.parse(body);
+    const topic = payload.topic;
+    if (!topic) {
+      return new Response("No topic in payload", { status: 400 });
+    }
+
+    const topicId = topic.id;
+    const topicUrl = `https://community.suews.io/t/${topic.slug}/${topicId}`;
+
+    // 3. POST to GitHub repository_dispatch
+    const ghResponse = await fetch(
+      "https://api.github.com/repos/UMEP-dev/SUEWS/dispatches",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `token ${env.GITHUB_PAT}`,
+          Accept: "application/vnd.github.v3+json",
+          "User-Agent": "discourse-to-github-worker",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          event_type: "discourse-topic",
+          client_payload: {
+            topic_id: topicId,
+            topic_url: topicUrl,
+          },
+        }),
+      }
+    );
+
+    if (!ghResponse.ok) {
+      const errText = await ghResponse.text();
+      return new Response(`GitHub API error: ${ghResponse.status} ${errText}`, {
+        status: 502,
+      });
+    }
+
+    return new Response("Dispatched", { status: 200 });
+  },
+};

--- a/scripts/cloudflare-worker/wrangler.toml
+++ b/scripts/cloudflare-worker/wrangler.toml
@@ -1,0 +1,7 @@
+name = "discourse-to-github-dispatch"
+main = "worker.js"
+compatibility_date = "2024-01-01"
+
+# Secrets (set via CLI, not committed):
+#   wrangler secret put DISCOURSE_WEBHOOK_SECRET
+#   wrangler secret put GITHUB_PAT


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that creates GitHub issues from Discourse forum topics (community.suews.io)
- Adds a Cloudflare Worker that bridges Discourse webhooks to GitHub repository_dispatch, with HMAC-SHA256 signature verification
- The workflow replies on Discourse with the GitHub issue link and tags the topic with `github-issue-created`

## Setup required

- Add `DISCOURSE_SUEWS_ADMIN_KEY` secret to the repo (for Discourse API access)
- Deploy the Cloudflare Worker with `DISCOURSE_WEBHOOK_SECRET` and `GITHUB_PAT` secrets
- Configure a webhook in Discourse admin pointing to the Worker URL

## Test plan

- [ ] Deploy Cloudflare Worker to staging and verify signature validation
- [ ] Trigger workflow manually via `workflow_dispatch` with a known topic ID
- [ ] Verify GitHub issue is created with correct title, body, and label
- [ ] Verify Discourse reply and tag are applied to the source topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)