### PR TITLE
Replace `df_state` restarts with typed checkpoints

### DIFF
--- a/docs/source/api/io-data-structures.rst
+++ b/docs/source/api/io-data-structures.rst
@@ -6,7 +6,8 @@ Key IO Data Structures
 Introduction
 ------------
 
-The Python API uses four key pandas DataFrame structures for simulation input and output:
+The Python API uses pandas DataFrame structures for analysis data and a typed
+checkpoint object for restart workflows:
 
 .. code-block:: python
 
@@ -14,23 +15,25 @@ The Python API uses four key pandas DataFrame structures for simulation input an
 
    # Load sample data and run simulation
    sim = SUEWSSimulation.from_sample_data()
-   sim.run()
+   output = sim.run()
 
    # Access the data structures
    df_state_init = sim.df_state_init   # Input: initial states
    df_forcing = sim.df_forcing         # Input: forcing data
    df_output = sim.results             # Output: simulation results
-   df_state_final = sim.df_state_final # Output: final states
+   df_state_final = sim.df_state_final # Legacy/developer final states
+   checkpoint = output.checkpoint      # Preferred restart artefact
 
 **Input DataFrames:**
 
 - ``df_state_init``: Model initial states and configuration parameters
 - ``df_forcing``: Meteorological forcing data time series
 
-**Output DataFrames:**
+**Output and restart objects:**
 
 - ``df_output`` (or ``sim.results``): Model output results for scientific analysis
-- ``df_state_final``: Model final states, usable as initial conditions for subsequent simulations
+- ``df_state_final``: Legacy/developer final states for compatibility and inspection
+- ``SUEWSCheckpoint``: Typed runtime state for continuation runs
 
 
 Input
@@ -161,14 +164,52 @@ model states.
 
    [2 rows x 1200 columns]
 
-This structure facilitates reuse as initial model states for subsequent simulations:
+This structure is retained for compatibility and state inspection:
 
 - **Runtime diagnostics**: Save intermediate states with ``save_state=True`` in ``run_supy``
-- **Chained simulations**: Use end state as initial conditions for future runs starting
-  at the ending time of previous runs
+- **Developer inspection**: Examine flattened state variables in DataFrame form
 
 The meanings of state variables in ``df_state_final`` are the same as in ``df_state_init``,
 documented in :doc:`/data-structures/df_state`.
+
+For new object-oriented continuation workflows, use ``SUEWSCheckpoint`` rather
+than ``df_state_final`` as the restart artefact.
+
+
+.. _suews_checkpoint:
+
+``SUEWSCheckpoint``: typed restart state
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``SUEWSCheckpoint`` carries typed backend runtime state keyed by grid ID. It is
+the preferred restart artefact for new object-oriented workflows.
+
+The checkpoint is intentionally only the typed runtime state. It does not
+contain the full YAML configuration or forcing data. To continue a run, load the
+same YAML configuration, attach the next forcing period, and run from
+``SUEWSSimulation.from_checkpoint(...)``:
+
+.. code-block:: python
+
+   from supy import SUEWSCheckpoint, SUEWSSimulation
+
+   checkpoint = SUEWSCheckpoint.from_file("{site}_SUEWS_checkpoint.json")
+
+   sim_next = SUEWSSimulation.from_checkpoint(
+       "config.yml",
+       checkpoint,
+   )
+   sim_next.update_forcing("forcing_next_period.txt")
+   output_next = sim_next.run()
+
+Use ``checkpoint.to_file(path)`` to write the checkpoint explicitly, or
+``sim.save(path)`` to save it alongside the configured output files. Checkpoints
+are keyed by grid ID, so checkpoint/configuration grid mismatches are rejected
+by the runtime.
+
+.. autoclass:: supy.SUEWSCheckpoint
+   :members: from_file, to_file
+   :undoc-members:
 
 
 Related Documentation
@@ -177,4 +218,5 @@ Related Documentation
 - :doc:`/data-structures/df_state` - Complete state variable reference
 - :doc:`/data-structures/df_forcing` - Forcing variable reference
 - :doc:`/data-structures/df_output` - Output variable reference
+- :ref:`suews_checkpoint` - Typed checkpoint restart artefact
 - :doc:`/auto_examples/tutorial_01_quick_start` - Interactive tutorial with DataFrame examples

--- a/docs/source/api/io-data-structures.rst
+++ b/docs/source/api/io-data-structures.rst
@@ -6,7 +6,8 @@ Key IO Data Structures
 Introduction
 ------------
 
-The Python API uses four key pandas DataFrame structures for simulation input and output:
+The Python API uses YAML configuration, a forcing DataFrame, an output
+DataFrame, and a typed checkpoint for restart/continuation workflows:
 
 .. code-block:: python
 
@@ -17,20 +18,25 @@ The Python API uses four key pandas DataFrame structures for simulation input an
    sim.run()
 
    # Access the data structures
-   df_state_init = sim.df_state_init   # Input: initial states
-   df_forcing = sim.df_forcing         # Input: forcing data
-   df_output = sim.results             # Output: simulation results
-   df_state_final = sim.df_state_final # Output: final states
+   config = sim.config                 # Input: YAML-backed configuration
+   df_forcing = sim.forcing.df         # Input: forcing data
+   df_output = output.df               # Output: simulation results
+   checkpoint = output.checkpoint      # Output: restart state
 
 **Input DataFrames:**
 
-- ``df_state_init``: Model initial states and configuration parameters
+- YAML ``SUEWSConfig``: User-facing model configuration
 - ``df_forcing``: Meteorological forcing data time series
 
 **Output DataFrames:**
 
 - ``df_output`` (or ``sim.results``): Model output results for scientific analysis
-- ``df_state_final``: Model final states, usable as initial conditions for subsequent simulations
+- ``SUEWSCheckpoint``: Typed restart state, used together with the YAML
+  configuration for subsequent simulations
+
+``df_state_init`` and ``df_state_final`` are retained as legacy compatibility
+structures for older tools and file converters. New restart workflows should
+use ``config.yml`` plus ``*_SUEWS_checkpoint.json``.
 
 
 Input
@@ -141,34 +147,37 @@ Output is recorded at the same temporal resolution as the forcing data:
    True
 
 
+.. _suews_checkpoint:
 .. _df_state_final:
 
-``df_state_final``: model final states
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``SUEWSCheckpoint``: restart state
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``df_state_final`` has the identical data structure as ``df_state_init`` except for an
-extra ``datetime`` level in the index, which stores temporal information associated with
-model states.
+``SUEWSCheckpoint`` stores the Rust backend's typed ``state_json`` payload by
+``grid_id``. It is the canonical restart artifact for new workflows and must be
+used with the original YAML configuration:
 
 .. code-block:: python
 
-   >>> df_state_final.head()
-   var                      ah_min       ah_slope_cooling  ...  z z0m_in zdm_in
-   ind_dim                    (0,)  (1,)             (0,)  ...  0      0      0
-   datetime            grid
-   2012-01-01 00:05:00 98     15.0  15.0              2.7  ... 49.6   1.9   14.2
-   2013-01-01 00:05:00 98     15.0  15.0              2.7  ... 49.6   1.9   14.2
+   >>> output = sim.run()
+   >>> output.checkpoint.to_file("Kc_SUEWS_checkpoint.json")
+   PosixPath('Kc_SUEWS_checkpoint.json')
+   >>> sim_next = SUEWSSimulation.from_checkpoint(
+   ...     "config.yml",
+   ...     "Kc_SUEWS_checkpoint.json",
+   ... )
 
-   [2 rows x 1200 columns]
+The checkpoint contains:
 
-This structure facilitates reuse as initial model states for subsequent simulations:
+- ``supy_version``
+- ``state_schema_version``
+- ``created_at``
+- ``last_timestamp``
+- ``grid_states`` keyed by ``grid_id``
 
-- **Runtime diagnostics**: Save intermediate states with ``save_state=True`` in ``run_supy``
-- **Chained simulations**: Use end state as initial conditions for future runs starting
-  at the ending time of previous runs
-
-The meanings of state variables in ``df_state_final`` are the same as in ``df_state_init``,
-documented in :doc:`/data-structures/df_state`.
+``df_state_final`` remains available as a legacy DataFrame for compatibility
+with older DFState files and developer tools, but it is no longer the preferred
+restart artifact.
 
 
 Related Documentation

--- a/docs/source/api/io-data-structures.rst
+++ b/docs/source/api/io-data-structures.rst
@@ -6,8 +6,7 @@ Key IO Data Structures
 Introduction
 ------------
 
-The Python API uses YAML configuration, a forcing DataFrame, an output
-DataFrame, and a typed checkpoint for restart/continuation workflows:
+The Python API uses four key pandas DataFrame structures for simulation input and output:
 
 .. code-block:: python
 
@@ -18,25 +17,20 @@ DataFrame, and a typed checkpoint for restart/continuation workflows:
    sim.run()
 
    # Access the data structures
-   config = sim.config                 # Input: YAML-backed configuration
-   df_forcing = sim.forcing.df         # Input: forcing data
-   df_output = output.df               # Output: simulation results
-   checkpoint = output.checkpoint      # Output: restart state
+   df_state_init = sim.df_state_init   # Input: initial states
+   df_forcing = sim.df_forcing         # Input: forcing data
+   df_output = sim.results             # Output: simulation results
+   df_state_final = sim.df_state_final # Output: final states
 
 **Input DataFrames:**
 
-- YAML ``SUEWSConfig``: User-facing model configuration
+- ``df_state_init``: Model initial states and configuration parameters
 - ``df_forcing``: Meteorological forcing data time series
 
 **Output DataFrames:**
 
 - ``df_output`` (or ``sim.results``): Model output results for scientific analysis
-- ``SUEWSCheckpoint``: Typed restart state, used together with the YAML
-  configuration for subsequent simulations
-
-``df_state_init`` and ``df_state_final`` are retained as legacy compatibility
-structures for older tools and file converters. New restart workflows should
-use ``config.yml`` plus ``*_SUEWS_checkpoint.json``.
+- ``df_state_final``: Model final states, usable as initial conditions for subsequent simulations
 
 
 Input
@@ -147,37 +141,34 @@ Output is recorded at the same temporal resolution as the forcing data:
    True
 
 
-.. _suews_checkpoint:
 .. _df_state_final:
 
-``SUEWSCheckpoint``: restart state
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``df_state_final``: model final states
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``SUEWSCheckpoint`` stores the Rust backend's typed ``state_json`` payload by
-``grid_id``. It is the canonical restart artifact for new workflows and must be
-used with the original YAML configuration:
+``df_state_final`` has the identical data structure as ``df_state_init`` except for an
+extra ``datetime`` level in the index, which stores temporal information associated with
+model states.
 
 .. code-block:: python
 
-   >>> output = sim.run()
-   >>> output.checkpoint.to_file("Kc_SUEWS_checkpoint.json")
-   PosixPath('Kc_SUEWS_checkpoint.json')
-   >>> sim_next = SUEWSSimulation.from_checkpoint(
-   ...     "config.yml",
-   ...     "Kc_SUEWS_checkpoint.json",
-   ... )
+   >>> df_state_final.head()
+   var                      ah_min       ah_slope_cooling  ...  z z0m_in zdm_in
+   ind_dim                    (0,)  (1,)             (0,)  ...  0      0      0
+   datetime            grid
+   2012-01-01 00:05:00 98     15.0  15.0              2.7  ... 49.6   1.9   14.2
+   2013-01-01 00:05:00 98     15.0  15.0              2.7  ... 49.6   1.9   14.2
 
-The checkpoint contains:
+   [2 rows x 1200 columns]
 
-- ``supy_version``
-- ``state_schema_version``
-- ``created_at``
-- ``last_timestamp``
-- ``grid_states`` keyed by ``grid_id``
+This structure facilitates reuse as initial model states for subsequent simulations:
 
-``df_state_final`` remains available as a legacy DataFrame for compatibility
-with older DFState files and developer tools, but it is no longer the preferred
-restart artifact.
+- **Runtime diagnostics**: Save intermediate states with ``save_state=True`` in ``run_supy``
+- **Chained simulations**: Use end state as initial conditions for future runs starting
+  at the ending time of previous runs
+
+The meanings of state variables in ``df_state_final`` are the same as in ``df_state_init``,
+documented in :doc:`/data-structures/df_state`.
 
 
 Related Documentation

