### PR TITLE
fix(dts): correct availability check and remove unsupported param

### DIFF
--- a/src/supy/_env.py
+++ b/src/supy/_env.py
@@ -119,10 +119,10 @@ def _init_dts_check():
         from . import supy_driver as _supy_driver
 
         # Check if DTS type classes exist (only present in full build with wrap_dts_types=true)
-        # The module_type_heat module exists in both builds, but the HEATSTATE class
+        # The module_type_heat module exists in both builds, but the HEAT_STATE class
         # is only generated when DTS type wrappers are enabled
         return hasattr(_supy_driver, "module_type_heat") and hasattr(
-            _supy_driver.module_type_heat, "HEATSTATE"
+            _supy_driver.module_type_heat, "HEAT_STATE"
         )
     except ImportError:
         return False

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -572,7 +572,6 @@ class SUEWSSimulation:
             df_output, dict_final_states = run_dts_multi(
                 df_forcing=df_forcing_slice,
                 config=self._config,
-                chunk_day=chunk_day,
                 n_jobs=n_jobs,
             )
             self._df_output = df_output


### PR DESCRIPTION
## Summary

Fixes two bugs that prevented DTS backend from working:

- Fix DTS availability check to use correct class name `HEAT_STATE` (was `HEATSTATE`)
- Remove unsupported `chunk_day` parameter from `run_dts_multi` call

## Test plan

- [x] `make test-smoke` passes
- [x] DTS backend runs successfully after fix

Closes #1186