### PR TITLE
Fix: reject negative lai forcing under laimethod=0 (#1296)

### DIFF
--- a/.claude/rules/fortran/conventions.md
+++ b/.claude/rules/fortran/conventions.md
@@ -100,6 +100,14 @@ When investigating "stack smashing detected" or similar buffer overruns:
 
 ---
 
+## Numerical Guarding
+
+- Comparisons like `< 0.0D0` do not catch `NaN`.
+- When validating floating-point inputs that must be finite or non-missing, check `IEEE_IS_NAN(...)` explicitly (import from intrinsic `ieee_arithmetic` as needed).
+- Add the `NaN` branch to the same fatal-error path as the ordinary invalid values unless the algorithm has a clearly documented recovery path.
+
+---
+
 ## Legacy Patterns (Track for Migration)
 
 When reviewing existing code, note these patterns for future migration:

--- a/.claude/rules/fortran/error-reporting.md
+++ b/.claude/rules/fortran/error-reporting.md
@@ -1,0 +1,115 @@
+# Error Reporting in SUEWS Fortran
+
+Rules for raising fatal errors and warnings from Fortran code inside SUEWS.
+
+---
+
+## Never use `WRITE(*,...)` + `STOP` to report errors
+
+SUEWS runs embedded inside Python via SuPy. A plain `STOP` terminates the
+entire Python interpreter, preventing SuPy from catching the failure and
+presenting a clean exception. Likewise, `WRITE(*, ...)` to stdout bypasses
+SuPy's logger — users see garbled output on some platforms, and parallel
+runs interleave messages illegibly.
+
+The `module_ctrl_error_state` module (in `suews_ctrl_error.f95`) was
+introduced in GH#1035 precisely to avoid this. Its header states:
+
+> Allows Python to detect Fortran errors without STOP terminating the
+> process.
+
+---
+
+## Use `set_supy_error` for fatal validation errors
+
+The canonical pattern when Fortran detects invalid input that must halt
+the run:
+
+```fortran
+MODULE module_phys_foo
+   USE module_ctrl_error_state, ONLY: set_supy_error
+
+   IMPLICIT NONE
+
+CONTAINS
+
+   SUBROUTINE compute_bar(input, output)
+      REAL(KIND(1D0)), INTENT(IN) :: input
+      REAL(KIND(1D0)), INTENT(OUT) :: output
+
+      ! Validate inputs at the top of the subroutine.
+      IF (input <= 0.0D0) THEN
+         CALL set_supy_error( &
+            <code>, &
+            'compute_bar: input must be positive')
+         output = -999.0D0      ! safe default to avoid undefined OUT
+         RETURN                 ! let the caller and driver surface the error
+      END IF
+
+      ! ... main body ...
+   END SUBROUTINE
+
+END MODULE
+```
+
+Key points:
+
+- **`USE module_ctrl_error_state, ONLY: set_supy_error`** at the module
+  header, not inside the subroutine.
+- **Message prefix with the subroutine name** (`'compute_bar: ...'`) so
+  the user can locate the offender from the Python traceback.
+- **Assign `-999.0D0` (or a type-appropriate sentinel) to `INTENT(OUT)`
+  arguments** before `RETURN` — an unassigned intent-out is undefined
+  behaviour under some compilers.
+- **`RETURN`** — do not continue. The driver checks `supy_error_flag`
+  between grids/timesteps and surfaces the error to Python.
+- **Never** call `STOP`, `ERROR STOP`, `CALL abort`, or `WRITE(*,...)`.
+
+Working examples: `suews_phys_stebbs.f95:469`, `suews_phys_rslprof.f95:658`,
+`suews_phys_dailystate.f95` (observed-LAI guard, GH#1296).
+
+---
+
+## Use `ErrorHint` for numbered messages with continuation semantics
+
+When the error message already exists in the numbered registry (1–99) or
+when the condition is non-fatal and the run should continue, use
+`ErrorHint`:
+
+```fortran
+CALL ErrorHint(15, 'In compute_bar, input at lower bound', value, value2, notUsedI, modState)
+```
+
+- `modState` is OPTIONAL — pass it where available (it enables the
+  thread-safe per-grid warning channel introduced in GH#1042).
+- Codes 1–99 map to hard-coded text in `ErrorHint` (`suews_ctrl_error.f95`).
+  Add a new code only with an accompanying change in that file.
+- For non-fatal warnings without a numbered code, use
+  `add_supy_warning(message)` from the same module.
+
+---
+
+## Register new error codes
+
+Fatal codes 100+ are maintained in the header of `suews_ctrl_error.f95`.
+When introducing a new error site:
+
+1. Pick the next free integer (last allocated was `105` for GH#1296 — DailyState observed-LAI non-negative guard).
+2. Add a one-line entry to the `Error Codes (GH#1035):` block at the top
+   of `suews_ctrl_error.f95` describing the scope.
+3. Reference the issue number so the history is traceable.
+
+---
+
+## Why this matters
+
+- `STOP` inside an embedded Fortran call kills Python — users see
+  `Abort trap: 6` or similar, with no stack, no test report, and no way
+  to continue batch runs.
+- `WRITE(*,...)` is not captured by pytest under some configurations,
+  and is interleaved unpredictably in parallel runs.
+- The state module is f90wrap-exposed to SuPy; clean errors become
+  clean Python `RuntimeError` / `ValueError` exceptions.
+
+When in doubt: **validate at the top, set the error state, assign safe
+defaults, and `RETURN`.** The driver handles the rest.

--- a/.claude/rules/python/deprecation.md
+++ b/.claude/rules/python/deprecation.md
@@ -77,6 +77,8 @@ def old_function(...):
 5. **Update docs**: Change references to point to new API
 6. **Remove from exports** (optional): Remove from `supy.util` etc. if appropriate
 
+Deprecated APIs remain part of the supported public surface until removal. Bug fixes and contract changes must be applied and tested there too; do not assume the modern OOP path is sufficient coverage.
+
 ---
 
 ## Standard Warning Format

--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -108,6 +108,18 @@ test/
 
 ---
 
+## Validation Edge Cases
+
+When a change tightens an input contract, add explicit regressions for all relevant invalid forms, not just the obvious one:
+
+- Negative values
+- Canonical sentinel values (for example `-999`)
+- `NaN` / missing values
+
+If the feature is available through more than one public API, include at least one regression per API path. Covering only the modern interface is not enough if deprecated or legacy entry points still exist.
+
+---
+
 ## Centralisation Patterns
 
 ### Shared Utilities in conftest.py

--- a/.claude/rules/tests/verification-methodology.md
+++ b/.claude/rules/tests/verification-methodology.md
@@ -10,16 +10,18 @@ Rules for numerical comparisons, test validation, and diagnostic investigations.
 
 2. **Run the existing test before writing custom scripts.** If a test exists for the comparison you need, run it (`pytest path::Class::method -v`). Only write custom code if no test covers the question.
 
+3. **Trace every public execution path before declaring a fix complete.** When a behavioural contract changes, verify the recommended API, deprecated APIs, and any unchecked/bypass mode separately. Shared validators are not enough unless every public path actually reaches them.
+
 ## When results look unexpected
 
-3. **Question your script, not the production code.** Ad-hoc comparison scripts are the most likely source of error — misaligned indices, wrong column parsing, off-by-one rows. Verify your comparison is correct before drawing conclusions about the code.
+4. **Question your script, not the production code.** Ad-hoc comparison scripts are the most likely source of error — misaligned indices, wrong column parsing, off-by-one rows. Verify your comparison is correct before drawing conclusions about the code.
 
-4. **Never fabricate explanations.** If you don't know why something differs, say "I don't know yet, let me verify." Do not construct plausible-sounding narratives from unverified data.
+5. **Never fabricate explanations.** If you don't know why something differs, say "I don't know yet, let me verify." Do not construct plausible-sounding narratives from unverified data.
 
-5. **When challenged, don't double down with another guess.** Stop, go back to basics, re-examine your data loading, and verify from scratch.
+6. **When challenged, don't double down with another guess.** Stop, go back to basics, re-examine your data loading, and verify from scratch.
 
 ## Reporting
 
-6. **State what you verified and how.** "I ran `pytest test_X` and it passed" is trustworthy. "The difference is because of X" without running any test is not.
+7. **State what you verified and how.** "I ran `pytest test_X` and it passed" is trustworthy. "The difference is because of X" without running any test is not.
 
-7. **Distinguish between verified facts and hypotheses.** If you haven't confirmed something, label it as a hypothesis, not a conclusion.
+8. **Distinguish between verified facts and hypotheses.** If you haven't confirmed something, label it as a hypothesis, not a conclusion.

--- a/docs/source/data-structures/df_forcing.rst
+++ b/docs/source/data-structures/df_forcing.rst
@@ -97,9 +97,11 @@
         Observed leaf area index [|m^-2| |m^-2|]. Used only when
         ``model.physics.laimethod`` is set to ``0``; otherwise ignored. When active,
         the scalar value is applied uniformly to all three vegetation classes
-        (evergreen trees, deciduous trees, grass) each day. Use the ``-999`` missing
-        sentinel (any value ``<= -900``) for timesteps with no observation; the
-        internally calculated LAI is kept for that day. Observed values are
+        (evergreen trees, deciduous trees, grass) each day, and every timestep
+        must carry a non-missing, non-negative observation. The ``-999`` missing
+        sentinel (and other negative placeholders) is not permitted on this path;
+        if observations are unavailable, either switch back to calculated LAI or
+        gap-fill the forcing with non-negative values first. Observed values are
         clamped into each vegetation class's ``[laimin, laimax]`` envelope at
         runtime — see :ref:`prescribed-lai` for the rationale (downstream
         rescaling requires ``LAI <= laimax``) and guidance on configuring
@@ -171,4 +173,3 @@
 
     :Description:
         Observed soil moisture [|m^3| |m^-3|] or [kg |kg^-1|]
-

--- a/docs/source/inputs/forcing-data.rst
+++ b/docs/source/inputs/forcing-data.rst
@@ -249,10 +249,15 @@ remote-sensing product is available, users can bypass the internal scheme by:
 
 1. Setting ``model.physics.laimethod: 0`` in the YAML configuration (0 = OBSERVED,
    1 = CALCULATED; default is 1).
-2. Populating the ``lai`` column of the meteorological forcing file with the observed
-   values in |m^2| |m^-2|. Use the ``-999`` missing sentinel for timesteps with no
-   observation; the calculated LAI is then kept for that day. A genuine zero
-   observation (e.g. complete winter dieback) is a valid input and will be honoured.
+2. Populating the ``lai`` column of the meteorological forcing file with a **non-negative**
+   observation at every timestep, in |m^2| |m^-2|. A genuine zero observation (e.g.
+   complete winter dieback) is valid. Choosing the observed path commits the user to
+   providing an observation for every timestep; the ``-999`` missing sentinel is
+   **not** a permitted fallback here and the pre-flight validator rejects any strictly
+   negative value (including ``-999`` and other sentinels). If observations are
+   unavailable for part of the run, either switch to ``laimethod: 1`` (internally
+   calculated) or gap-fill the ``lai`` column with non-negative values before feeding
+   it to SUEWS.
 
 .. note::
    When ``laimethod: 0`` is set, the single scalar ``lai`` value from the forcing file is
@@ -268,14 +273,12 @@ remote-sensing product is available, users can bypass the internal scheme by:
    ``suews_phys_biogenco2``) require ``LAI <= laimax`` to stay physically
    meaningful.
 
-   If you supply observations that should pass through unchanged — e.g. a
-   genuine winter dieback with ``LAI = 0`` — configure the corresponding
-   class's ``laimin`` to zero in the site configuration. Similarly, widen
-   ``laimax`` if observations legitimately exceed the default site canopy
-   capacity.
-
-   The pre-flight validator (:func:`~supy._check.check_forcing`) issues a
-   warning when any forcing value would be clamped, so the user sees once that
+   If you supply observations that should pass through unchanged — e.g. a genuine
+   winter dieback with ``LAI = 0`` — configure the corresponding class's
+   ``laimin`` to zero in the site configuration. Similarly, widen ``laimax`` if
+   observations legitimately exceed the default site canopy capacity. The
+   pre-flight validator (:func:`~supy._check.check_forcing`) issues a warning
+   when any forcing value would be clamped, so the user sees once that
    observations are being modified rather than discovering it through
    unexpected outputs.
 

--- a/src/suews/src/suews_ctrl_error.f95
+++ b/src/suews/src/suews_ctrl_error.f95
@@ -10,7 +10,7 @@
 !   102: STEBBS - Invalid thermal parameters (d, cp, rho must be positive; x1 in [0,1])
 !   103: RSL - Interpolation bounds error in interp_z
 !   104: Build/ABI mismatch - output array size disagreement across compilation units
-!   105: DailyState - laimethod=0 requires lai >= 0 at every timestep (GH#1296)
+!   105: DailyState - laimethod=0 requires non-missing lai >= 0 at every timestep (GH#1296)
 !
 ! Note: Error state uses SAVE variables, so is NOT thread-safe.
 !       Do not call SUEWS from multiple threads simultaneously.

--- a/src/suews/src/suews_ctrl_error.f95
+++ b/src/suews/src/suews_ctrl_error.f95
@@ -10,6 +10,7 @@
 !   102: STEBBS - Invalid thermal parameters (d, cp, rho must be positive; x1 in [0,1])
 !   103: RSL - Interpolation bounds error in interp_z
 !   104: Build/ABI mismatch - output array size disagreement across compilation units
+!   105: DailyState - laimethod=0 requires lai >= 0 at every timestep (GH#1296)
 !
 ! Note: Error state uses SAVE variables, so is NOT thread-safe.
 !       Do not call SUEWS from multiple threads simultaneously.

--- a/src/suews/src/suews_phys_dailystate.f95
+++ b/src/suews/src/suews_phys_dailystate.f95
@@ -3,6 +3,7 @@ MODULE module_phys_dailystate
    USE module_ctrl_const_allocate, ONLY: &
       ndays, nsurf, nvegsurf, ivConif, ivDecid, ivGrass, DecidSurf, ncolumnsDataOutDailyState
    USE module_ctrl_error_state, ONLY: set_supy_error, supy_error_flag
+   USE, INTRINSIC :: ieee_arithmetic, ONLY: IEEE_IS_NAN
 
    IMPLICIT NONE
 
@@ -338,6 +339,7 @@ CONTAINS
                         LAI_id_prev, &
                         GDD_id, SDD_id, & !inout
                         LAI_id) !output
+                     IF (supy_error_flag) RETURN
 
                      CALL update_Veg( &
                         LAImax, LAIMin, & !input
@@ -582,6 +584,17 @@ CONTAINS
 
       critDays = 50 !Critical limit for GDD when GDD or SDD is set to zero
 
+      IF (LAICalcYes == 0 .AND. (IEEE_IS_NAN(LAI_obs) .OR. LAI_obs < 0.0D0)) THEN
+         ! Invalid LAI_obs slipped past pre-flight — raise an error via the
+         ! SuPy error-state channel before mutating phenology state.
+         ! Assign a safe sentinel to the INTENT(OUT) array before RETURN.
+         LAI_id_next = -999.0D0
+         CALL set_supy_error( &
+            105, &
+            'update_GDDLAI: laimethod=0 requires a non-missing lai >= 0 at every timestep')
+         RETURN
+      END IF
+
       ! Loop through vegetation types (iv)
       DO iv = 1, NVegSurf
          ! Calculate GDD for each day from the minimum and maximum air temperature
@@ -686,12 +699,14 @@ CONTAINS
       END DO !End of loop over veg surfaces
 
       ! Observed-LAI override: when LAICalcYes == 0, every timestep's forcing
-      ! value must be a non-negative observation (LAI_obs >= 0). A genuine
+      ! value must be a non-missing, non-negative observation (LAI_obs >= 0).
+      ! A genuine
       ! zero observation (e.g. complete winter dieback) is valid — the
       ! site-specific clamp then raises it to LAImin if the configuration
-      ! retains a positive floor. Strictly negative values — including the
-      ! -999 missing sentinel — are rejected; choosing this path commits
-      ! the user to providing an observation for every timestep.
+      ! retains a positive floor. Missing/NaN values and strictly negative
+      ! values — including the -999 missing sentinel — are rejected;
+      ! choosing this path commits the user to providing an observation for
+      ! every timestep.
       ! The Python pre-flight validator (supy._check.check_forcing) enforces
       ! this contract before a run starts; the guard below is a defensive
       ! backstop for callers that bypass preflight. Reports via
@@ -699,29 +714,19 @@ CONTAINS
       ! never WRITE(*,...) + STOP, which kills the embedding Python process.
       ! The scalar-to-all-veg-classes limitation is tracked in #1292.
       IF (LAICalcYes == 0) THEN
-         IF (LAI_obs >= 0.0D0) THEN
-            LAI_id_next = LAI_obs
-            ! Clamp observed LAI to each vegetation class's [LAImin, LAImax]
-            ! envelope so that downstream ``LAI_id / LAImax`` ratios in
-            ! ``suews_phys_resist`` and ``suews_phys_biogenco2`` stay within
-            ! the site-specific canopy envelope. The pre-flight validator
-            ! warns when forcing values would be clamped.
-            DO iv = 1, NVegSurf
-               IF (LAI_id_next(iv) > LAImax(iv)) THEN
-                  LAI_id_next(iv) = LAImax(iv)
-               ELSEIF (LAI_id_next(iv) < LAImin(iv)) THEN
-                  LAI_id_next(iv) = LAImin(iv)
-               END IF
-            END DO
-         ELSE
-            ! Negative LAI_obs slipped past pre-flight — raise an error
-            ! via the SuPy error-state channel. Do NOT STOP: the driver
-            ! reads the flag and surfaces the message to Python.
-            CALL set_supy_error( &
-               105, &
-               'update_GDDLAI: laimethod=0 requires lai >= 0 at every timestep')
-            RETURN
-         END IF
+         LAI_id_next = LAI_obs
+         ! Clamp observed LAI to each vegetation class's [LAImin, LAImax]
+         ! envelope so that downstream ``LAI_id / LAImax`` ratios in
+         ! ``suews_phys_resist`` and ``suews_phys_biogenco2`` stay within
+         ! the site-specific canopy envelope. The pre-flight validator
+         ! warns when forcing values would be clamped.
+         DO iv = 1, NVegSurf
+            IF (LAI_id_next(iv) > LAImax(iv)) THEN
+               LAI_id_next(iv) = LAImax(iv)
+            ELSEIF (LAI_id_next(iv) < LAImin(iv)) THEN
+               LAI_id_next(iv) = LAImin(iv)
+            END IF
+         END DO
       END IF
       !------------------------------------------------------------------------------
 

--- a/src/suews/src/suews_phys_dailystate.f95
+++ b/src/suews/src/suews_phys_dailystate.f95
@@ -2,6 +2,7 @@
 MODULE module_phys_dailystate
    USE module_ctrl_const_allocate, ONLY: &
       ndays, nsurf, nvegsurf, ivConif, ivDecid, ivGrass, DecidSurf, ncolumnsDataOutDailyState
+   USE module_ctrl_error_state, ONLY: set_supy_error, supy_error_flag
 
    IMPLICIT NONE
 
@@ -684,31 +685,43 @@ CONTAINS
 
       END DO !End of loop over veg surfaces
 
-      ! Observed-LAI override: when LAICalcYes == 0 and the forcing column carries a
-      ! non-sentinel value, use forcing%LAI_obs for every vegetation class. Only the
-      ! -999 missing sentinel (matched defensively as ``LAI_obs <= -900``) is treated
-      ! as "no observation this day" and the calculated LAI is kept.
+      ! Observed-LAI override: when LAICalcYes == 0, every timestep's forcing
+      ! value must be a non-negative observation (LAI_obs >= 0). A genuine
+      ! zero observation (e.g. complete winter dieback) is valid — the
+      ! site-specific clamp then raises it to LAImin if the configuration
+      ! retains a positive floor. Strictly negative values — including the
+      ! -999 missing sentinel — are rejected; choosing this path commits
+      ! the user to providing an observation for every timestep.
+      ! The Python pre-flight validator (supy._check.check_forcing) enforces
+      ! this contract before a run starts; the guard below is a defensive
+      ! backstop for callers that bypass preflight. Reports via
+      ! module_ctrl_error_state so SuPy can surface a clean exception —
+      ! never WRITE(*,...) + STOP, which kills the embedding Python process.
       ! The scalar-to-all-veg-classes limitation is tracked in #1292.
-      IF (LAICalcYes == 0 .AND. LAI_obs > -900.0D0) THEN
-         LAI_id_next = LAI_obs
-         ! Clamp observed LAI to each vegetation class's [LAImin, LAImax]
-         ! envelope. The same clamp is applied to the parameterised branch
-         ! above; the observed branch honours it too so that:
-         !   * Downstream rescaling ratios ``LAI_id / LAImax`` in
-         !     ``suews_phys_resist`` and ``suews_phys_biogenco2`` stay <= 1.
-         !   * Observations cannot violate the site-specific canopy envelope
-         !     encoded in ``LAImin`` / ``LAImax``.
-         ! Users who expect genuine zero observations (e.g. winter dieback of
-         ! deciduous canopy) must set the corresponding class's ``LAImin`` to
-         ! zero in the site configuration — the pre-flight validator warns
-         ! when forcing values would be clamped.
-         DO iv = 1, NVegSurf
-            IF (LAI_id_next(iv) > LAImax(iv)) THEN
-               LAI_id_next(iv) = LAImax(iv)
-            ELSEIF (LAI_id_next(iv) < LAImin(iv)) THEN
-               LAI_id_next(iv) = LAImin(iv)
-            END IF
-         END DO
+      IF (LAICalcYes == 0) THEN
+         IF (LAI_obs >= 0.0D0) THEN
+            LAI_id_next = LAI_obs
+            ! Clamp observed LAI to each vegetation class's [LAImin, LAImax]
+            ! envelope so that downstream ``LAI_id / LAImax`` ratios in
+            ! ``suews_phys_resist`` and ``suews_phys_biogenco2`` stay within
+            ! the site-specific canopy envelope. The pre-flight validator
+            ! warns when forcing values would be clamped.
+            DO iv = 1, NVegSurf
+               IF (LAI_id_next(iv) > LAImax(iv)) THEN
+                  LAI_id_next(iv) = LAImax(iv)
+               ELSEIF (LAI_id_next(iv) < LAImin(iv)) THEN
+                  LAI_id_next(iv) = LAImin(iv)
+               END IF
+            END DO
+         ELSE
+            ! Negative LAI_obs slipped past pre-flight — raise an error
+            ! via the SuPy error-state channel. Do NOT STOP: the driver
+            ! reads the flag and surfaces the message to Python.
+            CALL set_supy_error( &
+               105, &
+               'update_GDDLAI: laimethod=0 requires lai >= 0 at every timestep')
+            RETURN
+         END IF
       END IF
       !------------------------------------------------------------------------------
 

--- a/src/supy/_check.py
+++ b/src/supy/_check.py
@@ -179,6 +179,77 @@ def _matches_option_value(actual_value, option_value) -> bool:
     return actual_value == option_value
 
 
+def _check_observed_lai_nonneg(
+    df_forcing: pd.DataFrame, list_issues: list
+) -> bool:
+    """Reject negative ``lai`` rows when ``laimethod=0`` is active.
+
+    Under the observed-LAI path every timestep must carry a non-negative
+    observation (``lai >= 0``). A genuine zero observation is valid and
+    is clamped to each vegetation class's ``laimin`` at runtime. Any
+    strictly negative value — including the ``-999`` missing sentinel
+    (and anything at or below ``SUEWS_MISSING_THRESHOLD``) — is refused:
+    users who cannot observe every timestep should use ``laimethod=1``
+    or gap-fill their forcing.
+
+    Parameters
+    ----------
+    df_forcing : pd.DataFrame
+        Forcing DataFrame. Must contain a ``lai`` column.
+    list_issues : list
+        Issue accumulator; a single summary message is appended when
+        invalid rows are present.
+
+    Returns
+    -------
+    bool
+        ``True`` when invalid rows were found and an issue was appended,
+        ``False`` otherwise.
+    """
+    from .util._missing import SUEWS_MISSING_THRESHOLD
+
+    if "lai" not in df_forcing.columns:
+        return False
+
+    ser_lai = df_forcing["lai"]
+    mask_invalid = ser_lai < 0.0
+    n_invalid = int(mask_invalid.sum())
+    if n_invalid == 0:
+        return False
+
+    n_sentinel = int((ser_lai <= SUEWS_MISSING_THRESHOLD).sum())
+    n_physically_invalid = n_invalid - n_sentinel
+
+    parts = []
+    if n_sentinel > 0:
+        parts.append(f"{n_sentinel} row(s) at/below the missing sentinel (-999)")
+    if n_physically_invalid > 0:
+        parts.append(
+            f"{n_physically_invalid} row(s) with negative values in "
+            f"({SUEWS_MISSING_THRESHOLD:g}, 0)"
+        )
+
+    sample_rows = [
+        f"{ts}={val:g}"
+        for ts, val in ser_lai[mask_invalid].head(5).items()
+    ]
+    sample_note = ", ".join(sample_rows)
+    if n_invalid > len(sample_rows):
+        sample_note += f", ... (+{n_invalid - len(sample_rows)} more)"
+
+    str_issue = (
+        f"Physics option 'laimethod=0' requires every 'lai' forcing value "
+        f"to be non-negative (>= 0); -999 and other sentinels are not "
+        f"permitted on this path. Found {n_invalid} invalid row(s): "
+        f"{'; '.join(parts)}. First offenders: {sample_note}. "
+        f"Use 'laimethod=1' or gap-fill the 'lai' column with non-negative "
+        f"observations. See documentation: "
+        f"https://docs.suews.io/en/latest/input_files/RunControl/RunControl.html#scheme-options"
+    )
+    list_issues.append(str_issue)
+    return True
+
+
 def _warn_observed_lai_clamping(
     df_forcing: pd.DataFrame, lai_bounds: dict
 ) -> None:
@@ -345,16 +416,36 @@ def check_forcing(
                 # treat the requirement as active if any grid selects the
                 # option value that triggers it.
                 if _matches_option_value(actual_value, option_value):
-                    # Pre-flight warning: observed LAI will be clamped into
-                    # each vegetation class's ``[LAImin, LAImax]`` envelope.
-                    if (
-                        option_name == "laimethod"
-                        and option_value == 0
-                        and lai_bounds is not None
-                    ):
-                        _warn_observed_lai_clamping(df_forcing, lai_bounds)
+                    is_observed_lai = (
+                        option_name == "laimethod" and option_value == 0
+                    )
+                    # Under laimethod=0 the non-negative check is strictly
+                    # stronger than the generic "all-missing" rejection —
+                    # it runs first and shadows the per-column loop for
+                    # the ``lai`` column.
+                    lai_nonneg_issue = False
+                    if is_observed_lai:
+                        lai_nonneg_issue = _check_observed_lai_nonneg(
+                            df_forcing, list_issues
+                        )
+                        if lai_nonneg_issue:
+                            flag_valid = False
+                        # Pre-flight warning: observed LAI will be clamped
+                        # into each vegetation class's ``[LAImin, LAImax]``
+                        # envelope. Skip when the non-negative check already
+                        # failed — a forcing full of sentinels will otherwise
+                        # trigger a noisy "below LAImin" warning on top of
+                        # the real error.
+                        if lai_bounds is not None and not lai_nonneg_issue:
+                            _warn_observed_lai_clamping(df_forcing, lai_bounds)
                     for col in required_cols:
                         if col in df_forcing.columns:
+                            # Under laimethod=0 the non-negative helper
+                            # already diagnoses the ``lai`` column — skip
+                            # the generic "all-missing" check to avoid
+                            # duplicate issues.
+                            if is_observed_lai and col == "lai":
+                                continue
                             # Treat any value at or below the missing
                             # threshold (-900) as missing, matching the Fortran
                             # runtime's defensive sentinel handling.

--- a/src/supy/_check.py
+++ b/src/supy/_check.py
@@ -182,12 +182,13 @@ def _matches_option_value(actual_value, option_value) -> bool:
 def _check_observed_lai_nonneg(
     df_forcing: pd.DataFrame, list_issues: list
 ) -> bool:
-    """Reject negative ``lai`` rows when ``laimethod=0`` is active.
+    """Reject missing or negative ``lai`` rows when ``laimethod=0`` is active.
 
-    Under the observed-LAI path every timestep must carry a non-negative
-    observation (``lai >= 0``). A genuine zero observation is valid and
-    is clamped to each vegetation class's ``laimin`` at runtime. Any
-    strictly negative value — including the ``-999`` missing sentinel
+    Under the observed-LAI path every timestep must carry a non-missing,
+    non-negative observation (``lai >= 0``). A genuine zero observation
+    is valid and is clamped to each vegetation class's ``laimin`` at
+    runtime. Any missing value, strictly negative value, or sentinel
+    placeholder — including ``NaN`` and the ``-999`` missing sentinel
     (and anything at or below ``SUEWS_MISSING_THRESHOLD``) — is refused:
     users who cannot observe every timestep should use ``laimethod=1``
     or gap-fill their forcing.
@@ -212,15 +213,21 @@ def _check_observed_lai_nonneg(
         return False
 
     ser_lai = df_forcing["lai"]
-    mask_invalid = ser_lai < 0.0
+    mask_missing = ser_lai.isna()
+    mask_negative = ser_lai < 0.0
+    mask_invalid = mask_missing | mask_negative
     n_invalid = int(mask_invalid.sum())
     if n_invalid == 0:
         return False
 
-    n_sentinel = int((ser_lai <= SUEWS_MISSING_THRESHOLD).sum())
-    n_physically_invalid = n_invalid - n_sentinel
+    mask_sentinel = (ser_lai <= SUEWS_MISSING_THRESHOLD).fillna(False)
+    n_missing = int(mask_missing.sum())
+    n_sentinel = int(mask_sentinel.sum())
+    n_physically_invalid = int((mask_negative & ~mask_sentinel).sum())
 
     parts = []
+    if n_missing > 0:
+        parts.append(f"{n_missing} row(s) with missing/NaN values")
     if n_sentinel > 0:
         parts.append(f"{n_sentinel} row(s) at/below the missing sentinel (-999)")
     if n_physically_invalid > 0:
@@ -230,7 +237,7 @@ def _check_observed_lai_nonneg(
         )
 
     sample_rows = [
-        f"{ts}={val:g}"
+        f"{ts}={'nan' if pd.isna(val) else f'{val:g}'}"
         for ts, val in ser_lai[mask_invalid].head(5).items()
     ]
     sample_note = ", ".join(sample_rows)
@@ -239,8 +246,9 @@ def _check_observed_lai_nonneg(
 
     str_issue = (
         f"Physics option 'laimethod=0' requires every 'lai' forcing value "
-        f"to be non-negative (>= 0); -999 and other sentinels are not "
-        f"permitted on this path. Found {n_invalid} invalid row(s): "
+        f"to be a non-missing, non-negative observation (>= 0); "
+        f"NaN, -999 and other sentinels are not permitted on this path. "
+        f"Found {n_invalid} invalid row(s): "
         f"{'; '.join(parts)}. First offenders: {sample_note}. "
         f"Use 'laimethod=1' or gap-fill the 'lai' column with non-negative "
         f"observations. See documentation: "
@@ -419,10 +427,10 @@ def check_forcing(
                     is_observed_lai = (
                         option_name == "laimethod" and option_value == 0
                     )
-                    # Under laimethod=0 the non-negative check is strictly
-                    # stronger than the generic "all-missing" rejection —
-                    # it runs first and shadows the per-column loop for
-                    # the ``lai`` column.
+                    # Under laimethod=0 the completeness/non-negative check
+                    # is strictly stronger than the generic "all-missing"
+                    # rejection — it runs first and shadows the per-column
+                    # loop for the ``lai`` column.
                     lai_nonneg_issue = False
                     if is_observed_lai:
                         lai_nonneg_issue = _check_observed_lai_nonneg(
@@ -440,9 +448,9 @@ def check_forcing(
                             _warn_observed_lai_clamping(df_forcing, lai_bounds)
                     for col in required_cols:
                         if col in df_forcing.columns:
-                            # Under laimethod=0 the non-negative helper
-                            # already diagnoses the ``lai`` column — skip
-                            # the generic "all-missing" check to avoid
+                            # Under laimethod=0 the completeness/non-negative
+                            # helper already diagnoses the ``lai`` column —
+                            # skip the generic "all-missing" check to avoid
                             # duplicate issues.
                             if is_observed_lai and col == "lai":
                                 continue

--- a/src/supy/_supy_module.py
+++ b/src/supy/_supy_module.py
@@ -26,7 +26,12 @@ import numpy as np
 import pandas
 import pandas as pd
 
-from ._check import FORCING_REQUIREMENTS, check_forcing, check_state
+from ._check import (
+    FORCING_REQUIREMENTS,
+    _check_observed_lai_nonneg,
+    check_forcing,
+    check_state,
+)
 from ._env import logger_supy, trv_supy_module
 from ._load import (
     load_df_state,
@@ -736,6 +741,23 @@ def _run_supy(
     from .util._forcing import convert_observed_soil_moisture
 
     config = SUEWSConfig.from_df_state(df_state_init)
+
+    try:
+        lai_val = getattr(config.model.physics, "laimethod", None)
+        if hasattr(lai_val, "value"):
+            lai_val = lai_val.value
+        lai_int = int(lai_val) if lai_val is not None else 1
+    except (AttributeError, TypeError, ValueError):
+        lai_int = 1
+
+    if lai_int == 0:
+        lai_issues = []
+        if _check_observed_lai_nonneg(df_forcing, lai_issues):
+            logger_supy.critical(
+                "`df_forcing` violates the observed-LAI contract under "
+                "`laimethod=0`."
+            )
+            raise RuntimeError(lai_issues[0])
 
     # Preprocess forcing for observed soil moisture if needed
     try:

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -368,7 +368,7 @@ class LAIMethod(Enum):
     """
     Method for determining leaf area index (LAI).
 
-    0: OBSERVED - Uses observed LAI values from the forcing file (lai column); same value applied to every vegetation class each day. Use the -999 missing sentinel (any value <= -900) for timesteps with no observation; the calculated LAI is kept for that day. Genuine zero observations are honoured.
+    0: OBSERVED - Uses observed LAI values from the forcing file (lai column); the same value is applied to every vegetation class each day, and every timestep must carry a non-missing, non-negative observation. The -999 missing sentinel (and other negative placeholders) is not permitted on this path. Genuine zero observations are honoured.
     1: CALCULATED - LAI calculated internally from growing-degree-day (GDD) and senescence-degree-day (SDD) thresholds.
     """
 

--- a/test/core/test_laimethod.py
+++ b/test/core/test_laimethod.py
@@ -1,4 +1,4 @@
-"""Regression tests for laimethod (issue #1291).
+"""Regression tests for laimethod (issues #1291, #1296).
 
 The `model.physics.laimethod` option controls whether SUEWS computes LAI
 internally via GDD/SDD thresholds (laimethod=1, default) or uses observed
@@ -6,8 +6,16 @@ values from the `lai` forcing column (laimethod=0). Issue #1291 reported
 that the forcing column was silently ignored because the dailystate routine
 hard-coded the local switch to `LAICalcYes = 1`.
 
+Issue #1296 tightened the contract for the observed path: under
+`laimethod=0` every row of the `lai` forcing column must be
+**non-negative** (`lai >= 0`). Zero observations are valid (and clamped
+to `laimin` when the site configuration retains a positive floor);
+**negative** values — including the `-999` missing sentinel — are
+rejected at pre-flight. Do not reintroduce sentinel-based fallback
+tests for the observed path.
+
 These tests guard against regression in:
-  * Validator plumbing (FORCING_REQUIREMENTS entry).
+  * Validator plumbing (FORCING_REQUIREMENTS entry, non-negative check).
   * Fortran/Python wiring (the switch actually routes `forcing%LAI_obs`
     through to `LAI_id_next`).
 """
@@ -103,6 +111,87 @@ class TestLAIMethodValidator:
         assert any(
             "laimethod=0" in issue and "lai" in issue for issue in issues
         )
+
+
+class TestLAIMethodNegativeRejected:
+    """Validator rejects every negative ``lai`` value under ``laimethod=0``.
+
+    Issue #1296 contract: the observed path requires a non-negative
+    observation (``lai >= 0``) at every timestep. Zero is valid (and
+    clamped to ``laimin`` at runtime when the site configuration retains
+    a positive floor). Sentinels (``-999``) and other negative values are
+    all rejected at pre-flight so the user sees a clear error before the
+    run starts.
+    """
+
+    def test_validator_accepts_lai_zero(self):
+        """``lai == 0`` across all rows is a valid observation."""
+        df_forcing = _base_forcing_df()
+        df_forcing["lai"] = 0.0
+        issues = check_forcing(
+            df_forcing, fix=False, physics={"laimethod": 0}
+        )
+        if issues:
+            assert not any(
+                "non-negative" in issue for issue in issues
+            ), issues
+
+    def test_validator_rejects_small_negative_lai(self):
+        """Small negative values (above the -900 threshold) are rejected."""
+        df_forcing = _base_forcing_df()
+        df_forcing["lai"] = -5.0
+        issues = check_forcing(
+            df_forcing, fix=False, physics={"laimethod": 0}
+        )
+        assert any(
+            "laimethod=0" in issue and "non-negative" in issue
+            for issue in issues
+        ), issues
+
+    def test_validator_rejects_missing_sentinel(self):
+        """``lai == -999`` is not a permitted fallback under laimethod=0."""
+        df_forcing = _base_forcing_df()  # lai column already set to -999
+        issues = check_forcing(
+            df_forcing, fix=False, physics={"laimethod": 0}
+        )
+        # Exactly one non-negative issue is emitted for this column — the
+        # generic all-missing check must be suppressed to avoid duplicates.
+        matching = [
+            issue for issue in issues
+            if "laimethod=0" in issue and "non-negative" in issue
+        ]
+        assert len(matching) == 1, (
+            f"Expected one non-negative issue; got {len(matching)}: {issues}"
+        )
+        assert "missing sentinel" in matching[0], matching[0]
+
+    def test_validator_rejects_partial_missing(self):
+        """A mix of valid observations and -999 fill-ins is still rejected."""
+        df_forcing = _base_forcing_df()
+        df_forcing["lai"] = 3.5
+        df_forcing.iloc[3:6, df_forcing.columns.get_loc("lai")] = -999.0
+        issues = check_forcing(
+            df_forcing, fix=False, physics={"laimethod": 0}
+        )
+        matching = [
+            issue for issue in issues
+            if "laimethod=0" in issue and "non-negative" in issue
+        ]
+        assert matching, issues
+        # Invalid-row count in the message should reflect the 3 sentinels.
+        assert "3" in matching[0], matching[0]
+
+    def test_validator_accepts_all_positive_lai(self):
+        """Strictly positive ``lai`` values pass the non-negative check."""
+        df_forcing = _base_forcing_df()
+        df_forcing["lai"] = 3.5
+        issues = check_forcing(
+            df_forcing, fix=False, physics={"laimethod": 0}
+        )
+        if issues:
+            assert not any(
+                "non-negative" in issue for issue in issues
+            ), issues
 
 
 @pytest.mark.core
@@ -230,20 +319,18 @@ class TestLAIMethodRuntime:
             surf.lai.laimax = laimax
 
     def test_zero_lai_observation_honoured(self):
-        """A genuine zero observation drives LAI to zero only when the site's
-        ``laimin`` is configured to 0 — otherwise the runtime clamp kicks in.
+        """A genuine zero observation drives LAI to zero when ``laimin = 0``.
 
-        This guards the documented contract: observations are clamped into the
-        per-class ``[LAImin, LAImax]`` envelope. Users who want zero
-        observations (e.g. winter dieback of deciduous canopy) must set
-        ``laimin`` accordingly in their site configuration.
+        Issue #1296 keeps zero as a valid observation: users who expect
+        complete canopy dieback (winter, browning) can set ``laimin`` to
+        zero in the site configuration and the observation is honoured.
         """
         sim = SUEWSSimulation.from_sample_data()
         self._set_lai_bounds(sim, laimin=0.0, laimax=10.0)
 
         end_index = TIMESTEPS_PER_DAY * self.N_DAYS - 1
         df_forcing = sim.forcing.df.copy().iloc[: end_index + 1].copy()
-        df_forcing["lai"] = 0.0  # genuine observation of bare canopy
+        df_forcing["lai"] = 0.0
 
         sim._config.model.physics.laimethod = LAIMethod.OBSERVED
         sim._df_state_init = sim._config.to_df_state()
@@ -265,8 +352,9 @@ class TestLAIMethodRuntime:
 
     def test_zero_lai_observation_clamped_to_laimin(self):
         """Zero observations are clamped up to ``laimin`` when the site
-        configuration retains a positive floor. This is the default behaviour
-        of the sample config (``laimin`` > 0 for all classes)."""
+        configuration retains a positive floor. This is the default
+        behaviour of the sample config (``laimin`` > 0 for all classes).
+        """
         sim = SUEWSSimulation.from_sample_data()
 
         df_state = sim._config.to_df_state()
@@ -342,23 +430,26 @@ class TestLAIMethodRuntime:
                 f"{df_lai_tail[column].max()}"
             )
 
-    def test_negative_sentinel_accepted_as_missing(self):
-        """Forcing values <= -900 must be treated as missing at the validator
-        level, matching the Fortran runtime's defensive sentinel handling."""
+    def test_negative_sentinel_rejected(self):
+        """Non-canonical sentinels (e.g. ``-950``) are still rejected.
+
+        Issue #1296 contract: under ``laimethod=0`` every ``lai`` row
+        must be non-negative (``>= 0``). Any strictly negative value —
+        the canonical ``-999`` sentinel and defensive variants such as
+        ``-950`` alike — is refused, because the observed path does not
+        permit falling back to the calculated branch on a per-timestep
+        basis.
+        """
         sim = SUEWSSimulation.from_sample_data()
 
         end_index = TIMESTEPS_PER_DAY * self.N_DAYS - 1
         df_forcing = sim.forcing.df.copy().iloc[: end_index + 1].copy()
-        df_forcing["lai"] = -950.0  # non-canonical but valid missing sentinel
+        df_forcing["lai"] = -950.0
 
         sim._config.model.physics.laimethod = LAIMethod.OBSERVED
         sim._df_state_init = sim._config.to_df_state()
         sim.update_forcing(df_forcing)
 
-        # The forcing is entirely missing, so the validator must raise exactly
-        # as it does for the canonical -999 sentinel (covered by
-        # ``test_run_rejects_all_missing_lai``). It must NOT fail because of a
-        # spurious "range" error on -950 values.
         with pytest.raises(ValueError, match="laimethod=0"):
             sim.run(end_date=df_forcing.index[-1])
 

--- a/test/core/test_laimethod.py
+++ b/test/core/test_laimethod.py
@@ -23,6 +23,7 @@ These tests guard against regression in:
 import numpy as np
 import pandas as pd
 import pytest
+import supy as sp
 
 from supy import SUEWSSimulation
 from supy._check import FORCING_REQUIREMENTS, check_forcing
@@ -180,6 +181,20 @@ class TestLAIMethodNegativeRejected:
         assert matching, issues
         # Invalid-row count in the message should reflect the 3 sentinels.
         assert "3" in matching[0], matching[0]
+
+    def test_validator_rejects_nan_gap(self):
+        """A NaN gap still breaks the every-timestep observed-LAI contract."""
+        df_forcing = _base_forcing_df()
+        df_forcing["lai"] = 3.5
+        df_forcing.iloc[3, df_forcing.columns.get_loc("lai")] = np.nan
+        issues = check_forcing(
+            df_forcing, fix=False, physics={"laimethod": 0}
+        )
+        matching = [
+            issue for issue in issues
+            if "laimethod=0" in issue and "missing/NaN" in issue
+        ]
+        assert matching, issues
 
     def test_validator_accepts_all_positive_lai(self):
         """Strictly positive ``lai`` values pass the non-negative check."""
@@ -452,6 +467,36 @@ class TestLAIMethodRuntime:
 
         with pytest.raises(ValueError, match="laimethod=0"):
             sim.run(end_date=df_forcing.index[-1])
+
+    def test_nan_lai_gap_rejected(self):
+        """Missing ``lai`` values are rejected before the run starts."""
+        sim = SUEWSSimulation.from_sample_data()
+
+        end_index = TIMESTEPS_PER_DAY * self.N_DAYS - 1
+        df_forcing = sim.forcing.df.copy().iloc[: end_index + 1].copy()
+        df_forcing["lai"] = 3.5
+        df_forcing.iloc[0, df_forcing.columns.get_loc("lai")] = np.nan
+
+        sim._config.model.physics.laimethod = LAIMethod.OBSERVED
+        sim._df_state_init = sim._config.to_df_state()
+        sim.update_forcing(df_forcing)
+
+        with pytest.raises(ValueError, match="laimethod=0"):
+            sim.run(end_date=df_forcing.index[-1])
+
+    def test_legacy_run_supy_unchecked_rejects_nan_gap(self):
+        """Legacy ``run_supy(..., check_input=False)`` still rejects NaN ``lai``."""
+        with pytest.deprecated_call():
+            df_state_init, df_forcing = sp.load_sample_data()
+
+        end_index = TIMESTEPS_PER_DAY * 2 - 1
+        df_forcing = df_forcing.iloc[: end_index + 1].copy()
+        df_forcing["lai"] = 3.5
+        df_forcing.iloc[0, df_forcing.columns.get_loc("lai")] = np.nan
+        df_state_init.loc[:, ("laimethod", "0")] = 0
+
+        with pytest.raises(Exception, match="laimethod=0"):
+            sp.run_supy(df_forcing, df_state_init, check_input=False)
 
 
 class TestLAIBoundsPreflightWarning:


### PR DESCRIPTION
## Summary

- Enforce `lai >= 0` at every timestep under `model.physics.laimethod = 0`: pre-flight validator rejects strictly negative values (including `-999`) and the Fortran runtime surfaces violations via `set_supy_error(105, ...)` + `RETURN` instead of `WRITE + STOP` (which would kill the embedding Python process).
- Zero stays a legitimate observation — clamped up to `laimin` at runtime when the site configuration retains a positive floor, honoured when `laimin = 0`.
- Tests and docs rewritten to match the new contract; a new repo rule (`.claude/rules/fortran/error-reporting.md`) codifies the `set_supy_error`-not-`STOP` convention for future Fortran validation.

Closes #1296.

## Test plan

- [x] `python -m pytest test/core/test_laimethod.py -v` (22/22 passing)
- [x] `make test-smoke` (9/9 passing)
- [ ] Full `make test` on CI