### PR TITLE
Fix interpolation bounds error in RSL profiles (GH#1223)

### DIFF
--- a/src/suews/src/suews_phys_resist.f95
+++ b/src/suews/src/suews_phys_resist.f95
@@ -1,6 +1,7 @@
 ! Main module following naming standard: matches filename
 MODULE module_phys_resist
    USE module_ctrl_error, ONLY: ErrorHint
+   USE module_ctrl_const_physconst, ONLY: eps_fp
    IMPLICIT NONE
 
 CONTAINS
@@ -532,6 +533,7 @@ CONTAINS
       REAL(KIND(1D0)) :: zdm_zh ! zdm for roughness elements (i.e. zh>0)
       REAL(KIND(1D0)) :: z0m_zh0 ! z0m for non-roughness elements (i.e. zh=0)
       REAL(KIND(1D0)) :: zdm_zh0 ! zdm for non-roughness elements (i.e. zh=0)
+      REAL(KIND(1D0)) :: non_rough_fraction
 
       ! calculated values of FAI
       ! REAL(KIND(1D0)), INTENT(out) :: FAIBldg_use
@@ -597,12 +599,18 @@ CONTAINS
             ! areaZh = (sfr_surf(BldgSurf) + sfr_surf(ConifSurf) + sfr_surf(DecidSurf))
             ! TS 19 Jun 2022: take porosity of trees into account; to be consistent with PAI calculation in RSL
             PAI = DOT_PRODUCT(sfr_surf([BldgSurf, ConifSurf, DecidSurf]), [1D0, 1 - porosity_evetr, 1 - porosity_dectr])
+            PAI = MIN(MAX(PAI, 0D0), 1D0)
 
             ! z0m for non-roughness elements (i.e. zh=0)
-            z0m_zh0 = (z0m_Paved*sfr_surf(PavSurf) &
-                       + z0m_Grass*sfr_surf(GrassSurf) &
-                       + z0m_BSoil*sfr_surf(BSoilSurf) &
-                       + z0m_Water*sfr_surf(WaterSurf))/(1 - PAI)
+            non_rough_fraction = 1D0 - PAI
+            IF (non_rough_fraction > eps_fp) THEN
+               z0m_zh0 = (z0m_Paved*sfr_surf(PavSurf) &
+                          + z0m_Grass*sfr_surf(GrassSurf) &
+                          + z0m_BSoil*sfr_surf(BSoilSurf) &
+                          + z0m_Water*sfr_surf(WaterSurf))/non_rough_fraction
+            ELSE
+               z0m_zh0 = 0D0
+            END IF
             zdm_zh0 = 0
 
             !------------------------------------------------------------------------------
@@ -659,8 +667,13 @@ CONTAINS
                             76.5*MIN(PAI, .7)**5 - 40.*MIN(PAI, .7)**6)*Zh
                END IF
                ! #271: to smooth the z0m (and zdm) values when other non-rough surfaces are present
-               z0m = DOT_PRODUCT([z0m_zh, z0m_zh0], [PAI, 1 - PAI])
-               zdm = DOT_PRODUCT([zdm_zh, zdm_zh0], [PAI, 1 - PAI])
+               IF (non_rough_fraction > eps_fp) THEN
+                  z0m = DOT_PRODUCT([z0m_zh, z0m_zh0], [PAI, non_rough_fraction])
+                  zdm = DOT_PRODUCT([zdm_zh, zdm_zh0], [PAI, non_rough_fraction])
+               ELSE
+                  z0m = z0m_zh
+                  zdm = zdm_zh
+               END IF
 
             ELSEIF (Zh == 0) THEN !If zh calculated to be zero, set default roughness length and displacement height
                IF (PAI /= 0) CALL ErrorHint(15, 'In SUEWS_RoughnessParameters.f95, zh = 0 m but areaZh > 0', zh, PAI, notUsedI, modState)

