### PR TITLE
ci: reusable workflow for clean skipped-job names

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -341,8 +341,7 @@ jobs:
             await script({ github, context });
 
   build_wheels:
-    name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
-    runs-on: ${{ matrix.buildplat[0] }}
+    name: Build standard wheels
     needs: [determine_matrix, create_nightly_tag, detect-changes, verify-release-tag]
     if: |
       always() &&
@@ -350,34 +349,18 @@ jobs:
       (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped') &&
       (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-build == 'true') &&
       (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true')
-    strategy:
-      matrix:
-        buildplat: ${{ fromJson(needs.determine_matrix.outputs.buildplat) }}
-        python: ${{ fromJson(needs.determine_matrix.outputs.python) }}
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: recursive
-
-      - name: Build SUEWS wheels (standard variant)
-        uses: ./.github/actions/build-suews
-        with:
-          buildplat: ${{ matrix.buildplat[0] }}
-          buildplat_name: ${{ matrix.buildplat[1] }}
-          buildplat_arch: ${{ matrix.buildplat[2] }}
-          python: ${{ matrix.python }}
-          is_umep_variant: 'false'
-          wheel_name_suffix: ''
-          test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
-          is_testpypi_build: ${{ github.event_name == 'schedule' || (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev')) }}
-          enable_dts: ${{ github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') }}
+    uses: ./.github/workflows/build-wheels-reusable.yml
+    with:
+      buildplat_json: ${{ needs.determine_matrix.outputs.buildplat }}
+      python_json: ${{ needs.determine_matrix.outputs.python }}
+      test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
+      is_umep_variant: 'false'
+      wheel_name_suffix: ''
+      is_testpypi_build: ${{ github.event_name == 'schedule' || (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev')) }}
+      enable_dts: ${{ github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') }}
 
   build_umep:
-    name: Build UMEP wheel (rc1/dev1) for ${{ matrix.python }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
-    runs-on: ${{ matrix.buildplat[0] }}
+    name: Build UMEP wheels
     needs: [determine_matrix, create_nightly_tag, detect-changes, verify-release-tag]
     # PRs skip UMEP unless compiled extension ABI may differ (fortran/build-system)
     if: |
@@ -387,31 +370,16 @@ jobs:
       (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-umep-build == 'true') &&
       (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true') &&
       (github.event_name != 'workflow_dispatch' || inputs.include_umep == true)
-    strategy:
-      matrix:
-        # Full platforms for production tags only; limited (win cp312) otherwise
-        buildplat: ${{ (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'dev')) && fromJson(needs.determine_matrix.outputs.buildplat) || fromJson(needs.determine_matrix.outputs.umep_buildplat) }}
-        python: ${{ fromJson(needs.determine_matrix.outputs.umep_python) }}
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: recursive
-
-      - name: Build SUEWS wheels (UMEP variant)
-        uses: ./.github/actions/build-suews
-        with:
-          buildplat: ${{ matrix.buildplat[0] }}
-          buildplat_name: ${{ matrix.buildplat[1] }}
-          buildplat_arch: ${{ matrix.buildplat[2] }}
-          python: ${{ matrix.python }}
-          is_umep_variant: 'true'
-          wheel_name_suffix: '-umep'
-          test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
-          is_testpypi_build: ${{ github.event_name == 'schedule' || (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev')) }}
-          enable_dts: ${{ github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') }}
+    uses: ./.github/workflows/build-wheels-reusable.yml
+    with:
+      # Full platforms for production tags only; limited (win cp312) otherwise
+      buildplat_json: ${{ (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'dev')) && needs.determine_matrix.outputs.buildplat || needs.determine_matrix.outputs.umep_buildplat }}
+      python_json: ${{ needs.determine_matrix.outputs.umep_python }}
+      test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
+      is_umep_variant: 'true'
+      wheel_name_suffix: '-umep'
+      is_testpypi_build: ${{ github.event_name == 'schedule' || (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev')) }}
+      enable_dts: ${{ github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') }}
 
   # Single consolidated check for branch protection (always runs for PRs/merge queue)
   pr-gate:

--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -1,0 +1,71 @@
+# Reusable workflow: build SUEWS wheels with a matrix strategy.
+#
+# Called by build-publish_to_pypi.yml for both standard and UMEP variants.
+# By isolating the matrix here, the caller jobs can use static names that
+# display cleanly when skipped (no unresolved ${{ matrix.* }} literals).
+
+name: Build wheels (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      buildplat_json:
+        description: 'JSON array of [runner, platform_name, arch] triples'
+        required: true
+        type: string
+      python_json:
+        description: 'JSON array of Python versions (e.g. ["cp312","cp313"])'
+        required: true
+        type: string
+      test_tier:
+        description: 'Test tier: smoke, core, cfg, standard, or all'
+        required: true
+        type: string
+      is_umep_variant:
+        description: 'Whether this is a UMEP variant build'
+        required: true
+        type: string
+      wheel_name_suffix:
+        description: 'Suffix for wheel artifact name (e.g. "", "-umep")'
+        required: false
+        type: string
+        default: ''
+      is_testpypi_build:
+        description: 'Whether this is a TestPyPI build'
+        required: false
+        type: string
+        default: 'false'
+      enable_dts:
+        description: 'Enable DTS type wrappers'
+        required: false
+        type: string
+        default: 'false'
+
+jobs:
+  build:
+    name: ${{ matrix.python }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
+    runs-on: ${{ matrix.buildplat[0] }}
+    strategy:
+      matrix:
+        buildplat: ${{ fromJson(inputs.buildplat_json) }}
+        python: ${{ fromJson(inputs.python_json) }}
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Build SUEWS wheels
+        uses: ./.github/actions/build-suews
+        with:
+          buildplat: ${{ matrix.buildplat[0] }}
+          buildplat_name: ${{ matrix.buildplat[1] }}
+          buildplat_arch: ${{ matrix.buildplat[2] }}
+          python: ${{ matrix.python }}
+          is_umep_variant: ${{ inputs.is_umep_variant }}
+          wheel_name_suffix: ${{ inputs.wheel_name_suffix }}
+          test_tier: ${{ inputs.test_tier }}
+          is_testpypi_build: ${{ inputs.is_testpypi_build }}
+          enable_dts: ${{ inputs.enable_dts }}


### PR DESCRIPTION
## Summary
- Extracts wheel-build matrix strategy into `.github/workflows/build-wheels-reusable.yml`
- Caller jobs (`build_wheels`, `build_umep`) now have static names that display cleanly when skipped by path filtering
- When running, the reusable workflow's internal matrix entries show resolved `cp312-manylinux x86_64` names as before

## Test plan
- [ ] PR with docs-only changes: caller jobs show "Build standard wheels" / "Build UMEP wheels" (skipped) — no `${{ matrix.* }}` literals
- [ ] PR with Fortran changes: reusable workflow runs, matrix entries display resolved platform names
- [ ] `pr-gate` validation passes (result propagation: caller reflects reusable workflow outcome)
- [ ] Artifacts from reusable workflow are accessible by deploy jobs

Closes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)