### PR TITLE
test: consolidate cli validation coverage

### DIFF
--- a/test/core/test_cli_validation.py
+++ b/test/core/test_cli_validation.py
@@ -202,6 +202,7 @@ def test_validate_second_run_not_truncated(suews_validate_exe, tmp_path):
             f"(size_before={size_before}, size_after={size_after})"
         )
 
+    assert reports3, "Third run on updated YAML produced no report files"
     latest_report = max(reports3, key=lambda p: p.stat().st_mtime)
     assert latest_report.stat().st_size > 0, "Latest report after third run is empty"
 


### PR DESCRIPTION
## Summary

- consolidate `test/core/test_cli_validation.py` from 12 overlapping tests down to 5 focused tests
- drop two fragile cases that were testing platform-specific file behaviour rather than SUEWS logic
- keep the existing helper coverage and the UTF-8 report unit test

## What changed

- merged the repeated minimal-invalid-YAML assertions into one test that checks output creation, non-empty files, and meaningful report content
- merged the re-run scenarios into a single three-run test covering both same-input and updated-YAML paths without truncation
- merged the issue `#1097` fixture checks into one test that preserves the non-empty and meaningful-content assertions
- merged the Windows-path coverage into one cross-platform test with platform-specific YAML setup
- removed the unused `os` and `stat` imports

## Testing

- `python3 -m compileall test/core/test_cli_validation.py`
- `pytest test/core/test_cli_validation.py -v`
  Blocked locally because `test/conftest.py` imports `supy`, and the current environment fails loading `f90wrap` with missing symbol `_sizeof_fortran_t_`
- `uv run --extra dev pytest test/core/test_cli_validation.py -v`
  Blocked locally by dependency resolution for `sphinx-design>=0.7.0` against the project `requires-python >=3.9`

Closes #1237
