### PR TITLE
build: drop NumPy build-time dependency (post-f2py cleanup)

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -170,18 +170,7 @@ runs:
           PATH="/cargo-cache/bin:$PATH"
         CIBW_BEFORE_ALL_LINUX: >
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&
-          pip install --upgrade pip setuptools wheel &&
-          if [[ "${{ inputs.is_umep_variant }}" == "true" ]]; then
-            echo "Installing oldest-supported-numpy for QGIS3 UMEP variant build" &&
-            pip install oldest-supported-numpy;
-          else
-            echo "Installing numpy>=2.0 for standard build" &&
-            pip install 'numpy>=2.0';
-          fi &&
-          if [[ "${{ inputs.python }}" == "cp313" ]] || [[ "${{ inputs.python }}" == "cp314" ]]; then
-            echo "Installing numpy for Python ${{ inputs.python }} build" &&
-            pip install numpy;
-          fi
+          pip install --upgrade pip setuptools wheel
         CIBW_BEFORE_ALL_MACOS: >
           brew install gfortran &&
           brew unlink gfortran &&

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "wheel",
-    "numpy>=2.0",
     "meson-python>=0.12.0",
 ]
 build-backend = 'mesonpy'


### PR DESCRIPTION
## Summary

- Remove `numpy>=2.0` from `[build-system].requires` in `pyproject.toml`
- Collapse the per-variant / per-CPython NumPy install logic in `CIBW_BEFORE_ALL_LINUX` down to `pip install --upgrade pip setuptools wheel`

## Why

The compiled extension is now the Rust bridge (PyO3 with `abi3-py39`), which has no NumPy C-API dependency — NumPy is used only at the Python level. Build-time NumPy pins are dead machinery from the f2py era.

This is the first of four independent PRs in a broader wheel-build simplification plan (next: abi3 wheel tagging + matrix collapse, UMEP retag, decoupled test architecture). This PR is self-contained and lands independently.

## Test plan

- [x] `make dev` builds cleanly on cp313 without NumPy as a build-system requirement
- [x] `make test-smoke` — 9/9 pass
- [ ] Verify Linux cibuildwheel still installs (CI)