### PR TITLE
Fix GH50: Separate infiltration from lateral water redistribution

### DIFF
--- a/docs/source/inputs/tables/SUEWS_SiteInfo/Input_Options.rst
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/Input_Options.rst
@@ -3851,7 +3851,7 @@ Input Options
 .. option:: ToRunoff
 
 	:Description:
-		Fraction of water going to `Runoff`
+		Fraction of drainage going to `Runoff` (applied after infiltration for pervious surfaces)
 
 	:Configuration:
 		.. csv-table::
@@ -3859,20 +3859,6 @@ Input Options
 			:file: csv-table/ToRunoff.csv
 			:header-rows: 1
 			:widths: 44 18 38
-
-
-.. option:: ToSoilStore
-
-	:Description:
-		Fraction of water going to `SoilStore`
-
-	:Configuration:
-		.. csv-table::
-			:class: longtable
-			:file: csv-table/ToSoilStore.csv
-			:header-rows: 1
-			:widths: 44 18 38
-
 
 .. option:: ToWater
 

--- a/docs/source/inputs/tables/SUEWS_SiteInfo/SUEWS_WithinGridWaterDist.rst
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/SUEWS_WithinGridWaterDist.rst
@@ -12,9 +12,8 @@ taken into account.
 Each row corresponds to a surface type (linked by the Code in column 1
 to the `SUEWS_SiteSelect.txt` columns:
 WithinGridPavedCode, WithinGridBldgsCode, …, WithinGridWaterCode). Each
-column contains the fraction of water flowing from the surface type to
-each of the other surface types or to runoff or the sub-surface soil
-store.
+column contains the fraction of drainage flowing from the source surface
+to each of the other surface types or to runoff.
 
 .. note::
 
@@ -24,9 +23,13 @@ store.
   -  The row corresponding to the water surface should be zero, as there
      is currently no flow permitted from the water surface to other
      surfaces by the model.
-  -  Currently water **CANNOT** go to both runoff and soil store (i.e. it
-     must go to one or the other – `Runoff` for impervious surfaces;
-     `SoilStore` for pervious surfaces).
+  -  For pervious surfaces (evergreen trees, deciduous trees, grass, bare
+     soil), drainage first infiltrates into the soil store up to remaining
+     capacity. The `Runoff` column then applies to the **remaining**
+     drainage (after infiltration), with the non-runoff fraction available
+     for lateral redistribution to other surfaces.
+  -  For impervious surfaces, the `Runoff` column gives the drainage
+     fraction routed directly to runoff.
 
 In the table below, for example,
 
@@ -34,8 +37,9 @@ In the table below, for example,
 -  90% of flow from buildings goes to runoff, with small amounts going
    to other surfaces (mostly paved surfaces as buildings are often
    surrounded by paved areas);
--  All flow from vegetated and bare soil areas goes into the sub-surface
-   soil store;
+-  For vegetated and bare soil areas, drainage first infiltrates into soil
+   (up to capacity); any remaining drainage is then partitioned between
+   runoff and redistribution using the row fractions;
 -  The row corresponding to water contains zeros (as it is currently not
    used).
 

--- a/docs/source/inputs/tables/SUEWS_SiteInfo/csv-table/SUEWS_WithinGridWaterDist.csv
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/csv-table/SUEWS_WithinGridWaterDist.csv
@@ -7,4 +7,3 @@ No.,Column Name,Use,Description
 6,`ToBSoil`,`MU`,Fraction of water going to ``BSoil``
 7,`ToWater`,`MU`,Fraction of water going to `Water`
 8,`ToRunoff`,`MU`,Fraction of water going to `Runoff`
-9,`ToSoilStore`,`MU`,Fraction of water going to `SoilStore`

--- a/docs/source/inputs/tables/SUEWS_SiteInfo/csv-table/WithinGridWaterDist.csv
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/csv-table/WithinGridWaterDist.csv
@@ -7,4 +7,3 @@
 6,"`ToBSoil`","`MU`","Fraction of water going to `BSoil`"
 7,"`ToWater`","`MU`","Fraction of water going to `Water`"
 8,"`ToRunoff`","`MU`","Fraction of water going to `Runoff`"
-9,"`ToSoilStore`","`MU`","Fraction of water going to `SoilStore`"

