### PR TITLE
fix(docs): ensure sphinx-gallery installed for RTD builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -55,6 +55,11 @@ build:
     post_install:
       # Re-pin Sphinx after RTD's own install step (which may upgrade beyond 8.2)
       - python -m pip install "sphinx>=4.0,<8.2"
+      # Ensure sphinx-gallery is installed (needed for sphinx_gallery.load_style
+      # extension even with pre-built gallery). The supy[dev] wheel from TestPyPI
+      # may not include it if the wheel metadata was built before the dependency
+      # was added to pyproject.toml.
+      - python -m pip install "sphinx-gallery>=0.16.0"
       # Generate RST files after package is installed (data model docs)
       - cd docs && make generate-rst
 


### PR DESCRIPTION
## Summary

- RTD `latest` builds are failing with `ModuleNotFoundError: No module named 'sphinx_gallery'`
- The `supy[dev]` wheel from TestPyPI doesn't include `sphinx-gallery` in its dependency metadata
- `conf.py` needs `sphinx_gallery.load_style` extension even with pre-built gallery artefacts
- Adds explicit `pip install sphinx-gallery>=0.16.0` to `.readthedocs.yml` `post_install` as a safety net

## Test plan

- [ ] Merge to `rtd` and verify RTD `latest` build succeeds
- [ ] Check docs render correctly at https://docs.suews.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)