### PR TITLE
feat(governance): add status tags for changelog entries

### DIFF
--- a/.claude/rules/changelog/format.md
+++ b/.claude/rules/changelog/format.md
@@ -23,15 +23,36 @@ Conventions for SUEWS CHANGELOG entries.
 
 ## Categories
 
-| Category | Use for |
-|----------|---------|
-| `[feature]` | New functionality |
-| `[bugfix]` | Bug fixes (link issue) |
-| `[change]` | User-facing changes |
-| `[maintenance]` | Internal/dev tooling, CLAUDE.md |
-| `[doc]` | User documentation (not CLAUDE.md) |
+- `[feature]` - New functionality
+- `[bugfix]` - Bug fixes (link issue)
+- `[change]` - User-facing/breaking changes
+- `[maintenance]` - Internal/dev tooling, CLAUDE.md
+- `[doc]` - User documentation (not CLAUDE.md)
 
 **IMPORTANT**: CLAUDE.md updates are `[maintenance]`, not `[doc]`
+
+---
+
+## Status Tags (Governance)
+
+For `[feature]` and `[change]` entries, add a status tag:
+
+- `[experimental]` - Under development, not for public announcement
+- `[stable]` - Governance-approved, can appear in public release notes
+- `[internal]` - Internal tooling, never announced publicly
+
+**Rules**:
+- New features default to `[experimental]` until governance approval
+- Only `[stable]` entries are included in public release announcements
+- `[bugfix]`, `[maintenance]`, `[doc]` do not need status tags
+
+**Format**: `[category][status] Description (#ref)`
+
+```markdown
+- [feature][experimental] Added new radiation scheme (#123)
+- [feature][stable] Added OOP interface for output data (#456)
+- [change][experimental] Refactored land cover API (#789)
+```
 
 ---
 

--- a/.claude/skills/audit-pr/SKILL.md
+++ b/.claude/skills/audit-pr/SKILL.md
@@ -16,17 +16,30 @@ gh pr diff {pr} --name-only
 
 ## Workflow
 
-| Step | Action | Skill/Reference |
-|------|--------|-----------------|
-| 1 | **Context** | Gather files, classify changes |
-| 2 | **Code Style** | lint-code |
-| 3 | **Scientific** | Physics validation (if applicable) |
-| 4 | **Testing** | Coverage, FIRST principles |
-| 5 | **Docs** | CHANGELOG, PR description |
-| 6 | **Build** | CI status, meson.build |
-| 7 | **Draft** | Comments for approval |
-| 8 | **Approval** | Wait for human confirmation |
-| 9 | **Post** | Only after approval |
+- **Step 1 - Context**: Gather files, classify changes
+- **Step 2 - Code Style**: lint-code
+- **Step 3 - Scientific**: Physics validation (if applicable)
+- **Step 4 - Testing**: Coverage, FIRST principles
+- **Step 5 - Docs**: CHANGELOG, PR description
+- **Step 6 - Governance**: Check feature status tags (see below)
+- **Step 7 - Build**: CI status, meson.build
+- **Step 8 - Draft**: Comments for approval
+- **Step 9 - Approval**: Wait for human confirmation
+- **Step 10 - Post**: Only after approval
+
+## Governance Check (Step 6)
+
+For PRs that add new features or breaking changes:
+
+- Verify CHANGELOG entries have appropriate status tags
+- New `[feature]` entries should have `[experimental]` tag by default
+- Flag if `[stable]` tag is used without governance approval
+- Check PR description mentions if feature is experimental
+
+**Questions to ask**:
+- Is this feature ready for public announcement?
+- Does it have associated publication/evaluation?
+- Has the governance panel reviewed it?
 
 Details: `references/workflow-steps.md`
 

--- a/.claude/skills/log-changes/SKILL.md
+++ b/.claude/skills/log-changes/SKILL.md
@@ -18,13 +18,21 @@ Fill CHANGELOG.md gap from last documented date to today.
 
 ## Categories
 