--- a/docs/source/api/simulation.rst
+++ b/docs/source/api/simulation.rst
@@ -13,7 +13,6 @@ Key Features
 - **YAML Configuration**: Load configurations from YAML files
 - **Configuration Updates**: Update configuration with dictionaries or YAML files
 - **Forcing Management**: Load single files, lists of files, or DataFrames
-- **Typed Restarts**: Continue runs from ``SUEWSCheckpoint`` JSON plus YAML config
 - **Simple API**: Clean interface focused on essential functionality
 - **Format Support**: Save results in txt or parquet formats via OutputConfig
 
@@ -53,8 +52,6 @@ For spin-up runs, state continuation, and deep model inspection.
 
     ~SUEWSSimulation.state_init
     ~SUEWSSimulation.state_final
-    ~SUEWSSimulation.checkpoint
-    ~SUEWSSimulation.state_checkpoint
 
 .. _sim_setup_methods:
 
@@ -69,8 +66,6 @@ Configure simulations, load forcing data, and initialise from various sources.
     ~SUEWSSimulation.update_config
     ~SUEWSSimulation.update_forcing
     ~SUEWSSimulation.from_sample_data
-    ~SUEWSSimulation.from_checkpoint
-    ~SUEWSSimulation.continue_from
     ~SUEWSSimulation.from_state
 
 .. _sim_execution_methods:

--- a/docs/source/api/simulation.rst
+++ b/docs/source/api/simulation.rst
@@ -13,6 +13,7 @@ Key Features
 - **YAML Configuration**: Load configurations from YAML files
 - **Configuration Updates**: Update configuration with dictionaries or YAML files
 - **Forcing Management**: Load single files, lists of files, or DataFrames
+- **Typed Restarts**: Continue runs from ``SUEWSCheckpoint`` JSON plus YAML config
 - **Simple API**: Clean interface focused on essential functionality
 - **Format Support**: Save results in txt or parquet formats via OutputConfig
 
@@ -52,6 +53,8 @@ For spin-up runs, state continuation, and deep model inspection.
 
     ~SUEWSSimulation.state_init
     ~SUEWSSimulation.state_final
+    ~SUEWSSimulation.checkpoint
+    ~SUEWSSimulation.state_checkpoint
 
 .. _sim_setup_methods:
 
@@ -66,6 +69,8 @@ Configure simulations, load forcing data, and initialise from various sources.
     ~SUEWSSimulation.update_config
     ~SUEWSSimulation.update_forcing
     ~SUEWSSimulation.from_sample_data
+    ~SUEWSSimulation.from_checkpoint
+    ~SUEWSSimulation.continue_from
     ~SUEWSSimulation.from_state
 
 .. _sim_execution_methods:

--- a/docs/source/api/simulation.rst
+++ b/docs/source/api/simulation.rst
@@ -13,6 +13,7 @@ Key Features
 - **YAML Configuration**: Load configurations from YAML files
 - **Configuration Updates**: Update configuration with dictionaries or YAML files
 - **Forcing Management**: Load single files, lists of files, or DataFrames
+- **Checkpoint Restarts**: Continue YAML-based runs from typed checkpoint JSON
 - **Simple API**: Clean interface focused on essential functionality
 - **Format Support**: Save results in txt or parquet formats via OutputConfig
 
@@ -52,6 +53,8 @@ For spin-up runs, state continuation, and deep model inspection.
 
     ~SUEWSSimulation.state_init
     ~SUEWSSimulation.state_final
+    ~SUEWSSimulation.checkpoint
+    ~SUEWSSimulation.state_checkpoint
 
 .. _sim_setup_methods:
 
@@ -66,6 +69,8 @@ Configure simulations, load forcing data, and initialise from various sources.
     ~SUEWSSimulation.update_config
     ~SUEWSSimulation.update_forcing
     ~SUEWSSimulation.from_sample_data
+    ~SUEWSSimulation.from_checkpoint
+    ~SUEWSSimulation.continue_from
     ~SUEWSSimulation.from_state
 
 .. _sim_execution_methods:
@@ -94,6 +99,20 @@ Save results to files and extract specific variables from output groups.
     ~SUEWSSimulation.save
     ~SUEWSSimulation.get_variable
 
+Run Output
+^^^^^^^^^^
+
+``run()`` returns a :class:`SUEWSOutput` object. Use its ``checkpoint`` property
+as the restart artefact for continuation runs; ``state_final`` is retained as a
+legacy/developer DataFrame view.
+
+.. autosummary::
+    :nosignatures:
+
+    ~SUEWSOutput.checkpoint
+    ~SUEWSOutput.state_checkpoint
+    ~SUEWSOutput.state_final
+
 
 Full Class Reference
 ^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +134,7 @@ Quick Example
     # Create and run simulation
     sim = SUEWSSimulation('config.yml')
     sim.update_forcing('forcing_data.txt')
-    sim.run()
+    output = sim.run()
 
     # Access results - use get_variable() for safe extraction
     qh = sim.get_variable('QH')              # Sensible heat flux
@@ -126,6 +145,15 @@ Quick Example
 
     # Save results
     sim.save('output_dir/')
+
+    # Continue from the typed checkpoint and the next forcing period
+    output.checkpoint.to_file('output_dir/{site}_SUEWS_checkpoint.json')
+    sim_next = SUEWSSimulation.from_checkpoint(
+        'config.yml',
+        'output_dir/{site}_SUEWS_checkpoint.json',
+    )
+    sim_next.update_forcing('forcing_next_period.txt')
+    output_next = sim_next.run()
 
     # Update configuration and re-run
     sim.update_config({'model': {'control': {'tstep': 600}}})
@@ -147,5 +175,6 @@ Related Documentation
    - :doc:`dts` - DTS backend for performance-optimised execution
 
 - :doc:`/inputs/yaml/index` - YAML configuration guide
+- :ref:`suews_checkpoint` - Typed checkpoint restart artefact
 - :doc:`/data-structures/df_forcing` - Forcing data format
 - :doc:`/data-structures/df_output` - Output data format

--- a/docs/source/inputs/yaml/examples/output_config_parquet.yml
+++ b/docs/source/inputs/yaml/examples/output_config_parquet.yml
@@ -33,4 +33,4 @@ sites:
 
 # Output files created:
 # - {site}_SUEWS_output.parquet - All output data (all years, all groups)
-# - {site}_SUEWS_checkpoint.json - Typed state for restart runs
+# - {site}_SUEWS_state_final.parquet - Final model state for restart runs

--- a/docs/source/inputs/yaml/examples/output_config_parquet.yml
+++ b/docs/source/inputs/yaml/examples/output_config_parquet.yml
@@ -33,4 +33,4 @@ sites:
 
 # Output files created:
 # - {site}_SUEWS_output.parquet - All output data (all years, all groups)
-# - {site}_SUEWS_state_final.parquet - Final model state for restart runs
+# - {site}_SUEWS_checkpoint.json - Typed restart checkpoint

--- a/docs/source/inputs/yaml/examples/output_config_parquet.yml
+++ b/docs/source/inputs/yaml/examples/output_config_parquet.yml
@@ -33,4 +33,4 @@ sites:
 
 # Output files created:
 # - {site}_SUEWS_output.parquet - All output data (all years, all groups)
-# - {site}_SUEWS_state_final.parquet - Final model state for restart runs
+# - {site}_SUEWS_checkpoint.json - Typed state for restart runs

--- a/docs/source/outputs/index.rst
+++ b/docs/source/outputs/index.rst
@@ -30,19 +30,23 @@ See :doc:`../inputs/yaml/index` for configuration details.
    legacy_text_columns
 
 
-State Output
-------------
+Restart Checkpoint
+------------------
 
-df_state_SSss.csv
-^^^^^^^^^^^^^^^^^
+{site}_SUEWS_checkpoint.json
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-SUEWS automatically outputs a df_state_SSss.csv file containing:
+Object-oriented SUEWS runs save ``{site}_SUEWS_checkpoint.json`` as the
+preferred restart artefact. It contains typed runtime state from the backend,
+keyed by grid ID.
 
-- Model configuration parameters
-- Initial and final states
-- Simulation metadata (SUEWS version, timestamps, etc.)
+The checkpoint is intentionally only the typed runtime state. To continue a run,
+load the same YAML configuration, attach the next forcing period, and run from
+``SUEWSSimulation.from_checkpoint(...)``.
 
-This file preserves model state for analysis and restart purposes.
+Legacy ``df_state_SSss.csv`` and state parquet files remain documented for
+backwards compatibility and developer inspection, but they are not the preferred
+restart artefact for new object-oriented workflows.
 
 
 Temporal Information

--- a/docs/source/outputs/index.rst
+++ b/docs/source/outputs/index.rst
@@ -30,19 +30,22 @@ See :doc:`../inputs/yaml/index` for configuration details.
    legacy_text_columns
 
 
-State Output
-------------
+Restart Output
+--------------
 
-df_state_SSss.csv
-^^^^^^^^^^^^^^^^^
+SSss_SUEWS_checkpoint.json
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-SUEWS automatically outputs a df_state_SSss.csv file containing:
+The object-oriented API writes a typed checkpoint JSON file containing:
 
-- Model configuration parameters
-- Initial and final states
-- Simulation metadata (SUEWS version, timestamps, etc.)
+- SUEWS/SuPy version metadata
+- State schema version
+- Last simulated timestamp
+- Typed Rust backend state for each grid
 
-This file preserves model state for analysis and restart purposes.
+Use this file together with the YAML configuration to restart or continue a
+simulation. Legacy ``save_supy()`` workflows may still produce
+``df_state_SSss.csv`` for backwards compatibility.
 
 
 Temporal Information

--- a/docs/source/outputs/index.rst
+++ b/docs/source/outputs/index.rst
@@ -30,22 +30,19 @@ See :doc:`../inputs/yaml/index` for configuration details.
    legacy_text_columns
 
 
-Restart Output
---------------
+State Output
+------------
 
-SSss_SUEWS_checkpoint.json
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+df_state_SSss.csv
+^^^^^^^^^^^^^^^^^
 
-The object-oriented API writes a typed checkpoint JSON file containing:
+SUEWS automatically outputs a df_state_SSss.csv file containing:
 
-- SUEWS/SuPy version metadata
-- State schema version
-- Last simulated timestamp
-- Typed Rust backend state for each grid
+- Model configuration parameters
+- Initial and final states
+- Simulation metadata (SUEWS version, timestamps, etc.)
 
-Use this file together with the YAML configuration to restart or continue a
-simulation. Legacy ``save_supy()`` workflows may still produce
-``df_state_SSss.csv`` for backwards compatibility.
+This file preserves model state for analysis and restart purposes.
 
 
 Temporal Information

--- a/docs/source/outputs/parquet_format.rst
+++ b/docs/source/outputs/parquet_format.rst
@@ -18,13 +18,18 @@ large-scale SUEWS simulations.
 Output Files
 ------------
 
-When using parquet format, SUEWS produces two output files:
+When using parquet format through the object-oriented API, SUEWS produces the
+analysis output parquet file and a checkpoint JSON restart artefact:
 
 - **SSss_SUEWS_output.parquet** - All simulation output in a single file, including
   all output groups and years. See :doc:`variables/index` for variable details.
 
-- **SSss_SUEWS_state_final.parquet** - Final model state for restart runs.
+- **{site}_SUEWS_checkpoint.json** - Typed runtime state for restart runs.
   See :ref:`State Persistence <state-persistence>` for details.
+
+Legacy and developer workflows may still produce
+``SSss_SUEWS_state_final.parquet`` for DataFrame state inspection, but it is not
+the preferred restart artefact for new object-oriented workflows.
 
 
 Reading Parquet Files

--- a/docs/source/outputs/parquet_format.rst
+++ b/docs/source/outputs/parquet_format.rst
@@ -18,13 +18,12 @@ large-scale SUEWS simulations.
 Output Files
 ------------
 
-When using parquet format through the object-oriented API, SUEWS produces
-Parquet output plus a checkpoint JSON file:
+When using parquet format, SUEWS produces two output files:
 
 - **SSss_SUEWS_output.parquet** - All simulation output in a single file, including
   all output groups and years. See :doc:`variables/index` for variable details.
 
-- **SSss_SUEWS_checkpoint.json** - Typed state for restart runs.
+- **SSss_SUEWS_state_final.parquet** - Final model state for restart runs.
   See :ref:`State Persistence <state-persistence>` for details.
 
 

