### PR TITLE
fix(ci): use repo label scheme for docs-sync merge conflict issues

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -95,7 +95,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'docs',
+              labels: '1-maintenance,2-doc:user',
               per_page: 10,
             });
             const duplicate = existing.data.find(i => i.title === title);
@@ -126,7 +126,7 @@ jobs:
                 'git push origin rtd',
                 '```',
               ].join('\n'),
-              labels: ['docs'],
+              labels: ['1-maintenance', '2-doc:user', '3-P1'],
             });
 
       - name: Abort on merge conflict


### PR DESCRIPTION
Replace non-existent 'docs' label with the repo's 4-tier labelling system (1-maintenance, 2-doc:user, 3-P1) for merge conflict issues.

The duplicate search now filters on two labels for more precise deduplication.

Resolves #1169