### PR TITLE
Add /add-rule skill for AI-assisted validation rules

### DIFF
--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: add-rule
+description: Generate validation rules from natural language descriptions with round-trip verification
+---
+
+# Add Validation Rule
+
+Generate Phase B validation rules from natural language descriptions. Uses a round-trip verification step to ensure the generated code matches the user's intent before writing files.
+
+## Workflow
+
+### Step 1 — Gather Rule Description
+
+Ask the user to describe the validation rule in plain English. Clarify if needed (one question at a time):
+
+- What data field(s) does this rule check?
+- What condition makes data invalid?
+- Should violations be ERROR or WARNING?
+- What fix should be suggested?
+
+Determine:
+- **rule_id**: short, snake_case identifier (e.g., `stebbs_props`, `ehc_heating_check`)
+- **target file**: which rules file to add to (existing or new)
+  - Existing files are in `src/supy/data_model/validation/pipeline/phase_b_rules/`
+  - New files should follow the `<module>_rules.py` naming pattern
+
+### Step 2 — Generate Code
+
+Read these files for context:
+- `src/supy/data_model/validation/pipeline/phase_b_rules/rules_core.py` (API reference)
+- Target rules file if it exists (for style consistency)
+- This skill's `references/rule-conventions.md` (coding patterns)
+
+Generate two blocks of code:
+
+**Rule function:**
+- `@RulesRegistry.add_phase_b("rule_id")` decorator
+- Structured docstring with `Spec:` section containing the user's original description verbatim
+- Follow all conventions in `references/rule-conventions.md`
+- Handle missing data gracefully (skip silently, never raise)
+
+**Test functions:**
+- At least 2 positive cases (valid data -> empty results list)
+- At least 2 negative cases (invalid data -> correct ValidationResult errors)
+- Use `RulesRegistry()["rule_id"](yaml_data)` invocation pattern
+- Test edge cases: missing keys, empty dicts, boundary values
+
+Present the generated code to the user but DO NOT write files yet.
+
+### Step 3 — Round-Trip Verification
+
+This is the critical verification step. Re-read the generated code and produce a plain-English summary of what the code actually does, independently of the original spec.
+
+Present the verification report:
+
+```
+=== ORIGINAL SPEC ===
+[user's description, verbatim]
+
+=== CODE SUMMARY ===
+[plain-English description of what the generated code does,
+ written by re-reading the code without reference to the spec]
+
+=== TEST COVERAGE ===
+- test_name_1: checks that [description]
+- test_name_2: checks that [description]
+...
+
+=== GAP ANALYSIS ===
+[any mismatches between spec and code, or "No gaps found"]
+```
+
+Ask the user to compare the ORIGINAL SPEC and CODE SUMMARY:
+- If they match: proceed to Step 4
+- If gaps found: regenerate the code addressing the gaps, then re-verify
+
+### Step 4 — Write Files
+
+After user confirmation:
+
+1. **Rule file**: Append the rule function to the target rules file
+   - Ensure `from .rules_core import RulesRegistry, ValidationResult` is present
+   - Add any other needed imports
+2. **Test file**: Append test functions to `test/data_model/test_validation.py`
+   - Ensure the RulesRegistry import path is correct
+   - Place tests near existing related tests
+
+### Step 5 — Run Tests
+
+Run only the new tests:
+
+```bash
+python -m pytest test/data_model/test_validation.py -k "test_<rule_id>" -xvs
+```
+
+Report results:
+- If all pass: done, summarise what was created
+- If failures: diagnose, fix the generated code, re-run
+
+## Safety Rules
+
+- **Never write files before Step 3 verification is confirmed by user**
+- **Never skip the round-trip verification** -- this is the whole point of the skill
+- **Preserve existing code**: append only, never modify existing rules or tests
+- **No side effects**: generated rules must be pure functions (no mutations to yaml_data)
+
+## References
+
+- `references/rule-conventions.md` -- coding patterns for rule functions

--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -11,7 +11,16 @@ Generate Phase B validation rules from natural language descriptions. Uses a rou
 
 ### Step 1 — Gather Rule Description
 
-Ask the user to describe the validation rule in plain English. Clarify if needed (one question at a time):
+Determine the input source:
+
+- **Issue mode**: If a GitHub issue number is provided (`/add-rule #N` or passed from `/start-work`),
+  fetch with `gh issue view <N> --json title,body,labels`. Parse the issue body as the rule spec.
+  Extract: fields to check, invalid condition, severity, suggested fix.
+  If the issue body is sufficiently detailed, skip the interview and proceed to Step 2.
+  If ambiguous, ask ONE clarifying question to resolve the gap.
+
+- **Free-text mode** (default): Ask the user to describe the validation rule in plain English.
+  Clarify if needed (one question at a time):
 
 - What data field(s) does this rule check?
 - What condition makes data invalid?
