### PR TITLE
docs(release): add umep-reqs update step to release workflow

### DIFF
--- a/.claude/skills/prep-release/SKILL.md
+++ b/.claude/skills/prep-release/SKILL.md
@@ -26,6 +26,7 @@ This workflow is **workspace-independent** - run from any worktree.
 6. **Submit PR** - Create PR, wait for CI, merge to master
 7. **Tag release** - Tag the merge commit on master
 8. **Verify** - Monitor Actions, PyPI, GitHub Release, Zenodo
+9. **Update umep-reqs** - PR to update supy version in UMEP-dev/umep-reqs
 
 Details: `references/release-steps.md`
 
@@ -60,7 +61,7 @@ Selection criteria:
 - Recent enough (includes desired changes)
 - No critical issues reported since
 
-## Pre-Release Checklist
+## Release Checklist
 
 ```
 [PASS/FAIL] No incomplete prior releases (all merged release PRs have tags)
@@ -74,6 +75,7 @@ Selection criteria:
 [PASS/FAIL] PR merged to master
 [PASS/FAIL] Git tag created on merge commit
 [PASS/FAIL] GitHub Release published (triggers Zenodo DOI)
+[PASS/FAIL] umep-reqs PR created (UMEP-dev/umep-reqs)
 Ready: YES/NO
 ```
 

--- a/.claude/skills/prep-release/references/release-steps.md
+++ b/.claude/skills/prep-release/references/release-steps.md
@@ -321,6 +321,34 @@ git push origin --delete release/$VERSION
 
 ---
 
+## Step 8: Update UMEP Requirements
+
+After the `rc1` build is published to PyPI, update the [umep-reqs](https://github.com/UMEP-dev/umep-reqs) package so QGIS/UMEP users get the new version.
+
+```bash
+# Clone and create branch
+cd /tmp && rm -rf umep-reqs
+gh repo clone UMEP-dev/umep-reqs && cd umep-reqs
+git checkout -b update-supy-${VERSION}rc1
+
+# Update pyproject.toml: change supy version
+# From: "supy==OLD_VERSION",
+# To:   "supy==${VERSION}rc1",
+
+# Commit and PR
+git add pyproject.toml
+git commit -m "chore(deps): update supy to ${VERSION}rc1"
+git push -u origin update-supy-${VERSION}rc1
+gh pr create --title "chore(deps): update supy to ${VERSION}rc1" \
+  --body "Updates supy to ${VERSION}rc1 for QGIS/UMEP compatibility.
+
+See: https://community.suews.io/t/suews-v${VERSION}-TOPIC_SLUG/TOPIC_ID"
+```
+
+**Why rc1?** The `rc1` variant is built with `numpy<2.0` constraint, compatible with QGIS's OSGeo environment which pins numpy to 1.26.x. Standard releases require numpy≥2.0.
+
+---
+
 ## Abort Release
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds Step 8/9 to release workflow: update UMEP-dev/umep-reqs after rc1 is published
- Adds checklist item for tracking

## Context

The `umep-reqs` meta-package pins supy version for QGIS/UMEP users. After each release, the rc1 build (with numpy<2.0 compatibility) needs to be updated there.

See: https://github.com/UMEP-dev/umep-reqs/pull/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)