### PR TITLE
fix: use upstream tracking branch in conductor setup fallback

### DIFF
--- a/scripts/conductor/setup.sh
+++ b/scripts/conductor/setup.sh
@@ -10,13 +10,21 @@ git fetch origin --prune
 # Get current branch name (empty if detached HEAD)
 branch=$(git branch --show-current)
 
-# Reset to remote tracking branch, fallback to origin/master if not available
+# Reset to remote branch:
+#   1. origin/$branch if it exists (branch already pushed — sync with remote)
+#   2. @{upstream} if set (new branch tracking e.g. origin/rtd)
+#   3. Skip reset (fresh worktree, already at the right commit)
 if [ -n "$branch" ] && git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
     echo "[setup] Resetting to origin/$branch"
     git reset --hard "origin/$branch"
 else
-    echo "[setup] Branch '$branch' not found on origin, falling back to origin/master"
-    git reset --hard origin/master
+    upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true)
+    if [ -n "$upstream" ]; then
+        echo "[setup] Branch '$branch' not on origin, resetting to upstream: $upstream"
+        git reset --hard "$upstream"
+    else
+        echo "[setup] Branch '$branch' has no remote or upstream — skipping reset"
+    fi
 fi
 
 # Remove any remotes other than origin


### PR DESCRIPTION
## Summary

- `scripts/conductor/setup.sh` previously fell back to `origin/master` when the current branch wasn't found on origin
- This silently overwrote worktree content for branches created from non-master bases (e.g. `origin/rtd`)
- Now uses `@{upstream}` as fallback — git sets this correctly when creating a worktree with `git worktree add -b <name> origin/<base>`
- If no upstream is configured, skips the reset entirely (fresh worktree already at the right commit)

## Test plan

- [ ] Create a new worktree from `origin/rtd`: `git worktree add /tmp/test-ws -b test-branch origin/rtd`
- [ ] Run `setup.sh` — should reset to `origin/rtd`, not `origin/master`
- [ ] Verify with `git log --oneline -1` that HEAD matches `origin/rtd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)