### PR TITLE
chore(conductor): make run/setup scripts self-heal build deps

### DIFF
--- a/scripts/conductor/run.sh
+++ b/scripts/conductor/run.sh
@@ -1,11 +1,30 @@
 #!/bin/bash
 # Conductor run script for SUEWS workspace
-# Starts browser-sync for site preview and Sphinx live documentation
+# Starts browser-sync for site preview and Sphinx live documentation.
+# Self-heals if .venv or supy build is missing so clicking Run just works.
 
 set -e
 
+if [ ! -d .venv ]; then
+    echo "[run] No .venv found — creating one with uv..."
+    uv venv
+fi
+
 echo "[run] Activating virtual environment..."
 source .venv/bin/activate
+
+if ! python -c "import supy" >/dev/null 2>&1; then
+    echo "[run] supy not importable — running 'make dev' (first build takes a few minutes)..."
+    make dev
+fi
+
+if ! command -v sphinx-autobuild >/dev/null 2>&1; then
+    echo "[run] sphinx-autobuild missing — running 'make docs-setup'..."
+    make docs-setup
+fi
+
+# Make sure background jobs (browser-sync) die with this script
+trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
 
 echo "[run] Starting browser-sync for site preview..."
 npx -y browser-sync start --server site --port 3000 --files 'site/**/*' &

--- a/scripts/conductor/setup.sh
+++ b/scripts/conductor/setup.sh
@@ -35,4 +35,10 @@ uv venv --clear
 echo "[setup] Activating virtual environment..."
 source .venv/bin/activate
 
+echo "[setup] Building supy in editable mode (make dev)..."
+make dev
+
+echo "[setup] Installing documentation dependencies (make docs-setup)..."
+make docs-setup
+
 echo "[setup] Done."


### PR DESCRIPTION
## Summary
- `scripts/conductor/run.sh` now bootstraps the workspace on demand: creates `.venv` with `uv venv` if missing, runs `make dev` if `supy` isn't importable, and runs `make docs-setup` if `sphinx-autobuild` isn't on PATH. Also adds a trap so the backgrounded `browser-sync` dies with the script.
- `scripts/conductor/setup.sh` now runs `make dev` and `make docs-setup` after creating the venv, so first-time Setup leaves the workspace immediately runnable.

## Why
In a fresh Conductor workspace, clicking **Run** failed twice in a row:
- First, `supy.data_model.doc_utils` couldn't import because `make dev` had never run.
- After that, `make livehtml` failed with `sphinx-autobuild: command not found` because `[docs]` extras weren't installed.

With these changes, clicking Run just works — the script repairs whichever dependency layer is missing.

## Test plan
- [ ] Delete `.venv` in a fresh clone, click Run in Conductor → browser-sync and sphinx-autobuild start successfully after the bootstrap.
- [ ] With a warm workspace (supy + docs deps already installed) Run starts quickly with no reinstall.
- [ ] Ctrl-C on Run exits the script and leaves no orphan `browser-sync` process.