### PR TITLE
feat(dts): add run_dts_multi for multi-grid simulation support

### DIFF
--- a/src/supy/dts/__init__.py
+++ b/src/supy/dts/__init__.py
@@ -75,7 +75,7 @@ if _DTS_AVAILABLE:
         populate_storedrainprm,
         populate_timer_from_datetime,
     )
-    from ._runner import run_dts
+    from ._runner import run_dts, run_dts_multi
 
 else:
     # Fast build - provide stub functions that raise clear errors
@@ -160,6 +160,10 @@ else:
         """Stub: DTS not available."""
         _check_dts_available()
 
+    def run_dts_multi(*args, **kwargs):
+        """Stub: DTS not available."""
+        _check_dts_available()
+
 
 __all__ = [
     "build_full_output_dataframe",
@@ -182,6 +186,7 @@ __all__ = [
     "populate_storedrainprm",
     "populate_timer_from_datetime",
     "run_dts",
+    "run_dts_multi",
     # Utility for checking availability
     "_DTS_AVAILABLE",
     "_check_dts_available",

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -20,7 +20,7 @@ from ._run import run_supy_ser
 from ._supy_module import _save_supy
 from .data_model import RefValue
 from .data_model.core import SUEWSConfig
-from .dts import _check_dts_available, run_dts
+from .dts import _check_dts_available, run_dts_multi
 
 # Import new OOP classes
 from .suews_forcing import SUEWSForcing
@@ -83,6 +83,7 @@ class SUEWSSimulation:
         self._df_output = None
         self._df_state_final = None
         self._initial_states_final = None  # Pydantic state for DTS backend
+        self._dict_final_states = None  # Per-grid final states for DTS backend
         self._run_completed = False
 
         if config is not None:
@@ -549,14 +550,20 @@ class SUEWSSimulation:
         # Run simulation with selected backend
         if backend == "dts":
             # DTS backend: direct Pydantic-to-Fortran execution
-            df_output, final_state = run_dts(
+            df_output, dict_final_states = run_dts_multi(
                 df_forcing=df_forcing_slice,
                 config=self._config,
             )
             self._df_output = df_output
             # DTS extracts state to Pydantic InitialStates (not DataFrame)
             self._df_state_final = None
-            self._initial_states_final = final_state.get("initial_states")
+            # Store per-grid final states; expose first site's initial_states
+            # for single-grid backward compatibility
+            self._dict_final_states = dict_final_states
+            first_grid = self._config.sites[0].gridiv
+            self._initial_states_final = dict_final_states[first_grid].get(
+                "initial_states"
+            )
         else:
             # Traditional backend: DataFrame-based execution
             result = run_supy_ser(

--- a/test/core/test_dts_multi_grid.py
+++ b/test/core/test_dts_multi_grid.py
@@ -1,0 +1,141 @@
+"""Tests for DTS multi-grid support.
+
+Verifies that run_dts_multi iterates over all sites in a configuration,
+produces output with a grid-level MultiIndex, and matches single-grid
+run_dts results for the single-site case.
+
+Note: These tests require a full build with DTS type wrappers (make dev-dts).
+      They are automatically skipped when running with a fast build (make dev).
+"""
+
+import copy
+
+import pandas as pd
+import pytest
+
+from supy import load_SampleData
+from supy.data_model import SUEWSConfig
+from supy.dts import _DTS_AVAILABLE, run_dts, run_dts_multi
+
+# Skip all tests in this module if DTS is not available (fast build)
+pytestmark = pytest.mark.skipif(
+    not _DTS_AVAILABLE, reason="DTS not available (fast build without type wrappers)"
+)
+
+# Number of timesteps for quick tests (4 hours at 5-min resolution)
+N_TIMESTEPS = 48
+
+
+@pytest.fixture
+def sample_data():
+    """Load sample data and build a single-site SUEWSConfig."""
+    df_state_init, df_forcing = load_SampleData()
+    grid_id = df_state_init.index.get_level_values("grid")[0]
+    config = SUEWSConfig.from_df_state(df_state_init.loc[[grid_id]])
+    df_forcing_subset = df_forcing.iloc[:N_TIMESTEPS]
+    return config, df_forcing_subset
+
+
+@pytest.fixture
+def multi_site_config(sample_data):
+    """Create a two-site config by duplicating the sample site with a different gridiv."""
+    config, df_forcing = sample_data
+    # Deep-copy the existing site and assign a new grid id
+    site_copy = copy.deepcopy(config.sites[0])
+    site_copy.gridiv = 99
+    site_copy.name = "duplicate site"
+    config_multi = copy.deepcopy(config)
+    config_multi.sites.append(site_copy)
+    return config_multi, df_forcing
+
+
+class TestRunDtsMultiSingleGrid:
+    """Tests for run_dts_multi with a single-site config."""
+
+    @pytest.mark.core
+    def test_single_grid_output_has_grid_index(self, sample_data):
+        """Output from single-site run_dts_multi has a grid level in the index."""
+        config, df_forcing = sample_data
+        df_output, _ = run_dts_multi(df_forcing, config)
+
+        assert isinstance(df_output.index, pd.MultiIndex)
+        assert "grid" in df_output.index.names
+        assert "datetime" in df_output.index.names
+
+    @pytest.mark.core
+    def test_single_grid_matches_run_dts(self, sample_data):
+        """Single-site run_dts_multi matches run_dts output values."""
+        config, df_forcing = sample_data
+
+        df_single, _ = run_dts(df_forcing, config, site_index=0)
+        df_multi, _ = run_dts_multi(df_forcing, config)
+
+        # Both should have identical values
+        pd.testing.assert_frame_equal(df_multi, df_single)
+
+    @pytest.mark.core
+    def test_single_grid_state_dict(self, sample_data):
+        """Final states dict has one entry for the single grid."""
+        config, df_forcing = sample_data
+        _, dict_states = run_dts_multi(df_forcing, config)
+
+        grid_id = config.sites[0].gridiv
+        assert grid_id in dict_states
+        assert len(dict_states) == 1
+        assert "initial_states" in dict_states[grid_id]
+
+
+class TestRunDtsMultiMultiGrid:
+    """Tests for run_dts_multi with a multi-site config."""
+
+    @pytest.mark.core
+    def test_multi_grid_output_has_grid_index(self, multi_site_config):
+        """Output from multi-site run has expected grid values in the index."""
+        config, df_forcing = multi_site_config
+        df_output, _ = run_dts_multi(df_forcing, config)
+
+        grids = df_output.index.get_level_values("grid").unique()
+        expected_grids = {s.gridiv for s in config.sites}
+        assert set(grids) == expected_grids
+
+    @pytest.mark.core
+    def test_multi_grid_output_shape(self, multi_site_config):
+        """Multi-grid output has n_timesteps * n_grids rows."""
+        config, df_forcing = multi_site_config
+        df_output, _ = run_dts_multi(df_forcing, config)
+
+        n_grids = len(config.sites)
+        assert len(df_output) == N_TIMESTEPS * n_grids
+
+    @pytest.mark.core
+    def test_multi_grid_state_per_grid(self, multi_site_config):
+        """Final states dict has one entry per grid."""
+        config, df_forcing = multi_site_config
+        _, dict_states = run_dts_multi(df_forcing, config)
+
+        assert len(dict_states) == len(config.sites)
+        for site in config.sites:
+            assert site.gridiv in dict_states
+            assert "initial_states" in dict_states[site.gridiv]
+
+
+class TestSimulationDtsMultiGrid:
+    """Tests for SUEWSSimulation.run(backend='dts') with multi-grid config."""
+
+    @pytest.mark.core
+    def test_simulation_dts_multi_grid(self, multi_site_config):
+        """SUEWSSimulation.run(backend='dts') works with multi-site config."""
+        from supy import SUEWSSimulation
+
+        config, df_forcing = multi_site_config
+
+        sim = SUEWSSimulation(config=config)
+        sim.update_forcing(df_forcing)
+
+        output = sim.run(backend="dts")
+        df = output.df
+
+        grids = df.index.get_level_values("grid").unique()
+        expected_grids = {s.gridiv for s in config.sites}
+        assert set(grids) == expected_grids
+        assert len(df) == N_TIMESTEPS * len(config.sites)


### PR DESCRIPTION
## Summary

Implements multi-site DTS execution with run_dts_multi, which iterates over all sites in a configuration and aggregates results into a single DataFrame with grid-level MultiIndex. Addresses all review comments with proper error handling, attribute initialization, and public API testing.

## Changes

• New run_dts_multi function for multi-grid simulations
• Validation for unique gridiv values to prevent silent overwrites
• Initialize _dict_final_states in SUEWSSimulation.__init__
• Remove dead hasattr fallback in site accessors
• Comprehensive test coverage for single and multi-grid configurations
• Tests use public API rather than direct attribute manipulation

## Test Plan

- [x] Tests verify single-grid output matches run_dts
- [x] Tests confirm multi-grid aggregation and grid index structure
- [x] Tests use public SUEWSSimulation API (constructor + update_forcing)
- [x] Tests ensure per-grid final states are stored correctly

🤖 Generated with Claude Code