### PR TITLE
chore: gitignore Claude Code scheduler lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -582,6 +582,7 @@ quick-test.py
 # Only ignore local settings and truly temporary files
 .claude/settings.local.json
 .claude/workspace/temp-*
+.claude/scheduled_tasks.lock
 
 # auto-generated files for building docs
 docs/schema.json


### PR DESCRIPTION
## Summary

- Adds `.claude/scheduled_tasks.lock` to `.gitignore`.

The file is a runtime artefact produced by the Claude Code harness's task scheduler and has no source-control value. It kept reappearing as an untracked file during work on #1306, so ignoring it keeps `git status` quiet.

Placed alongside the existing `.claude/settings.local.json` and `.claude/workspace/temp-*` entries for consistency.

## Test plan

- [x] `git status` on a clean checkout with an active Claude Code scheduler no longer lists `.claude/scheduled_tasks.lock`.