### PR TITLE
fix(ci): allow .gitignore divergence in rtd branch validation

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -294,6 +294,7 @@ jobs:
           FORBIDDEN=$(git diff --name-only origin/master..HEAD -- \
             ':!docs/' \
             ':!.readthedocs.yml' \
+            ':!.gitignore' \
             ':!env.yml' \
             ':!pyproject.toml' \
           )
@@ -302,7 +303,7 @@ jobs:
             echo "::error::rtd branch has non-docs divergence from master:"
             echo "$FORBIDDEN"
             echo ""
-            echo "Only these paths may differ: docs/, .readthedocs.yml, env.yml, pyproject.toml"
+            echo "Only these paths may differ: docs/, .readthedocs.yml, .gitignore, env.yml, pyproject.toml"
             exit 1
           fi
           echo "✓ rtd branch diverges from master only in docs-allowed paths"


### PR DESCRIPTION
## Summary

- Add `.gitignore` to allowed paths in docs-sync's `Validate docs-only divergence` step
- The `rtd` branch legitimately differs from `master` in `.gitignore` (un-ignoring pre-built gallery artefacts)

Fixes docs-sync failure: https://github.com/UMEP-dev/SUEWS/actions/runs/21517963266

🤖 Generated with [Claude Code](https://claude.com/claude-code)