### PR TITLE
Implement gh1338 dual-write DataFrame state

### DIFF
--- a/src/supy/data_model/core/df_column_renames.py
+++ b/src/supy/data_model/core/df_column_renames.py
@@ -27,6 +27,7 @@ seam to route through.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Mapping
 from typing import Any, Dict
 
 import pandas as pd
@@ -159,9 +160,115 @@ def _assert_registry_invariants() -> None:
 _assert_registry_invariants()
 
 
-# -- Dual-read helper --------------------------------------------------------
+# -- Dual-write / dual-read helpers -----------------------------------------
 
 _MISSING = object()
+_STRUCTURED_SUFFIXES = ("_surf", "_roof", "_wall")
+_SURFACE_IRRIGATION_SUFFIXES = (
+    "paved",
+    "bldgs",
+    "evetr",
+    "dectr",
+    "grass",
+    "bsoil",
+    "water",
+)
+
+
+def _new_alias_for_legacy_name(name: str) -> str | None:
+    new_name = ALL_DF_COLUMN_RENAMES.get(name)
+    if new_name is not None:
+        return new_name
+
+    for structured_suffix in _STRUCTURED_SUFFIXES:
+        if not name.endswith(structured_suffix):
+            continue
+        base = name[: -len(structured_suffix)]
+        new_base = ALL_DF_COLUMN_RENAMES.get(base)
+        if new_base is not None:
+            return f"{new_base}{structured_suffix}"
+
+    for suffix in _SURFACE_IRRIGATION_SUFFIXES:
+        if name == f"irrfrac{suffix}":
+            return f"irrigation_fraction{suffix}"
+
+    return None
+
+
+def _legacy_alias_for_new_name(name: str) -> str | None:
+    legacy_name = _REVERSE_DF_COLUMN_RENAMES.get(name)
+    if legacy_name is not None:
+        return legacy_name
+
+    for structured_suffix in _STRUCTURED_SUFFIXES:
+        if not name.endswith(structured_suffix):
+            continue
+        base = name[: -len(structured_suffix)]
+        legacy_base = _REVERSE_DF_COLUMN_RENAMES.get(base)
+        if legacy_base is not None:
+            return f"{legacy_base}{structured_suffix}"
+
+    for suffix in _SURFACE_IRRIGATION_SUFFIXES:
+        if name == f"irrigation_fraction{suffix}":
+            return f"irrfrac{suffix}"
+
+    return None
+
+
+def _aliased_column_key(column: Any) -> Any:
+    """Return the new-name alias for a column key, or ``None``.
+
+    State columns are normally ``MultiIndex`` tuples with the variable
+    name at level 0 and the index dimension at level 1. A few tests and
+    helper call sites use plain string columns, so both shapes are
+    handled here.
+    """
+    if isinstance(column, tuple):
+        if not column:
+            return None
+        new_name = _new_alias_for_legacy_name(column[0])
+        if new_name is None:
+            return None
+        return (new_name, *column[1:])
+
+    new_name = _new_alias_for_legacy_name(column)
+    if new_name is None:
+        return None
+    return new_name
+
+
+def dual_write_df_column_aliases(cols: Mapping[Any, Any]) -> dict[Any, Any]:
+    """Return ``cols`` plus new-name aliases for registered legacy keys.
+
+    Existing new-name columns are never overwritten. This lets specialised
+    ``to_df_state`` implementations keep writing their bridge-compatible
+    legacy names while emitting the Phase 3 snake_case aliases in parallel.
+    """
+    out = dict(cols)
+    for column, value in cols.items():
+        alias = _aliased_column_key(column)
+        if alias is not None and alias not in out:
+            out[alias] = value
+    return out
+
+
+def dual_write_df_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` plus new-name aliases for registered legacy columns."""
+    alias_cols = {}
+    for column in df.columns:
+        alias = _aliased_column_key(column)
+        if alias is not None and alias not in df.columns and alias not in alias_cols:
+            alias_cols[alias] = df[column]
+
+    if not alias_cols:
+        return df
+
+    aliases = pd.DataFrame(alias_cols, index=df.index)
+    if isinstance(df.columns, pd.MultiIndex):
+        aliases.columns = pd.MultiIndex.from_tuples(
+            aliases.columns, names=df.columns.names
+        )
+    return pd.concat([df, aliases], axis=1)
 
 
 def _has_top_level_column(df: pd.DataFrame, name: str) -> bool:
@@ -218,7 +325,7 @@ def read_df_column(
     if _has_top_level_column(df, new_name):
         return df[new_name]
 
-    legacy_name = _REVERSE_DF_COLUMN_RENAMES.get(new_name)
+    legacy_name = _legacy_alias_for_new_name(new_name)
     if legacy_name is not None and _has_top_level_column(df, legacy_name):
         warnings.warn(
             f"DataFrame column '{legacy_name}' is deprecated; "

--- a/src/supy/data_model/core/hydro.py
+++ b/src/supy/data_model/core/hydro.py
@@ -1,7 +1,8 @@
 from pydantic import ConfigDict, BaseModel, Field, PrivateAttr
 from typing import Optional
 import pandas as pd
-from .type import RefValue, Reference, SurfaceType, FlexibleRefValue
+from .type import RefValue, Reference, SurfaceType, FlexibleRefValue, df_from_cols
+from .df_column_renames import read_df_column
 import math
 
 
@@ -289,20 +290,13 @@ class WaterDistribution(BaseModel):
                 param_tuples.append(("waterdist", f"({i}, {surf_idx})"))
                 values.append(value)
 
-        # Create MultiIndex columns
-        columns = pd.MultiIndex.from_tuples(param_tuples, names=["var", "ind_dim"])
-
         # Convert RefValue to float
         values = [
             value.value if isinstance(value, RefValue) else value for value in values
         ]
 
-        # Create DataFrame with single row
-        df = pd.DataFrame(
-            index=pd.Index([grid_id], name="grid"),
-            columns=columns,
-            data=[values],
-            dtype=float,
+        df = df_from_cols(
+            dict(zip(param_tuples, values)), index=pd.Index([grid_id], name="grid")
         )
 
         return df
@@ -349,8 +343,9 @@ class WaterDistribution(BaseModel):
         }
 
         # Extract the values from the DataFrame
+        waterdist = read_df_column(df, "waterdist")
         params = {
-            param: df.loc[grid_id, ("waterdist", f"({idx}, {surf_idx})")]
+            param: waterdist.loc[grid_id, f"({idx}, {surf_idx})"]
             for param, idx in param_map.items()
         }
         for param, value in params.items():
@@ -359,7 +354,7 @@ class WaterDistribution(BaseModel):
                 setattr(instance, param, value)
 
         # set the last to_soilstore or to_runoff
-        waterdist_last = df.loc[grid_id, ("waterdist", f"(7, {surf_idx})")]
+        waterdist_last = waterdist.loc[grid_id, f"(7, {surf_idx})"]
         waterdist_last = RefValue(waterdist_last)
         if getattr(instance, "to_soilstore") is None:
             setattr(instance, "to_runoff", waterdist_last)
@@ -439,15 +434,7 @@ class StorageDrainParams(BaseModel):
             ])
         ]
 
-        # Create MultiIndex columns
-        columns = pd.MultiIndex.from_tuples(param_tuples, names=["var", "ind_dim"])
-
-        # Create DataFrame with single row
-        df = pd.DataFrame(
-            index=pd.Index([grid_id], name="grid"), columns=columns, dtype=float
-        )
-
-        # Fill values
+        cols = {}
         for i, var in enumerate([
             "store_min",
             "drain_eq",
@@ -461,9 +448,9 @@ class StorageDrainParams(BaseModel):
                 val = field_val.value if isinstance(field_val, RefValue) else field_val
             else:
                 val = 0.0  # Default to 0.0 for DataFrame compatibility
-            df.loc[grid_id, ("storedrainprm", f"({i}, {surf_idx})")] = val
+            cols[("storedrainprm", f"({i}, {surf_idx})")] = val
 
-        return df
+        return df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
     @classmethod
     def from_df_state(
@@ -491,8 +478,9 @@ class StorageDrainParams(BaseModel):
         }
 
         # Extract the values from the DataFrame
+        storedrainprm = read_df_column(df, "storage_drain_params")
         params = {
-            param: df.loc[grid_id, ("storedrainprm", f"({idx}, {surf_idx})")]
+            param: storedrainprm.loc[grid_id, f"({idx}, {surf_idx})"]
             for param, idx in param_map.items()
         }
 

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -12,6 +12,7 @@ from .field_renames import (
     MODELPHYSICS_SUFFIX_RENAMES,
     apply_field_renames,
 )
+from .df_column_renames import read_df_column
 
 
 def _enum_description(enum_class: type[Enum]) -> str:
@@ -874,23 +875,23 @@ class ModelPhysics(BaseModel):
         properties: dict = {}
 
         required_attrs = [
-            "netradiationmethod",
-            "emissionsmethod",
-            "storageheatmethod",
-            "ohmincqf",
-            "roughlenmommethod",
-            "roughlenheatmethod",
-            "stabilitymethod",
-            "smdmethod",
-            "waterusemethod",
-            "rslmethod",
-            "faimethod",
-            "rsllevel",
-            "gsmodel",
-            "snowuse",
-            "stebbsmethod",
-            "rcmethod",
-            "setpointmethod",
+            "net_radiation",
+            "emissions",
+            "storage_heat",
+            "ohm_inc_qf",
+            "roughness_length_momentum",
+            "roughness_length_heat",
+            "stability",
+            "soil_moisture_deficit",
+            "water_use",
+            "roughness_sublayer",
+            "frontal_area_index",
+            "roughness_sublayer_level",
+            "surface_conductance",
+            "snow_use",
+            "stebbs",
+            "outer_cap_fraction",
+            "setpoint",
         ]
 
         # New options: optional in legacy DataFrames, default if missing
@@ -904,14 +905,16 @@ class ModelPhysics(BaseModel):
 
         for attr in required_attrs:
             try:
-                properties[attr] = RefValue(int(df.loc[grid_id, (attr, "0")]))
+                properties[attr] = RefValue(
+                    int(read_df_column(df, attr).loc[grid_id, "0"])
+                )
             except KeyError:
                 raise ValueError(f"Missing attribute '{attr}' in the DataFrame")
 
         # Optional new attributes
         for attr, default_enum in optional_new_attrs_with_defaults.items():
             try:
-                value = df.loc[grid_id, (attr, "0")]
+                value = read_df_column(df, attr).loc[grid_id, "0"]
                 properties[attr] = RefValue(int(value))
             except KeyError:
                 properties[attr] = RefValue(int(default_enum))

--- a/src/supy/data_model/core/profile.py
+++ b/src/supy/data_model/core/profile.py
@@ -2,6 +2,7 @@ from pydantic import ConfigDict, BaseModel, Field, field_validator, model_valida
 from typing import Optional, Dict
 import pandas as pd
 from .type import Reference, df_from_cols
+from .df_column_renames import read_df_column
 
 
 class DayProfile(BaseModel):
@@ -63,13 +64,14 @@ class DayProfile(BaseModel):
         }
 
         # Extract values for working day and holiday from the DataFrame
+        param_df = read_df_column(df, param_name)
         params = {}
         for day, idx in day_map.items():
-            col = (param_name, f"({idx},)")
-            if col in df.columns:
-                params[day] = df.loc[grid_id, col]
+            col = f"({idx},)"
+            if col in param_df.columns:
+                params[day] = param_df.loc[grid_id, col]
             else:
-                raise KeyError(f"Column {col} not found in DataFrame")
+                raise KeyError(f"Column ({param_name}, {col}) not found in DataFrame")
 
         return cls(**params)
 
@@ -142,8 +144,9 @@ class WeeklyProfile(BaseModel):
         }
 
         # Extract values from DataFrame for each day
+        param_df = read_df_column(df, param_name)
         params = {
-            day: df.loc[grid_id, (param_name, f"({idx},)")]
+            day: param_df.loc[grid_id, f"({idx},)"]
             for day, idx in day_map.items()
         }
 
@@ -233,14 +236,15 @@ class HourlyProfile(BaseModel):
             HourlyProfile: Instance of HourlyProfile
         """
         # Extract working day values (index 0)
+        param_df = read_df_column(df, param_name)
         working_day = {
-            str(hour + 1): df.loc[grid_id, (param_name, f"({hour}, 0)")]
+            str(hour + 1): param_df.loc[grid_id, f"({hour}, 0)"]
             for hour in range(24)
         }
 
         # Extract holiday values (index 1)
         holiday = {
-            str(hour + 1): df.loc[grid_id, (param_name, f"({hour}, 1)")]
+            str(hour + 1): param_df.loc[grid_id, f"({hour}, 1)"]
             for hour in range(24)
         }
 
@@ -328,14 +332,15 @@ class TenMinuteProfile(BaseModel):
             TenMinuteProfile: Instance of TenMinuteProfile
         """
         # Extract working day values (index 0)
+        param_df = read_df_column(df, param_name)
         working_day = {
-            str(i + 1): df.loc[grid_id, (param_name, f"({i}, 0)")]
+            str(i + 1): param_df.loc[grid_id, f"({i}, 0)"]
             for i in range(144)
         }
 
         # Extract holiday values (index 1)
         holiday = {
-            str(i + 1): df.loc[grid_id, (param_name, f"({i}, 1)")]
+            str(i + 1): param_df.loc[grid_id, f"({i}, 1)"]
             for i in range(144)
         }
 

--- a/src/supy/data_model/core/site.py
+++ b/src/supy/data_model/core/site.py
@@ -39,6 +39,7 @@ from .field_renames import (
     SNOWPARAMS_INTERMEDIATE_RENAMES,
     apply_field_renames,
 )
+from .df_column_renames import read_df_column
 from .human_activity import AnthropogenicEmissions, IrrigationParams
 from .hydro import (
     WaterDistribution,
@@ -53,6 +54,12 @@ from pytz import timezone
 from pytz.exceptions import AmbiguousTimeError, NonExistentTimeError
 import pytz
 import warnings
+
+
+def _df_state_value(
+    df: pd.DataFrame, grid_id: int, col_name: str, ind_dim: str
+):
+    return read_df_column(df, col_name).loc[grid_id, ind_dim]
 
 
 class VegetationParams(BaseModel):
@@ -343,11 +350,12 @@ class LAIPowerCoefficients(BaseModel):
             LAIPowerCoefficients: Instance of LAIPowerCoefficients
         """
         # Map each coefficient to its corresponding index
+        lai_power = read_df_column(df, "lai_power")
         coefficients = [
-            RefValue(df.loc[grid_id, ("laipower", f"(0, {veg_idx})")]),
-            RefValue(df.loc[grid_id, ("laipower", f"(1, {veg_idx})")]),
-            RefValue(df.loc[grid_id, ("laipower", f"(2, {veg_idx})")]),
-            RefValue(df.loc[grid_id, ("laipower", f"(3, {veg_idx})")]),
+            RefValue(lai_power.loc[grid_id, f"(0, {veg_idx})"]),
+            RefValue(lai_power.loc[grid_id, f"(1, {veg_idx})"]),
+            RefValue(lai_power.loc[grid_id, f"(2, {veg_idx})"]),
+            RefValue(lai_power.loc[grid_id, f"(3, {veg_idx})"]),
         ]
 
         # Return the instance with coefficients
@@ -503,17 +511,19 @@ class LAIParams(BaseModel):
         # Helper function to extract values from DataFrame
         def get_df_value(col_name: str, indices: Union[Tuple, int]) -> float:
             idx_str = str(indices) if isinstance(indices, int) else str(indices)
-            return df.loc[grid_id, (col_name, idx_str)]
+            return _df_state_value(df, grid_id, col_name, idx_str)
 
         # Extract basic LAI parameters
         lai_params = {
-            "baset": get_df_value("baset", (veg_idx,)),
-            "gddfull": get_df_value("gddfull", (veg_idx,)),
-            "basete": get_df_value("basete", (veg_idx,)),
-            "sddfull": get_df_value("sddfull", (veg_idx,)),
-            "laimin": get_df_value("laimin", (veg_idx,)),
-            "laimax": get_df_value("laimax", (veg_idx,)),
-            "laitype": int(get_df_value("laitype", (veg_idx,))),
+            "base_temperature": get_df_value("base_temperature", (veg_idx,)),
+            "gdd_full": get_df_value("gdd_full", (veg_idx,)),
+            "base_temperature_senescence": get_df_value(
+                "base_temperature_senescence", (veg_idx,)
+            ),
+            "sdd_full": get_df_value("sdd_full", (veg_idx,)),
+            "lai_min": get_df_value("lai_min", (veg_idx,)),
+            "lai_max": get_df_value("lai_max", (veg_idx,)),
+            "lai_type": int(get_df_value("lai_type", (veg_idx,))),
         }
 
         # Convert scalar parameters to RefValue
@@ -687,20 +697,24 @@ class VegetatedSurfaceProperties(SurfaceProperties):
         instance = super().from_df_state(df, grid_id, surf_idx)
         # add ordinary float properties
         for new_attr, col_name in [
-            ("beta_bio_co2", "beta_bioco2"),
+            ("beta_bio_co2", "beta_bio_co2"),
             ("beta_enh_bioco2", "beta_enh_bioco2"),
-            ("alpha_bio_co2", "alpha_bioco2"),
+            ("alpha_bio_co2", "alpha_bio_co2"),
             ("alpha_enh_bioco2", "alpha_enh_bioco2"),
             ("resp_a", "resp_a"),
             ("resp_b", "resp_b"),
-            ("theta_bio_co2", "theta_bioco2"),
-            ("max_conductance", "maxconductance"),
+            ("theta_bio_co2", "theta_bio_co2"),
+            ("max_conductance", "max_conductance"),
             ("min_res_bioco2", "min_res_bioco2"),
             ("ie_a", "ie_a"),
             ("ie_m", "ie_m"),
         ]:
             setattr(
-                instance, new_attr, RefValue(df.loc[grid_id, (col_name, f"({surf_idx - 2},)")])
+                instance,
+                new_attr,
+                RefValue(
+                    _df_state_value(df, grid_id, col_name, f"({surf_idx - 2},)")
+                ),
             )
 
         instance.lai = LAIParams.from_df_state(df, grid_id, surf_idx)
@@ -770,9 +784,9 @@ class EvetrProperties(VegetatedSurfaceProperties):  # TODO: Move waterdist VWD h
         )
 
         # Create new columns DataFrame and merge (avoids PerformanceWarning)
-        new_cols = {col: [val] for col, val in values_to_assign.items()}
-        new_df = pd.DataFrame(new_cols, index=[grid_id])
-        new_df.columns = pd.MultiIndex.from_tuples(new_df.columns)
+        new_df = df_from_cols(
+            values_to_assign, index=pd.Index([grid_id], name="grid")
+        )
 
         # Drop existing columns from df_state that we're updating, then concat
         cols_to_drop = [c for c in new_df.columns if c in df_state.columns]
@@ -788,8 +802,12 @@ class EvetrProperties(VegetatedSurfaceProperties):  # TODO: Move waterdist VWD h
         surf_idx = 2
         instance = super().from_df_state(df, grid_id, surf_idx)
 
-        instance.fai_evergreen_tree = RefValue(df.loc[grid_id, ("faievetree", "0")])
-        instance.height_evergreen_tree = RefValue(df.loc[grid_id, ("evetreeh", "0")])
+        instance.fai_evergreen_tree = RefValue(
+            _df_state_value(df, grid_id, "fai_evergreen_tree", "0")
+        )
+        instance.height_evergreen_tree = RefValue(
+            _df_state_value(df, grid_id, "height_evergreen_tree", "0")
+        )
 
         instance.alb_min = RefValue(df.loc[grid_id, ("albmin_evetr", "0")])
         instance.alb_max = RefValue(df.loc[grid_id, ("albmax_evetr", "0")])
@@ -896,9 +914,9 @@ class DectrProperties(VegetatedSurfaceProperties):
         )
 
         # Create new columns DataFrame and merge (avoids PerformanceWarning)
-        new_cols = {col: [val] for col, val in values_to_assign.items()}
-        new_df = pd.DataFrame(new_cols, index=[grid_id])
-        new_df.columns = pd.MultiIndex.from_tuples(new_df.columns)
+        new_df = df_from_cols(
+            values_to_assign, index=pd.Index([grid_id], name="grid")
+        )
 
         # Drop existing columns from df_state that we're updating, then concat
         cols_to_drop = [c for c in new_df.columns if c in df_state.columns]
@@ -914,12 +932,24 @@ class DectrProperties(VegetatedSurfaceProperties):
         surf_idx = 3
         instance = super().from_df_state(df, grid_id, surf_idx)
 
-        instance.fai_deciduous_tree = RefValue(df.loc[grid_id, ("faidectree", "0")])
-        instance.height_deciduous_tree = RefValue(df.loc[grid_id, ("dectreeh", "0")])
-        instance.porosity_min_deciduous = RefValue(df.loc[grid_id, ("pormin_dec", "0")])
-        instance.porosity_max_deciduous = RefValue(df.loc[grid_id, ("pormax_dec", "0")])
-        instance.capacity_max_deciduous = RefValue(df.loc[grid_id, ("capmax_dec", "0")])
-        instance.capacity_min_deciduous = RefValue(df.loc[grid_id, ("capmin_dec", "0")])
+        instance.fai_deciduous_tree = RefValue(
+            _df_state_value(df, grid_id, "fai_deciduous_tree", "0")
+        )
+        instance.height_deciduous_tree = RefValue(
+            _df_state_value(df, grid_id, "height_deciduous_tree", "0")
+        )
+        instance.porosity_min_deciduous = RefValue(
+            _df_state_value(df, grid_id, "porosity_min_deciduous", "0")
+        )
+        instance.porosity_max_deciduous = RefValue(
+            _df_state_value(df, grid_id, "porosity_max_deciduous", "0")
+        )
+        instance.capacity_max_deciduous = RefValue(
+            _df_state_value(df, grid_id, "capacity_max_deciduous", "0")
+        )
+        instance.capacity_min_deciduous = RefValue(
+            _df_state_value(df, grid_id, "capacity_min_deciduous", "0")
+        )
 
         instance.alb_min = RefValue(df.loc[grid_id, ("albmin_dectr", "0")])
         instance.alb_max = RefValue(df.loc[grid_id, ("albmax_dectr", "0")])
@@ -962,9 +992,9 @@ class GrassProperties(VegetatedSurfaceProperties):
         }
 
         # Create new columns DataFrame and merge (avoids PerformanceWarning)
-        new_cols = {col: [val] for col, val in values_to_assign.items()}
-        new_df = pd.DataFrame(new_cols, index=[grid_id])
-        new_df.columns = pd.MultiIndex.from_tuples(new_df.columns)
+        new_df = df_from_cols(
+            values_to_assign, index=pd.Index([grid_id], name="grid")
+        )
 
         # Drop existing columns from df_state that we're updating, then concat
         cols_to_drop = [c for c in new_df.columns if c in df_state.columns]
@@ -1182,33 +1212,54 @@ class SnowParams(BaseModel):
         """
         # Extract scalar attributes
         scalar_params = {
-            "crwmax": df.loc[grid_id, ("crwmax", "0")],
-            "crwmin": df.loc[grid_id, ("crwmin", "0")],
-            "narp_emis_snow": df.loc[grid_id, ("narp_emis_snow", "0")],
-            "preciplimit": df.loc[grid_id, ("preciplimit", "0")],
-            "preciplimitalb": df.loc[grid_id, ("preciplimitalb", "0")],
-            "snowalbmax": df.loc[grid_id, ("snowalbmax", "0")],
-            "snowalbmin": df.loc[grid_id, ("snowalbmin", "0")],
-            "snowdensmin": df.loc[grid_id, ("snowdensmin", "0")],
-            "snowdensmax": df.loc[grid_id, ("snowdensmax", "0")],
-            "snowlimbldg": df.loc[grid_id, ("snowlimbldg", "0")],
-            "snowlimpaved": df.loc[grid_id, ("snowlimpaved", "0")],
-            "tau_a": df.loc[grid_id, ("tau_a", "0")],
-            "tau_f": df.loc[grid_id, ("tau_f", "0")],
-            "tau_r": df.loc[grid_id, ("tau_r", "0")],
-            "tempmeltfact": df.loc[grid_id, ("tempmeltfact", "0")],
-            "radmeltfact": df.loc[grid_id, ("radmeltfact", "0")],
+            "water_holding_capacity_max": _df_state_value(
+                df, grid_id, "water_holding_capacity_max", "0"
+            ),
+            "water_holding_capacity_min": _df_state_value(
+                df, grid_id, "water_holding_capacity_min", "0"
+            ),
+            "narp_emissivity_snow": _df_state_value(
+                df, grid_id, "narp_emissivity_snow", "0"
+            ),
+            "temperature_rain_snow_threshold": _df_state_value(
+                df, grid_id, "temperature_rain_snow_threshold", "0"
+            ),
+            "precipitation_threshold_albedo_reset": _df_state_value(
+                df, grid_id, "precipitation_threshold_albedo_reset", "0"
+            ),
+            "snow_albedo_max": _df_state_value(df, grid_id, "snow_albedo_max", "0"),
+            "snow_albedo_min": _df_state_value(df, grid_id, "snow_albedo_min", "0"),
+            "snow_density_min": _df_state_value(df, grid_id, "snow_density_min", "0"),
+            "snow_density_max": _df_state_value(df, grid_id, "snow_density_max", "0"),
+            "snow_depth_limit_building": _df_state_value(
+                df, grid_id, "snow_depth_limit_building", "0"
+            ),
+            "snow_depth_limit_paved": _df_state_value(
+                df, grid_id, "snow_depth_limit_paved", "0"
+            ),
+            "tau_cold_snow": _df_state_value(df, grid_id, "tau_cold_snow", "0"),
+            "tau_melting_snow": _df_state_value(df, grid_id, "tau_melting_snow", "0"),
+            "tau_refreezing_snow": _df_state_value(
+                df, grid_id, "tau_refreezing_snow", "0"
+            ),
+            "temperature_melt_factor": _df_state_value(
+                df, grid_id, "temperature_melt_factor", "0"
+            ),
+            "radiation_melt_factor": _df_state_value(
+                df, grid_id, "radiation_melt_factor", "0"
+            ),
         }
 
         # Convert scalar parameters to RefValue
         scalar_params = {key: RefValue(value) for key, value in scalar_params.items()}
 
-        # Extract HourlyProfile (DF column stays "snowprof_24hr" for the Fortran bridge;
-        # the Pydantic shim renames the kwarg to `snow_profile_24hr` on the way in).
-        snowprof_24hr = HourlyProfile.from_df_state(df, grid_id, "snowprof_24hr")
+        # Extract HourlyProfile using the new name while accepting legacy frames.
+        snowprof_24hr = HourlyProfile.from_df_state(
+            df, grid_id, "snow_profile_24hr"
+        )
 
         # Construct and return the SnowParams instance
-        return cls(snowprof_24hr=snowprof_24hr, **scalar_params)
+        return cls(snow_profile_24hr=snowprof_24hr, **scalar_params)
 
 
 class LandCover(BaseModel):
@@ -1909,42 +1960,36 @@ class ArchetypeProperties(BaseModel):
                 continue
 
             if field_name in string_fields:
-                col_name = cls._ARCHETYPE_LEGACY_COL_NAMES.get(field_name, field_name).lower()
-                col = (col_name, "0")
-                if col in df.columns:
-                    value = df.loc[grid_id, col]
+                col_name = field_name.lower()
+                try:
+                    value = _df_state_value(df, grid_id, col_name, "0")
                     params[field_name] = (
                         getattr(default_instance, field_name)
                         if pd.isna(value)
                         else value
                     )
-                else:
+                except KeyError:
                     params[field_name] = getattr(default_instance, field_name)
                 continue
 
             if field_name in ten_minute_profile_fields:
-                col_name = cls._ARCHETYPE_LEGACY_COL_NAMES.get(field_name, field_name).lower()
-                has_profile_columns = any(col[0] == col_name for col in df.columns)
-                if has_profile_columns:
-                    try:
-                        params[field_name] = ten_minute_profile_classes[field_name].from_df_state(
-                            df, grid_id, col_name
-                        )
-                    except KeyError:
-                        params[field_name] = getattr(default_instance, field_name)
-                else:
+                col_name = field_name.lower()
+                try:
+                    params[field_name] = ten_minute_profile_classes[
+                        field_name
+                    ].from_df_state(df, grid_id, col_name)
+                except KeyError:
                     params[field_name] = getattr(default_instance, field_name)
                 continue
 
-            col_name = cls._ARCHETYPE_LEGACY_COL_NAMES.get(field_name, field_name).lower()
-            col = (col_name, "0")
-            if col in df.columns:
-                value = df.loc[grid_id, col]
+            col_name = field_name.lower()
+            try:
+                value = _df_state_value(df, grid_id, col_name, "0")
                 if pd.isna(value):
                     params[field_name] = getattr(default_instance, field_name)
                 else:
                     params[field_name] = RefValue(value)
-            else:
+            except KeyError:
                 params[field_name] = getattr(default_instance, field_name)
 
         return cls(**params)
@@ -2458,28 +2503,23 @@ class StebbsProperties(BaseModel):
                 continue
 
             if field_name in tenmin_profile_fields:
-                col_name = cls._STEBBS_LEGACY_COL_NAMES.get(field_name, field_name).lower()
-                has_profile_columns = any(col[0] == col_name for col in df.columns)
-                if has_profile_columns:
-                    try:
-                        params[field_name] = TenMinuteProfile.from_df_state(
-                            df, grid_id, col_name
-                        )
-                    except KeyError:
-                        params[field_name] = getattr(default_instance, field_name)
-                else:
+                col_name = field_name.lower()
+                try:
+                    params[field_name] = TenMinuteProfile.from_df_state(
+                        df, grid_id, col_name
+                    )
+                except KeyError:
                     params[field_name] = getattr(default_instance, field_name)
                 continue
 
-            col_name = cls._STEBBS_LEGACY_COL_NAMES.get(field_name, field_name).lower()
-            col = (col_name, "0")
-            if col in df.columns:
-                value = df.loc[grid_id, col]
+            col_name = field_name.lower()
+            try:
+                value = _df_state_value(df, grid_id, col_name, "0")
                 if pd.isna(value):
                     params[field_name] = getattr(default_instance, field_name)
                 else:
                     params[field_name] = RefValue(value)
-            else:
+            except KeyError:
                 params[field_name] = getattr(default_instance, field_name)
 
         return cls(**params)

--- a/src/supy/data_model/core/surface.py
+++ b/src/supy/data_model/core/surface.py
@@ -20,6 +20,13 @@ from .type import SurfaceType
 
 from .hydro import WaterDistribution, StorageDrainParams
 from .field_renames import SURFACEPROPERTIES_RENAMES, apply_field_renames
+from .df_column_renames import read_df_column
+
+
+def _df_state_value(
+    df: pd.DataFrame, grid_id: int, col_name: str, ind_dim: str
+):
+    return read_df_column(df, col_name).loc[grid_id, ind_dim]
 
 
 class ThermalLayers(BaseModel):
@@ -452,9 +459,7 @@ class SurfaceProperties(BaseModel):
             "water",
         ][surf_idx]
 
-        # (old/DataFrame column name, new Python field name) pairs.
-        # Old names are used as constructor kwargs — the model_validator
-        # converts them to new field names automatically.
+        # (new/DataFrame column name, new Python field name) pairs.
         _from_df_mapping = [
             ("sfr", "sfr"),
             ("emis", "emis"),
@@ -462,81 +467,84 @@ class SurfaceProperties(BaseModel):
             ("rho_cp_anohm", "rho_cp_anohm"),
             ("k_anohm", "k_anohm"),
             ("ohm_coef", "ohm_coef"),
-            ("ohm_threshsw", "ohm_threshold_summer_winter"),
-            ("ohm_threshwd", "ohm_threshold_wet_dry"),
-            ("soildepth", "soil_depth"),
-            ("soilstorecap", "soil_store_capacity"),
-            ("statelimit", "state_limit"),
-            ("wetthresh", "wet_threshold"),
-            ("sathydraulicconduct", "saturated_hydraulic_conductivity"),
-            ("soildensity", "soil_density"),
+            ("ohm_threshold_summer_winter", "ohm_threshold_summer_winter"),
+            ("ohm_threshold_wet_dry", "ohm_threshold_wet_dry"),
+            ("soil_depth", "soil_depth"),
+            ("soil_store_capacity", "soil_store_capacity"),
+            ("state_limit", "state_limit"),
+            ("wet_threshold", "wet_threshold"),
+            ("saturated_hydraulic_conductivity", "saturated_hydraulic_conductivity"),
+            ("soil_density", "soil_density"),
             ("waterdist", "waterdist"),
-            ("storedrainprm", "storage_drain_params"),
-            ("snowpacklimit", "snowpack_limit"),
+            ("storage_drain_params", "storage_drain_params"),
+            ("snowpack_limit", "snowpack_limit"),
             ("thermal_layers", "thermal_layers"),
-            ("irrfrac", "irrigation_fraction"),
+            ("irrigation_fraction", "irrigation_fraction"),
         ]
 
         # Create a dictionary to hold the properties and their values.
-        # Keys use old names — model_validator handles old->new conversion.
         property_values = {}
 
         # Process each property
         for col_name, field_name in _from_df_mapping:
             # Handle nested properties with their own from_df_state methods
-            if col_name in [
+            if field_name in [
                 "waterdist",
-                "storedrainprm",
+                "storage_drain_params",
                 # "ohm_coef",
                 # "lai",
             ]:
                 nested_obj = cls.model_fields[field_name].annotation
                 if nested_obj is not None and hasattr(nested_obj, "from_df_state"):
-                    property_values[col_name] = nested_obj.from_df_state(
+                    property_values[field_name] = nested_obj.from_df_state(
                         df, grid_id, surf_idx
                     )
                 continue
             elif col_name == "ohm_coef":  # moved seperately as optional fails hasattr()
                 if cls.model_fields[field_name].annotation is not None:
-                    property_values[col_name] = (
+                    property_values[field_name] = (
                         OHM_Coefficient_season_wetness.from_df_state(
                             df, grid_id, surf_idx
                         )
                     )
             elif col_name == "thermal_layers":
-                property_values[col_name] = cls.model_fields[
+                property_values[field_name] = cls.model_fields[
                     field_name
                 ].annotation.from_df_state(df, grid_id, surf_idx, surf_name)
-            elif col_name == "irrfrac":
-                value = df.loc[grid_id, (f"{col_name}{surf_name}", "0")]
-                property_values[col_name] = RefValue(value)
-            elif col_name in ["sfr", "soilstorecap", "statelimit", "wetthresh"]:
-                value = df.loc[grid_id, (f"{col_name}_surf", f"({surf_idx},)")]
-                property_values[col_name] = RefValue(value)
+            elif col_name == "irrigation_fraction":
+                value = _df_state_value(df, grid_id, f"{col_name}{surf_name}", "0")
+                property_values[field_name] = RefValue(value)
+            elif col_name in ["sfr", "soil_store_capacity", "state_limit", "wet_threshold"]:
+                value = _df_state_value(df, grid_id, f"{col_name}_surf", f"({surf_idx},)")
+                property_values[field_name] = RefValue(value)
             elif col_name == "rho_cp_anohm":  # Moved to cp in df_state
                 value = df.loc[grid_id, ("cpanohm", f"({surf_idx},)")]
-                property_values[col_name] = RefValue(value)
+                property_values[field_name] = RefValue(value)
             elif col_name == "ch_anohm":  # Moved to ch in df_state
                 value = df.loc[grid_id, ("chanohm", f"({surf_idx},)")]
-                property_values[col_name] = RefValue(value)
+                property_values[field_name] = RefValue(value)
             elif col_name == "k_anohm":  # Moved to k in df_state
                 value = df.loc[grid_id, ("kkanohm", f"({surf_idx},)")]
-                property_values[col_name] = RefValue(value)
+                property_values[field_name] = RefValue(value)
             else:
                 # Check if column exists (for backwards compatibility with old tables)
                 col_key = (col_name, f"({surf_idx},)")
-                if col_key in df.columns:
-                    value = df.loc[grid_id, col_key]
-                    property_values[col_name] = RefValue(value)
-                else:
-                    # Column doesn't exist - skip if optional, raise if required
-                    field_info = cls.model_fields.get(field_name)
-                    if field_info and not field_info.is_required():
-                        logger_supy.debug(
-                            f"Column {col_key} not found for surface {surf_idx}, "
-                            "using None (backwards compatibility)"
-                        )
-                        property_values[col_name] = None
+                try:
+                    value = _df_state_value(df, grid_id, col_name, f"({surf_idx},)")
+                    property_values[field_name] = RefValue(value)
+                except KeyError:
+                    if col_key in df.columns:
+                        value = df.loc[grid_id, col_key]
+                        property_values[field_name] = RefValue(value)
+                    else:
+                        # Column doesn't exist - skip if optional, raise if required
+                        field_info = cls.model_fields.get(field_name)
+                        if field_info and not field_info.is_required():
+                            logger_supy.debug(
+                                f"Column {col_key} not found for surface {surf_idx}, "
+                                "using None (backwards compatibility)"
+                            )
+                            property_values[field_name] = None
                     # If required, let Pydantic validation catch it later
 
         return cls(**property_values)
@@ -638,12 +646,9 @@ class PavedProperties(
                     values.append(value)
 
         if param_tuples:  # Only create DataFrame if we have properties to add
-            columns = pd.MultiIndex.from_tuples(param_tuples, names=["var", "ind_dim"])
-            df = pd.DataFrame(
+            df = df_from_cols(
+                dict(zip(param_tuples, values)),
                 index=pd.Index([grid_id], name="grid"),
-                columns=columns,
-                data=[values],
-                dtype=float,
             )
             dfs.append(df)
 
@@ -841,9 +846,15 @@ class BuildingLayer(
         params = {
             "alb": df.loc[grid_id, (f"alb_{prefix}", layer_idx_str)],
             "emis": df.loc[grid_id, (f"emis_{prefix}", layer_idx_str)],
-            "statelimit": df.loc[grid_id, (f"statelimit_{prefix}", layer_idx_str)],
-            "soilstorecap": df.loc[grid_id, (f"soilstorecap_{prefix}", layer_idx_str)],
-            "wetthresh": df.loc[grid_id, (f"wetthresh_{prefix}", layer_idx_str)],
+            "state_limit": _df_state_value(
+                df, grid_id, f"state_limit_{prefix}", layer_idx_str
+            ),
+            "soil_store_capacity": _df_state_value(
+                df, grid_id, f"soil_store_capacity_{prefix}", layer_idx_str
+            ),
+            "wet_threshold": _df_state_value(
+                df, grid_id, f"wet_threshold_{prefix}", layer_idx_str
+            ),
         }
 
         # Extract optional parameters

--- a/src/supy/data_model/core/type.py
+++ b/src/supy/data_model/core/type.py
@@ -181,6 +181,9 @@ def FlexibleRefValue(type_param):
 
 
 def df_from_cols(cols: dict, index: pd.Index) -> pd.DataFrame:
+    from .df_column_renames import dual_write_df_column_aliases
+
+    cols = dual_write_df_column_aliases(cols)
     df_state = pd.DataFrame(cols, index=index)
     df_state.columns = pd.MultiIndex.from_tuples(
         df_state.columns, names=["var", "ind_dim"]

--- a/test/core/test_soil_obs_conversion.py
+++ b/test/core/test_soil_obs_conversion.py
@@ -401,6 +401,8 @@ class TestObservedSoilMoistureIntegration:
         # Configure for observed soil moisture
         df_state_obs = df_state.copy()
         df_state_obs[("smdmethod", "0")] = 1
+        if ("soil_moisture_deficit", "0") in df_state_obs.columns:
+            df_state_obs[("soil_moisture_deficit", "0")] = 1
         df_state_obs[("obs_sm_depth", "0")] = 150.0
         df_state_obs[("obs_sm_smcap", "0")] = 0.35
         df_state_obs[("obs_sm_soil_not_rocks", "0")] = 0.85
@@ -432,6 +434,8 @@ class TestObservedSoilMoistureIntegration:
         df_state, df_forcing = sp.load_sample_data()
         df_state_obs = df_state.copy()
         df_state_obs[("smdmethod", "0")] = 1
+        if ("soil_moisture_deficit", "0") in df_state_obs.columns:
+            df_state_obs[("soil_moisture_deficit", "0")] = 1
         df_state_obs[("obs_sm_depth", "0")] = 150.0
         df_state_obs[("obs_sm_smcap", "0")] = 0.35
         df_state_obs[("obs_sm_soil_not_rocks", "0")] = 0.85

--- a/test/data_model/test_df_column_renames.py
+++ b/test/data_model/test_df_column_renames.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from supy.data_model import SUEWSConfig
 
 pytestmark = pytest.mark.api
 
@@ -39,6 +40,8 @@ from supy.data_model.core.df_column_renames import (
     STEBBSPROPERTIES_DF_RENAMES,
     SURFACEPROPERTIES_DF_RENAMES,
     VEGETATEDSURFACEPROPERTIES_DF_RENAMES,
+    dual_write_df_column_aliases,
+    dual_write_df_columns,
     read_df_column,
 )
 from supy.data_model.core.field_renames import ALL_FIELD_RENAMES
@@ -57,6 +60,35 @@ _RUST_FIELD_RENAMES_PATH = (
 def _rust_field_renames_text() -> str:
     """Return the full text of ``field_renames.rs`` for static alignment checks."""
     return _RUST_FIELD_RENAMES_PATH.read_text(encoding="utf-8")
+
+
+def _aliased_name(name: str) -> str | None:
+    if name in ALL_DF_COLUMN_RENAMES:
+        return ALL_DF_COLUMN_RENAMES[name]
+    for structured_suffix in ("_surf", "_roof", "_wall"):
+        if not name.endswith(structured_suffix):
+            continue
+        base = name[: -len(structured_suffix)]
+        if base in ALL_DF_COLUMN_RENAMES:
+            return f"{ALL_DF_COLUMN_RENAMES[base]}{structured_suffix}"
+    for suffix in ("paved", "bldgs", "evetr", "dectr", "grass", "bsoil", "water"):
+        if name == f"irrfrac{suffix}":
+            return f"irrigation_fraction{suffix}"
+    return None
+
+
+def _drop_aliased_columns(df: pd.DataFrame, *, keep: str) -> pd.DataFrame:
+    columns_to_drop = []
+    for col in df.columns:
+        legacy_name = col[0]
+        new_name = _aliased_name(legacy_name)
+        if new_name is not None:
+            new_col = (new_name, *col[1:])
+            if new_col in df.columns and keep == "new":
+                columns_to_drop.append(col)
+            elif new_col in df.columns and keep == "legacy":
+                columns_to_drop.append(new_col)
+    return df.drop(columns=list(dict.fromkeys(columns_to_drop)))
 
 
 class TestRegistryIntegrity:
@@ -123,6 +155,46 @@ class TestArchetypePropertiesLowercasing:
             assert new == new.lower()
 
 
+class TestDualWriteHelpers:
+    def test_dual_write_aliases_multiindex_keys(self):
+        cols = {
+            ("gridiv", "0"): 1,
+            ("netradiationmethod", "0"): 3,
+            ("soilstorecap_surf", "(0,)"): 150.0,
+            ("irrfracpaved", "0"): 0.2,
+        }
+
+        out = dual_write_df_column_aliases(cols)
+
+        assert out[("net_radiation", "0")] == 3
+        assert out[("soil_store_capacity_surf", "(0,)")] == 150.0
+        assert out[("irrigation_fractionpaved", "0")] == 0.2
+        assert out[("netradiationmethod", "0")] == 3
+
+    def test_dual_write_aliases_plain_keys(self):
+        out = dual_write_df_column_aliases({"soildepth": 0.2})
+        assert out["soil_depth"] == 0.2
+
+    def test_dual_write_does_not_overwrite_existing_new_name(self):
+        out = dual_write_df_column_aliases(
+            {
+                ("netradiationmethod", "0"): 3,
+                ("net_radiation", "0"): 4,
+            }
+        )
+        assert out[("net_radiation", "0")] == 4
+
+    def test_dual_write_df_columns_multiindex(self):
+        df = pd.DataFrame({("netradiationmethod", "0"): [3]})
+        df.columns = pd.MultiIndex.from_tuples(df.columns)
+
+        out = dual_write_df_columns(df)
+
+        assert ("netradiationmethod", "0") in out.columns
+        assert ("net_radiation", "0") in out.columns
+        assert out.loc[0, ("net_radiation", "0")] == 3
+
+
 class TestHelperNewName:
     def test_new_name_single_index_returns_series_silently(self):
         df = pd.DataFrame({"net_radiation": [3]})
@@ -183,6 +255,65 @@ class TestHelperMissing:
         df = pd.DataFrame({"unrelated": [1]})
         with pytest.raises(KeyError, match="net_radiation"):
             read_df_column(df, "net_radiation")
+
+
+class TestConfigRoundTrips:
+    sample_config_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "supy"
+        / "sample_data"
+        / "sample_config.yml"
+    )
+
+    def test_generated_dual_write_frame_round_trips(self):
+        config = SUEWSConfig.from_yaml(self.sample_config_path)
+        df_state = config.to_df_state()
+
+        config_roundtrip = SUEWSConfig.from_df_state(df_state)
+
+        assert config_roundtrip.model.physics.net_radiation.value == (
+            config.model.physics.net_radiation.value
+        )
+        assert config_roundtrip.sites[0].properties.snow.snow_albedo_max.value == (
+            config.sites[0].properties.snow.snow_albedo_max.value
+        )
+
+    def test_new_name_only_frame_round_trips_without_rename_warning(self):
+        config = SUEWSConfig.from_yaml(self.sample_config_path)
+        df_state = _drop_aliased_columns(config.to_df_state(), keep="new")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            config_roundtrip = SUEWSConfig.from_df_state(df_state)
+
+        assert config_roundtrip.model.physics.net_radiation.value == (
+            config.model.physics.net_radiation.value
+        )
+        assert config_roundtrip.sites[0].properties.snow.snow_albedo_max.value == (
+            config.sites[0].properties.snow.snow_albedo_max.value
+        )
+
+    def test_legacy_name_only_frame_round_trips_with_deprecation_warning(self):
+        config = SUEWSConfig.from_yaml(self.sample_config_path)
+        df_state = _drop_aliased_columns(config.to_df_state(), keep="legacy")
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", DeprecationWarning)
+            config_roundtrip = SUEWSConfig.from_df_state(df_state)
+
+        messages = [
+            str(w.message)
+            for w in captured
+            if issubclass(w.category, DeprecationWarning)
+        ]
+        assert any("netradiationmethod" in message for message in messages)
+        assert config_roundtrip.model.physics.net_radiation.value == (
+            config.model.physics.net_radiation.value
+        )
+        assert config_roundtrip.sites[0].properties.snow.snow_albedo_max.value == (
+            config.sites[0].properties.snow.snow_albedo_max.value
+        )
 
 
 class TestRustBridgeAlignment:

--- a/test/data_model/test_field_renames.py
+++ b/test/data_model/test_field_renames.py
@@ -4,7 +4,7 @@ Verifies:
 - New field names are accessible as Pydantic attributes.
 - Old field names still work via ``@model_validator(mode='before')`` (backward compat).
 - Deprecation warnings are emitted when old names are used.
-- ``to_df_state()`` emits DataFrame columns under legacy names (Fortran bridge).
+- ``to_df_state()`` emits legacy and new DataFrame columns during Tier C dual-write.
 - Providing both old and new names raises ``ValueError``.
 - Category 1 intermediate spellings (Schema 2026.5 shape) still load with a
   deprecation warning via MODELPHYSICS_SUFFIX_RENAMES (#1321).
@@ -330,15 +330,14 @@ class TestRawDictCompatibility:
 
 
 class TestDataFrameColumnsPreserveLegacyNames:
-    """DataFrame column names must stay as the old (fused) names so the Rust /
-    Fortran bridge keeps working. Only the Python attribute names change.
-    """
+    """DataFrame output keeps bridge legacy names and emits snake_case aliases."""
 
     def test_model_physics_columns(self):
         df = ModelPhysics().to_df_state(grid_id=1)
         flat_cols = {col[0] for col in df.columns}
-        for old_name in MODELPHYSICS_RENAMES:
+        for old_name, new_name in MODELPHYSICS_RENAMES.items():
             assert old_name in flat_cols, f"Missing legacy column {old_name!r}"
+            assert new_name in flat_cols, f"Missing new column {new_name!r}"
 
     def test_lai_params_columns(self):
         df = LAIParams(base_temperature=5.0).to_df_state(grid_id=1, surf_idx=2)
@@ -346,6 +345,9 @@ class TestDataFrameColumnsPreserveLegacyNames:
         # LAIPowerCoefficients column is separate; only top-level LAI scalars here.
         for old_name in ("baset", "gddfull", "basete", "sddfull", "laimin", "laimax", "laitype"):
             assert old_name in flat_cols, f"Missing legacy column {old_name!r}"
+            assert LAIPARAMS_RENAMES[old_name] in flat_cols, (
+                f"Missing new column {LAIPARAMS_RENAMES[old_name]!r}"
+            )
 
     def test_snow_params_columns(self):
         df = SnowParams().to_df_state(grid_id=1)
@@ -355,6 +357,9 @@ class TestDataFrameColumnsPreserveLegacyNames:
         }
         for old_name in scalar_old_names:
             assert old_name in flat_cols, f"Missing legacy column {old_name!r}"
+            assert SNOWPARAMS_RENAMES[old_name] in flat_cols, (
+                f"Missing new column {SNOWPARAMS_RENAMES[old_name]!r}"
+            )
 
     def test_archetype_ext_columns(self):
         # The Fortran bridge (src/suews_bridge/src/building_archetype_prm.rs)
@@ -374,6 +379,4 @@ class TestDataFrameColumnsPreserveLegacyNames:
             # assertion above already covered it.
             if old_name.lower() == new_name:
                 continue
-            assert new_name not in flat_cols, (
-                f"Unexpected new-name column {new_name!r} in bridge output"
-            )
+            assert new_name in flat_cols, f"Missing new column {new_name!r}"


### PR DESCRIPTION
## Summary
- add dual-write DataFrame column aliases for the Tier C rename cascade
- route data-model df_state emission through the aliasing helper and update renamed from_df_state reads to prefer new names
- cover helper behaviour, dual-write columns, and generated/new-only/legacy-only config round-trips

Closes #1338

## Validation
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest test/data_model/test_df_column_renames.py test/data_model/test_field_renames.py test/data_model/test_data_model.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest test/core/test_soil_obs_conversion.py::TestObservedSoilMoistureIntegration::test_run_supy_reads_renamed_smd_method -q`
- `PATH="$PWD/.venv/bin:$PATH" make test-smoke`
- `PATH="$PWD/.venv/bin:$PATH" make test`
- `git diff --check`