--- a/src/suews/src/suews_phys_rslprof.f95
+++ b/src/suews/src/suews_phys_rslprof.f95
@@ -7,6 +7,7 @@ MODULE module_phys_rslprof
    USE module_ctrl_const_physconst, ONLY: eps_fp
    USE module_ctrl_error_state, ONLY: set_supy_error, add_supy_warning
    USE module_ctrl_error, ONLY: ErrorHint
+   USE, INTRINSIC :: ieee_arithmetic, ONLY: IEEE_IS_NAN
    IMPLICIT NONE
 
    INTEGER, PARAMETER :: nz = 30 ! number of levels 10 levels in canopy plus 20 (3 x Zh) above the canopy
@@ -149,7 +150,16 @@ CONTAINS
 
       ! Start just above displacement height plus roughness length
       ! This ensures (z - zdm)/z0m > 1, keeping the LOG argument positive
-      z_start = 1.01D0 * (zdm + z0m)  ! 1% above to avoid LOG singularity
+      z_start = MAX(1.01D0*(zdm + z0m), 0.1D0)  ! Keep above the roughness sublayer and avoid 0*Inf
+
+      IF (zMeas <= z_start) THEN
+         ! Degenerate case: keep a small positive monotonic array for downstream interpolation.
+         z_temp = MAX(z_start*1.5D0, z_start + 1.0D0)
+         DO i = 1, nz
+            zarray(i) = z_start + (i - 1)*(z_temp - z_start)/(nz - 1)
+         END DO
+         RETURN
+      END IF
 
       ! Calculate ratio for logarithmic spacing
       z_ratio = (zMeas/z_start)**(1.0D0/(nz-1))
@@ -377,6 +387,8 @@ CONTAINS
             vegfraction => siteInfo%vegfraction, &
             NonWaterFraction => siteInfo%NonWaterFraction, &
             zMeas => siteInfo%z, &
+            z0m_in => siteInfo%z0m_in, &
+            zdm_in => siteInfo%zdm_in, &
             tstep_real => timer%tstep_real, &
             ! tsfc_surf => heatState_out%tsfc_surf, &
             ! tsfc_roof => heatState_out%tsfc_roof, &
@@ -484,8 +496,20 @@ CONTAINS
 
             ELSE
                ! ========== MOST APPROACH ==========
-               ! Generate MOST height array
-               CALL setup_MOST_heights(nz, zdm, z0m, zMeas, zarray)
+               !correct RSL-based using SUEWS system-wide values
+               z0_RSL = z0m
+               zd_RSL = zdm
+               IF (IEEE_IS_NAN(z0_RSL) .OR. z0_RSL <= 0D0) THEN
+                  z0_RSL = MAX(z0m_in, 0.03D0)
+                  CALL add_supy_warning('RSLProfile: invalid MOST roughness length, using site z0m_in')
+               END IF
+               IF (IEEE_IS_NAN(zd_RSL) .OR. zd_RSL < 0D0) THEN
+                  zd_RSL = MAX(zdm_in, 0D0)
+                  CALL add_supy_warning('RSLProfile: invalid MOST displacement height, using site zdm_in')
+               END IF
+
+               ! Generate MOST height array from sanitised roughness values
+               CALL setup_MOST_heights(nz, zd_RSL, z0_RSL, zMeas, zarray)
 
                ! Initialize arrays
                psihatm_z = 0.0D0
@@ -494,9 +518,6 @@ CONTAINS
                ! use L_MOD as in other parts of SUEWS
                L_MOD_RSL = L_MOD
 
-               !correct RSL-based using SUEWS system-wide values
-               z0_RSL = z0m
-               zd_RSL = zdm
                zH_RSL = Zh
 
                Lc = -999
@@ -638,6 +659,18 @@ CONTAINS
 
       ! initialise variables
       idx_x = 0