--- a/docs/source/outputs/parquet_format.rst
+++ b/docs/source/outputs/parquet_format.rst
@@ -18,12 +18,13 @@ large-scale SUEWS simulations.
 Output Files
 ------------
 
-When using parquet format, SUEWS produces two output files:
+When using parquet format through the object-oriented API, SUEWS produces
+Parquet output plus a checkpoint JSON file:
 
 - **SSss_SUEWS_output.parquet** - All simulation output in a single file, including
   all output groups and years. See :doc:`variables/index` for variable details.
 
-- **SSss_SUEWS_state_final.parquet** - Final model state for restart runs.
+- **SSss_SUEWS_checkpoint.json** - Typed state for restart runs.
   See :ref:`State Persistence <state-persistence>` for details.
 
 

--- a/docs/source/outputs/text_format.rst
+++ b/docs/source/outputs/text_format.rst
@@ -4,13 +4,13 @@ Text Format Output
 ==================
 
 Since version ``2025.10.15`` (see :ref:`release notes <new_2025.10.15>`), when using
-text format (default), the object-oriented API produces two types of output files:
+text format (default), SUEWS produces two types of output files:
 
 1. **Simulation output files** - Tab-delimited files organised by output group and
    simulation year. See :ref:`Output Groups <output-groups>` for details.
 
-2. **Checkpoint file** - A JSON file (``SSss_SUEWS_checkpoint.json``) containing
-   typed restart state. See :ref:`State Persistence <state-persistence>`.
+2. **State persistence file** - A CSV file (``df_state_SSss.csv``) containing model
+   state for restart and analysis. See :ref:`State Persistence <state-persistence>`.
 
 .. note::
 
@@ -18,9 +18,8 @@ text format (default), the object-oriented API produces two types of output file
    Some features are retained in the modern format (e.g., output level control via
    ``groups``), while others have been adapted:
 
-   - **State persistence**: Legacy ``InitialConditionsSSss_YYYY.nml`` files are
-     replaced by typed checkpoint JSON for new runs. Legacy ``save_supy()`` can
-     still write ``df_state_SSss.csv`` for compatibility.
+   - **State persistence**: Legacy ``InitialConditionsSSss_YYYY.nml`` files replaced
+     by modern ``df_state_SSss.csv``
    - **Error/warning messages**: Legacy ``problems.txt`` and ``warnings.txt`` files
      are no longer written; diagnostics are emitted to stdout/stderr and handled by
      the Python runtime logger (SuPy).
@@ -214,28 +213,22 @@ Group Details
 State Persistence
 -----------------
 
-SUEWS restart/continuation now uses a typed checkpoint JSON file together with
-the YAML configuration file.
+SUEWS automatically saves model state for restart and analysis purposes using the
+modern CSV-based state file format.
 
-At the end of an object-oriented simulation, ``SUEWSSimulation.save()`` writes a
-``{site}_SUEWS_checkpoint.json`` file containing:
+At the end of each simulation, SUEWS writes a ``df_state_SSss.csv`` file containing:
 
-- ``supy_version``
-- ``state_schema_version``
-- ``created_at``
-- ``last_timestamp``
-- typed Rust state payloads in ``grid_states``
+- Model configuration parameters
+- Initial and final states for all surface types
+- Simulation metadata (SUEWS version, timestamps, etc.)
 
 This file can be used to:
 
-1. **Restart simulations** - Continue from ``config.yml`` plus checkpoint JSON
-2. **Chain simulations** - Use the final typed backend state as the next initial state
+1. **Restart simulations** - Continue from a saved state
+2. **Analyse model state** - Inspect internal variables
+3. **Chain simulations** - Use end state as input for subsequent runs
 
-Legacy ``save_supy()`` callers may still write ``df_state_SSss.csv`` for
-backwards compatibility. New workflows should not use DFState CSV as the
-restart artifact.
-
-See :ref:`suews_checkpoint` for details.
+See `df_state_final: model final states <../api/io-data-structures.html#df-state-final>`_ for details on the state data structure.
 
 
 .. _legacy-output-control:
@@ -281,7 +274,7 @@ Legacy Initial Conditions Output
 
 **InitialConditionsSSss_YYYY.nml**
    The legacy namelist-based initial conditions files are deprecated.
-   Use checkpoint JSON files instead (see :ref:`State Persistence <state-persistence>`).
+   Use the modern ``df_state_SSss.csv`` files instead (see :ref:`State Persistence <state-persistence>`).
 
 See :doc:`variables/index` for the complete list of output variables.
 

--- a/docs/source/outputs/text_format.rst
+++ b/docs/source/outputs/text_format.rst
@@ -4,13 +4,13 @@ Text Format Output
 ==================
 
 Since version ``2025.10.15`` (see :ref:`release notes <new_2025.10.15>`), when using
-text format (default), SUEWS produces two types of output files:
+text format (default), the object-oriented API produces two types of output files:
 
 1. **Simulation output files** - Tab-delimited files organised by output group and
    simulation year. See :ref:`Output Groups <output-groups>` for details.
 
-2. **State persistence file** - A CSV file (``df_state_SSss.csv``) containing model
-   state for restart and analysis. See :ref:`State Persistence <state-persistence>`.
+2. **Checkpoint file** - A JSON file (``SSss_SUEWS_checkpoint.json``) containing
+   typed restart state. See :ref:`State Persistence <state-persistence>`.
 
 .. note::
 
@@ -18,8 +18,9 @@ text format (default), SUEWS produces two types of output files:
    Some features are retained in the modern format (e.g., output level control via
    ``groups``), while others have been adapted:
 
-   - **State persistence**: Legacy ``InitialConditionsSSss_YYYY.nml`` files replaced
-     by modern ``df_state_SSss.csv``
+   - **State persistence**: Legacy ``InitialConditionsSSss_YYYY.nml`` files are
+     replaced by typed checkpoint JSON for new runs. Legacy ``save_supy()`` can
+     still write ``df_state_SSss.csv`` for compatibility.
    - **Error/warning messages**: Legacy ``problems.txt`` and ``warnings.txt`` files
      are no longer written; diagnostics are emitted to stdout/stderr and handled by
      the Python runtime logger (SuPy).
@@ -213,22 +214,28 @@ Group Details
 State Persistence
 -----------------
 
-SUEWS automatically saves model state for restart and analysis purposes using the
-modern CSV-based state file format.
+SUEWS restart/continuation now uses a typed checkpoint JSON file together with
+the YAML configuration file.
 
-At the end of each simulation, SUEWS writes a ``df_state_SSss.csv`` file containing:
+At the end of an object-oriented simulation, ``SUEWSSimulation.save()`` writes a
+``{site}_SUEWS_checkpoint.json`` file containing:
 
-- Model configuration parameters
-- Initial and final states for all surface types
-- Simulation metadata (SUEWS version, timestamps, etc.)
+- ``supy_version``
+- ``state_schema_version``
+- ``created_at``
+- ``last_timestamp``
+- typed Rust state payloads in ``grid_states``
 
 This file can be used to:
 
-1. **Restart simulations** - Continue from a saved state
-2. **Analyse model state** - Inspect internal variables
-3. **Chain simulations** - Use end state as input for subsequent runs
+1. **Restart simulations** - Continue from ``config.yml`` plus checkpoint JSON
+2. **Chain simulations** - Use the final typed backend state as the next initial state
 
-See `df_state_final: model final states <../api/io-data-structures.html#df-state-final>`_ for details on the state data structure.
+Legacy ``save_supy()`` callers may still write ``df_state_SSss.csv`` for
+backwards compatibility. New workflows should not use DFState CSV as the
+restart artifact.
+
+See :ref:`suews_checkpoint` for details.
 
 
 .. _legacy-output-control:
@@ -274,7 +281,7 @@ Legacy Initial Conditions Output
 
 **InitialConditionsSSss_YYYY.nml**
    The legacy namelist-based initial conditions files are deprecated.
-   Use the modern ``df_state_SSss.csv`` files instead (see :ref:`State Persistence <state-persistence>`).
+   Use checkpoint JSON files instead (see :ref:`State Persistence <state-persistence>`).
 
 See :doc:`variables/index` for the complete list of output variables.
 

--- a/docs/source/outputs/text_format.rst
+++ b/docs/source/outputs/text_format.rst
@@ -3,14 +3,17 @@
 Text Format Output
 ==================
 
-Since version ``2025.10.15`` (see :ref:`release notes <new_2025.10.15>`), when using
-text format (default), SUEWS produces two types of output files:
+Since version ``2025.10.15`` (see :ref:`release notes <new_2025.10.15>`), text
+format output is organised as tab-delimited simulation files by output group and
+simulation year. Current object-oriented workflows also save a typed checkpoint
+JSON file for continuation runs:
 
-1. **Simulation output files** - Tab-delimited files organised by output group and
-   simulation year. See :ref:`Output Groups <output-groups>` for details.
+- **Simulation output files** - Tab-delimited files organised by output group and
+  simulation year. See :ref:`Output Groups <output-groups>` for details.
 
-2. **State persistence file** - A CSV file (``df_state_SSss.csv``) containing model
-   state for restart and analysis. See :ref:`State Persistence <state-persistence>`.
+- **Restart checkpoint** - A JSON file (``{site}_SUEWS_checkpoint.json``)
+  containing typed runtime state for continuation runs. See
+  :ref:`State Persistence <state-persistence>`.
 
 .. note::
 
@@ -18,8 +21,9 @@ text format (default), SUEWS produces two types of output files:
    Some features are retained in the modern format (e.g., output level control via
    ``groups``), while others have been adapted:
 
-   - **State persistence**: Legacy ``InitialConditionsSSss_YYYY.nml`` files replaced
-     by modern ``df_state_SSss.csv``
+   - **State persistence**: Legacy ``InitialConditionsSSss_YYYY.nml`` files are
+     replaced by typed checkpoint JSON in new object-oriented workflows.
+     ``df_state_SSss.csv`` remains available for legacy and developer workflows.
    - **Error/warning messages**: Legacy ``problems.txt`` and ``warnings.txt`` files
      are no longer written; diagnostics are emitted to stdout/stderr and handled by
      the Python runtime logger (SuPy).
@@ -213,22 +217,31 @@ Group Details
 State Persistence
 -----------------
 
-SUEWS automatically saves model state for restart and analysis purposes using the
-modern CSV-based state file format.
+SUEWS saves typed runtime state for continuation runs using checkpoint JSON.
 
-At the end of each simulation, SUEWS writes a ``df_state_SSss.csv`` file containing:
+At the end of each object-oriented simulation, ``sim.run()`` exposes
+``output.checkpoint`` and ``sim.save(...)`` writes
+``{site}_SUEWS_checkpoint.json``. The checkpoint contains:
 
-- Model configuration parameters
-- Initial and final states for all surface types
-- Simulation metadata (SUEWS version, timestamps, etc.)
+- Backend runtime state keyed by grid ID
+- SUEWS/SuPy version metadata
+- The last forcing timestamp represented by the checkpoint
 
 This file can be used to:
 
 1. **Restart simulations** - Continue from a saved state
-2. **Analyse model state** - Inspect internal variables
-3. **Chain simulations** - Use end state as input for subsequent runs
+2. **Chain simulations** - Use end state as input for subsequent runs
+3. **Preserve typed backend state** - Avoid lossy DataFrame restart conversion
 
-See `df_state_final: model final states <../api/io-data-structures.html#df-state-final>`_ for details on the state data structure.
+The checkpoint is intentionally only the typed runtime state. To continue a run,
+load the same YAML configuration, attach the next forcing period, and run from
+``SUEWSSimulation.from_checkpoint(...)``.
+
+``df_state_SSss.csv`` and ``df_state_final`` remain legacy/developer-facing
+DataFrame structures for backwards compatibility and state inspection. They are
+not the preferred restart artefact for new object-oriented workflows. See
+`SUEWSCheckpoint: typed restart state <../api/io-data-structures.html#suews-checkpoint>`_
+for details.
 
 
 .. _legacy-output-control:
@@ -274,7 +287,9 @@ Legacy Initial Conditions Output
 
 **InitialConditionsSSss_YYYY.nml**
    The legacy namelist-based initial conditions files are deprecated.
