### PR TITLE
ci: gate tag-triggered deployments on master ancestry

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -256,6 +256,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Verify that tag pushes originate from master before allowing releases.
+  # Non-master tags (e.g. docs-fix commits) skip deployment entirely.
+  verify-release-tag:
+    name: Verify tag is on master
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    outputs:
+      on-master: ${{ steps.check.outputs.on-master }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check
+        run: |
+          if git merge-base --is-ancestor $GITHUB_SHA refs/remotes/origin/master; then
+            echo "on-master=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Tag ${{ github.ref_name }} not on master — skipping release"
+            echo "on-master=false" >> $GITHUB_OUTPUT
+          fi
+
   # Create nightly tag BEFORE building to ensure correct version
   create_nightly_tag:
     name: Create nightly tag for scheduled builds
@@ -530,16 +551,18 @@ jobs:
   build_wheels:
     name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
     runs-on: ${{ matrix.buildplat[0] }}
-    needs: [determine_matrix, create_nightly_tag, detect-changes]
+    needs: [determine_matrix, create_nightly_tag, detect-changes, verify-release-tag]
     # Run if:
     # 1. Not a PR (push/tag/schedule always build), OR
     # 2. PR with code changes (detect-changes.outputs.needs-build == 'true')
     # 3. AND other dependencies succeeded/skipped
+    # 4. For tag events: only build if tag is on master (verify-release-tag gate)
     if: |
       always() &&
       needs.determine_matrix.result == 'success' &&
       (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped') &&
-      (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-build == 'true')
+      (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-build == 'true') &&
+      (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true')
     strategy:
       matrix:
         buildplat: ${{ fromJson(needs.determine_matrix.outputs.buildplat) }}
@@ -570,11 +593,12 @@ jobs:
   build_umep:
     name: Build UMEP wheel (rc1/dev1) for ${{ matrix.python }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
     runs-on: ${{ matrix.buildplat[0] }}
-    needs: [determine_matrix, create_nightly_tag, detect-changes]
+    needs: [determine_matrix, create_nightly_tag, detect-changes, verify-release-tag]
     # Run if:
     # 1. Not a PR (push/tag/schedule always build), OR
     # 2. PR with code changes (detect-changes.outputs.needs-build == 'true')
     # 3. AND other dependencies succeeded/skipped
+    # 4. For tag events: only build if tag is on master (verify-release-tag gate)
     # UMEP versioning:
     #   - Production tags: X.Y.Zrc1 (pre-release for QGIS)
     #   - Dev/nightly: X.Y.Z.dev1 (incremented to avoid collision with standard .dev0)
@@ -583,6 +607,7 @@ jobs:
       needs.determine_matrix.result == 'success' &&
       (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped') &&
       (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-build == 'true') &&
+      (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true') &&
       (github.event_name != 'workflow_dispatch' || inputs.include_umep == true)
     strategy:
       matrix:
@@ -703,13 +728,16 @@ jobs:
       - determine_matrix
       - build_wheels
       - create_nightly_tag  # Will be skipped for non-nightly builds
+      - verify-release-tag  # Will be skipped for non-tag events
     # Deploy to TestPyPI for nightly builds even if some platforms fail
     # This ensures continuous availability of development builds
     # Also allows manual dispatch with deploy_target == 'testpypi'
+    # For tag events: only deploy if tag is on master (verify-release-tag gate)
     if: |
       always() &&
       needs.build_wheels.result != 'cancelled' &&
       (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped') &&
+      (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true') &&
       (
         github.event_name == 'schedule' ||
         (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev')) ||
@@ -743,15 +771,18 @@ jobs:
       - build_wheels
       - build_umep  # UMEP builds (rc1 variants)
       - create_nightly_tag  # Will be skipped for non-nightly builds
+      - verify-release-tag  # Will be skipped for non-tag events
     # Only run for tagged releases WITHOUT 'dev' in the tag name
     # Deploy only if BOTH standard AND UMEP builds succeed (complete release)
+    # For tag events: only deploy if tag is on master (verify-release-tag gate)
     if: |
       always() &&
       startsWith(github.ref, 'refs/tags') &&
       !contains(github.ref, 'dev') &&
       needs.build_wheels.result == 'success' &&
       needs.build_umep.result == 'success' &&
-      (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped')
+      (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped') &&
+      (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true')
 
     # Set up permissions for OIDC authentication
     permissions:

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -43,6 +43,18 @@ jobs:
           fetch-tags: true
 
       # ------------------------------------------------------------------
+      # 1a. Verify tag is on master (skip docs sync for non-master tags)
+      # ------------------------------------------------------------------
+      - name: Verify tag is on master
+        if: github.ref_type == 'tag'
+        run: |
+          git fetch origin master --depth=50
+          if ! git merge-base --is-ancestor $GITHUB_SHA refs/remotes/origin/master; then
+            echo "::error::Tag ${{ github.ref_name }} not on master — skipping docs sync"
+            exit 1
+          fi
+
+      # ------------------------------------------------------------------
       # 2. Configure git identity
       # ------------------------------------------------------------------
       - name: Configure git


### PR DESCRIPTION
## Summary

- Add `verify-release-tag` job to `build-publish_to_pypi.yml` that checks whether a pushed tag is an ancestor of `master`
- Gate all build and deploy jobs on this check for tag events — prevents accidental PyPI releases from non-master tags (e.g. docs-fix commits)
- Add equivalent early check to `docs-sync.yml` so non-master tags do not trigger `rtd` branch merges or `rtd/*` tag creation
- Non-tag events (PRs, schedule, dispatch) are completely unaffected — the gate job is skipped and downstream jobs treat `skipped` as passing

## Context

This is needed before re-tagging `2026.1.28` with buildable RTD docs. Without this gate, pushing a tag on a non-master commit would trigger the full PyPI release pipeline.

## Test plan

- [ ] Push a test tag on a non-master branch → verify CI does NOT trigger deployment jobs
- [ ] Verify nightly builds still work (gate job skipped for schedule events)
- [ ] Verify PR validation still works (gate job skipped for PR events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)