### PR TITLE
Refactor: DataFrame column rename scaffolding for Tier C (gh#1325)

### DIFF
--- a/src/supy/data_model/core/df_column_renames.py
+++ b/src/supy/data_model/core/df_column_renames.py
@@ -1,0 +1,213 @@
+"""Registry of legacy -> new DataFrame column names (gh#1325, Tier C).
+
+Tier A (#1308) renamed the Pydantic/YAML field names to snake_case but
+deliberately kept DataFrame state columns under the legacy fused
+spellings so the Fortran bridge and its JSON registries would keep
+working. Tier B (#1331) aligned the Rust-internal codec field names.
+
+Tier C (gh#1325) renames the DataFrame column names in a phased rollout.
+This module is the Phase 1 + Phase 2 deliverable:
+
+* ``ALL_DF_COLUMN_RENAMES`` -- the closed set of legacy -> new DataFrame
+  column names. Mirrors ``field_renames.ALL_FIELD_RENAMES`` because the
+  design intent is that the DataFrame column name matches the Pydantic
+  attribute name on each class.
+* ``read_df_column`` -- the dual-read helper that every subsequent
+  consumer migration will route through. Reads a column by its new name;
+  falls back to the legacy name with a ``DeprecationWarning`` when the
+  DataFrame still carries the old spelling.
+
+PR 1 (issue #1325, phases 1 and 2) is additive only: no ``to_df_state`` /
+``from_df_state`` changes, no consumer migration, no schema bump. The
+registry and helper exist so PR 2 (dual-write in ``to_df_state``), PR 3
+(consumer sweep), and PR 4 (drop-legacy + schema bump) have a single
+seam to route through.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict
+
+import pandas as pd
+
+from .field_renames import (
+    ARCHETYPEPROPERTIES_RENAMES,
+    DECTRPROPERTIES_RENAMES,
+    EVETRPROPERTIES_RENAMES,
+    LAIPARAMS_RENAMES,
+    MODELPHYSICS_RENAMES,
+    SNOWPARAMS_RENAMES,
+    SURFACEPROPERTIES_RENAMES,
+    VEGETATEDSURFACEPROPERTIES_RENAMES,
+)
+
+
+# -- Per-domain DataFrame column rename maps ---------------------------------
+#
+# Each dict is keyed by the legacy DataFrame column name (as currently
+# emitted by the class's ``to_df_state``) and maps to the target new name.
+# For every class listed below, the legacy DataFrame column name coincides
+# with the legacy Pydantic attribute name handled by ``field_renames.py``,
+# so these dicts are re-exports of the corresponding Pydantic rename dicts.
+# They are re-exported under DataFrame-specific names so the Tier C
+# inventory is auditable on its own and so the cascade can diverge from
+# the Pydantic-side set without breaking contract callers depend on.
+
+MODELPHYSICS_DF_RENAMES: Dict[str, str] = dict(MODELPHYSICS_RENAMES)
+SURFACEPROPERTIES_DF_RENAMES: Dict[str, str] = dict(SURFACEPROPERTIES_RENAMES)
+LAIPARAMS_DF_RENAMES: Dict[str, str] = dict(LAIPARAMS_RENAMES)
+VEGETATEDSURFACEPROPERTIES_DF_RENAMES: Dict[str, str] = dict(
+    VEGETATEDSURFACEPROPERTIES_RENAMES
+)
+EVETRPROPERTIES_DF_RENAMES: Dict[str, str] = dict(EVETRPROPERTIES_RENAMES)
+DECTRPROPERTIES_DF_RENAMES: Dict[str, str] = dict(DECTRPROPERTIES_RENAMES)
+SNOWPARAMS_DF_RENAMES: Dict[str, str] = dict(SNOWPARAMS_RENAMES)
+
+# STEBBS (``ArchetypeProperties``) is a special case: the Pydantic field
+# names are PascalCase by design (to match the Fortran-side STEBBS
+# interface, see ``.claude/rules/00-project-essentials.md``), and
+# ``to_df_state`` on that class lowercases the field name before writing
+# it into the DataFrame (see ``site.py`` ``ArchetypeProperties.to_df_state``).
+# We mirror that lowercasing here so the registry keys match the actual
+# column names the DataFrame carries today and will carry after Tier C.
+ARCHETYPEPROPERTIES_DF_RENAMES: Dict[str, str] = {
+    old.lower(): new.lower() for old, new in ARCHETYPEPROPERTIES_RENAMES.items()
+}
+
+
+# -- Combined -----------------------------------------------------------------
+
+ALL_DF_COLUMN_RENAMES: Dict[str, str] = {
+    **MODELPHYSICS_DF_RENAMES,
+    **SURFACEPROPERTIES_DF_RENAMES,
+    **LAIPARAMS_DF_RENAMES,
+    **VEGETATEDSURFACEPROPERTIES_DF_RENAMES,
+    **EVETRPROPERTIES_DF_RENAMES,
+    **DECTRPROPERTIES_DF_RENAMES,
+    **ARCHETYPEPROPERTIES_DF_RENAMES,
+    **SNOWPARAMS_DF_RENAMES,
+}
+
+# Reverse map: new -> legacy. Required by ``read_df_column`` when the
+# caller passes the new name but the DataFrame still carries the legacy
+# spelling.
+_REVERSE_DF_COLUMN_RENAMES: Dict[str, str] = {
+    new: old for old, new in ALL_DF_COLUMN_RENAMES.items()
+}
+
+
+# -- Registry integrity (import-time assertions) -----------------------------
+#
+# Mirrors the invariants in ``field_renames.py`` so drift between the two
+# registries fails at import time rather than at simulation time.
+
+def _assert_registry_invariants() -> None:
+    per_class_total = (
+        len(MODELPHYSICS_DF_RENAMES)
+        + len(SURFACEPROPERTIES_DF_RENAMES)
+        + len(LAIPARAMS_DF_RENAMES)
+        + len(VEGETATEDSURFACEPROPERTIES_DF_RENAMES)
+        + len(EVETRPROPERTIES_DF_RENAMES)
+        + len(DECTRPROPERTIES_DF_RENAMES)
+        + len(ARCHETYPEPROPERTIES_DF_RENAMES)
+        + len(SNOWPARAMS_DF_RENAMES)
+    )
+    if len(ALL_DF_COLUMN_RENAMES) != per_class_total:
+        raise RuntimeError(
+            "ALL_DF_COLUMN_RENAMES size mismatch: "
+            f"expected {per_class_total}, got {len(ALL_DF_COLUMN_RENAMES)}. "
+            "A legacy DataFrame column appears in more than one per-class dict."
+        )
+    new_names = list(ALL_DF_COLUMN_RENAMES.values())
+    if len(set(new_names)) != len(new_names):
+        raise RuntimeError(
+            "Duplicate new DataFrame column names detected in the registry."
+        )
+    legacy_names = set(ALL_DF_COLUMN_RENAMES.keys())
+    shared = legacy_names & set(new_names)
+    if shared:
+        raise RuntimeError(
+            "Legacy and new DataFrame column name sets overlap: "
+            f"{sorted(shared)}"
+        )
+
+
+_assert_registry_invariants()
+
+
+# -- Dual-read helper --------------------------------------------------------
+
+_MISSING = object()
+
+
+def _has_top_level_column(df: pd.DataFrame, name: str) -> bool:
+    """Return True if ``name`` sits at level 0 of ``df.columns``.
+
+    SUEWS DataFrame state uses a ``MultiIndex`` with the field name at
+    level 0 (``("netradiationmethod", "0")`` etc.). Plain
+    ``name in df.columns`` tests the full tuple on a ``MultiIndex`` and
+    never matches a single-string ``name``, so the top level is walked
+    explicitly.
+    """
+    if isinstance(df.columns, pd.MultiIndex):
+        return name in df.columns.get_level_values(0)
+    return name in df.columns
+
+
+def read_df_column(
+    df: pd.DataFrame,
+    new_name: str,
+    *,
+    default: Any = _MISSING,
+) -> Any:
+    """Read a DataFrame column by its new snake_case name.
+
+    Falls back to the legacy fused spelling with a ``DeprecationWarning``
+    when the DataFrame still carries the old column. This is the single
+    seam consumer code migrated in gh#1325 Phase 4 routes through, so the
+    consumer can be written against the new spelling today while still
+    reading DataFrames emitted by unmigrated code paths.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        State DataFrame whose columns are addressed by a top-level name
+        (either a plain ``Index`` or a ``MultiIndex`` with the field name
+        at level 0).
+    new_name : str
+        Target snake_case column name to read.
+    default : Any, optional
+        Returned when neither ``new_name`` nor its legacy alias is
+        present. If omitted, a missing column raises ``KeyError``.
+
+    Returns
+    -------
+    pandas.Series or pandas.DataFrame
+        ``df[new_name]`` when present, otherwise ``df[legacy_name]`` with
+        a deprecation warning, otherwise ``default``.
+
+    Raises
+    ------
+    KeyError
+        If neither spelling is present and no ``default`` was provided.
+    """
+    if _has_top_level_column(df, new_name):
+        return df[new_name]
+
+    legacy_name = _REVERSE_DF_COLUMN_RENAMES.get(new_name)
+    if legacy_name is not None and _has_top_level_column(df, legacy_name):
+        warnings.warn(
+            f"DataFrame column '{legacy_name}' is deprecated; "
+            f"use '{new_name}' instead (gh#1325 Tier C).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return df[legacy_name]
+
+    if default is _MISSING:
+        raise KeyError(
+            f"DataFrame column '{new_name}' (legacy alias '{legacy_name}') "
+            "not found."
+        )
+    return default

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -82,6 +82,7 @@ py.install_sources(
             'data_model/doc_utils.py',
             'data_model/core/__init__.py',
             'data_model/core/config.py',
+            'data_model/core/df_column_renames.py',
             'data_model/core/field_renames.py',
             'data_model/core/human_activity.py',
             'data_model/core/hydro.py',

--- a/test/data_model/test_df_column_renames.py
+++ b/test/data_model/test_df_column_renames.py
@@ -1,0 +1,261 @@
+"""Tests for the DataFrame column rename registry and helper (gh#1325 Tier C).
+
+PR 1 lands the registry (``ALL_DF_COLUMN_RENAMES``) and the dual-read
+helper (``read_df_column``). Neither changes what columns
+``to_df_state`` currently emits -- those changes arrive in Phase 3
+(gh#1325 PR 2) -- so these tests exercise the scaffolding in isolation:
+
+* Registry integrity (no duplicates, disjoint legacy/new sets,
+  snake_case for the non-STEBBS surface, size matches the per-class
+  dicts).
+* Helper behaviour (reads new name silently, falls back to legacy with
+  a ``DeprecationWarning``, raises or returns ``default`` when neither
+  is present).
+* Cross-layer parity: every legacy DF column appears in the Rust
+  ``FIELD_RENAMES`` table at ``src/suews_bridge/src/field_renames.rs``
+  so drift between the Python and Rust name registries fails here,
+  ahead of ``_validate_output_layout`` at simulation time.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.api
+
+from supy.data_model.core.df_column_renames import (
+    ALL_DF_COLUMN_RENAMES,
+    ARCHETYPEPROPERTIES_DF_RENAMES,
+    DECTRPROPERTIES_DF_RENAMES,
+    EVETRPROPERTIES_DF_RENAMES,
+    LAIPARAMS_DF_RENAMES,
+    MODELPHYSICS_DF_RENAMES,
+    SNOWPARAMS_DF_RENAMES,
+    SURFACEPROPERTIES_DF_RENAMES,
+    VEGETATEDSURFACEPROPERTIES_DF_RENAMES,
+    read_df_column,
+)
+from supy.data_model.core.field_renames import ALL_FIELD_RENAMES
+
+
+_SNAKE_CASE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_RUST_FIELD_RENAMES_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "suews_bridge"
+    / "src"
+    / "field_renames.rs"
+)
+
+
+def _rust_field_renames_text() -> str:
+    """Return the full text of ``field_renames.rs`` for static alignment checks."""
+    return _RUST_FIELD_RENAMES_PATH.read_text(encoding="utf-8")
+
+
+class TestRegistryIntegrity:
+    def test_all_renames_combines_per_class_dicts(self):
+        expected = (
+            len(MODELPHYSICS_DF_RENAMES)
+            + len(SURFACEPROPERTIES_DF_RENAMES)
+            + len(LAIPARAMS_DF_RENAMES)
+            + len(VEGETATEDSURFACEPROPERTIES_DF_RENAMES)
+            + len(EVETRPROPERTIES_DF_RENAMES)
+            + len(DECTRPROPERTIES_DF_RENAMES)
+            + len(ARCHETYPEPROPERTIES_DF_RENAMES)
+            + len(SNOWPARAMS_DF_RENAMES)
+        )
+        assert len(ALL_DF_COLUMN_RENAMES) == expected
+
+    def test_no_duplicate_new_names(self):
+        values = list(ALL_DF_COLUMN_RENAMES.values())
+        assert len(set(values)) == len(values), "Duplicate new DataFrame column names"
+
+    def test_no_duplicate_legacy_names(self):
+        keys = list(ALL_DF_COLUMN_RENAMES.keys())
+        assert len(set(keys)) == len(keys), "Duplicate legacy DataFrame column names"
+
+    def test_legacy_and_new_sets_disjoint(self):
+        """No column can simultaneously be a legacy and a new name."""
+        legacy = set(ALL_DF_COLUMN_RENAMES.keys())
+        new = set(ALL_DF_COLUMN_RENAMES.values())
+        assert legacy.isdisjoint(new), (
+            f"Legacy and new DataFrame column name sets overlap: "
+            f"{sorted(legacy & new)}"
+        )
+
+    def test_snake_case_targets(self):
+        """All new DataFrame column names are lowercase snake_case.
+
+        STEBBS ``ArchetypeProperties`` columns are lowercased during
+        ``to_df_state`` emission, so the DF registry stores them in
+        lowercase -- they satisfy snake_case checks even though the
+        Pydantic attribute is PascalCase.
+        """
+        for legacy, new in ALL_DF_COLUMN_RENAMES.items():
+            assert _SNAKE_CASE_RE.match(new), (
+                f"New DataFrame column name must be lowercase snake_case: "
+                f"{legacy!r} -> {new!r}"
+            )
+
+
+class TestArchetypePropertiesLowercasing:
+    """STEBBS DF columns are lowercased during emission; the registry
+    mirrors that casing so the helper works against real DataFrames."""
+
+    def test_wall_external_thickness_lowercased(self):
+        assert ARCHETYPEPROPERTIES_DF_RENAMES["wallextthickness"] == (
+            "wallexternalthickness"
+        )
+
+    def test_all_keys_and_values_lowercase(self):
+        for legacy, new in ARCHETYPEPROPERTIES_DF_RENAMES.items():
+            assert legacy == legacy.lower()
+            assert new == new.lower()
+
+
+class TestHelperNewName:
+    def test_new_name_single_index_returns_series_silently(self):
+        df = pd.DataFrame({"net_radiation": [3]})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            series = read_df_column(df, "net_radiation")
+        assert list(series) == [3]
+
+    def test_new_name_multiindex_returns_sub_df_silently(self):
+        df = pd.DataFrame({("net_radiation", "0"): [3]})
+        df.columns = pd.MultiIndex.from_tuples(df.columns)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            sub = read_df_column(df, "net_radiation")
+        assert sub.iloc[0, 0] == 3
+
+
+class TestHelperLegacyFallback:
+    def test_legacy_name_emits_deprecation_warning(self):
+        df = pd.DataFrame({("netradiationmethod", "0"): [3]})
+        df.columns = pd.MultiIndex.from_tuples(df.columns)
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", DeprecationWarning)
+            sub = read_df_column(df, "net_radiation")
+        messages = [
+            str(w.message)
+            for w in captured
+            if issubclass(w.category, DeprecationWarning)
+        ]
+        assert any(
+            "netradiationmethod" in m and "net_radiation" in m for m in messages
+        ), f"Expected deprecation warning, got: {messages}"
+        assert sub.iloc[0, 0] == 3
+
+    def test_single_index_legacy_fallback(self):
+        df = pd.DataFrame({"soildepth": [0.2]})
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", DeprecationWarning)
+            series = read_df_column(df, "soil_depth")
+        messages = [
+            str(w.message)
+            for w in captured
+            if issubclass(w.category, DeprecationWarning)
+        ]
+        assert any("soildepth" in m and "soil_depth" in m for m in messages)
+        assert list(series) == [0.2]
+
+
+class TestHelperMissing:
+    def test_missing_with_default_returns_default(self):
+        df = pd.DataFrame({"unrelated": [1]})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = read_df_column(df, "net_radiation", default=-999)
+        assert result == -999
+
+    def test_missing_without_default_raises(self):
+        df = pd.DataFrame({"unrelated": [1]})
+        with pytest.raises(KeyError, match="net_radiation"):
+            read_df_column(df, "net_radiation")
+
+
+class TestRustBridgeAlignment:
+    """Every legacy DataFrame column must appear in the Rust
+    ``FIELD_RENAMES`` table so the two name registries stay aligned.
+
+    STEBBS is excluded from the lowercase comparison because the Rust
+    table stores the PascalCase Pydantic spelling (``WallextThickness``)
+    while the DataFrame registry stores the lowercased DF-column form
+    (``wallextthickness``).
+    """
+
+    def test_every_non_stebbs_legacy_column_listed_in_rust(self):
+        rust_text = _rust_field_renames_text()
+        stebbs_legacy = set(ARCHETYPEPROPERTIES_DF_RENAMES.keys())
+        missing = []
+        for legacy in ALL_DF_COLUMN_RENAMES.keys():
+            if legacy in stebbs_legacy:
+                continue
+            # Rust FIELD_RENAMES entries are `(new_name, legacy_name)`; look
+            # for the legacy name surrounded by quotes so substring collisions
+            # (e.g. `baset` inside `basete`) don't give a false positive.
+            if f'"{legacy}"' not in rust_text:
+                missing.append(legacy)
+        assert not missing, (
+            f"Legacy DataFrame columns absent from Rust field_renames.rs: "
+            f"{missing}"
+        )
+
+    def test_stebbs_legacy_columns_present_as_pascal_case_in_rust(self):
+        rust_text = _rust_field_renames_text()
+        missing = []
+        for legacy_lower in ARCHETYPEPROPERTIES_DF_RENAMES.keys():
+            # The Rust table keeps PascalCase; reconstruct the expected
+            # spelling from the Pydantic side of the rename.
+            from supy.data_model.core.field_renames import (
+                ARCHETYPEPROPERTIES_RENAMES,
+            )
+
+            pascal_match = next(
+                (
+                    old
+                    for old in ARCHETYPEPROPERTIES_RENAMES
+                    if old.lower() == legacy_lower
+                ),
+                None,
+            )
+            assert pascal_match is not None, (
+                f"STEBBS legacy column {legacy_lower!r} has no PascalCase "
+                f"source in ARCHETYPEPROPERTIES_RENAMES"
+            )
+            if f'"{pascal_match}"' not in rust_text:
+                missing.append(pascal_match)
+        assert not missing, (
+            f"STEBBS legacy columns absent from Rust field_renames.rs: "
+            f"{missing}"
+        )
+
+
+class TestPydanticRegistryMirror:
+    """The DF column rename registry is sourced from the Pydantic
+    ``ALL_FIELD_RENAMES`` registry (plus STEBBS lowercasing). If Tier A
+    adds a new Pydantic rename that should also rename the DataFrame
+    column, this test forces an explicit decision rather than silent drift.
+    """
+
+    def test_non_stebbs_df_renames_match_field_renames(self):
+        from supy.data_model.core.field_renames import (
+            ARCHETYPEPROPERTIES_RENAMES,
+        )
+
+        stebbs_legacy = set(ARCHETYPEPROPERTIES_RENAMES.keys())
+        for legacy, new in ALL_FIELD_RENAMES.items():
+            if legacy in stebbs_legacy:
+                # STEBBS is the lowercased exception, covered by its own test.
+                continue
+            assert ALL_DF_COLUMN_RENAMES.get(legacy) == new, (
+                f"Pydantic rename {legacy!r} -> {new!r} missing or divergent "
+                f"in ALL_DF_COLUMN_RENAMES"
+            )


### PR DESCRIPTION
## Summary

Phase 1 (inventory) + Phase 2 (dual-read helper) of the gh#1325 cascade — lays groundwork for renaming DataFrame state columns from legacy fused spellings (`netradiationmethod`, `soildepth`, `baset`, ...) to snake_case so the Python DF layer matches the Pydantic field names and the Rust codec FIELDS already shipped in #1331.

- Adds `src/supy/data_model/core/df_column_renames.py`: 68-entry legacy→new column registry mirroring `field_renames.ALL_FIELD_RENAMES` (STEBBS keys/values lowercased to match `to_df_state` emission), with import-time integrity guards and the `read_df_column()` dual-read helper that emits a `DeprecationWarning` when the DF still carries the legacy spelling.
- Adds `test/data_model/test_df_column_renames.py`: 16 tests covering registry integrity, STEBBS lowercasing, helper behaviour (single-index, MultiIndex, legacy fallback, missing+default, missing KeyError), Rust `field_renames.rs` alignment, and Pydantic registry mirror.
- Pure addition: no `to_df_state`/`from_df_state` changes, no consumer migration, no schema bump. Subsequent PRs (Phases 3–5) will dual-write emitters, sweep `_load.py`/`_check.py`/`_var_metadata.py` + JSON registries, then drop the shim and bump the schema.

Refs #1325, #1323, #1331.

## Test plan

- [x] `pytest test/data_model/test_df_column_renames.py -v` — 16/16 pass
- [x] `pytest test/data_model/test_field_renames.py -v` — 39/39 unchanged
- [x] `pytest test/data_model/` — 501/501 pass
- [x] `make test-smoke` — 9/9 pass, including `test_sample_output_validation` (Rust/Python column parity unchanged)