-   Use the modern ``df_state_SSss.csv`` files instead (see :ref:`State Persistence <state-persistence>`).
+   Use checkpoint JSON for new object-oriented restart workflows (see
+   :ref:`State Persistence <state-persistence>`). ``df_state_SSss.csv`` remains
+   a legacy/developer compatibility file.
 
 See :doc:`variables/index` for the complete list of output variables.
 

--- a/docs/source/tutorials/tutorial_03_initial_conditions.py
+++ b/docs/source/tutorials/tutorial_03_initial_conditions.py
@@ -59,9 +59,10 @@ print(soil_cols[:5])
 # Run a short simulation to see state evolution
 _ = sim.run()
 
-# The typed checkpoint is the restart artifact created by the run.
-print("State checkpoint created:")
-print(f"  Last timestamp: {sim.checkpoint.last_timestamp}")
+# Compare initial and final states for soil moisture
+print("State evolution during simulation:")
+print(f"  Initial soil moisture (mean): {sim.state_init.filter(like='soilstore').mean().mean():.1f} mm")
+print(f"  Final soil moisture (mean): {sim.state_final.filter(like='soilstore').mean().mean():.1f} mm")
 
 # %%
 # Method 1: Full Year Spin-Up
@@ -74,14 +75,14 @@ print(f"  Last timestamp: {sim.checkpoint.last_timestamp}")
 sim_spinup = SUEWSSimulation.from_sample_data()
 _ = sim_spinup.run()
 
-# Step 2: Save the typed checkpoint
-checkpoint_equilibrated = sim_spinup.checkpoint
+# Step 2: Get equilibrated state
+state_equilibrated = sim_spinup.state_final.copy()
 
 print("Spin-up complete!")
-print("Checkpoint ready for analysis period")
+print("Equilibrated state ready for analysis period")
 
 # Step 3: Use for analysis (in practice, you'd load new forcing data)
-# sim_analysis = SUEWSSimulation.from_checkpoint(sim_spinup.config, checkpoint_equilibrated)
+# sim_analysis = SUEWSSimulation.from_state(state_equilibrated)
 # sim_analysis.update_forcing('forcing_2015.txt')
 # sim_analysis.run()
 
@@ -92,40 +93,49 @@ print("Checkpoint ready for analysis period")
 # For limited forcing data, repeat the same year until states converge.
 # Typically 2-3 iterations are sufficient.
 
-# Track checkpoint timestamps for each iteration.
-checkpoint_times = []
+# Track soil moisture convergence
+soil_history = []
 sim = SUEWSSimulation.from_sample_data()
 
 # Initial run
 _ = sim.run()
-checkpoint_times.append(sim.checkpoint.last_timestamp)
+soil_history.append(sim.state_final.filter(like="soilstore").mean().mean())
 
 # Capture forcing once -- it stays the same across all spin-up iterations.
 forcing_data = sim.forcing
 
-# Spin-up iterations: reuse the same forcing but transfer typed checkpoint state.
+# Spin-up iterations: reuse the same forcing but transfer evolved state.
+# Typically 2-3 iterations suffice for convergence (change < 1 mm).
 n_spinup = 3
 for i in range(n_spinup):
-    # Create new simulation from checkpoint and re-attach forcing
-    sim_next = SUEWSSimulation.from_checkpoint(sim.config, sim.checkpoint)
+    # Create new simulation from final state and re-attach forcing
+    sim_next = SUEWSSimulation.from_state(sim.state_final)
     sim_next.update_forcing(forcing_data)
     _ = sim_next.run()
-    checkpoint_times.append(sim_next.checkpoint.last_timestamp)
-    print(f"Spin-up {i+1}: checkpoint timestamp = {checkpoint_times[-1]}")
+    soil_history.append(sim_next.state_final.filter(like="soilstore").mean().mean())
+
+    # Check convergence
+    change = abs(soil_history[-1] - soil_history[-2])
+    print(f"Spin-up {i+1}: Soil moisture = {soil_history[-1]:.1f} mm (change: {change:.2f} mm)")
 
     # Carry forward for next iteration
     sim = sim_next
 
 # %%
-# Inspect the Checkpoint Chain
-# ----------------------------
+# Visualise Spin-Up Convergence
+# -----------------------------
 #
 # Plot how soil moisture evolves across spin-up iterations.
 
-print("Checkpoint chain:")
-for i, timestamp in enumerate(checkpoint_times):
-    label = "Initial" if i == 0 else f"Year {i}"
-    print(f"  {label}: {timestamp}")
+fig, ax = plt.subplots(figsize=(8, 5))
+ax.plot(range(len(soil_history)), soil_history, "bo-", markersize=10, linewidth=2)
+ax.set_xlabel("Spin-up Iteration")
+ax.set_ylabel("Mean Soil Moisture (mm)")
+ax.set_title("Soil Moisture Convergence During Spin-Up")
+ax.set_xticks(range(len(soil_history)))
+ax.set_xticklabels(["Initial"] + [f"Year {i+1}" for i in range(n_spinup)])
+ax.grid(True, alpha=0.3)
+plt.tight_layout()
 
 # %%
 # Seasonal Initial Conditions

--- a/docs/source/tutorials/tutorial_03_initial_conditions.py
+++ b/docs/source/tutorials/tutorial_03_initial_conditions.py
@@ -59,10 +59,9 @@ print(soil_cols[:5])
 # Run a short simulation to see state evolution
 _ = sim.run()
 
-# Compare initial and final states for soil moisture
-print("State evolution during simulation:")
-print(f"  Initial soil moisture (mean): {sim.state_init.filter(like='soilstore').mean().mean():.1f} mm")
-print(f"  Final soil moisture (mean): {sim.state_final.filter(like='soilstore').mean().mean():.1f} mm")
+# The typed checkpoint is the restart artifact created by the run.
+print("State checkpoint created:")
+print(f"  Last timestamp: {sim.checkpoint.last_timestamp}")
 
 # %%
 # Method 1: Full Year Spin-Up