@@ -94,8 +103,63 @@ python -m pytest test/data_model/test_validation.py -k "test_<rule_id>" -xvs
 ```
 
 Report results:
-- If all pass: done, summarise what was created
+- If all pass: proceed to Step 6
 - If failures: diagnose, fix the generated code, re-run
+
+### Step 6 — Commit & CHANGELOG
+
+After tests pass, prepare for integration:
+
+**Commit message** (present to user for approval):
+```
+Feat: add <rule_id> validation rule (#<issue_number>)
+
+<One-line description of what the rule checks.>
+```
+
+If no issue number was provided, omit the `(#N)` reference.
+
+**CHANGELOG entry** (present to user for approval):
+```
+- [feature][experimental] Add <rule_id> validation rule (#<issue_number>)
+```
+
+Use the `[feature][experimental]` category by default. Follow the format conventions
+in `.claude/rules/changelog/format.md`.
+
+After user approves both texts:
+1. Stage the modified files: `git add <rule_file> <test_file>`
+2. Commit with the approved message
+3. Append the CHANGELOG entry under today's date heading in `CHANGELOG.md`
+4. Stage and commit the CHANGELOG update separately
+
+### Step 7 — PR Description (standalone only)
+
+If invoked standalone (not via `/start-work`), offer to generate a PR description.
+If invoked from `/start-work`, this step is handled by the parent workflow -- skip it.
+
+Generate a PR description template:
+
+```
+## Summary
+
+- Add `<rule_id>` validation rule for <short description>
+- <What the rule checks and what severity level>
+
+## Linked issue
+
+Closes #<N>
+
+## Test plan
+
+- [x] Round-trip verification confirms code matches spec
+- [x] N positive test cases pass (valid data produces no errors)
+- [x] N negative test cases pass (invalid data produces correct errors)
+- [x] Edge cases tested: missing keys, empty dicts, boundary values
+- [x] `pytest test/data_model/test_validation.py -k "test_<rule_id>"` passes
+```
+
+Present to user for approval before creating the PR.
 
 ## Safety Rules
 
@@ -103,7 +167,10 @@ Report results:
 - **Never skip the round-trip verification** -- this is the whole point of the skill
 - **Preserve existing code**: append only, never modify existing rules or tests
 - **No side effects**: generated rules must be pure functions (no mutations to yaml_data)
+- **Issue body is a starting point, not gospel**: when parsing a GitHub issue, treat the body as a
+  first draft. If the description is vague or contradictory, clarify with the user before generating.
 
 ## References
 
 - `references/rule-conventions.md` -- coding patterns for rule functions
+- `.claude/rules/changelog/format.md` -- CHANGELOG entry format conventions

--- a/.claude/skills/add-rule/references/rule-conventions.md
+++ b/.claude/skills/add-rule/references/rule-conventions.md
@@ -1,0 +1,153 @@
+# Rule Conventions
+
+Coding patterns for Phase B validation rules, extracted from existing implementations.
+
+## Function Structure
+
+```python
+@RulesRegistry.add_phase_b("rule_id")
+def check_descriptive_name(yaml_data):
+    """Short description of what this rule validates.
+
+    Spec:
+        [Original natural language description from the user, verbatim.
+         This serves as the persistent record of intent.]
+
+    Parameters
+    ----------
+    yaml_data : dict
+        Full YAML configuration dictionary.
+
+    Returns
+    -------
+    list[ValidationResult]
+        Empty list if all checks pass.
+    """
+    results = []
+    sites = yaml_data.get("sites", [])
+    for site_idx, site in enumerate(sites):
+        props = site.get("properties", {})
+        site_gridid = site.get("gridiv")
+
+        # Access the relevant section
+        section = props.get("<section_name>", {})
+
+        # Validation logic here
+        # ...
+
+        if violation_found:
+            results.append(
+                ValidationResult(
+                    status="ERROR",
+                    category="MODEL_OPTIONS",
+                    parameter="section.field",
+                    site_index=site_idx,
+                    site_gridid=site_gridid,
+                    message="Human-readable: expected X, got Y.",
+                    suggested_value="Description of the fix",
+                )
+            )
+    return results
+```
+
+## Imports
+
+```python
+from .rules_core import RulesRegistry, ValidationResult
+```
+
+## Naming
+
+- **rule_id**: short, snake_case (e.g., `stebbs_props`, `archetype_properties`)
+- **Function name**: `check_<descriptive_name>` (e.g., `check_stebbs_properties`)
+- **No British/American spelling variants** in identifiers (see project essentials)
+
+## Data Access Patterns
+
+- **Site iteration**: `for site_idx, site in enumerate(yaml_data.get("sites", [])):`
+- **Property access**: chain `.get()` with empty dict defaults
+  ```python
+  props = site.get("properties", {})
+  stebbs = props.get("stebbs", {})
+  ```
+- **GRIDID**: `site_gridid = site.get("gridiv")`
+- **RefValue handling**: some values are wrapped in `{"value": X}` dicts
+  ```python
+  entry = section.get("FieldName", {})
+  value = entry.get("value") if isinstance(entry, dict) else entry
+  ```
+- **Profile iteration** (working_day/holiday patterns):
+  ```python
+  for daytype in ("working_day", "holiday"):
+      profile = section.get(daytype, {})
+      if isinstance(profile, dict):
+          for hour_str, v in profile.items():
+              # validate v
+  ```
+
+## Missing Data
+
+- Use `.get()` with sensible defaults (empty dict, empty list)
+- If the checked field is absent, skip silently (return empty results)
+- Never raise exceptions -- return ValidationResult errors instead
+
+## ValidationResult Fields
+
+- `status`: "ERROR" (violation), "WARNING" (advisory), "PASS" (explicit pass)
+- `category`: one of "MODEL_OPTIONS", "PHYSICS", "GEOGRAPHY", "SEASONAL", "LAND_COVER", "Archetype"
+- `parameter`: dot-path to the checked field (e.g., `"stebbs.HotWaterFlowProfile.working_day.0"`)
+- `site_index`: integer index in the sites array
+- `site_gridid`: GRIDID value from the site (for display)
+- `message`: human-readable, includes actual and expected values
+- `suggested_value`: string describing the recommended fix
+- `applied_fix`: leave as default `False` (rules don't auto-fix)
+
+## Test Patterns
+
+```python
+def test_rule_id_valid_data():
+    """Valid data should produce no errors."""
+    yaml_data = {
+        "sites": [{
+            "gridiv": 101,
+            "properties": {
+                "<section>": {
+                    # valid data here
+                }
+            }
+        }]
+    }
+    results = RulesRegistry()["rule_id"](yaml_data)
+    assert not results
+
+def test_rule_id_invalid_data():
+    """Invalid data should produce specific errors."""
+    yaml_data = {
+        "sites": [{
+            "gridiv": 102,
+            "properties": {
+                "<section>": {
+                    # invalid data here
+                }
+            }
+        }]
+    }
+    results = RulesRegistry()["rule_id"](yaml_data)
+    assert len(results) == N  # expected number of violations
+    assert all(r.status == "ERROR" for r in results)
+    assert "expected message fragment" in results[0].message
+
+def test_rule_id_missing_data():
+    """Missing fields should be skipped silently."""
+    yaml_data = {"sites": [{"gridiv": 103, "properties": {}}]}
+    results = RulesRegistry()["rule_id"](yaml_data)
+    assert not results
+```
+
+## Existing Rules (as Examples)
+
+Reference these in `src/supy/data_model/validation/pipeline/phase_b_rules/stebbs_rules.py`:
+
+- `archetype_properties` -- Wall/Roof reflectivity + absorptivity + transmissivity must sum to 1.0
+- `occupants_metabolism` -- zero occupants should not have nonzero metabolism profile
+- `stebbs_props` -- HotWaterFlowProfile values must be 0 or 1

--- a/.claude/skills/start-work/SKILL.md
+++ b/.claude/skills/start-work/SKILL.md
@@ -31,6 +31,7 @@ Based on the category selected, present a second AskUserQuestion:
 - **Bug Fix** -- Fix a reported problem (requires issue)
 - **Refactoring** -- Restructure code, preserve behaviour (requires issue)
 - **Documentation** -- Update docs only
+- **Validation Rule** -- Add a Phase B validation rule (issue optional)
 
 ### If Review:
 - **Examine Issue** -- Analyse a GitHub issue in depth
@@ -61,6 +62,18 @@ After selection, run the initial stages for the chosen workflow:
 2. `make dev` -- build the project
 3. `make docs` -- verify baseline documentation builds
 4. Report readiness with editing guidance
+
+### Create: Validation Rule
+
+1. Ask for issue number (GitHub `#N`) -- optional for this workflow
+2. If issue provided: run `/examine-issue <N>` -- extract rule spec from issue body
+3. If issue provided: run `/gh-link <N>` -- create branch linked to issue
+   If no issue: create branch `feat/<rule_id>`
+4. `make dev` -- build the project
+5. `make test-smoke` -- baseline
+6. Run `/add-rule` (passing issue number if available) -- generates rule + tests + verification
+7. `/log-changes` -- verify CHANGELOG entry from `/add-rule` Step 6
+8. Report readiness for PR creation
 
 ### Review: Examine Issue
 

--- a/.claude/skills/start-work/references/workflow-details.md
+++ b/.claude/skills/start-work/references/workflow-details.md
@@ -100,6 +100,51 @@ Stage 7: PR
 
 ---
 
+## Validation Rule
+
+**Requires**: GitHub issue number (optional) or free-text description
+
+```
+Stage 1: Issue Analysis (if issue provided)
+  /examine-issue <N>  -->  extract rule spec from issue body
+  Parse: fields, condition, severity, suggested fix
+
+Stage 2: Workspace Setup  [handled by /start-work]
+  /gh-link <N>  -->  branch linked to issue (or feat/<rule_id> if no issue)
+  make dev  -->  build
+  make test-smoke  -->  baseline
+
+Stage 3: Rule Generation  [handled by /add-rule]
+  /add-rule <N>  -->  7-step workflow:
+    1. Gather spec (from issue or interview)
+    2. Generate rule function + tests
+    3. Round-trip verification (CRITICAL: never skip)
+    4. Write files
+    5. Run tests
+    6. Commit + CHANGELOG entry
+    7. PR description (standalone only)
+
+Stage 4: Quality Gate
+  git commit  -->  pre-commit hook auto-runs file-type checks + smoke tests
+
+Stage 5: Documentation
+  /log-changes  -->  verify CHANGELOG entry ([feature][experimental] category)
+  (Docs build not usually needed for validation rules)
+
+Stage 6: PR Creation
+  /gh-sync  -->  rebase on master (if needed)
+  gh pr create  -->  open PR with generated description
+
+Stage 7: PR Review
+  /audit-pr <N>  -->  review (focus on test coverage + rule correctness)
+```
+
+**Key difference from Feature**: Stage 3 is fully handled by `/add-rule`, which includes its own round-trip verification. The user confirms the rule matches their intent before any files are written. No separate implementation guidance needed.
+
+**Key difference from Bug Fix**: No regression test needed beyond the rule's own tests -- validation rules are pure functions with no side effects.
+
+---
+
 # Review Workflows
 
 ## Examine Issue
@@ -192,6 +237,16 @@ Determines which auto-loaded rules apply and which test tier to use:
 - **Smoke** (`make test-smoke`): Default for Feature, Bug Fix, CI/Build -- fast validation (~30-60s)
 - **Standard** (`make test`): When physics modules or test files change (~2-3 min)
 - **Full** (`make test-all`): Refactoring baseline comparison, release pre-flight (~4-5 min)
+
+## Rule Verification Gate (Validation Rule, Stage 3)
+
+The `/add-rule` skill's round-trip verification is the decision gate for this workflow:
+
+- **Match**: Code summary matches original spec --> proceed to write files
+- **Gap found**: Regenerate code addressing gaps, re-verify
+- **User rejects**: Abort or restart from Step 1
+
+This gate replaces the standard implementation review for validation rules.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a new Claude Code skill (`/add-rule`) that generates Phase B validation rules from natural language descriptions
- Includes round-trip verification: AI generates code, then summarises it back in plain English so the user can compare against their original spec
- Builds on the RulesRegistry pattern from #1246

## Motivation

See [comment on #1246](https://github.com/UMEP-dev/SUEWS/pull/1246#issuecomment-4070135598) for the experiment that prompted this.

Domain experts who understand SUEWS physics but don't write Python can describe rules in natural language. The skill handles code generation, test generation, and verification.

## What's included

- `.claude/skills/add-rule/SKILL.md` — 5-step workflow (gather description, generate, verify, write, test)
- `.claude/skills/add-rule/references/rule-conventions.md` — coding patterns extracted from existing rules

## Test plan

- [x] Tested with stebbs_props rule spec — generated code is functionally identical to hand-written implementation
- [ ] Test with a novel rule description to verify end-to-end file writing
- [ ] Verify generated tests pass with `make test-smoke`


🤖 Generated with [Claude Code](https://claude.com/claude-code)