### PR TITLE
test: add physics/api nature marker axis (PR A for #1300)

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -162,6 +162,13 @@ runs:
         # After pytest, enforce bridge-manifest coverage of public Fortran types.
         # Uses run_ci_tests.py wrapper to avoid shell-level && chaining,
         # which breaks on Windows cmd.exe with quoted marker expressions.
+        # gh#1300: the expressions below compose tier markers only. A
+        # follow-up PR splits the matrix on the `physics` vs `api` nature
+        # axis — `physics` runs once per (OS, arch) on the canonical
+        # Python while `api` runs per (platform x Python). No behaviour
+        # change here yet; the new markers are registered in
+        # pyproject.toml and applied to every test file, ready to be
+        # consumed when the matrix split lands.
         CIBW_TEST_COMMAND: >-
           python {project}/scripts/suews/run_ci_tests.py {project}
           -v --tb=short --durations=10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ EXAMPLES:
 
 ### 18 Apr 2026
 
+- [maintenance] Register `physics` / `api` pytest markers as an orthogonal axis to the existing tier markers (#1300)
+  - `physics` covers numerical / binary correctness (one canonical Python per `(OS, arch)` suffices post-abi3); `api` covers Python wrapper surface (pandas / numpy / pydantic, CLI, `SUEWSSimulation`) and needs full `(platform x Python)` coverage
+  - Applied module-level `pytestmark` to all 43 non-UMEP test files; the 5 UMEP test files pick up `api` via the existing `pytest_collection_modifyitems` hook
+  - Added a collection-time lint in `test/conftest.py` that fails any full-tree run where a test file lacks both markers; subset runs (`pytest test/core/test_x.py`) are unaffected
+  - `.github/actions/build-suews/action.yml` carries a breadcrumb for the follow-up CI matrix split; this PR registers and applies markers only, no CI behaviour change
 - [change][experimental] Collapse wheel-build matrix via abi3 and retire the UMEP (NumPy<2) variant (#1299)
   - One cp39-abi3 wheel per (OS, arch) now covers cp39..cp3xx (standard nightly: 24 → 4 build jobs); enabled by `tool.meson-python.limited-api = true` plus the Rust bridge's PyO3 `abi3-py39` ABI
   - Loosened runtime pin to `numpy>=1.22` so the same wheel installs cleanly into QGIS 3 LTR (NumPy 1.26.4), QGIS 4 (NumPy 2.x), and modern Python environments — the compiled extension has no NumPy C-ABI dependency, so the separate UMEP variant is no longer needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,17 @@ suews-schema = "supy.cmd.schema_cli:main"
 filterwarnings = [
     "ignore::UserWarning:pydantic.main",
 ]
-# Test markers for tiered CI testing
+# Test markers.
+# Two orthogonal axes (gh#1300):
+#   nature:  physics | api   -- what the test actually exercises
+#   tier:    smoke | core | cfg | slow | util -- how fast/expensive it is
+# Every test file must carry at least one of {physics, api}; tier markers
+# compose with the nature axis.
 markers = [
+    # Nature axis (gh#1300) -- orthogonal to tier.
+    "physics: Numerical/binary correctness; sufficient to run once per (OS, arch) on the canonical Python",
+    "api: Python wrapper correctness; run across (platform x Python) because pandas/numpy/pydantic surface varies",
+    # Tier axis
     "smoke: Minimal wheel validation (~6 tests, ~60s)",
     "smoke_bridge: Bridge-loading subset run across cp39..cp3xx after a single abi3 build",
     "core: Core physics & logic tests (Fortran, driver)",

--- a/test/README.md
+++ b/test/README.md
@@ -67,6 +67,70 @@ pytest test/core/test_sample_output.py -v    # Fast validation
 pytest test/physics/test_core_physics.py -v  # Physics checks
 ```
 
+## Markers
+
+Markers sit on two orthogonal axes (gh#1300). Every test file must carry at
+least one marker from the **nature** axis; markers from the **tier** axis
+compose on top.
+
+### Nature axis — what is the test actually exercising?
+
+- `physics` — numerical / binary correctness. Outputs are determined by the
+  compiled artefact and CPU floating-point, so running once per
+  `(OS, arch)` on the canonical Python is sufficient. Examples: mass /
+  energy balance, DailyState accumulation, surface-temperature regression.
+- `api` — Python wrapper correctness. Exercises the pandas / numpy /
+  pydantic surface, config validation, CLI UX, or `SUEWSSimulation`
+  methods. Runs across `(platform × Python)` because the dependency
+  surface varies per interpreter.
+
+Rare files belong on **both** axes (e.g. the main integration test that
+runs the model *and* heavily exercises the wrapper). Use list form:
+
+```python
+pytestmark = [pytest.mark.physics, pytest.mark.api]
+```
+
+UMEP tests pick up `api` automatically via `test/umep/conftest.py`; they
+are gated to Windows + Python 3.12 by the existing `qgis` marker.
+
+### Tier axis — how fast or expensive is the test?
+
+- `smoke` — minimal wheel validation (~6 tests, ~60s).
+- `smoke_bridge` — bridge-loading subset run across cp39..cp3xx after a
+  single abi3 build.
+- `core` — core physics and logic tests (Fortran, driver).
+- `rust` — Rust bridge backend tests (requires `suews_bridge` with the
+  `physics` feature).
+- `util` — utility function tests (non-critical).
+- `cfg` — config / schema validation tests.
+- `slow` — tests taking more than 30s individually.
+- `qgis` — UMEP plugin tests in `test/umep/` (Windows + Python 3.12).
+
+### Selecting a subset
+
+```bash
+pytest -m physics                  # numerical / binary correctness only
+pytest -m api                      # wrapper surface only
+pytest -m "physics and smoke"      # physics tests in the smoke tier
+pytest -m "api and not slow"       # wrapper surface, skip slow tests
+pytest -m "physics and api"        # files that straddle both axes
+```
+
+### Adding a new test file
+
+Decide which axis the file belongs on, then add one of:
+
+```python
+pytestmark = pytest.mark.api        # or pytest.mark.physics
+# or, for a file that straddles both axes:
+pytestmark = [pytest.mark.physics, pytest.mark.api]
+```
+
+A collection-time lint in `test/conftest.py` fails any full-tree
+invocation that encounters a test file lacking both `physics` and `api`.
+Subset runs (`pytest test/core/test_x.py`) are unaffected.
+
 ## Test Order
 
 The test suite uses `conftest.py` to ensure `test_sample_output.py` runs first. This is necessary because the Fortran model maintains internal state between test runs, and running this benchmark test first ensures consistent results.

--- a/test/cmd/test_df_state_conversion.py
+++ b/test/cmd/test_df_state_conversion.py
@@ -17,6 +17,8 @@ from supy.util.converter import (
 )
 from supy.util.converter.df_state import validate_converted_df_state
 
+pytestmark = pytest.mark.api
+
 
 class TestDfStateDetection:
     """Test input type and version detection."""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import warnings
+from pathlib import Path
 
 import pytest
 import supy
@@ -245,3 +246,67 @@ def pytest_collection_modifyitems(items):
         + api_equivalence_tests
         + other_tests
     )
+
+
+# =============================================================================
+# gh#1300 — enforce the physics/api nature axis on full-tree runs.
+# =============================================================================
+
+
+def _invocation_targets_full_test_tree(config):
+    """True when the pytest invocation covers the whole `test/` tree.
+
+    The lint below should fire on CI-style invocations (`pytest test`,
+    `pytest` from rootdir, or with marker-only filters) and stay out of the
+    way during local iteration on a single file or subdirectory.
+    """
+    args = list(config.invocation_params.args or ())
+    path_args = [a for a in args if not a.startswith("-")]
+    if not path_args:
+        return True
+    test_dir = (Path(str(config.rootpath)) / "test").resolve()
+    for arg in path_args:
+        try:
+            resolved = Path(arg).resolve()
+        except (OSError, ValueError):
+            return False
+        if resolved != test_dir:
+            return False
+    return True
+
+
+def pytest_collection_finish(session):
+    """Enforce that every collected test carries `physics` or `api` (gh#1300).
+
+    Rationale: the two-axis taxonomy only works if every file declares which
+    axis it belongs to. A missing nature marker would silently drop a file
+    out of CI once the matrix is split in a follow-up PR. Fail loudly at
+    collection time on full-tree runs so the gap is caught before CI.
+    """
+    if not _invocation_targets_full_test_tree(session.config):
+        return
+
+    missing_files = []
+    for item in session.items:
+        marker_names = {m.name for m in item.iter_markers()}
+        if "physics" in marker_names or "api" in marker_names:
+            continue
+        try:
+            rel = Path(str(item.fspath)).resolve().relative_to(
+                Path(str(session.config.rootpath)).resolve()
+            )
+        except ValueError:
+            rel = Path(str(item.fspath))
+        rel_str = str(rel)
+        if rel_str not in missing_files:
+            missing_files.append(rel_str)
+
+    if missing_files:
+        bullet = "\n  - ".join(missing_files)
+        raise pytest.UsageError(
+            "gh#1300 marker lint: these test files are missing both "
+            "`physics` and `api` markers. Every test file must carry at "
+            "least one of the two nature markers (use `pytestmark = "
+            "pytest.mark.api` or `pytest.mark.physics` at module level, or "
+            "auto-apply via `pytest_collection_modifyitems`):\n  - " + bullet
+        )

--- a/test/core/test_audit_python_startup.py
+++ b/test/core/test_audit_python_startup.py
@@ -6,6 +6,10 @@ import importlib.util
 from pathlib import Path
 import sys
 
+import pytest
+
+pytestmark = pytest.mark.api
+
 
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "security" / "audit_python_startup.py"
 SCRIPT_SPEC = importlib.util.spec_from_file_location("audit_python_startup", SCRIPT_PATH)

--- a/test/core/test_cli_conversion.py
+++ b/test/core/test_cli_conversion.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.api
+
 # Import shared CLI testing utilities from conftest
 from conftest import run_cli_command
 

--- a/test/core/test_cli_run.py
+++ b/test/core/test_cli_run.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.api
+
 # Import the CLI command for in-process testing
 from supy.cmd.SUEWS import SUEWS
 

--- a/test/core/test_cli_validation.py
+++ b/test/core/test_cli_validation.py
@@ -6,6 +6,8 @@ import sys
 
 import pytest
 
+pytestmark = pytest.mark.api
+
 
 # Locate the CLI; skip tests if not available
 @pytest.fixture(scope="module")

--- a/test/core/test_forcing_path_resolution.py
+++ b/test/core/test_forcing_path_resolution.py
@@ -13,6 +13,8 @@ except ImportError:
 
 from supy.suews_sim import SUEWSSimulation
 
+pytestmark = pytest.mark.api
+
 
 @contextmanager
 def temp_config_setup(config_content, forcing_location="next_to_config"):

--- a/test/core/test_fortran_state_persistence.py
+++ b/test/core/test_fortran_state_persistence.py
@@ -22,6 +22,8 @@ from conftest import TIMESTEPS_PER_DAY
 import pytest
 import supy as sp
 
+pytestmark = pytest.mark.physics
+
 # Suppress logging to get clean output
 logging.getLogger("SuPy").setLevel(logging.CRITICAL)
 

--- a/test/core/test_kernel_serialization.py
+++ b/test/core/test_kernel_serialization.py
@@ -12,6 +12,8 @@ MPI/OpenMP).
 
 import pytest
 
+pytestmark = pytest.mark.api
+
 
 # =============================================================================
 # State-based error handling tests

--- a/test/core/test_laimethod.py
+++ b/test/core/test_laimethod.py
@@ -31,6 +31,8 @@ from supy.data_model.core.model import LAIMethod
 
 from conftest import TIMESTEPS_PER_DAY
 
+pytestmark = pytest.mark.physics
+
 
 def _base_forcing_df(n_timesteps: int = 24) -> pd.DataFrame:
     """Build a minimal hourly forcing DataFrame (mirrors the pattern in

--- a/test/core/test_load.py
+++ b/test/core/test_load.py
@@ -17,6 +17,8 @@ import supy as sp
 from conftest import TIMESTEPS_PER_DAY
 from supy.util.converter import convert_table, detect_table_version
 
+pytestmark = pytest.mark.api
+
 
 class TestInitSuPy(TestCase):
     """Test init_supy functionality."""

--- a/test/core/test_post.py
+++ b/test/core/test_post.py
@@ -8,10 +8,13 @@ output resampling, aggregation, and data manipulation utilities.
 from unittest import TestCase
 
 import pandas as pd
+import pytest
 
 import supy as sp
 from conftest import TIMESTEPS_PER_DAY
 from supy._post import dict_var_aggm, resample_output  # noqa: PLC2701
+
+pytestmark = pytest.mark.api
 
 
 class TestResampleOutput(TestCase):

--- a/test/core/test_public_api_wrappers.py
+++ b/test/core/test_public_api_wrappers.py
@@ -21,6 +21,8 @@ from supy.suews_sim import SUEWSSimulation
 # The conftest.py saves deprecated versions before monkeypatching
 # We'll access those to test the actual public API wrappers
 
+pytestmark = pytest.mark.api
+
 
 class TestPublicAPIFunctionality:
     """Test that deprecated public API functions still work correctly."""

--- a/test/core/test_qe_qh_edge_cases.py
+++ b/test/core/test_qe_qh_edge_cases.py
@@ -14,6 +14,8 @@ import pytest
 
 import supy as sp
 
+pytestmark = pytest.mark.physics
+
 
 class TestQEQHEdgeCases:
     """Fast edge case tests for QE/QH stability."""

--- a/test/core/test_remove_legacy_namespace_pth.py
+++ b/test/core/test_remove_legacy_namespace_pth.py
@@ -6,6 +6,10 @@ import importlib.util
 from pathlib import Path
 import sys
 
+import pytest
+
+pytestmark = pytest.mark.api
+
 
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "security" / "remove_legacy_namespace_pth.py"
 SCRIPT_SPEC = importlib.util.spec_from_file_location("remove_legacy_namespace_pth", SCRIPT_PATH)

--- a/test/core/test_run_rust.py
+++ b/test/core/test_run_rust.py
@@ -2,6 +2,8 @@ from importlib import import_module
 
 import pytest
 
+pytestmark = pytest.mark.api
+
 _run_rust = import_module("supy._run_rust")
 
 

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -38,6 +38,8 @@ import supy as sp
 
 from conftest import TIMESTEPS_PER_DAY
 
+pytestmark = pytest.mark.physics
+
 # Get the test data directory
 test_data_dir = Path(__file__).parent.parent / "fixtures" / "data_test"
 p_df_sample = Path(test_data_dir) / "sample_output.csv.gz"

--- a/test/core/test_soil_obs_conversion.py
+++ b/test/core/test_soil_obs_conversion.py
@@ -7,7 +7,7 @@ import pytest
 from supy.util._forcing import convert_observed_soil_moisture
 
 # All tests in this module are core physics tests
-pytestmark = pytest.mark.core
+pytestmark = [pytest.mark.core, pytest.mark.physics]
 FAIL_FAST_STEPS_ENV = "SUEWS_FAIL_FAST_STEPS"
 # Default to full-window validation; set SUEWS_FAIL_FAST_STEPS>0 for fast debugging.
 DEFAULT_FAIL_FAST_STEPS = 0

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -13,6 +13,8 @@ except ImportError:
 import supy as sp
 from supy.suews_sim import SUEWSSimulation
 
+pytestmark = pytest.mark.api
+
 
 class TestInit:
     """Test initialization."""

--- a/test/core/test_supy.py
+++ b/test/core/test_supy.py
@@ -35,6 +35,8 @@ flag_full_test = True
 # Note: Sample data loading moved to individual test methods to avoid test interference
 # This prevents caching issues when tests run in sequence
 
+pytestmark = [pytest.mark.physics, pytest.mark.api]
+
 
 class TestSuPy(TestCase):
     # test if single-tstep mode can run

--- a/test/core/test_util_atm.py
+++ b/test/core/test_util_atm.py
@@ -22,6 +22,8 @@ from supy.util._atm import (
     correct_wind_height,
 )
 
+pytestmark = pytest.mark.api
+
 
 class TestAtmosphericCalculations(TestCase):
     """Test atmospheric calculation functions."""

--- a/test/core/test_util_era5.py
+++ b/test/core/test_util_era5.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 from supy.util._era5 import gen_forcing_era5, download_era5_timeseries
 
+pytestmark = pytest.mark.api
+
 
 def has_cds_credentials():
     """Check if CDS API credentials are configured."""

--- a/test/core/test_util_gs.py
+++ b/test/core/test_util_gs.py
@@ -6,6 +6,8 @@ import pytest
 
 from supy.util._gs import cal_rs_FG, cal_rs_iPM, cal_rs_obs
 
+pytestmark = pytest.mark.api
+
 
 class TestSurfaceConductance:
     """Test surface conductance/resistance calculation functions."""

--- a/test/core/test_util_ohm.py
+++ b/test/core/test_util_ohm.py
@@ -6,6 +6,8 @@ import pytest
 
 from supy.util._ohm import derive_ohm_coef, sim_ohm
 
+pytestmark = pytest.mark.api
+
 
 class TestOHMCalculations:
     """Test OHM coefficient derivation and heat storage calculations."""

--- a/test/core/test_wind_speed_validation.py
+++ b/test/core/test_wind_speed_validation.py
@@ -6,6 +6,8 @@ import numpy as np
 from supy._check import check_forcing, check_range, FORCING_REQUIREMENTS
 from supy._check import dict_rules_indiv
 
+pytestmark = pytest.mark.api
+
 
 class TestWindSpeedValidation:
     """Test class for wind speed validation."""

--- a/test/data_model/test_data_model.py
+++ b/test/data_model/test_data_model.py
@@ -25,6 +25,8 @@ from supy.data_model import (
 )
 from supy.data_model.core.model import ModelControl
 
+pytestmark = pytest.mark.api
+
 
 class TestSUEWSConfig(unittest.TestCase):
     def setUp(self):

--- a/test/data_model/test_integration.py
+++ b/test/data_model/test_integration.py
@@ -21,6 +21,8 @@ from supy.data_model.validation.core.yaml_helpers import (
     get_mean_monthly_air_temperature,
 )
 
+pytestmark = pytest.mark.api
+
 
 class TestCRUDataLoading:
     """Test that CRU data loads properly for temperature initialization."""

--- a/test/data_model/test_output_models.py
+++ b/test/data_model/test_output_models.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.api
+
 # Add src/supy/data_model directly to path to avoid importing full supy package
 # This allows testing the output variable definitions without building the Fortran components
 _DATA_MODEL_PATH = (

--- a/test/data_model/test_schema_versioning.py
+++ b/test/data_model/test_schema_versioning.py
@@ -8,6 +8,8 @@ import warnings
 from unittest.mock import patch, MagicMock
 import sys
 
+pytestmark = pytest.mark.api
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 

--- a/test/data_model/test_timezone_enum.py
+++ b/test/data_model/test_timezone_enum.py
@@ -8,6 +8,8 @@ import yaml
 import supy as sp
 from supy.data_model.core.timezone_enum import TimezoneOffset
 
+pytestmark = pytest.mark.api
+
 
 def test_timezone_enum_support():
     """Test that timezone accepts valid timezone offsets and converts them to enum"""

--- a/test/data_model/test_to_yaml_roundtrip.py
+++ b/test/data_model/test_to_yaml_roundtrip.py
@@ -13,6 +13,8 @@ from supy._env import trv_supy_module
 from supy.data_model.core.config import SUEWSConfig
 from supy.data_model.validation.pipeline.phase_a import find_extra_parameters
 
+pytestmark = pytest.mark.api
+
 
 @pytest.fixture
 def standard_data():

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -51,6 +51,8 @@ from supy.data_model.validation.pipeline.phase_b import (
 import types
 import copy
 
+pytestmark = pytest.mark.api
+
 # A tiny “site” stub that only carries exactly the properties our validators look at
 class DummySite:
     def __init__(self, properties, name="SiteX"):

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -32,8 +32,11 @@ from pathlib import Path
 import tempfile
 import unittest
 
+import pytest
 import yaml
 from supy._env import trv_supy_module
+
+pytestmark = pytest.mark.api
 
 try:
     from importlib.resources import as_file

--- a/test/io_tests/test_dailystate_output.py
+++ b/test/io_tests/test_dailystate_output.py
@@ -10,6 +10,8 @@ import pytest
 import supy as sp
 from conftest import TIMESTEPS_PER_DAY
 
+pytestmark = pytest.mark.physics
+
 
 class TestDailyStateOutput:
     """Test suite for DailyState output handling."""

--- a/test/io_tests/test_forcing_interpolation.py
+++ b/test/io_tests/test_forcing_interpolation.py
@@ -5,6 +5,8 @@ import pandas as pd
 import pytest
 from supy._load import resample_forcing_met
 
+pytestmark = [pytest.mark.physics, pytest.mark.api]
+
 
 class TestForcingInterpolation:
     """Test suite for forcing data interpolation issues."""

--- a/test/io_tests/test_gen_epw_resample.py
+++ b/test/io_tests/test_gen_epw_resample.py
@@ -7,6 +7,8 @@ import pytest
 import supy as sp
 from conftest import TIMESTEPS_PER_DAY
 
+pytestmark = pytest.mark.api
+
 
 class TestGenEpwResample:
     """Tests for gen_epw with frequency parameter and resample_output exposure."""

--- a/test/io_tests/test_output_config.py
+++ b/test/io_tests/test_output_config.py
@@ -12,6 +12,8 @@ from supy.data_model.core.config import SUEWSConfig
 from pathlib import Path
 import yaml
 
+pytestmark = pytest.mark.api
+
 
 def test_output_config_creation():
     """Test creating OutputConfig objects"""

--- a/test/io_tests/test_resample_output.py
+++ b/test/io_tests/test_resample_output.py
@@ -14,6 +14,8 @@ from conftest import (
     debug_on_ci,
 )
 
+pytestmark = pytest.mark.api
+
 
 class TestResampleOutput:
     """Test suite for resample_output functionality."""

--- a/test/io_tests/test_save_supy.py
+++ b/test/io_tests/test_save_supy.py
@@ -8,6 +8,8 @@ import tempfile
 import shutil
 import supy as sp
 
+pytestmark = pytest.mark.api
+
 
 class TestSaveSuPy:
     """Test saving functionality of SuPy outputs."""

--- a/test/io_tests/test_yaml_annotation.py
+++ b/test/io_tests/test_yaml_annotation.py
@@ -13,6 +13,8 @@ import tempfile
 from pathlib import Path
 from supy.data_model import SUEWSConfig
 
+pytestmark = pytest.mark.api
+
 
 def test_json_based_yaml_annotation():
     """Test JSON-based YAML annotation for precise positioning."""

--- a/test/physics/test_anthro.py
+++ b/test/physics/test_anthro.py
@@ -7,6 +7,8 @@ Regression test for Issue #240: NaN QF due to zero population density.
 import pytest
 import supy as sp
 
+pytestmark = pytest.mark.physics
+
 
 @pytest.mark.parametrize(
     "scenario",

--- a/test/physics/test_attribution.py
+++ b/test/physics/test_attribution.py
@@ -36,6 +36,8 @@ from supy.util._attribution._physics import (
     decompose_flux_budget,
 )
 
+pytestmark = pytest.mark.physics
+
 
 class TestShapleyDecomposition(TestCase):
     """Test Shapley value calculations for exact closure."""

--- a/test/physics/test_core_physics.py
+++ b/test/physics/test_core_physics.py
@@ -23,9 +23,12 @@ from unittest import TestCase, skipIf
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import supy as sp
 from conftest import TIMESTEPS_PER_DAY
+
+pytestmark = pytest.mark.physics
 
 
 class TestPhysicalValidation(TestCase):

--- a/test/physics/test_rslprof.py
+++ b/test/physics/test_rslprof.py
@@ -13,6 +13,8 @@ import pytest
 
 import supy as sp
 
+pytestmark = pytest.mark.physics
+
 
 class TestWindProfiles:
     """Test suite for wind profile calculations."""

--- a/test/test_api_surface.py
+++ b/test/test_api_surface.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.api
+
 # Files to skip when scanning for imports
 _SKIP_FILES = {"conftest.py", "debug_utils.py", "__init__.py"}
 

--- a/test/umep/conftest.py
+++ b/test/umep/conftest.py
@@ -25,11 +25,17 @@ except ImportError:
 
 
 def pytest_collection_modifyitems(items):
-    """Apply qgis marker and skip condition to all tests in this directory."""
+    """Auto-apply qgis + api markers and skip condition to all tests in this directory.
+
+    UMEP tests are Python wrapper tests (pydantic/pandas/QGIS plugin glue), so they
+    carry the `api` nature marker (gh#1300). The `qgis` tier gates them to Windows +
+    Python 3.12; the platform skip below enforces that at runtime.
+    """
     for item in items:
         # Only apply to tests in test/umep/
         if "test/umep" in str(item.fspath) or "test\\umep" in str(item.fspath):
             item.add_marker(pytest.mark.qgis)
+            item.add_marker(pytest.mark.api)
             if not _IS_QGIS_TARGET:
                 item.add_marker(
                     pytest.mark.skip(


### PR DESCRIPTION
## Summary

Implements PR A of [#1300](https://github.com/UMEP-dev/SUEWS/issues/1300): register a `physics` / `api` pytest-marker axis orthogonal to the existing tier axis (`smoke`/`core`/`cfg`/`slow`/`util`), apply it to every test file, and add a lint that enforces its presence. No CI behaviour change — the matrix split that actually consumes the new axis is deferred to PR B.

- `physics` — numerical / binary correctness. Determined by the compiled artefact + CPU floating-point, so one canonical Python per `(OS, arch)` suffices post-abi3 (#1299).
- `api` — Python wrapper correctness. Exercises pandas / numpy / pydantic, CLI, `SUEWSSimulation`. Needs full `(platform × Python)` coverage because the dependency surface varies per interpreter.

## What's in this PR

- `pyproject.toml` — register `physics` and `api` markers with a header comment documenting the two orthogonal axes
- **43 non-UMEP test files** — module-level `pytestmark = pytest.mark.<nature>` (list form for the 2 "both" files and the existing core-tier physics file)
- `test/umep/conftest.py` — extend the existing `pytest_collection_modifyitems` hook to auto-apply `api` alongside `qgis` (keeps the 5 UMEP files marker-free at file level; they remain gated to Windows + cp312 by the existing `qgis` platform skip)
- `test/conftest.py` — new `pytest_collection_finish` hook that fails full-tree runs (`pytest test/`, `pytest`) when any test file lacks both nature markers; subset runs (`pytest test/core/test_x.py`) are unaffected
- `test/README.md` — document the two axes and how contributors should pick a marker for new tests
- `.github/actions/build-suews/action.yml` — breadcrumb comment pointing at the follow-up PR B; no behaviour change here

## Classification summary

- **physics** only (10): `test/physics/*.py` (4); `test/core/test_fortran_state_persistence.py`, `test_laimethod.py`, `test_qe_qh_edge_cases.py`, `test_sample_output.py`, `test_soil_obs_conversion.py`; `test/io_tests/test_dailystate_output.py`
- **api** only (32): all of `test/data_model/*.py`; `test/core/test_cli_*.py`, `test_load.py`, `test_post.py`, `test_public_api_wrappers.py`, `test_run_rust.py`, `test_suews_simulation.py`, `test_util_*.py`, `test_kernel_serialization.py`, `test_audit_python_startup.py`, `test_remove_legacy_namespace_pth.py`, `test_wind_speed_validation.py`, `test_forcing_path_resolution.py`; `test/cmd/test_df_state_conversion.py`; `test/io_tests/test_save_supy.py`, `test_resample_output.py`, `test_output_config.py`, `test_gen_epw_resample.py`, `test_yaml_annotation.py`; `test/test_api_surface.py`
- **both** (2): `test/core/test_supy.py`, `test/io_tests/test_forcing_interpolation.py`
- **UMEP** (5): auto-applied via `test/umep/conftest.py`

`test/core/test_kernel_serialization.py` was re-classified from "mixed" to `api` only after rereading the file — it tests the Python wrapper call path, not Fortran numerics.

## Test plan

- [x] `pytest --collect-only -m physics test/` → 106 / 778 tests
- [x] `pytest --collect-only -m api test/` → 688 / 778 tests
- [x] `pytest --collect-only -m "physics and api" test/` → 16 tests (the two "both" files)
- [x] `pytest --collect-only -m "not physics and not api" test/` → 0 tests (every test has a nature marker)
- [x] Lint fires with exit code 4 when a marker is removed on a full-tree run, with the offending file named in the error message
- [x] Lint stays silent on subset runs (`pytest test/core/test_util_gs.py`) even if a marker is missing
- [x] `make test-smoke` passes unchanged (9 passed, 769 deselected, ~50s)
- [ ] CI: full build matrix on PR

## Follow-up (separate PR)

PR B will split `.github/scripts/determine-matrix.sh` / `build-suews/action.yml` so `physics` runs once per `(OS, arch)` on the canonical Python and `api` runs per `(platform × Python)`. The markers, lint, and documentation are all in place; the follow-up is just CI matrix plumbing.

Closes #1300 (partially — PR B to come).