--- a/docs/source/inputs/tables/SUEWS_SiteInfo/sample-table/SUEWS_WithinGridWaterDist.txt
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/sample-table/SUEWS_WithinGridWaterDist.txt
@@ -1,28 +1,28 @@
-1    	 2       	 3       	 4       	 5       	 6       	 7       	 8       	 9        	 10
-Code 	 ToPaved 	 ToBldgs 	 ToEveTr 	 ToDecTr 	 ToGrass 	 ToBSoil 	 ToWater 	 ToRunoff 	 ToSoilStore !
-10   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1        	 0           ! Paved     	 Example
-20   	 0.06    	 0       	 0.01    	 0.01    	 0.01    	 0.01    	 0       	 0.9      	 0           ! Buildings 	 Example
-30   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! Evergreen 	 Example
-40   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! Decid     	 Example
-50   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! Grass     	 Example
-60   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! UnmanBare 	 Example
-70   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 0           ! Water     	 Example
-21   	 0.03    	 0       	 0.01    	 0.01    	 0.01    	 0.01    	 0       	 0.93     	 0           ! Buildings 	 Example
+1    	 2       	 3       	 4       	 5       	 6       	 7       	 8       	 9
+Code 	 ToPaved 	 ToBldgs 	 ToEveTr 	 ToDecTr 	 ToGrass 	 ToBSoil 	 ToWater 	 ToRunoff !
+10   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! Paved     	 Example
+20   	 0.06    	 0       	 0.01    	 0.01    	 0.01    	 0.01    	 0       	 0.9         ! Buildings 	 Example
+30   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! Evergreen 	 Example
+40   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! Decid     	 Example
+50   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! Grass     	 Example
+60   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! UnmanBare 	 Example
+70   	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0           ! Water     	 Example
+21   	 0.03    	 0       	 0.01    	 0.01    	 0.01    	 0.01    	 0       	 0.93        ! Buildings 	 Example
 
-551  	 0       	 0       	 0       	 0       	 0.02    	 0       	 0       	 0.98     	 0           ! Paved     	 Swindon
-552  	 0.08    	 0       	 0       	 0       	 0.02    	 0       	 0       	 0.9      	 0           ! Bldgs     	 Swindon
-553  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! EveTr     	 Swindon
-554  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! DecTr     	 Swindon
-555  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! Grass     	 Swindon
-556  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! Bsoil     	 Swindon
-557  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 0           ! Water     	 Swindon 	 (not   present)
+551  	 0       	 0       	 0       	 0       	 0.02    	 0       	 0       	 0.98        ! Paved     	 Swindon
+552  	 0.08    	 0       	 0       	 0       	 0.02    	 0       	 0       	 0.9         ! Bldgs     	 Swindon
+553  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! EveTr     	 Swindon
+554  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! DecTr     	 Swindon
+555  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! Grass     	 Swindon
+556  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! Bsoil     	 Swindon
+557  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0           ! Water     	 Swindon 	 (not   present)
 
-661  	 0       	 0       	 0       	 0       	 0.02    	 0       	 0       	 0.98     	 0           ! Paved     	 London
-662  	 0.1     	 0       	 0       	 0       	 0       	 0       	 0       	 0.9      	 0           ! Bldgs     	 London
-663  	 0.1     	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 0.9         ! EveTr     	 London  	 (not   present)
-664  	 0.1     	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 0.9         ! DecTr     	 London
-665  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! Grass     	 London
-666  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 1           ! Bsoil     	 London  	 (not   present)
-667  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0        	 0           ! Water     	 London
+661  	 0       	 0       	 0       	 0       	 0.02    	 0       	 0       	 0.98        ! Paved     	 London
+662  	 0.1     	 0       	 0       	 0       	 0       	 0       	 0       	 0.9         ! Bldgs     	 London
+663  	 0.1     	 0       	 0       	 0       	 0       	 0       	 0       	 0.9         ! EveTr     	 London  	 (not   present)
+664  	 0.1     	 0       	 0       	 0       	 0       	 0       	 0       	 0.9         ! DecTr     	 London
+665  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! Grass     	 London
+666  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 1           ! Bsoil     	 London  	 (not   present)
+667  	 0       	 0       	 0       	 0       	 0       	 0       	 0       	 0           ! Water     	 London
 -9
 -9

