### PR TITLE
fix: pin pydantic>=2.12 for QGIS/OSGeo4W compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     # dask removed - CLI uses stdlib multiprocessing.pool.ThreadPool
 
     # Model requirements
-    "pydantic",
+    "pydantic>=2.12",
     "pyyaml",  # YAML configuration parsing (used in data_model/core/config.py)
     "f90nml",
     


### PR DESCRIPTION
## Summary

- Pin `pydantic>=2.12` in `pyproject.toml` to ensure pip upgrades past the older `pydantic_core` shipped with OSGeo4W/QGIS

## Context

OSGeo4W bundles an older `pydantic_core` that lacks `validate_core_schema` (introduced in pydantic-core 2.33 / pydantic 2.12). When users install supy via `pip install --user supy`, pip considers the system pydantic as satisfying the unpinned `"pydantic"` dependency, so the outdated `pydantic_core` remains. This causes an `ImportError` when loading the UMEP plugin in QGIS.

Reported in UMEP-dev/UMEP#821.

## Test plan

- [ ] Verify CI wheels build successfully with the new pin
- [ ] Confirm `pip install --user supy` on a clean OSGeo4W environment pulls pydantic >= 2.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)