### PR TITLE
ci: protect rtd branch with PAT auth and file-scope validation

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -37,10 +37,13 @@ jobs:
       # ------------------------------------------------------------------
       # 1. Checkout full history (needed for merge + change detection)
       # ------------------------------------------------------------------
+      # Uses RTD_PUSH_TOKEN (admin PAT) instead of GITHUB_TOKEN so that
+      # pushes to the protected rtd branch bypass the PR requirement.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ secrets.RTD_PUSH_TOKEN }}
 
       # ------------------------------------------------------------------
       # 1a. Verify tag is on master (skip docs sync for non-master tags)
@@ -280,6 +283,29 @@ jobs:
           RTD_TAG="rtd/${TAG_NAME}"
           echo "Creating tag: $RTD_TAG"
           git tag "$RTD_TAG"
+
+      # ------------------------------------------------------------------
+      # 7a. Validate rtd only diverges from master in docs-related paths
+      # ------------------------------------------------------------------
+      - name: Validate docs-only divergence
+        run: |
+          # After merge + gallery commit, rtd should only differ from master
+          # in documentation-related files. Reject any other divergence.
+          FORBIDDEN=$(git diff --name-only origin/master..HEAD -- \
+            ':!docs/' \
+            ':!.readthedocs.yml' \
+            ':!env.yml' \
+            ':!pyproject.toml' \
+          )
+
+          if [ -n "$FORBIDDEN" ]; then
+            echo "::error::rtd branch has non-docs divergence from master:"
+            echo "$FORBIDDEN"
+            echo ""
+            echo "Only these paths may differ: docs/, .readthedocs.yml, env.yml, pyproject.toml"
+            exit 1
+          fi
+          echo "✓ rtd branch diverges from master only in docs-allowed paths"
 
       # ------------------------------------------------------------------
       # 8. Push rtd branch (and tag if created)


### PR DESCRIPTION
## Summary

- Switch docs-sync checkout to `RTD_PUSH_TOKEN` (admin PAT) so the workflow can push to the now-protected `rtd` branch
- Add pre-push validation step that ensures `rtd` only diverges from `master` in docs-related paths (`docs/`, `.readthedocs.yml`, `env.yml`, `pyproject.toml`)
- Any non-docs divergence blocks the push with a clear error message

## Context

The `rtd` branch now has a GitHub ruleset (ID 12293961) requiring PRs for non-bypass actors. Only admin role can bypass. The workflow uses `RTD_PUSH_TOKEN` (admin PAT) to authenticate pushes, bypassing the PR requirement.

Protection layers:
- **GitHub ruleset**: blocks direct pushes from non-admin contributors
- **File validation**: blocks workflow pushes if non-docs files diverge
- **CI tag gate** (PR #1162): blocks non-master tags from triggering deployment

## Test plan

- [ ] docs-sync workflow runs successfully after merge (PAT auth works)
- [ ] File validation passes for normal master → rtd sync
- [ ] Non-admin direct push to `rtd` is rejected by ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)