### PR TITLE
Cap pyarrow<23 to fix QGIS 4 import failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dependencies = [
     "chardet",
     "click",
     "pyarrow>=20,<21; python_version < '3.14' and platform_system == 'Linux'",  # Linux needs manylinux2014 wheels on CPython 3.9-3.13
-    "pyarrow>=20; python_version < '3.14' and platform_system != 'Linux'",  # Non-Linux platforms may use newer pyarrow binaries
-    "pyarrow>=22; python_version >= '3.14'",  # 22.x provides cp314 wheels on manylinux_2_28/macOS/Windows
+    "pyarrow>=20,<23; python_version < '3.14' and platform_system != 'Linux'",  # pyarrow 23 removed match_substring_regex (pandas compat)
+    "pyarrow>=22,<23; python_version >= '3.14'",  # 22.x provides cp314 wheels; 23 breaks pandas str ops
 
     # Scientific packages
     "atmosp",


### PR DESCRIPTION
## Summary

- Cap `pyarrow<23` on non-Linux and Python 3.14 dependency lines in `pyproject.toml`
- pyarrow 23.0.1 removed `pyarrow.compute.match_substring_regex`, breaking `pandas.Series.str.contains()` with regex on arrow-backed strings
- This caused `supy` to fail on import in OSGeo4W/QGIS 4 environments (Python 3.12 + pandas 3.0.1 + pyarrow 23)

Closes #1252

## Test plan

- [x] Verified fix on @biglimp's QGIS 4 machine via SSH (downgraded pyarrow 23 -> 22, `supy.load_sample_data()` works)
- [ ] CI passes with capped pyarrow versions

## Notes

The docstring-parsing code in `_load.py` that triggered this has already been refactored out on `master` (replaced by static `_var_metadata`). A new release would also resolve this inherently for the released version. The cap is a safety net until pandas releases a version compatible with pyarrow 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)