--- a/src/suews/src/suews_ctrl_driver.f95
+++ b/src/suews/src/suews_ctrl_driver.f95
@@ -2094,6 +2094,10 @@ CONTAINS
       TYPE(SUEWS_STATE), INTENT(INout) :: modState
 
       REAL(KIND(1D0)), DIMENSION(nsurf) :: state_id !wetness states of each surface [mm]
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: SoilStoreCap !Capacity of soil store for each surface [mm]
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: drain_surf_redist !Drainage remaining for redistribution/runoff partition [mm]
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: runoff_scale !Scale runoff fraction to use post-infiltration residual drainage [-]
+      REAL(KIND(1D0)) :: infiltration
 
       REAL(KIND(1D0)), DIMENSION(6, nsurf) :: StoreDrainPrm ! drain storage capacity [mm]
       REAL(KIND(1D0)), DIMENSION(nsurf + 1, nsurf - 1) :: WaterDist !Within-grid water distribution to other surfaces and runoff/soil store [-]
@@ -2122,6 +2126,7 @@ CONTAINS
             addWaterBody => hydroState%addWaterBody, &
             drain_per_tstep => hydroState%drain_per_tstep, &
             drain_surf => hydroState%drain_surf, &
+            soilstore_surf => hydroState%soilstore_surf, &
             frac_water2runoff => hydroState%frac_water2runoff, &
             AdditionalWater => hydroState%AdditionalWater, &
             runoffPipes => hydroState%runoffPipes, &
@@ -2138,6 +2143,15 @@ CONTAINS
 
             state_id = hydroState%state_surf
             StoreDrainPrm = phenState%StoreDrainPrm
+            SoilStoreCap = [ &
+                           pavedPrm%soil%soilstorecap, &
+                           bldgPrm%soil%soilstorecap, &
+                           evetrPrm%soil%soilstorecap, &
+                           dectrPrm%soil%soilstorecap, &
+                           grassPrm%soil%soilstorecap, &
+                           bsoilPrm%soil%soilstorecap, &
+                           waterPrm%soil%soilstorecap &
+                           ]
 
             ! sfr_surf = [pavedPrm%sfr, bldgPrm%sfr, evetrPrm%sfr, dectrPrm%sfr, grassPrm%sfr, bsoilPrm%sfr, waterPrm%sfr]
             WaterDist(1, 1) = pavedPrm%waterdist%to_paved
@@ -2239,13 +2253,37 @@ CONTAINS
 
             drain_surf(WaterSurf) = 0 ! Set drainage from water body to zero
 
+            ! Infiltrate pervious-surface drainage before lateral redistribution.
+            ! Keep drain_surf for surface-state balance (A8), and use reduced drainage
+            ! for redistribution and runoff partitioning.
+            drain_surf_redist = drain_surf
+            runoff_scale = 1.0D0
+            DO is = ConifSurf, BSoilSurf
+               infiltration = MIN( &
+                              drain_surf_redist(is), &
+                              MAX(0.0D0, SoilStoreCap(is) - soilstore_surf(is)) &
+                              )
+               soilstore_surf(is) = soilstore_surf(is) + infiltration
+               drain_surf_redist(is) = drain_surf_redist(is) - infiltration
+               IF (drain_surf(is) > 0.0D0) THEN
+                  runoff_scale(is) = drain_surf_redist(is)/drain_surf(is)
+               ELSE
+                  runoff_scale(is) = 0.0D0
+               END IF
+            END DO
+
             ! Distribute water within grid, according to WithinGridWaterDist matrix (Cols 1-7)
             IF (Diagnose == 1) WRITE (*, *) 'Calling ReDistributeWater...'
             ! CALL ReDistributeWater
             !Calculates AddWater(is)
             CALL ReDistributeWater( &
-               SnowUse, WaterDist, sfr_surf, drain_surf, & ! input:
+               SnowUse, WaterDist, sfr_surf, drain_surf_redist, & ! input:
                frac_water2runoff, AddWater) ! output
+
+            ! Apply runoff fractions to post-infiltration residual drainage for pervious surfaces.
+            DO is = ConifSurf, BSoilSurf
+               frac_water2runoff(is) = frac_water2runoff(is)*runoff_scale(is)
+            END DO
 
          END ASSOCIATE
       END ASSOCIATE

--- a/src/suews/src/suews_phys_waterdist.f95
+++ b/src/suews/src/suews_phys_waterdist.f95
@@ -181,7 +181,6 @@ CONTAINS
 
       !Extra evaporation [mm] from impervious surfaces which cannot happen due to lack of water
       REAL(KIND(1D0)) :: EvPart