-| Category | Use for |
-|----------|---------|
-| `[feature]` | New functionality |
-| `[bugfix]` | Bug fixes |
-| `[change]` | User-facing changes |
-| `[maintenance]` | Dev tooling, CLAUDE.md |
-| `[doc]` | User docs (not CLAUDE.md) |
+- `[feature]` - New functionality
+- `[bugfix]` - Bug fixes
+- `[change]` - User-facing changes
+- `[maintenance]` - Dev tooling, CLAUDE.md
+- `[doc]` - User docs (not CLAUDE.md)
+
+## Status Tags (Governance)
+
+For `[feature]` and `[change]` entries, add a status tag:
+
+- `[experimental]` - Default for new features, not publicly announced
+- `[stable]` - Governance-approved, included in release notes
+- `[internal]` - Internal tooling, never announced
+
+**Default behaviour**: New `[feature]` and `[change]` entries get `[experimental]` tag unless explicitly marked otherwise.
 
 ## Key Rules
 
@@ -32,6 +40,7 @@ Fill CHANGELOG.md gap from last documented date to today.
 - Include refs: `(#123)` for PRs, `(abc1234)` for commits
 - Skip minor changes (formatting, typos)
 - British English
+- **New features default to `[experimental]`** — only governance-approved features get `[stable]`
 
 Details: `references/workflow-details.md`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,28 @@
-<!-- Each entry should fall into one of the following categories: -->
-<!-- [feature]: New feature -->
-<!-- [bugfix]: Bug fixes; also, create a related GitHub issue -->
-<!-- [maintenance]: Codebase maintenance (including Claude Code/dev tooling) -->
-<!-- [doc]: Documentation updates -->
-<!-- [change]: Changes exposed to users -->
+<!-- CHANGELOG ENTRY GUIDELINES -->
+<!--
+CATEGORIES (required):
+  [feature]     - New functionality
+  [bugfix]      - Bug fixes (link related GitHub issue)
+  [change]      - Breaking changes or user-facing API changes
+  [maintenance] - Internal/dev tooling, CI, CLAUDE.md updates
+  [doc]         - User documentation updates
+
+STATUS TAGS (for [feature] and [change] only):
+  [experimental] - Under development, not for public announcement
+  [stable]       - Reviewed and approved for public release notes
+  [internal]     - Internal tooling, never announced publicly
+
+DEFAULTS:
+  - New [feature] entries default to [experimental]
+  - Only governance-approved features get [stable] tag
+  - [bugfix], [maintenance], [doc] don't need status tags
+
+EXAMPLES:
+  - [feature][experimental] Added new radiation scheme (#123)
+  - [feature][stable] Added OOP interface for output data (#456)
+  - [change][experimental] Refactored land cover fraction API (#789)
+  - [bugfix] Fixed temperature calculation (#124)
+-->
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary

Introduces governance-aware status tags for CHANGELOG entries to control what gets publicly announced vs kept internal during development.

**New status tags** (for `[feature]` and `[change]` entries):
- `[experimental]` - default for new features, not publicly announced
- `[stable]` - governance-approved, included in release notes  
- `[internal]` - internal tooling, never announced

**Changes**:
- Updated CHANGELOG.md header with new guidelines
- Updated `.claude/rules/changelog/format.md` with status tag documentation
- Updated `/log-changes` skill to default new features to `[experimental]`
- Updated `/audit-pr` skill with new Step 6: Governance Check

## Context

Addresses the governance discussion from the 3 Feb 2026 team meeting regarding control over public-facing announcements. This is Phase 1 of the governance framework - providing tooling to tag entries appropriately.

## Test plan

- [ ] Verify `/log-changes` skill adds `[experimental]` tag by default for new features
- [ ] Verify `/audit-pr` skill flags features without status tags
- [ ] Verify CHANGELOG.md header renders correctly