### PR TITLE
docs: align 2026.1.28 release notes with stable RTD

### DIFF
--- a/.github/releases/2026.1.28.md
+++ b/.github/releases/2026.1.28.md
@@ -6,43 +6,53 @@ pip install --upgrade supy
 
 ## What's New
 
-Buildings breathe. They warm up during the day, release heat at night, and their occupants follow rhythms—turning on heating in the morning, cooling in the afternoon, running appliances in the evening. Until now, SUEWS modelled these patterns with static daily profiles. Version 2026.1.28 changes that.
+Version 2026.1.28 (released on 28 January 2026)
 
-### Dynamic Building Profiles
+This release focuses on stability improvements for QGIS/UMEP users, physics corrections, and executable documentation.
 
-STEBBS now supports 10-minute resolution profiles for heating setpoints, cooling setpoints, appliance usage, occupancy, and hot water demand. This means your building energy simulations can finally capture the sharp morning ramp-up when residents wake, the midday lull, and the evening peak—patterns that matter for urban heat island studies and demand-side energy research. (#1038)
+### Notable Changes
 
-### Improved Surface Heat Storage
+**QGIS Crash Fix**
 
-Different surfaces store heat differently. Roofs behave unlike roads; grass unlike concrete. The dynamic Objective Hysteresis Model (dyOHM) now calculates heat storage separately for each surface type, improving accuracy for mixed urban landscapes where surface composition varies block by block. (#1122)
+- Resolved crash issue where SUEWS caused QGIS to fail mid-run
+- Removed stdout writes (`PRINT *`, `WRITE(*,*)`) that conflicted with QGIS output handling
+- Replaced problematic code with structured warnings
+- Improved thread safety for parallel simulations
+- Related PRs: #1086, #1083
 
-### Executable Documentation
+**QGIS/UMEP Test Suite**
 
-Documentation you can run. Sphinx-gallery now powers executable tutorial examples that generate their own output and plots during documentation builds, so the examples you read are always up-to-date with the code. (#1057)
+- Added comprehensive compatibility tests to catch QGIS integration issues before release (#905)
 
-### Stability for QGIS Users
+**Executable Documentation**
 
-QGIS users know the frustration: a long SUEWS run crashes mid-way, losing hours of computation. This release eliminates several crash sources. We removed stdout writes that conflicted with QGIS's output handling (#1086), fixed thread-safety issues in parallel runs (#1083), and added a comprehensive QGIS/UMEP test suite to catch these problems before they reach you (#905).
+- Tutorial examples now run during documentation builds via sphinx-gallery
+- Ensures code examples remain current (#1057)
 
-### Physics Corrections
+### Physics Fixes
 
-Two CO2 flux calculations now work correctly:
-- **Biogenic CO2**: FcRespi (ecosystem respiration) now uses local temperature instead of a global average—critical for regional studies where climate varies across your domain (#1117)
-- **Population scaling**: NumCapita initialisation fixed, eliminating NaN values in anthropogenic CO2 calculations (#1053)
+- **Biogenic CO2**: Fixed FcRespi calculation to use local climate instead of global average temperature (#1117)
 
-### Future-Proofing
+- **NumCapita Initialisation**: Fixed uninitialised NumCapita causing NaN values in CO2 flux calculations (#1053)
 
-Pandas 3.0 brings breaking changes to Copy-on-Write behaviour and `asfreq()`. This release handles both, so your existing scripts will continue working when you upgrade Pandas (#1106).
+- **Error Flag Management**: Reset error flag before kernel calls to prevent stale errors across runs (#1109)
 
-### No Breaking Changes
+### Other Improvements
 
-Your existing SUEWS configurations and scripts work unchanged. Upgrade with confidence.
+- Pandas 3.0 forward compatibility (#1106)
+- Improved validation ranges for albedo and emissivity (#978, #979)
+- Structured error handling with detailed validation reports (#1070)
+- Vendored f90wrap runtime to eliminate pip dependency conflicts (#963)
+
+### Breaking Changes
+
+None. Full backward compatibility maintained with version 2025.11.20.
 
 ---
 
 ## Full Changelog
 
-For the complete list of changes including validation enhancements, build system improvements, and CI updates, see the [CHANGELOG](https://github.com/UMEP-dev/SUEWS/blob/master/CHANGELOG.md).
+For complete details, see the [CHANGELOG](https://github.com/UMEP-dev/SUEWS/blob/master/CHANGELOG.md).
 
 ## Citation
 


### PR DESCRIPTION
## Summary

Align GitHub release notes with the version published on ReadTheDocs stable documentation. This update focuses on tested, stable functionality actually released in 2026.1.28.

## Changes

- Focus narrative on QGIS stability, physics fixes, and validated features
- Align with live RTD v2026.1.28 documentation
- Omit unvalidated enhancements from original draft

## Verification

Release notes now match content at https://docs.suews.io/stable/version-history/v2026.1.28.html

🤖 Generated with Claude Code