-      REAL(KIND(1D0)), PARAMETER :: NotUsed = -55.5
 
       !Threshold for intense precipitation [mm hr-1]
       REAL(KIND(1D0)), PARAMETER :: IPThreshold_mmhr = 10 ! NB:this should be an input and can be specified. SG 25 Apr 2018
@@ -312,22 +311,9 @@ CONTAINS
          ! Recalculate change in surface state_id from difference with previous timestep
          chang(is) = state_out(is) - state_in(is)
 
-         !Where should this go? Used to be before previous part!!
-         ! soilstore_id -------------------------------------------------
-         ! For pervious surfaces (not water), some of drain(is) goes to soil storage
-         ! Drainage (that is not flowing to other surfaces) goes to soil storages
-         soilstore(is) = soilstore(is) + drain_surf(is)*frac_water2runoff(is)
-
-         ! If soilstore is full, the excess will go to runoff
-         IF (soilstore(is) > SoilStoreCap(is)) THEN ! TODO: this should also go to flooding of some sort
-            runoff(is) = runoff(is) + (soilstore(is) - SoilStoreCap(is))
-            soilstore(is) = SoilStoreCap(is)
-         ELSEIF (soilstore(is) < 0) THEN !! QUESTION: But where does this lack of water go? !!Can this really happen here?
-            CALL ErrorHint(62, 'SUEWS_store: soilstore_id(is) < 0 ', soilstore(is), NotUsed, is, modState)
-            IF (supy_error_flag) RETURN
-            ! Code this properly - soilstore_id(is) < 0 shouldn't happen given the above loops
-            !soilstore_id(is)=0   !Groundwater / deeper soil should kick in
-         END IF
+         ! Runoff -------------------------------------------------------
+         ! For pervious surfaces, fraction of remaining drainage goes to runoff
+         runoff(is) = runoff(is) + drain_surf(is)*frac_water2runoff(is)
 
       CASE (WaterSurf)
          IF (sfr_surf(WaterSurf) /= 0) THEN

--- a/src/supy/_load.py
+++ b/src/supy/_load.py
@@ -1,24 +1,15 @@
-import functools
 from datetime import timedelta
+import functools
 from pathlib import Path
 
 import f90nml
 import numpy as np
-import pandas as pd
-
-
-from pathlib import Path
-
-import pandas as pd
 from packaging import version
-
+import pandas as pd
 
 from . import _supy_driver as _sd
-from . import supy_driver as sd
-
-
-from ._env import logger_supy, trv_supy_module, ISSUES_URL
-from ._misc import path_insensitive 
+from ._env import ISSUES_URL, logger_supy, trv_supy_module
+from ._misc import path_insensitive
 
 # choose different second representation to accommodate different pandas versions
 # pandas version <1.5
@@ -362,7 +353,14 @@ def lookup_code_lib(libCode, codeKey, codeValue, path_input):
     if codeKey == ":":
         res = lib.loc[int(np.unique(codeValue).item()), :].tolist()
     else:
-        res = lib.loc[int(np.unique(codeValue).item()), codeKey]
+        try:
+            res = lib.loc[int(np.unique(codeValue).item()), codeKey]
+        except KeyError:
+            # Legacy compatibility: ToSoilStore was removed from table schema.
+            # Treat missing ToSoilStore as zero and rely on ToRunoff.
+            if codeKey == "ToSoilStore":
+                return 0.0
+            raise
         if isinstance(res, pd.Series):
             # drop duolicates, otherwise duplicate values
             # will be introduced with more complexity
@@ -623,7 +621,8 @@ def resample_linear_avg(data_raw_avg, tstep_in, tstep_mod):
 
     # insert the shifted
     idx_comb = (
-        data_raw_tstep.index.append(data_raw_shift.index)
+        data_raw_tstep.index
+        .append(data_raw_shift.index)
         .append(data_tstep.index)
         .unique()
     )
