### PR TITLE
test: tag data_model YAML drift tests with api marker

### DIFF
--- a/test/data_model/test_from_yaml_errors.py
+++ b/test/data_model/test_from_yaml_errors.py
@@ -19,6 +19,8 @@ from supy._env import trv_supy_module
 from supy.data_model.core.config import SUEWSConfig
 from supy.data_model.schema import CURRENT_SCHEMA_VERSION
 
+pytestmark = pytest.mark.api
+
 
 @pytest.fixture
 def sample_config_dict() -> dict:

--- a/test/data_model/test_release_compat.py
+++ b/test/data_model/test_release_compat.py
@@ -15,6 +15,8 @@ import pytest
 
 from supy.data_model.core.config import SUEWSConfig
 
+pytestmark = pytest.mark.api
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 RELEASE_FIXTURES = REPO_ROOT / "test" / "fixtures" / "release_configs"
 DOCS_EXAMPLES = REPO_ROOT / "docs" / "source" / "inputs" / "yaml" / "examples"

--- a/test/data_model/test_yaml_upgrade.py
+++ b/test/data_model/test_yaml_upgrade.py
@@ -24,6 +24,8 @@ from supy.util.converter.yaml_upgrade import (
     upgrade_yaml,
 )
 
+pytestmark = pytest.mark.api
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 RELEASE_FIXTURE = (
     REPO_ROOT / "test" / "fixtures" / "release_configs" / "2026.4.3.yml"


### PR DESCRIPTION
Adds the missing api nature-axis marker to the three test/data_model modules that landed after the matrix split work. These tests exercise YAML config validation and the suews-convert yaml-upgrade wrapper path, so they belong on the API axis rather than physics. This keeps the marker lint and API matrix selection aligned with the current suite. Refs #1300.