@@ -75,14 +74,14 @@ print(f"  Final soil moisture (mean): {sim.state_final.filter(like='soilstore').
 sim_spinup = SUEWSSimulation.from_sample_data()
 _ = sim_spinup.run()
 
-# Step 2: Get equilibrated state
-state_equilibrated = sim_spinup.state_final.copy()
+# Step 2: Save the typed checkpoint
+checkpoint_equilibrated = sim_spinup.checkpoint
 
 print("Spin-up complete!")
-print("Equilibrated state ready for analysis period")
+print("Checkpoint ready for analysis period")
 
 # Step 3: Use for analysis (in practice, you'd load new forcing data)
-# sim_analysis = SUEWSSimulation.from_state(state_equilibrated)
+# sim_analysis = SUEWSSimulation.from_checkpoint(sim_spinup.config, checkpoint_equilibrated)
 # sim_analysis.update_forcing('forcing_2015.txt')
 # sim_analysis.run()
 
@@ -93,49 +92,40 @@ print("Equilibrated state ready for analysis period")
 # For limited forcing data, repeat the same year until states converge.
 # Typically 2-3 iterations are sufficient.
 
-# Track soil moisture convergence
-soil_history = []
+# Track checkpoint timestamps for each iteration.
+checkpoint_times = []
 sim = SUEWSSimulation.from_sample_data()
 
 # Initial run
 _ = sim.run()
-soil_history.append(sim.state_final.filter(like="soilstore").mean().mean())
+checkpoint_times.append(sim.checkpoint.last_timestamp)
 
 # Capture forcing once -- it stays the same across all spin-up iterations.
 forcing_data = sim.forcing
 
-# Spin-up iterations: reuse the same forcing but transfer evolved state.
-# Typically 2-3 iterations suffice for convergence (change < 1 mm).
+# Spin-up iterations: reuse the same forcing but transfer typed checkpoint state.
 n_spinup = 3
 for i in range(n_spinup):
-    # Create new simulation from final state and re-attach forcing
-    sim_next = SUEWSSimulation.from_state(sim.state_final)
+    # Create new simulation from checkpoint and re-attach forcing
+    sim_next = SUEWSSimulation.from_checkpoint(sim.config, sim.checkpoint)
     sim_next.update_forcing(forcing_data)
     _ = sim_next.run()
-    soil_history.append(sim_next.state_final.filter(like="soilstore").mean().mean())
-
-    # Check convergence
-    change = abs(soil_history[-1] - soil_history[-2])
-    print(f"Spin-up {i+1}: Soil moisture = {soil_history[-1]:.1f} mm (change: {change:.2f} mm)")
+    checkpoint_times.append(sim_next.checkpoint.last_timestamp)
+    print(f"Spin-up {i+1}: checkpoint timestamp = {checkpoint_times[-1]}")
 
     # Carry forward for next iteration
     sim = sim_next
 
 # %%
-# Visualise Spin-Up Convergence
-# -----------------------------
+# Inspect the Checkpoint Chain
+# ----------------------------
 #
 # Plot how soil moisture evolves across spin-up iterations.
 
-fig, ax = plt.subplots(figsize=(8, 5))
-ax.plot(range(len(soil_history)), soil_history, "bo-", markersize=10, linewidth=2)
-ax.set_xlabel("Spin-up Iteration")
-ax.set_ylabel("Mean Soil Moisture (mm)")
-ax.set_title("Soil Moisture Convergence During Spin-Up")
-ax.set_xticks(range(len(soil_history)))
-ax.set_xticklabels(["Initial"] + [f"Year {i+1}" for i in range(n_spinup)])
-ax.grid(True, alpha=0.3)
-plt.tight_layout()
+print("Checkpoint chain:")
+for i, timestamp in enumerate(checkpoint_times):
+    label = "Initial" if i == 0 else f"Year {i}"
+    print(f"  {label}: {timestamp}")
 
 # %%
 # Seasonal Initial Conditions

--- a/docs/source/tutorials/tutorial_03_initial_conditions.py
+++ b/docs/source/tutorials/tutorial_03_initial_conditions.py
@@ -12,6 +12,7 @@ You will learn:
 
 1. **Understanding state variables** - What SUEWS tracks and why it matters
 2. **Spin-up strategies** - Equilibrating the model before analysis
+   and carrying typed checkpoints forward
 3. **Seasonal adjustments** - Setting appropriate states for different start dates
 4. **Common pitfalls** - Avoiding unrealistic initial conditions
 
@@ -68,21 +69,21 @@ print(f"  Final soil moisture (mean): {sim.state_final.filter(like='soilstore').
 # Method 1: Full Year Spin-Up
 # ---------------------------
 #
-# Run one year before your analysis period and use the final state as
-# initial conditions. This is the most robust approach.
+# Run one year before your analysis period and use the typed checkpoint as
+# the restart artefact. This is the most robust approach.
 
 # Step 1: Run spin-up year
 sim_spinup = SUEWSSimulation.from_sample_data()
 _ = sim_spinup.run()
 
-# Step 2: Get equilibrated state
-state_equilibrated = sim_spinup.state_final.copy()
+# Step 2: Get equilibrated typed checkpoint
+checkpoint_equilibrated = sim_spinup.checkpoint
 
 print("Spin-up complete!")
-print("Equilibrated state ready for analysis period")
+print("Equilibrated checkpoint ready for analysis period")
 
 # Step 3: Use for analysis (in practice, you'd load new forcing data)
-# sim_analysis = SUEWSSimulation.from_state(state_equilibrated)
+# sim_analysis = SUEWSSimulation.from_checkpoint(sim_spinup.config, checkpoint_equilibrated)
 # sim_analysis.update_forcing('forcing_2015.txt')
 # sim_analysis.run()
 
@@ -104,12 +105,12 @@ soil_history.append(sim.state_final.filter(like="soilstore").mean().mean())
 # Capture forcing once -- it stays the same across all spin-up iterations.
 forcing_data = sim.forcing
 
-# Spin-up iterations: reuse the same forcing but transfer evolved state.
+# Spin-up iterations: reuse the same forcing but transfer evolved checkpoints.
 # Typically 2-3 iterations suffice for convergence (change < 1 mm).
 n_spinup = 3
 for i in range(n_spinup):
-    # Create new simulation from final state and re-attach forcing
-    sim_next = SUEWSSimulation.from_state(sim.state_final)
+    # Create new simulation from checkpoint and re-attach forcing
+    sim_next = SUEWSSimulation.from_checkpoint(sim.config, sim.checkpoint)
     sim_next.update_forcing(forcing_data)
     _ = sim_next.run()
     soil_history.append(sim_next.state_final.filter(like="soilstore").mean().mean())

--- a/docs/source/tutorials/tutorial_05_results_analysis.py
+++ b/docs/source/tutorials/tutorial_05_results_analysis.py
@@ -423,11 +423,11 @@ export_df = get_vars(output, export_vars)
 print(f"Export DataFrame shape: {export_df.shape}")
 print(f"Ready to save with: export_df.to_csv('suews_output.csv')")
 
-# Export final state for restart runs
-final_state = sim.state_final
-# final_state.to_csv('final_state.csv')  # Uncomment to save
-print(f"\nFinal state shape: {final_state.shape}")
-print("Ready to save with: final_state.to_csv('final_state.csv')")
+# Save typed checkpoint for restart runs
+checkpoint = output.checkpoint
+# checkpoint.to_file('Kc_SUEWS_checkpoint.json')  # Uncomment to save
+print("\nCheckpoint ready for restart runs")
+print("Ready to save with: checkpoint.to_file('Kc_SUEWS_checkpoint.json')")
 
 # %%
 # Summary

--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -332,13 +332,37 @@ Once you have a YAML configuration file, use the `SUEWSSimulation` class:
    sim = SUEWSSimulation("path/to/your/config_suews.yml")
 
    # Run simulation (forcing data loaded from config)
-   sim.run()
+   output = sim.run()
 
    # Access results
    print(sim.results)
 
    # Save outputs
    sim.save("output_directory/")
+
+   # Save the typed restart artefact explicitly
+   checkpoint_path = output.checkpoint.to_file(
+       "output_directory/{site}_SUEWS_checkpoint.json"
+   )
+
+To continue a simulation, pair the same YAML configuration with the checkpoint
+from the previous run and the next forcing period:
+
+.. code-block:: python
+
+   from supy import SUEWSSimulation
+
+   sim_next = SUEWSSimulation.from_checkpoint(
+       "path/to/your/config_suews.yml",
+       "output_directory/{site}_SUEWS_checkpoint.json",
+   )
+   sim_next.update_forcing("forcing_next_period.txt")
+   output_next = sim_next.run()
+
+The checkpoint is intentionally only the typed runtime state. To continue a
+run, load the same YAML configuration, attach the next forcing period, and run
+from ``SUEWSSimulation.from_checkpoint(...)``. Checkpoints are keyed by grid ID,
+so checkpoint/configuration grid mismatches are rejected by the runtime.
 
 For detailed examples, see :doc:`/sub-tutorials/suews-simulation-tutorial`.
 
@@ -381,8 +405,8 @@ Multi-Site and Comparative Studies
    def run_site(config_file):
        """Run SUEWS for a single site configuration"""
        sim = SUEWSSimulation(config_file)
-       sim.run()
-       return config_file, (sim.results, sim.state_final)
+       output = sim.run()
+       return config_file, output
 
    # Configuration files for different sites
    site_configs = [
@@ -395,19 +419,15 @@ Multi-Site and Comparative Studies
    with Pool() as pool:
        results = pool.map(run_site, site_configs)
 
-   # Note: Each result tuple contains (df_output, df_state_final)
-   # We need to access variables using the simulation object or helper
+   # Note: Each result tuple contains a SUEWSOutput object. Its checkpoint
+   # can be saved or passed to SUEWSSimulation.from_checkpoint(...) later.
 
-   # Create simulations from stored states to access get_variable()
    monthly_temps = {}
-   for name, (output, state) in results:
-       # Recreate sim with results for get_variable() access
-       sim_temp = SUEWSSimulation()
-       sim_temp._df_output = output
-       sim_temp._run_completed = True
-
-       t2 = sim_temp.get_variable('T2', group='SUEWS')
+   checkpoints = {}
+   for name, output in results:
+       t2 = output.get_variable('T2', group='SUEWS')
        monthly_temps[name] = t2.iloc[:, 0].groupby(t2.index.month).mean()
+       checkpoints[name] = output.checkpoint
 
    temp_comparison = pd.DataFrame(monthly_temps)
    temp_comparison.plot(kind='bar', title='Monthly Temperature Comparison')

--- a/src/supy/__init__.py
+++ b/src/supy/__init__.py
@@ -51,6 +51,7 @@ __all__ = [
     "ValidationResult",
     # Modern interface
     "SUEWSSimulation",
+    "SUEWSCheckpoint",
     "SUEWSForcing",
     "SUEWSOutput",
     # Exceptions
@@ -145,6 +146,15 @@ def __getattr__(name):
             from .suews_sim import SUEWSSimulation
 
             _lazy_cache[name] = SUEWSSimulation
+            return _lazy_cache[name]
+        except ImportError:
+            return None
+
+    if name == "SUEWSCheckpoint":
+        try:
+            from .suews_checkpoint import SUEWSCheckpoint
+
+            _lazy_cache[name] = SUEWSCheckpoint
             return _lazy_cache[name]
         except ImportError:
             return None

--- a/src/supy/_run_rust.py
+++ b/src/supy/_run_rust.py
@@ -522,10 +522,26 @@ def run_suews_rust_chunked(
         )
 
     sites = config.sites
-    list_gridiv = [s.gridiv for s in sites]
+    list_gridiv = [_normalise_grid_id(s.gridiv) for s in sites]
     list_dupes = [g for g in list_gridiv if list_gridiv.count(g) > 1]
     if list_dupes:
         raise ValueError(f"Duplicate gridiv values in config.sites: {set(list_dupes)}")
+
+    if initial_state_json_by_grid:
+        checkpoint_grid_ids = set(initial_state_json_by_grid)
+        config_grid_ids = set(list_gridiv)
+        if checkpoint_grid_ids != config_grid_ids:
+            parts = []
+            missing = sorted(config_grid_ids - checkpoint_grid_ids)
+            unexpected = sorted(checkpoint_grid_ids - config_grid_ids)
+            if missing:
+                parts.append(f"missing checkpoint states for grids {missing}")
+            if unexpected:
+                parts.append(f"unexpected checkpoint states for grids {unexpected}")
+            raise ValueError(
+                "Checkpoint grid IDs do not match config.sites: "
+                + "; ".join(parts)
+            )
 
     dict_state_json: dict[int, str] = dict(initial_state_json_by_grid)
     list_df_output: list[pd.DataFrame] = []

--- a/src/supy/_run_rust.py
+++ b/src/supy/_run_rust.py
@@ -487,13 +487,20 @@ def run_suews_rust_chunked(
     df_forcing: pd.DataFrame,
     chunk_day: int = 366,
     serial_mode: bool = False,
+    initial_state_json_by_grid: dict[int, str] | None = None,
 ) -> tuple[pd.DataFrame, dict[int, str] | None]:
     """Run SUEWS via Rust bridge with multi-chunk state chaining.
 
     Splits forcing into chunks of *chunk_day* days, runs each chunk
     sequentially, and threads the final state of chunk N into chunk N+1
-    for every grid.  Single-chunk forcing delegates without overhead.
+    for every grid.  When *initial_state_json_by_grid* is provided, the first
+    chunk also runs through ``run_suews_with_state`` for those grids.
     """
+    initial_state_json_by_grid = {
+        _normalise_grid_id(grid_id): state_json
+        for grid_id, state_json in (initial_state_json_by_grid or {}).items()
+    }
+
     # Group forcing into chunks (same logic as traditional backend)
     idx_start = df_forcing.index.min()
     idx_all = df_forcing.index
@@ -502,16 +509,17 @@ def run_suews_rust_chunked(
     )
 
     n_chunk = len(grp_forcing_chunk)
-    if n_chunk <= 1:
+    if n_chunk <= 1 and not initial_state_json_by_grid:
         return run_suews_rust_multi(
             config, df_forcing, serial_mode=serial_mode
         )
 
-    logger_supy.info(
-        "Rust backend: forcing split into %d chunks of <= %d days.",
-        n_chunk,
-        chunk_day,
-    )
+    if n_chunk > 1:
+        logger_supy.info(
+            "Rust backend: forcing split into %d chunks of <= %d days.",
+            n_chunk,
+            chunk_day,
+        )
 
     sites = config.sites
     list_gridiv = [s.gridiv for s in sites]
@@ -519,7 +527,7 @@ def run_suews_rust_chunked(
     if list_dupes:
         raise ValueError(f"Duplicate gridiv values in config.sites: {set(list_dupes)}")
 
-    dict_state_json: dict[int, str] = {}
+    dict_state_json: dict[int, str] = dict(initial_state_json_by_grid)
     list_df_output: list[pd.DataFrame] = []
 
     for chunk_idx, grp in enumerate(grp_forcing_chunk.groups):

--- a/src/supy/_save.py
+++ b/src/supy/_save.py
@@ -592,6 +592,7 @@ def save_df_output_parquet(
     site: str = "",
     path_dir_save: Path = Path("."),
     save_tstep=False,
+    save_state: bool = True,
 ) -> list:
     """Save supy output to Parquet format.
 
@@ -672,15 +673,17 @@ def save_df_output_parquet(
     )
     list_path_save.append(path_output)
 
-    # Save final state separately
-    filename_state = (
-        f"{site}_SUEWS_state_final.parquet" if site else "SUEWS_state_final.parquet"
-    )
-    path_state = path_dir_save / filename_state
-    df_state_final.to_parquet(
-        path_state, engine=engine, compression="snappy", index=True
-    )
-    list_path_save.append(path_state)
+    if save_state:
+        filename_state = (
+            f"{site}_SUEWS_state_final.parquet"
+            if site
+            else "SUEWS_state_final.parquet"
+        )
+        path_state = path_dir_save / filename_state
+        df_state_final.to_parquet(
+            path_state, engine=engine, compression="snappy", index=True
+        )
+        list_path_save.append(path_state)
 
     # Save metadata as a separate small parquet file
     filename_meta = (

--- a/src/supy/_supy_module.py
+++ b/src/supy/_supy_module.py
@@ -884,6 +884,7 @@ def _save_supy(
     debug=False,
     output_config=None,
     output_format=None,
+    save_state: bool = True,
 ) -> list:
     """Save SuPy run results to files.
 
@@ -914,6 +915,10 @@ def _save_supy(
         whether to enable debug mode (e.g., writing out in serial mode, and other debug uses), by default False.
     output_config : OutputConfig, optional
         Output configuration object specifying format, frequency, and groups to save. If provided, overrides freq_s parameter.
+    save_state : bool, optional
+        Whether to write the legacy DFState restart artifact. Legacy callers
+        keep the historical default ``True``; the OOP API writes typed
+        checkpoint JSON instead.
 
 
     Returns
@@ -1013,6 +1018,7 @@ def _save_supy(
             site,
             path_dir_save,
             save_tstep,
+            save_state=save_state,
         )
     else:
         # Save as text files (existing behavior)
@@ -1030,11 +1036,11 @@ def _save_supy(
 
         # MP: Parquet saves this already - breaks the parquet save check
         # save df_state
-        if path_runcontrol is not None:
+        if save_state and path_runcontrol is not None:
             # save as nml as SUEWS binary
             list_path_nml = save_initcond_nml(df_state_final, site, path_dir_save)
             list_path_save += list_path_nml
-        else:
+        elif save_state:
             # save as supy csv for later use
             path_state_save = save_df_state(df_state_final, site, path_dir_save)
             # update list_path_save

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -13,6 +13,7 @@ py.install_sources(
         '_var_metadata.py',
         '_version.py',
         '_version_scm.py',
+        'suews_checkpoint.py',
         'suews_forcing.py',
         'suews_output.py',
         'suews_sim.py',

--- a/src/supy/suews_checkpoint.py
+++ b/src/supy/suews_checkpoint.py
@@ -1,0 +1,157 @@
+"""Typed restart checkpoint support for SUEWS simulations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+
+from ._version_scm import __version__
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _normalise_timestamp(value: Any | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, pd.Timestamp):
+        return value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _state_to_json(value: Any) -> str:
+    if isinstance(value, str):
+        json.loads(value)
+        return value
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _state_to_object(value: str) -> Any:
+    return json.loads(value)
+
+
+def _normalise_grid_states(grid_states: Mapping[Any, Any]) -> dict[int, str]:
+    if not grid_states:
+        raise ValueError("SUEWSCheckpoint requires at least one grid state.")
+
+    normalised: dict[int, str] = {}
+    for grid_id, state in grid_states.items():
+        normalised[int(grid_id)] = _state_to_json(state)
+    return normalised
+
+
+def _infer_state_schema_version(grid_states: Mapping[int, str]) -> int | None:
+    versions: set[int] = set()
+    for state_json in grid_states.values():
+        payload = _state_to_object(state_json)
+        if isinstance(payload, dict) and payload.get("schema_version") is not None:
+            versions.add(int(payload["schema_version"]))
+
+    if len(versions) > 1:
+        raise ValueError(
+            "SUEWSCheckpoint grid states contain multiple state schema versions: "
+            f"{sorted(versions)}"
+        )
+    return next(iter(versions), None)
+
+
+@dataclass(frozen=True)
+class SUEWSCheckpoint:
+    """Typed restart artifact carrying Rust SUEWS state JSON by grid ID."""
+
+    grid_states: dict[int, str]
+    supy_version: str = __version__
+    state_schema_version: int | None = None
+    created_at: str = field(default_factory=_utc_now_iso)
+    last_timestamp: str | None = None
+
+    def __post_init__(self) -> None:
+        normalised_states = _normalise_grid_states(self.grid_states)
+        object.__setattr__(self, "grid_states", normalised_states)
+        object.__setattr__(self, "supy_version", self.supy_version or __version__)
+        object.__setattr__(self, "created_at", self.created_at or _utc_now_iso())
+
+        if self.state_schema_version is None:
+            object.__setattr__(
+                self,
+                "state_schema_version",
+                _infer_state_schema_version(normalised_states),
+            )
+        else:
+            object.__setattr__(
+                self, "state_schema_version", int(self.state_schema_version)
+            )
+
+        object.__setattr__(
+            self, "last_timestamp", _normalise_timestamp(self.last_timestamp)
+        )
+
+    @classmethod
+    def from_grid_states(
+        cls,
+        grid_states: Mapping[Any, Any],
+        *,
+        supy_version: str | None = None,
+        state_schema_version: int | None = None,
+        created_at: str | None = None,
+        last_timestamp: Any | None = None,
+    ) -> "SUEWSCheckpoint":
+        """Build a checkpoint from Rust ``state_json`` values keyed by grid ID."""
+        return cls(
+            grid_states=dict(grid_states),
+            supy_version=supy_version or __version__,
+            state_schema_version=state_schema_version,
+            created_at=created_at or _utc_now_iso(),
+            last_timestamp=_normalise_timestamp(last_timestamp),
+        )
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SUEWSCheckpoint":
+        """Load a checkpoint from a decoded JSON mapping."""
+        if "grid_states" not in payload:
+            raise ValueError("Checkpoint JSON must contain a 'grid_states' object.")
+        return cls(
+            grid_states=dict(payload["grid_states"]),
+            supy_version=str(payload.get("supy_version") or __version__),
+            state_schema_version=payload.get("state_schema_version"),
+            created_at=str(payload.get("created_at") or _utc_now_iso()),
+            last_timestamp=payload.get("last_timestamp"),
+        )
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "SUEWSCheckpoint":
+        """Read a checkpoint JSON file."""
+        path = Path(path).expanduser().resolve()
+        with path.open("r", encoding="utf-8") as checkpoint_file:
+            payload = json.load(checkpoint_file)
+        return cls.from_dict(payload)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable checkpoint payload."""
+        return {
+            "supy_version": self.supy_version,
+            "state_schema_version": self.state_schema_version,
+            "created_at": self.created_at,
+            "last_timestamp": self.last_timestamp,
+            "grid_states": {
+                str(grid_id): _state_to_object(state_json)
+                for grid_id, state_json in sorted(self.grid_states.items())
+            },
+        }
+
+    def to_file(self, path: str | Path) -> Path:
+        """Write the checkpoint JSON file and return its path."""
+        path = Path(path).expanduser().resolve()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as checkpoint_file:
+            json.dump(self.to_dict(), checkpoint_file, indent=2)
+            checkpoint_file.write("\n")
+        return path

--- a/src/supy/suews_output.py
+++ b/src/supy/suews_output.py
@@ -4,10 +4,14 @@ SUEWSOutput - OOP wrapper for SUEWS simulation results.
 Provides a structured interface for accessing and exporting SUEWS model output data.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
+
+from .suews_checkpoint import SUEWSCheckpoint
 
 
 class SUEWSOutput:
@@ -25,6 +29,8 @@ class SUEWSOutput:
         Final model state DataFrame
     config : SUEWSConfig, optional
         Configuration used for this run
+    checkpoint : SUEWSCheckpoint, optional
+        Typed restart checkpoint from the Rust backend
     metadata : dict, optional
         Additional metadata (timing, version, etc.)
 
@@ -54,7 +60,7 @@ class SUEWSOutput:
 
     Restart runs:
 
-    >>> sim2 = SUEWSSimulation.from_state(output.state_final)
+    >>> sim2 = SUEWSSimulation.from_checkpoint(config, output.checkpoint)
     """
 
     def __init__(
@@ -63,6 +69,7 @@ class SUEWSOutput:
         df_state_final: pd.DataFrame,
         config: Optional[Any] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        checkpoint: Optional[SUEWSCheckpoint] = None,
     ):
         """
         Initialise SUEWSOutput.
@@ -75,6 +82,8 @@ class SUEWSOutput:
             Final model state DataFrame
         config : SUEWSConfig, optional
             Configuration used for this run (for save context)
+        checkpoint : SUEWSCheckpoint, optional
+            Typed restart checkpoint from the Rust backend
         metadata : dict, optional
             Additional metadata (timing, version, etc.)
         """
@@ -83,6 +92,7 @@ class SUEWSOutput:
             df_state_final.copy() if df_state_final is not None else None
         )
         self._config = config
+        self._checkpoint = checkpoint
         self._metadata = metadata or {}
 
     # =========================================================================
@@ -112,9 +122,9 @@ class SUEWSOutput:
     @property
     def state_final(self) -> pd.DataFrame:
         """
-        Final model state for restart runs.
+        Legacy final model state DataFrame.
 
-        Use with SUEWSSimulation.from_state() or from_output() to continue simulations.
+        Prefer ``checkpoint`` for restart/continuation workflows.
 
         Returns
         -------
@@ -122,6 +132,16 @@ class SUEWSOutput:
             Final state DataFrame ready for restart
         """
         return self._df_state_final.copy()
+
+    @property
+    def checkpoint(self) -> Optional[SUEWSCheckpoint]:
+        """Typed checkpoint for restart/continuation runs."""
+        return self._checkpoint
+
+    @property
+    def state_checkpoint(self) -> Optional[SUEWSCheckpoint]:
+        """Alias for ``checkpoint``."""
+        return self._checkpoint
 
     @property
     def times(self) -> pd.DatetimeIndex:
@@ -397,10 +417,11 @@ class SUEWSOutput:
 
         resampled = resample_output(self, freq, _internal=True)
         return SUEWSOutput(
-            resampled,
-            self._df_state_final,
-            self._config,
-            {**self._metadata, "resampled_to": freq},
+            df_output=resampled,
+            df_state_final=self._df_state_final,
+            config=self._config,
+            metadata={**self._metadata, "resampled_to": freq},
+            checkpoint=self._checkpoint,
         )
 
     # =========================================================================
@@ -458,7 +479,7 @@ class SUEWSOutput:
             except AttributeError:
                 pass
 
-        return _save_supy(
+        list_path_save = _save_supy(
             df_output=self._df_output,
             df_state_final=self._df_state_final,
             freq_s=int(freq),
@@ -466,7 +487,17 @@ class SUEWSOutput:
             path_dir_save=str(path),
             output_config=output_config,
             output_format=format,
+            save_state=False,
         )
+
+        if self._checkpoint is not None:
+            checkpoint_name = (
+                f"{site}_SUEWS_checkpoint.json" if site else "SUEWS_checkpoint.json"
+            )
+            checkpoint_path = self._checkpoint.to_file(path / checkpoint_name)
+            list_path_save.append(checkpoint_path)
+
+        return list_path_save
 
     # =========================================================================
     # Rich display

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -22,6 +22,7 @@ from .data_model import RefValue
 from .data_model.core import SUEWSConfig
 
 # Import new OOP classes
+from .suews_checkpoint import SUEWSCheckpoint
 from .suews_forcing import SUEWSForcing
 from .suews_output import SUEWSOutput
 from .util._io import read_forcing
@@ -81,6 +82,7 @@ class SUEWSSimulation:
         self._df_forcing = None
         self._df_output = None
         self._df_state_final = None
+        self._checkpoint = None
         self._run_completed = False
 
         if config is not None:
@@ -540,14 +542,26 @@ class SUEWSSimulation:
             raise ValueError(f"Invalid forcing data: {issues_summary}{suffix}")
 
         # Run simulation via Rust bridge
-        df_output, _ = run_suews_rust_chunked(
+        initial_state_json_by_grid = (
+            self._checkpoint.grid_states if self._checkpoint is not None else None
+        )
+        df_output, dict_state_json = run_suews_rust_chunked(
             config=self._config,
             df_forcing=df_forcing_slice,
             chunk_day=chunk_day,
+            initial_state_json_by_grid=initial_state_json_by_grid,
         )
         self._df_output = df_output
+        self._checkpoint = (
+            SUEWSCheckpoint.from_grid_states(
+                dict_state_json,
+                last_timestamp=df_forcing_slice.index.max(),
+            )
+            if dict_state_json
+            else None
+        )
 
-        # Build state_final: copy initial state + version metadata
+        # Keep a legacy DFState-shaped final state for compatibility only.
         from ._version import __version__
 
         df_state_final = self._df_state_init.copy()
@@ -561,6 +575,7 @@ class SUEWSSimulation:
             df_output=self._df_output,
             df_state_final=self._df_state_final,
             config=self._config,
+            checkpoint=self._checkpoint,
         )
 
     def save(
@@ -676,7 +691,16 @@ class SUEWSSimulation:
             # **save_kwargs # Problematic, save_supy expects explicit arguments
             output_config=output_config,
             output_format=output_format,
+            save_state=False,
         )
+
+        if self._checkpoint is not None:
+            checkpoint_name = (
+                f"{site}_SUEWS_checkpoint.json" if site else "SUEWS_checkpoint.json"
+            )
+            checkpoint_path = self._checkpoint.to_file(output_path / checkpoint_name)
+            list_path_save.append(checkpoint_path)
+
         return list_path_save
 
     def reset(self) -> "SUEWSSimulation":
@@ -694,6 +718,7 @@ class SUEWSSimulation:
         """
         self._df_output = None
         self._df_state_final = None
+        self._checkpoint = None
         self._run_completed = False
         return self
 
@@ -755,13 +780,62 @@ class SUEWSSimulation:
         sim._df_forcing = df_forcing
         return sim
 
+    @staticmethod
+    def _coerce_checkpoint(
+        checkpoint: Union[str, Path, SUEWSCheckpoint],
+    ) -> SUEWSCheckpoint:
+        if isinstance(checkpoint, SUEWSCheckpoint):
+            return checkpoint
+        if isinstance(checkpoint, (str, Path)):
+            return SUEWSCheckpoint.from_file(checkpoint)
+        raise TypeError(
+            "checkpoint must be a SUEWSCheckpoint, str, or Path, "
+            f"got {type(checkpoint).__name__}"
+        )
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        config: Union[str, Path, dict, SUEWSConfig],
+        checkpoint: Union[str, Path, SUEWSCheckpoint],
+    ) -> "SUEWSSimulation":
+        """Create a continuation simulation from YAML config and checkpoint."""
+        if config is None:
+            raise ValueError(
+                "Checkpoint continuation requires a YAML/SUEWSConfig "
+                "configuration as well as the checkpoint."
+            )
+
+        sim = cls()
+        if not isinstance(config, (str, Path, dict)):
+            config = copy.deepcopy(config)
+        sim.update_config(config, auto_load_forcing=False)
+        return sim.continue_from(checkpoint)
+
+    def continue_from(
+        self, checkpoint: Union[str, Path, SUEWSCheckpoint]
+    ) -> "SUEWSSimulation":
+        """Use a typed checkpoint as the initial runtime state."""
+        if self._config is None:
+            raise RuntimeError(
+                "Checkpoint continuation requires a loaded configuration. "
+                "Use SUEWSSimulation.from_checkpoint(config, checkpoint) or "
+                "call update_config() before continue_from()."
+            )
+
+        self._checkpoint = self._coerce_checkpoint(checkpoint)
+        self._df_output = None
+        self._df_state_final = None
+        self._run_completed = False
+        return self
+
     @classmethod
     def from_state(cls, state: Union[str, Path, pd.DataFrame]):
-        """Create SUEWSSimulation from saved state for continuation runs.
+        """Create SUEWSSimulation from legacy DFState.
 
-        Load a previously saved model state to continue simulation from where
-        it left off. Useful for multi-period runs or scenario testing with
-        different forcing data.
+        This compatibility adapter reads older DFState CSV/parquet/DataFrame
+        artifacts. New continuation workflows should use
+        ``from_checkpoint(config, checkpoint)``.
 
         Parameters
         ----------
@@ -785,7 +859,7 @@ class SUEWSSimulation:
 
         Examples
         --------
-        Continue from saved file:
+        Legacy import from saved file:
 
         >>> # Period 1
         >>> sim1 = SUEWSSimulation("config.yaml")
@@ -793,12 +867,12 @@ class SUEWSSimulation:
         >>> sim1.run()
         >>> paths = sim1.save("output/")
 
-        >>> # Period 2 - continue from saved state
+        >>> # Period 2 - legacy DFState continuation
         >>> sim2 = SUEWSSimulation.from_state("output/df_state.csv")
         >>> sim2.update_forcing("forcing_2024.txt")
         >>> sim2.run()
 
-        Continue from DataFrame directly:
+        Legacy import from DataFrame directly:
 
         >>> # In-memory continuation without saving to file
         >>> sim1 = SUEWSSimulation.from_sample_data()
@@ -818,10 +892,19 @@ class SUEWSSimulation:
 
         See Also
         --------
-        save : Save simulation results and state
+        from_checkpoint : Create continuation from YAML config and checkpoint
+        save : Save simulation results and checkpoint
         reset : Clear results and reset to initial state
-        state_final : Access final state from completed simulation
+        checkpoint : Access typed checkpoint from completed simulation
         """
+        warnings.warn(
+            "SUEWSSimulation.from_state() is a legacy DFState compatibility "
+            "adapter. Use SUEWSSimulation.from_checkpoint(config, checkpoint) "
+            "for restart/continuation runs.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         from ._version import __version__ as current_version
 
         # Load state from file or use DataFrame directly
@@ -901,7 +984,7 @@ class SUEWSSimulation:
         Returns
         -------
         SUEWSSimulation
-            Simulation instance initialised with final state from output,
+            Simulation instance initialised with checkpoint from output,
             ready for new forcing data and run.
 
         Examples
@@ -913,24 +996,34 @@ class SUEWSSimulation:
         >>> sim1.update_forcing("forcing_2023.txt")
         >>> output1 = sim1.run()
 
-        >>> # Continue from output state
+        >>> # Continue from output checkpoint
         >>> sim2 = SUEWSSimulation.from_output(output1)
         >>> sim2.update_forcing("forcing_2024.txt")
         >>> output2 = sim2.run()
 
         See Also
         --------
-        from_state : Create from saved state file or DataFrame
-        SUEWSOutput.state_final : Final state property for restart
+        from_checkpoint : Create from YAML config and checkpoint
+        SUEWSOutput.checkpoint : Typed checkpoint property for restart
         """
-        df_state_init = output.state_final
-        sim = cls()
-        sim._df_state_init = df_state_init
-        # Deep copy config to avoid shared state issues
-        if output.config is not None:
-            sim._config = copy.deepcopy(output.config)
+        if output.checkpoint is not None:
+            if output.config is None:
+                raise RuntimeError(
+                    "SUEWSOutput has a checkpoint but no configuration. "
+                    "Use SUEWSSimulation.from_checkpoint(config, checkpoint)."
+                )
+            return cls.from_checkpoint(
+                copy.deepcopy(output.config),
+                output.checkpoint,
+            )
 
-        return sim
+        warnings.warn(
+            "SUEWSSimulation.from_output() is falling back to legacy DFState. "
+            "Prefer SUEWSSimulation.from_checkpoint(config, output.checkpoint).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.from_state(output.state_final)
 
     def __repr__(self) -> str:
         """Concise representation showing simulation status.
@@ -1240,6 +1333,7 @@ class SUEWSSimulation:
             df_output=self._df_output,
             df_state_final=self._df_state_final,
             config=self._config,
+            checkpoint=self._checkpoint,
         )
 
     @property
@@ -1255,8 +1349,8 @@ class SUEWSSimulation:
         See Also
         --------
         :ref:`df_state_var` : Complete state data structure and variable descriptions
-        state_final : Final state after simulation
-        from_state : Create simulation from existing state
+        checkpoint : Typed checkpoint after simulation
+        from_checkpoint : Create simulation from checkpoint
 
         Examples
         --------
@@ -1268,15 +1362,14 @@ class SUEWSSimulation:
 
     @property
     def state_final(self) -> Optional[pd.DataFrame]:
-        """Final state DataFrame after simulation.
+        """Legacy final state DataFrame after simulation.
 
-        Available only after running simulation. Contains evolved
-        state variables that can be used to continue simulation.
+        Prefer ``checkpoint`` for restart/continuation workflows.
 
         Returns
         -------
         pandas.DataFrame or None
-            Final state after simulation run.
+            Legacy final state after simulation run.
             None if simulation hasn't been run yet.
 
         See Also
@@ -1284,7 +1377,8 @@ class SUEWSSimulation:
         :ref:`df_state_var` : Complete state data structure and variable descriptions
         state_init : Initial state before simulation
         reset : Clear results and reset to initial state
-        from_state : Create new simulation from this final state
+        checkpoint : Typed restart artifact
+        from_checkpoint : Create new simulation from checkpoint
 
         Examples
         --------
@@ -1294,3 +1388,13 @@ class SUEWSSimulation:
         True
         """
         return self._df_state_final
+
+    @property
+    def checkpoint(self) -> Optional[SUEWSCheckpoint]:
+        """Typed checkpoint produced by the most recent run."""
+        return self._checkpoint
+
+    @property
+    def state_checkpoint(self) -> Optional[SUEWSCheckpoint]:
+        """Alias for ``checkpoint``."""
+        return self._checkpoint

--- a/test/core/test_checkpoint.py
+++ b/test/core/test_checkpoint.py
@@ -1,0 +1,152 @@
+"""Tests for typed SUEWS restart checkpoints."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
+
+from supy.suews_checkpoint import SUEWSCheckpoint
+from supy.suews_sim import SUEWSSimulation
+
+pytestmark = pytest.mark.api
+
+
+def test_checkpoint_json_roundtrip(tmp_path):
+    """Checkpoint files preserve typed Rust state by grid ID."""
+    payload = {"schema_version": 3, "members": {"demo_state": {"value": 1}}}
+    checkpoint = SUEWSCheckpoint.from_grid_states(
+        {1: json.dumps(payload)},
+        last_timestamp=pd.Timestamp("2012-01-01 00:55:00"),
+    )
+
+    path = checkpoint.to_file(tmp_path / "site_SUEWS_checkpoint.json")
+    loaded = SUEWSCheckpoint.from_file(path)
+
+    assert loaded.grid_states.keys() == {1}
+    assert json.loads(loaded.grid_states[1]) == payload
+    assert loaded.state_schema_version == 3
+    assert loaded.last_timestamp == "2012-01-01T00:55:00"
+
+
+def test_run_stores_non_empty_checkpoint():
+    """SUEWSSimulation.run() exposes Rust state_json as a checkpoint."""
+    sim = SUEWSSimulation.from_sample_data()
+    forcing = sim.forcing.df.iloc[:12]
+    sim.update_forcing(forcing)
+
+    output = sim.run()
+
+    assert isinstance(sim.checkpoint, SUEWSCheckpoint)
+    assert output.checkpoint == sim.checkpoint
+    assert sim.checkpoint.grid_states
+    assert sim.checkpoint.last_timestamp == forcing.index.max().isoformat()
+
+
+def test_checkpoint_continuation_calls_rust_state_path(monkeypatch):
+    """Continuation from checkpoint uses run_suews_with_state."""
+    import supy._run_rust as rust_module
+
+    sim1 = SUEWSSimulation.from_sample_data()
+    forcing = sim1.forcing.df.iloc[:24]
+    sim1.update_forcing(forcing.iloc[:12])
+    sim1.run()
+
+    calls = {"count": 0}
+    original = rust_module.run_suews_rust_with_state
+
+    def wrapped_run_suews_rust_with_state(*args, **kwargs):
+        calls["count"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        rust_module,
+        "run_suews_rust_with_state",
+        wrapped_run_suews_rust_with_state,
+    )
+
+    sim2 = SUEWSSimulation.from_checkpoint(sim1.config, sim1.checkpoint)
+    sim2.update_forcing(forcing.iloc[12:24])
+    sim2.run()
+
+    assert calls["count"] >= 1
+
+
+def test_split_run_matches_continuous_run_with_checkpoint():
+    """A checkpoint continuation matches key continuous-run outputs."""
+    sim_full = SUEWSSimulation.from_sample_data()
+    forcing = sim_full.forcing.df.iloc[:48]
+    sim_full.update_forcing(forcing)
+    output_full = sim_full.run()
+
+    sim_first = SUEWSSimulation.from_sample_data()
+    sim_first.update_forcing(forcing.iloc[:24])
+    sim_first.run()
+
+    sim_second = SUEWSSimulation.from_checkpoint(
+        sim_first.config,
+        sim_first.checkpoint,
+    )
+    sim_second.update_forcing(forcing.iloc[24:48])
+    output_second = sim_second.run()
+
+    expected_second = output_full.df.loc[output_second.df.index]
+    tolerances = {
+        "QN": {"rtol": 0.008, "atol": 0.1},
+        "QF": {"rtol": 0.008, "atol": 0.1},
+        "QS": {"rtol": 0.010, "atol": 0.2},
+        "QE": {"rtol": 0.010, "atol": 0.2},
+        "QH": {"rtol": 0.010, "atol": 0.2},
+        "T2": {"rtol": 0.005, "atol": 0.05},
+        "RH2": {"rtol": 0.010, "atol": 0.5},
+        "U10": {"rtol": 0.010, "atol": 0.05},
+    }
+
+    for var_name, tolerance in tolerances.items():
+        column = ("SUEWS", var_name)
+        if column not in output_second.df.columns:
+            continue
+        assert np.allclose(
+            output_second.df[column],
+            expected_second[column],
+            rtol=tolerance["rtol"],
+            atol=tolerance["atol"],
+            equal_nan=True,
+        ), f"{var_name} differs outside tolerance"
+
+
+def test_from_checkpoint_requires_config():
+    """A checkpoint alone is not enough to continue a run."""
+    checkpoint = SUEWSCheckpoint.from_grid_states(
+        {1: {"schema_version": 1, "members": {}}}
+    )
+
+    with pytest.raises(ValueError, match="requires a YAML/SUEWSConfig"):
+        SUEWSSimulation.from_checkpoint(None, checkpoint)
+
+    with pytest.raises(RuntimeError, match="requires a loaded configuration"):
+        SUEWSSimulation().continue_from(checkpoint)
+
+
+def test_checkpoint_file_continuation_roundtrip(tmp_path):
+    """Checkpoint JSON files can be read back into continuation runs."""
+    config_path = files("supy").joinpath("sample_data/sample_config.yml")
+    sim1 = SUEWSSimulation(str(config_path))
+    forcing = sim1.forcing.df.iloc[:24]
+    sim1.update_forcing(forcing.iloc[:12])
+    sim1.run()
+
+    checkpoint_path = sim1.checkpoint.to_file(tmp_path / "Kc_SUEWS_checkpoint.json")
+    sim2 = SUEWSSimulation.from_checkpoint(config_path, checkpoint_path)
+    sim2.update_forcing(forcing.iloc[12:24])
+    output = sim2.run()
+
+    assert output.checkpoint is not None
+    assert not output.df.empty
+    assert Path(checkpoint_path).exists()

--- a/test/core/test_checkpoint.py
+++ b/test/core/test_checkpoint.py
@@ -134,6 +134,21 @@ def test_from_checkpoint_requires_config():
         SUEWSSimulation().continue_from(checkpoint)
 
 
+def test_checkpoint_grid_ids_must_match_config():
+    """Checkpoint continuation rejects missing and unexpected grid states."""
+    config_path = files("supy").joinpath("sample_data/sample_config.yml")
+    sim = SUEWSSimulation(str(config_path))
+    forcing = sim.forcing.df.iloc[:12]
+    sim.update_forcing(forcing)
+    checkpoint = SUEWSCheckpoint.from_grid_states(
+        {2: {"schema_version": 1, "members": {}}}
+    )
+    sim.continue_from(checkpoint)
+
+    with pytest.raises(ValueError, match="missing checkpoint states.*unexpected"):
+        sim.run()
+
+
 def test_checkpoint_file_continuation_roundtrip(tmp_path):
     """Checkpoint JSON files can be read back into continuation runs."""
     config_path = files("supy").joinpath("sample_data/sample_config.yml")

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -11,6 +11,7 @@ except ImportError:
     from importlib_resources import files
 
 import supy as sp
+from supy.suews_checkpoint import SUEWSCheckpoint
 from supy.suews_sim import SUEWSSimulation
 
 pytestmark = pytest.mark.api
@@ -500,6 +501,8 @@ class TestSave:
         assert isinstance(paths, list)
         assert len(paths) > 0
         assert any(Path(p).exists() for p in paths)
+        assert any("checkpoint.json" in Path(p).name for p in paths)
+        assert not any("df_state" in Path(p).name for p in paths)
 
     def test_save_without_results(self):
         """Test save fails without results."""
@@ -775,10 +778,10 @@ class TestPathResolution:
 
 
 class TestContinuationRuns:
-    """Test continuation runs using from_state() method."""
+    """Test continuation runs using typed checkpoints."""
 
-    def test_from_state_csv(self, tmp_path):
-        """Test loading state from CSV for continuation."""
+    def test_from_checkpoint_file(self, tmp_path):
+        """Test loading typed checkpoint JSON for continuation."""
         # Run initial simulation
         sim1 = SUEWSSimulation.from_sample_data()
 
@@ -787,18 +790,18 @@ class TestContinuationRuns:
 
         df_forcing = df_forcing_full.iloc[:TIMESTEPS_PER_DAY]  # First day only
         sim1.update_forcing(df_forcing)
-        sim1.run()
+        output1 = sim1.run()
+        assert isinstance(output1.checkpoint, SUEWSCheckpoint)
 
-        # Save state
+        # Save checkpoint
         paths = sim1.save(str(tmp_path))
 
-        # Find state file
-        state_file = [p for p in paths if "df_state" in str(p)][0]
-        assert Path(state_file).exists()
+        checkpoint_file = [p for p in paths if "checkpoint.json" in str(p)][0]
+        assert Path(checkpoint_file).exists()
 
         # Load state for continuation
-        sim2 = SUEWSSimulation.from_state(state_file)
-        assert sim2._df_state_init is not None
+        sim2 = SUEWSSimulation.from_checkpoint(sim1.config, checkpoint_file)
+        assert sim2.checkpoint is not None
         assert sim2.is_ready() is False  # No forcing yet
 
         # Add forcing and run continuation
@@ -811,8 +814,8 @@ class TestContinuationRuns:
         sim2.run()
         assert sim2.is_complete() is True
 
-    def test_from_state_parquet(self, tmp_path):
-        """Test loading state from Parquet for continuation."""
+    def test_save_parquet_writes_checkpoint_not_df_state(self, tmp_path):
+        """Test OOP parquet save writes checkpoint as the restart artifact."""
         pytest.importorskip("pyarrow", reason="Parquet support requires pyarrow")
 
         # Run initial simulation
@@ -825,16 +828,16 @@ class TestContinuationRuns:
         sim1.update_forcing(df_forcing)
         sim1.run()
 
-        # Save state in Parquet format
+        # Save output in Parquet format
         paths = sim1.save(str(tmp_path), format="parquet")
 
-        # Find state file (looks for pattern: {site}_SUEWS_state_final.parquet)
-        state_file = [p for p in paths if "SUEWS_state_final.parquet" in str(p)][0]
-        assert Path(state_file).exists()
+        checkpoint_file = [p for p in paths if "checkpoint.json" in str(p)][0]
+        assert Path(checkpoint_file).exists()
+        assert not any("SUEWS_state_final.parquet" in str(p) for p in paths)
 
         # Load state for continuation
-        sim2 = SUEWSSimulation.from_state(state_file)
-        assert sim2._df_state_init is not None
+        sim2 = SUEWSSimulation.from_checkpoint(sim1.config, checkpoint_file)
+        assert sim2.checkpoint is not None
 
         # Continue simulation
         df_forcing_2 = df_forcing_full.iloc[
@@ -860,7 +863,8 @@ class TestContinuationRuns:
         df_state_final = sim1.state_final
 
         # Create new simulation from DataFrame
-        sim2 = SUEWSSimulation.from_state(df_state_final)
+        with pytest.warns(DeprecationWarning, match="legacy DFState"):
+            sim2 = SUEWSSimulation.from_state(df_state_final)
         assert sim2._df_state_init is not None
         assert sim2.is_ready() is False  # No forcing yet
 
@@ -885,10 +889,13 @@ class TestContinuationRuns:
         state_file = tmp_path / "df_state_old.csv"
         df_state.to_csv(state_file)
 
-        # Loading should trigger version warning
-        with pytest.warns(UserWarning, match="compatibility issues"):
+        # Loading should trigger legacy and version warnings
+        with pytest.warns(Warning) as warning_record:
             sim2 = SUEWSSimulation.from_state(state_file)
 
+        warning_messages = [str(item.message) for item in warning_record]
+        assert any("legacy DFState" in msg for msg in warning_messages)
+        assert any("compatibility issues" in msg for msg in warning_messages)
         assert sim2._df_state_init is not None
 
     def test_from_state_file_not_found(self):

--- a/test/core/test_supy.py
+++ b/test/core/test_supy.py
@@ -240,16 +240,16 @@ class TestSuPy(TestCase):
         print("Metadata columns correctly stored as plain strings")
 
     def test_version_tracking_save_load_cycle(self):
-        """Test complete save→load→run cycle with version tracking.
+        """Test complete checkpoint save/load/run cycle with version tracking.
 
         This test verifies that:
         1. Version info is automatically saved with state
-        2. Saved state (with version) can be loaded
-        3. Loaded state can be used to continue simulation
+        2. A typed checkpoint can be saved and loaded
+        3. Loaded checkpoint can be used to continue simulation
         4. Version info persists through the cycle
         """
         print("\n========================================")
-        print("Testing complete save→load→run cycle with version tracking...")
+        print("Testing complete checkpoint save/load/run cycle with version tracking...")
 
         # Run 1: Initial simulation
         sim1 = SUEWSSimulation.from_sample_data()
@@ -260,17 +260,28 @@ class TestSuPy(TestCase):
         version_from_run1 = sim1.state_final[("version", "0")].iloc[0]
         self.assertEqual(version_from_run1, sp.__version__)
 
-        # Save state to temporary location
+        # Save checkpoint to temporary location
         with tempfile.TemporaryDirectory() as tmpdir:
             save_path = Path(tmpdir)
             sim1.save(save_path)
 
-            # Verify state file was created
+            # Verify checkpoint file was created as the restart artifact
+            checkpoint_files = list(save_path.glob("*_checkpoint.json"))
+            self.assertGreater(
+                len(checkpoint_files),
+                0,
+                "Checkpoint file should be created",
+            )
             state_files = list(save_path.glob("*_state_*.csv"))
-            self.assertGreater(len(state_files), 0, "State file should be created")
+            self.assertEqual(
+                state_files,
+                [],
+                "OOP save should not create legacy DFState CSV by default",
+            )
 
-            # Run 2: Load saved state and continue simulation
-            sim2 = SUEWSSimulation.from_state(sim1.state_final)
+            # Run 2: Load saved checkpoint and continue simulation
+            checkpoint = sp.SUEWSCheckpoint.from_file(checkpoint_files[0])
+            sim2 = SUEWSSimulation.from_checkpoint(sim1.config, checkpoint)
 
             # Load forcing for continuation (using remaining timesteps)
             sim2.update_forcing(sim1.forcing.iloc[12:24])  # Next 12 timesteps
@@ -288,10 +299,11 @@ class TestSuPy(TestCase):
             self.assertEqual(
                 version_from_run2,
                 sp.__version__,
-                "Version should persist through save→load→run cycle",
+                "Version should persist through checkpoint save/load/run cycle",
             )
+            self.assertEqual(sim2.checkpoint.supy_version, sp.__version__)
 
-        print("✓ Version tracking works correctly through save→load→run cycle")
+        print("Version tracking works correctly through checkpoint save/load/run cycle")
 
     # # test if single-tstep and multi-tstep modes can produce the same SUEWS results
     # @skipUnless(flag_full_test, "Full test is not required.")

--- a/test/umep/test_processor.py
+++ b/test/umep/test_processor.py
@@ -2,10 +2,9 @@
 
 This module tests the functions used by UMEP Processor plugin:
 - init_config_from_yaml(): Load configuration
-- config.to_df_state(): Convert to DataFrame
+- SUEWSSimulation(config.yml): Preferred YAML-backed runtime
 - load_forcing_grid(): Load forcing data
-- run_supy(): Execute model
-- save_supy(): Save output
+- run_supy()/save_supy(): Legacy DFState compatibility
 
 Reference:
 https://github.com/UMEP-dev/UMEP-processing/blob/82bc3266d8cb4d04359994b1cae5cf082d09c47c/processor/suews_algorithm.py#L265
@@ -53,27 +52,15 @@ class TestSUEWSProcessorAPI(TestCase):
         self.assertTrue(hasattr(config, "model"))
         self.assertTrue(hasattr(config, "sites"))
 
-    def test_config_to_df_state(self):
-        """Test config.to_df_state() method used by UMEP."""
-        from supy.data_model import init_config_from_yaml
-
+    def test_yaml_config_runtime(self):
+        """Test the preferred YAML-backed runtime used by UMEP."""
         if not self.sample_config.exists():
             self.skipTest("Sample config not available")
 
-        config = init_config_from_yaml(self.sample_config)
-
-        # UMEP calls config.to_df_state()
-        self.assertTrue(
-            hasattr(config, "to_df_state"),
-            "Config object must have to_df_state() method",
-        )
-
-        df_state = config.to_df_state()
-
-        # Verify DataFrame structure
-        self.assertIsInstance(df_state, pd.DataFrame)
-        self.assertFalse(df_state.empty)
-        self.assertEqual(df_state.index.name, "grid")
+        sim = sp.SUEWSSimulation(self.sample_config)
+        self.assertIsNotNone(sim.config)
+        self.assertIsNotNone(sim.state_init)
+        self.assertIsNotNone(sim.forcing)
 
     def test_load_forcing_grid_import(self):
         """Test that load_forcing_grid is importable from expected location."""


### PR DESCRIPTION
## Summary

Supersedes #1343 and redirects #1338 away from DFState dual-write.

- add `SUEWSCheckpoint` as a typed JSON restart artifact carrying Rust `state_json` by `grid_id`
- thread checkpoint state through `SUEWSSimulation.run()` and `run_suews_rust_chunked()` so continuation uses `run_suews_with_state`
- expose `checkpoint` / `state_checkpoint` on `SUEWSSimulation` and `SUEWSOutput`
- add `SUEWSSimulation.from_checkpoint(config, checkpoint)` and `sim.continue_from(checkpoint)`
- keep DFState through deprecated legacy adapters while OOP save writes checkpoint JSON instead of new DFState restart files
- update tests and docs to treat YAML config + checkpoint JSON as the restart/continue path

## Tests

- `PYTHONPATH=src .venv/bin/python -m pytest test/core/test_checkpoint.py -q`
- `PYTHONPATH=src .venv/bin/python -m pytest test/core/test_suews_simulation.py::TestSave test/core/test_suews_simulation.py::TestContinuationRuns test/umep/test_processor.py -q`
- `PYTHONPATH=src .venv/bin/python -m pytest test/core/test_public_api_wrappers.py test/core/test_supy.py::TestSuPy::test_is_supy_save_working -q`
- `PYTHONPATH=src PYTHON=.venv/bin/python make test-smoke`

Closes #1338