@@ -707,7 +706,8 @@ def resample_forcing_met(
 
         # combine the resampled individual dataframes
         data_met_tstep = (
-            pd.concat(
+            pd
+            .concat(
                 [data_met_tstep_inst, data_met_tstep_avg, data_met_tstep_sum], axis=1
             )
             .interpolate()
@@ -754,7 +754,8 @@ def set_index_dt(df_raw: pd.DataFrame) -> pd.DataFrame:
 
     # set timestamp as index
     idx_dt = pd.date_range(
-        *df_raw.iloc[[0, -1], :4]
+        *df_raw
+        .iloc[[0, -1], :4]
         .astype(int)
         .astype(str)
         .apply(lambda ser: ser.str.cat(sep=" "), axis=1)
@@ -762,7 +763,8 @@ def set_index_dt(df_raw: pd.DataFrame) -> pd.DataFrame:
         periods=df_raw.shape[0],
     )
     list_dt = [
-        *df_raw.iloc[:, :4]
+        *df_raw
+        .iloc[:, :4]
         .astype(int)
         .astype(str)
         .apply(lambda ser: ser.str.cat(sep=" "), axis=1)
@@ -829,6 +831,7 @@ def load_SUEWS_Forcing_met_df_pattern(path_input, file_pattern):
     """
     # from dask import dataframe as dd
     from pathlib import Path
+
     from .util._io import read_suews
 
     # list of met forcing files
@@ -865,6 +868,7 @@ def load_SUEWS_Forcing_met_df_pattern(path_input, file_pattern):
 
 def load_SUEWS_Forcing_met_df_yaml(path_forcing):
     from pathlib import Path
+
     from .util._io import read_suews
 
     if isinstance(path_forcing, (str, Path)):
@@ -1358,8 +1362,8 @@ def load_SUEWS_SurfaceChar_df(path_input):
             val_x0 = val.reshape((len_grid, 9, 6))
             # directly load the values for common land covers
             val_x1 = val_x0[:, :7]
-            # process the ToSoilStore and ToRunoff entries
-            # since only one of ToSoilStore and ToRunoff can be non-zero for each row, we sum them up and combine them
+            # Process legacy ToSoilStore + ToRunoff entries.
+            # Current schema uses ToRunoff only; ToSoilStore (if present) is folded in.
             val_x2 = val_x0[:, 7:].reshape(len_grid, 6, 2).sum(axis=2).reshape(-1, 1, 6)
             # combine valuees of common land convers and special cases
             val_x = np.hstack((val_x1, val_x2))
@@ -2166,7 +2170,6 @@ def load_InitialCond_grid_df(path_runcontrol, force_reload=True):
     # print('localclimatemethod is in df_init')
     # else:
     # print('localclimatemethod is not in df_init')
-
 
     return df_init
 

--- a/src/supy/data_model/core/hydro.py
+++ b/src/supy/data_model/core/hydro.py
@@ -1,8 +1,10 @@
-from pydantic import ConfigDict, BaseModel, Field, PrivateAttr
-from typing import Optional
-import pandas as pd
-from .type import RefValue, Reference, SurfaceType, FlexibleRefValue
 import math
+from typing import Optional
+
+import pandas as pd
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+
+from .type import FlexibleRefValue, Reference, RefValue, SurfaceType
 
 
 class WaterDistribution(BaseModel):
@@ -68,18 +70,11 @@ class WaterDistribution(BaseModel):
     )
     to_runoff: Optional[FlexibleRefValue(float)] = Field(
         None,
-        description="Fraction of water going to surface runoff (for impervious surfaces: paved and buildings)",
+        description="Fraction of drainage going to surface runoff after within-grid redistribution",
         json_schema_extra={"unit": "dimensionless", "display_name": "To Runoff"},
         ge=0,
         le=1,
-    )  # For paved/bldgs
-    to_soilstore: Optional[FlexibleRefValue(float)] = Field(
-        None,
-        description="Fraction of water going to subsurface soil storage (for pervious surfaces: vegetation and bare soil)",
-        json_schema_extra={"unit": "dimensionless", "display_name": "To Soil Store"},
-        ge=0,
-        le=1,
-    )  # For vegetated surfaces
+    )
     _surface_type: Optional[SurfaceType] = PrivateAttr(None)
 
     ref: Optional[Reference] = None
@@ -93,6 +88,19 @@ class WaterDistribution(BaseModel):
         if surface_type:
             self._set_defaults(surface_type)
             self.validate_distribution(surface_type)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_to_soilstore(cls, data):
+        """Map legacy to_soilstore to to_runoff for backward compatibility."""
+        if not isinstance(data, dict):
+            return data
+
+        migrated = dict(data)
+        if "to_runoff" not in migrated and "to_soilstore" in migrated:
+            migrated["to_runoff"] = migrated["to_soilstore"]
+        migrated.pop("to_soilstore", None)
+        return migrated
 
     def _set_defaults(self, surface_type: SurfaceType):
         # Default distributions based on surface type
@@ -122,7 +130,7 @@ class WaterDistribution(BaseModel):
                 "to_grass": RefValue(0.1),
                 "to_bsoil": RefValue(0.1),
                 "to_water": RefValue(0.1),
-                "to_soilstore": RefValue(0.4),
+                "to_runoff": RefValue(0.4),
             },
             SurfaceType.DECTR: {
                 "to_paved": RefValue(0.1),
@@ -131,7 +139,7 @@ class WaterDistribution(BaseModel):
                 "to_grass": RefValue(0.1),
                 "to_bsoil": RefValue(0.1),
                 "to_water": RefValue(0.1),
-                "to_soilstore": RefValue(0.4),
+                "to_runoff": RefValue(0.4),
             },
             SurfaceType.GRASS: {
                 "to_paved": RefValue(0.1),
@@ -140,7 +148,7 @@ class WaterDistribution(BaseModel):
                 "to_evetr": RefValue(0.1),
                 "to_bsoil": RefValue(0.1),
                 "to_water": RefValue(0.1),
-                "to_soilstore": RefValue(0.4),
+                "to_runoff": RefValue(0.4),
             },
             SurfaceType.BSOIL: {
                 "to_paved": RefValue(0.1),
@@ -149,7 +157,7 @@ class WaterDistribution(BaseModel):
                 "to_evetr": RefValue(0.1),
                 "to_grass": RefValue(0.1),
                 "to_water": RefValue(0.1),
-                "to_soilstore": RefValue(0.4),
+                "to_runoff": RefValue(0.4),
             },
         }
 
@@ -188,7 +196,7 @@ class WaterDistribution(BaseModel):
                 "to_grass",
                 "to_bsoil",
                 "to_water",
-                "to_soilstore",
+                "to_runoff",
             ],
             SurfaceType.EVETR: [
                 "to_paved",
@@ -197,7 +205,7 @@ class WaterDistribution(BaseModel):
                 "to_grass",
                 "to_bsoil",
                 "to_water",
-                "to_soilstore",
+                "to_runoff",
             ],
             SurfaceType.GRASS: [
                 "to_paved",
@@ -206,7 +214,7 @@ class WaterDistribution(BaseModel):
                 "to_evetr",
                 "to_bsoil",
                 "to_water",
-                "to_soilstore",
+                "to_runoff",
             ],
             SurfaceType.BSOIL: [
                 "to_paved",
@@ -215,7 +223,7 @@ class WaterDistribution(BaseModel):
                 "to_evetr",
                 "to_grass",
                 "to_water",
-                "to_soilstore",
+                "to_runoff",
             ],
             SurfaceType.WATER: None,  # Water surface doesn't have water distribution
         }
@@ -268,8 +276,6 @@ class WaterDistribution(BaseModel):
             "to_grass",
             "to_bsoil",
             "to_water",
-            # "to_soilstore",
-            # "to_runoff",
         ]):
             value = getattr(self, attr)
             if value is None:
@@ -277,11 +283,7 @@ class WaterDistribution(BaseModel):
             else:
                 list_waterdist_value.append(value)
 
-        # either to_soilstore or to_runoff must be provided - the other must be 0
-        to_soilstore_or_runoff = (
-            self.to_runoff if self.to_soilstore is None else self.to_soilstore
-        )
-        list_waterdist_value.append(to_soilstore_or_runoff)
+        list_waterdist_value.append(0.0 if self.to_runoff is None else self.to_runoff)
 
         # 2. Create param_tuples and values - only add non-None values following the order of the list
         for i, value in enumerate(list_waterdist_value):
@@ -344,8 +346,6 @@ class WaterDistribution(BaseModel):
             "to_grass": 4,
             "to_bsoil": 5,
             "to_water": 6,
-            # "to_soilstore": 7,
-            # "to_runoff": 8,
         }
 
         # Extract the values from the DataFrame
@@ -358,13 +358,10 @@ class WaterDistribution(BaseModel):
             if getattr(instance, param) is not None:
                 setattr(instance, param, value)
 
-        # set the last to_soilstore or to_runoff
+        # Set the last water distribution column as to_runoff
         waterdist_last = df.loc[grid_id, ("waterdist", f"(7, {surf_idx})")]
         waterdist_last = RefValue(waterdist_last)
-        if getattr(instance, "to_soilstore") is None:
-            setattr(instance, "to_runoff", waterdist_last)
-        else:
-            setattr(instance, "to_soilstore", waterdist_last)
+        setattr(instance, "to_runoff", waterdist_last)
 
         return instance
 

--- a/src/supy/dts/_populate.py
+++ b/src/supy/dts/_populate.py
@@ -844,7 +844,8 @@ def _populate_landcover_common(
         wd_dts.to_grass = _unwrap(wd.to_grass) if wd.to_grass is not None else 0.0
         wd_dts.to_bsoil = _unwrap(wd.to_bsoil) if wd.to_bsoil is not None else 0.0
         wd_dts.to_water = _unwrap(wd.to_water) if wd.to_water is not None else 0.0
-        # to_soilstore is the last column
+        # to_runoff is stored in the last waterdist column.
+        # Keep legacy to_soilstore support for backward compatibility.
         if hasattr(wd, "to_soilstore") and wd.to_soilstore is not None:
             wd_dts.to_soilstore = _unwrap(wd.to_soilstore)
         elif hasattr(wd, "to_runoff") and wd.to_runoff is not None:

--- a/src/supy/util/converter/yaml.py
+++ b/src/supy/util/converter/yaml.py
@@ -14,6 +14,31 @@ from ...data_model.core.model import OutputConfig
 from .table import convert_table
 
 
+def _normalise_legacy_waterdist_fields(config: SUEWSConfig) -> None:
+    """Normalise legacy waterdist fields to the current to_runoff key."""
+    for site in getattr(config, "sites", []):
+        properties = getattr(site, "properties", None)
+        land_cover = getattr(properties, "land_cover", None)
+        if land_cover is None:
+            continue
+
+        for surface_name in ("paved", "bldgs", "evetr", "dectr", "grass", "bsoil"):
+            surface = getattr(land_cover, surface_name, None)
+            waterdist = (
+                getattr(surface, "waterdist", None) if surface is not None else None
+            )
+            if waterdist is None:
+                continue
+
+            # Keep support for migrated/legacy objects that still expose to_soilstore.
+            if getattr(waterdist, "to_runoff", None) is None and hasattr(
+                waterdist, "to_soilstore"
+            ):
+                legacy_value = getattr(waterdist, "to_soilstore")
+                if legacy_value is not None:
+                    setattr(waterdist, "to_runoff", legacy_value)
+
+
 def _prepare_processing_dir(
     input_path: Path,
     from_ver: Optional[str],
@@ -168,9 +193,9 @@ def convert_to_yaml(
     """
     from . import detect_input_type
     from .df_state import (
-        load_df_state_file,
-        detect_df_state_version,
         convert_df_state_format,
+        detect_df_state_version,
+        load_df_state_file,
         validate_converted_df_state,
     )
 
@@ -255,6 +280,7 @@ def convert_to_yaml(
 
         # Save to YAML
         click.echo(f"Saving to: {output_path}")
+        _normalise_legacy_waterdist_fields(config)
         config.to_yaml(output_path)
 
     finally:


### PR DESCRIPTION
## Summary

- Physically separates infiltration (vertical water entry into soil) from lateral redistribution (horizontal water flow between land cover types)
- Infiltration now happens automatically based on soil capacity before redistribution, rather than being gated by the `ToSoilStore` parameter
- Renames `ToSoilStore` to `ToRunoff` in `WithinGridWaterDist` to clarify it controls runoff partitioning of post-infiltration drainage

## Changes

- Add automatic infiltration step in `suews_ctrl_driver.f95` before `ReDistributeWater`, capacity-limited for pervious surfaces only
- Remove manual soil store accumulation from `suews_phys_waterdist.f95`
- Rename `ToSoilStore` column to `ToRunoff` in `WithinGridWaterDist` matrix and sample files
- Update Python data model (`WaterDistribution`), YAML converter (legacy compatibility), and documentation
- Legacy `to_soilstore` values are automatically migrated to `to_runoff` via model validator

## Test plan

- [x] Smoke tests pass (13 passed, 2 skipped)
- [ ] Full test suite (`make test`)
- [ ] Verify sample output parity with updated test fixture

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)