### PR TITLE
ci: pre-build docs HTML on CI, serve from rtd branch

### DIFF
--- a/.github/scripts/pr-gate.sh
+++ b/.github/scripts/pr-gate.sh
@@ -67,9 +67,8 @@ if [[ "${NEEDS_BUILD}" == "true" ]]; then
 else
   echo "No code changes - builds not required"
 
-  # Empty matrix = success (0 entries); job-level if=false = skipped; both valid
-  if { [[ "${BUILD_WHEELS_RESULT}" == "skipped" ]] || [[ "${BUILD_WHEELS_RESULT}" == "success" ]]; } && \
-     { [[ "${BUILD_UMEP_RESULT}" == "skipped" ]] || [[ "${BUILD_UMEP_RESULT}" == "success" ]]; }; then
+  if [[ "${BUILD_WHEELS_RESULT}" == "skipped" ]] && \
+     [[ "${BUILD_UMEP_RESULT}" == "skipped" ]]; then
     echo "[OK] Code builds correctly skipped"
   else
     echo "Note: Unexpected build activity for non-code PR"

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -348,12 +348,12 @@ jobs:
       always() &&
       needs.determine_matrix.result == 'success' &&
       (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped') &&
+      (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-build == 'true') &&
       (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true')
     strategy:
       matrix:
-        # Empty matrix when no build needed — avoids unresolved ${{ matrix.* }} in UI
-        buildplat: ${{ (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-build == 'true') && fromJson(needs.determine_matrix.outputs.buildplat) || fromJson('[]') }}
-        python: ${{ (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-build == 'true') && fromJson(needs.determine_matrix.outputs.python) || fromJson('[]') }}
+        buildplat: ${{ fromJson(needs.determine_matrix.outputs.buildplat) }}
+        python: ${{ fromJson(needs.determine_matrix.outputs.python) }}
       fail-fast: false
 
     steps:
@@ -384,14 +384,14 @@ jobs:
       always() &&
       needs.determine_matrix.result == 'success' &&
       (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped') &&
+      (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-umep-build == 'true') &&
       (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true') &&
       (github.event_name != 'workflow_dispatch' || inputs.include_umep == true)
     strategy:
       matrix:
-        # Empty matrix when no UMEP build needed — avoids unresolved ${{ matrix.* }} in UI
         # Full platforms for production tags only; limited (win cp312) otherwise
-        buildplat: ${{ (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-umep-build == 'true') && ((startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'dev')) && fromJson(needs.determine_matrix.outputs.buildplat) || fromJson(needs.determine_matrix.outputs.umep_buildplat)) || fromJson('[]') }}
-        python: ${{ (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-umep-build == 'true') && fromJson(needs.determine_matrix.outputs.umep_python) || fromJson('[]') }}
+        buildplat: ${{ (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'dev')) && fromJson(needs.determine_matrix.outputs.buildplat) || fromJson(needs.determine_matrix.outputs.umep_buildplat) }}
+        python: ${{ fromJson(needs.determine_matrix.outputs.umep_python) }}
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Shifts documentation delivery from RTD source builds to a pre-built model. The docs-sync workflow now builds full HTML+gallery and commits to the rtd branch; RTD config is simplified to just copy the pre-built output.

Key changes:
- Removes fragile Fortran/pip/wheel fallback logic (fixes Sphinx 8 compatibility from #1157)
- Defensive guards: git rm stale HTML before re-add, RTD fails with clear error if no build found
- Expands change detection to all docs/ changes for full consistency
- Broader CI cost trade-off documented for future optimisation if needed

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>