+
+      IF (IEEE_IS_NAN(z_x)) THEN
+         CALL set_supy_error(103, 'interp_z: target height z_x is NaN')
+         v_x = 0.0D0
+         RETURN
+      END IF
+
+      IF (ANY(IEEE_IS_NAN(z))) THEN
+         CALL set_supy_error(103, 'interp_z: height array contains NaN')
+         v_x = 0.0D0
+         RETURN
+      END IF
 
       dif = z - z_x
       idx_x = MAXLOC(dif, 1, ABS(dif) < 1.D-6)
@@ -1325,4 +1358,3 @@ END MODULE module_phys_rslprof
 MODULE rsl_module
    USE module_phys_rslprof
 END MODULE rsl_module
-

--- a/src/suews_bridge/build.rs
+++ b/src/suews_bridge/build.rs
@@ -227,6 +227,7 @@ fn main() {
                     lib_path.display()
                 );
             }
+            println!("cargo:rerun-if-changed={}", lib_path.display());
         }
 
         println!("cargo:rustc-link-search=native={}", suews_lib_dir.display());

--- a/test/physics/test_rslprof.py
+++ b/test/physics/test_rslprof.py
@@ -5,6 +5,9 @@ Regression tests for Issue #572 where the MIN constraint on height arrays
 caused negative LOG arguments and negative wind speeds for tall buildings.
 """
 
+import logging
+import warnings
+
 import numpy as np
 import pytest
 
@@ -107,3 +110,39 @@ class TestWindProfiles:
             wind_speeds = df_output[u_cols].iloc[0].values
             valid_winds = wind_speeds[~np.isnan(wind_speeds)]
             assert np.all(valid_winds >= 0), "Negative wind speeds detected"
+
+    def test_full_building_auto_rsl_grid_runs_without_nan(self, sample_data):
+        """Regression test for GH#1223 full-building grids in the auto MOST path."""
+        df_state_init, df_forcing = sample_data
+        df_state_issue = df_state_init.iloc[[0]].copy()
+        df_forcing_short = df_forcing.iloc[:2]
+
+        for idx in range(7):
+            df_state_issue.loc[:, ("sfr_surf", f"({idx},)")] = 0.0
+        df_state_issue.loc[:, ("sfr_surf", "(1,)")] = 1.0
+
+        df_state_issue.loc[:, ("bldgh", "0")] = 17.464
+        df_state_issue.loc[:, ("evetreeh", "0")] = 0.0
+        df_state_issue.loc[:, ("dectreeh", "0")] = 0.0
+        df_state_issue.loc[:, ("faibldg", "0")] = 0.011
+        df_state_issue.loc[:, ("faievetree", "0")] = 0.0
+        df_state_issue.loc[:, ("faidectree", "0")] = 0.0
+        df_state_issue.loc[:, ("faimethod", "0")] = 0
+        df_state_issue.loc[:, ("roughlenmommethod", "0")] = 2
+        df_state_issue.loc[:, ("rslmethod", "0")] = 2
+        df_state_issue.loc[:, ("stabilitymethod", "0")] = 3
+        df_state_issue.loc[:, ("z", "0")] = 52.392
+        df_state_issue.loc[:, ("z0m_in", "0")] = 0.03
+        df_state_issue.loc[:, ("zdm_in", "0")] = 17.464
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            df_output, _ = sp.run_supy(
+                df_forcing_short,
+                df_state_issue,
+                logging_level=logging.CRITICAL,
+                check_input=False,
+            )
+
+        u10 = df_output[("SUEWS", "U10")]
+        assert not u10.isna().all(), "Full-building auto MOST grid returned only NaN wind output"


### PR DESCRIPTION
Fixes #1223

Adds defensive checks to prevent NaN and invalid values in MOST height generation:

- Validate z_x and height array for NaN before interpolation
- Clamp PAI to valid range [0,1] and protect division by zero
- Fall back to input z0m_in/zdm_in when computed values are invalid  
- Ensure minimum height above roughness sublayer for degenerate cases
- Includes regression test for full-building urban grids