### PR TITLE
docs: document typed checkpoint restarts

### DIFF
--- a/docs/source/api/io-data-structures.rst
+++ b/docs/source/api/io-data-structures.rst
@@ -6,7 +6,8 @@ Key IO Data Structures
 Introduction
 ------------
 
-The Python API uses four key pandas DataFrame structures for simulation input and output:
+The Python API uses pandas DataFrame structures for analysis data and a typed
+checkpoint object for restart workflows:
 
 .. code-block:: python
 
@@ -14,23 +15,25 @@ The Python API uses four key pandas DataFrame structures for simulation input an
 
    # Load sample data and run simulation
    sim = SUEWSSimulation.from_sample_data()
-   sim.run()
+   output = sim.run()
 
    # Access the data structures
    df_state_init = sim.df_state_init   # Input: initial states
    df_forcing = sim.df_forcing         # Input: forcing data
    df_output = sim.results             # Output: simulation results
-   df_state_final = sim.df_state_final # Output: final states
+   df_state_final = sim.df_state_final # Legacy/developer final states
+   checkpoint = output.checkpoint      # Preferred restart artefact
 
 **Input DataFrames:**
 
 - ``df_state_init``: Model initial states and configuration parameters
 - ``df_forcing``: Meteorological forcing data time series
 
-**Output DataFrames:**
+**Output and restart objects:**
 
 - ``df_output`` (or ``sim.results``): Model output results for scientific analysis
-- ``df_state_final``: Model final states, usable as initial conditions for subsequent simulations
+- ``df_state_final``: Legacy/developer final states for compatibility and inspection
+- ``SUEWSCheckpoint``: Typed runtime state for continuation runs
 
 
 Input
@@ -161,14 +164,52 @@ model states.
 
    [2 rows x 1200 columns]
 
-This structure facilitates reuse as initial model states for subsequent simulations:
+This structure is retained for compatibility and state inspection:
 
 - **Runtime diagnostics**: Save intermediate states with ``save_state=True`` in ``run_supy``
-- **Chained simulations**: Use end state as initial conditions for future runs starting
-  at the ending time of previous runs
+- **Developer inspection**: Examine flattened state variables in DataFrame form
 
 The meanings of state variables in ``df_state_final`` are the same as in ``df_state_init``,
 documented in :doc:`/data-structures/df_state`.
+
+For new object-oriented continuation workflows, use ``SUEWSCheckpoint`` rather
+than ``df_state_final`` as the restart artefact.
+
+
+.. _suews_checkpoint:
+
+``SUEWSCheckpoint``: typed restart state
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``SUEWSCheckpoint`` carries typed backend runtime state keyed by grid ID. It is
+the preferred restart artefact for new object-oriented workflows.
+
+The checkpoint is intentionally only the typed runtime state. It does not
+contain the full YAML configuration or forcing data. To continue a run, load the
+same YAML configuration, attach the next forcing period, and run from
+``SUEWSSimulation.from_checkpoint(...)``:
+
+.. code-block:: python
+
+   from supy import SUEWSCheckpoint, SUEWSSimulation
+
+   checkpoint = SUEWSCheckpoint.from_file("{site}_SUEWS_checkpoint.json")
+
+   sim_next = SUEWSSimulation.from_checkpoint(
+       "config.yml",
+       checkpoint,
+   )
+   sim_next.update_forcing("forcing_next_period.txt")
+   output_next = sim_next.run()
+
+Use ``checkpoint.to_file(path)`` to write the checkpoint explicitly, or
+``sim.save(path)`` to save it alongside the configured output files. Checkpoints
+are keyed by grid ID, so checkpoint/configuration grid mismatches are rejected
+by the runtime.
+
+.. autoclass:: supy.SUEWSCheckpoint
+   :members: from_file, to_file
+   :undoc-members:
 
 
 Related Documentation
@@ -177,4 +218,5 @@ Related Documentation
 - :doc:`/data-structures/df_state` - Complete state variable reference
 - :doc:`/data-structures/df_forcing` - Forcing variable reference
 - :doc:`/data-structures/df_output` - Output variable reference
+- :ref:`suews_checkpoint` - Typed checkpoint restart artefact
 - :doc:`/auto_examples/tutorial_01_quick_start` - Interactive tutorial with DataFrame examples

--- a/docs/source/api/simulation.rst
+++ b/docs/source/api/simulation.rst
@@ -13,6 +13,7 @@ Key Features
 - **YAML Configuration**: Load configurations from YAML files
 - **Configuration Updates**: Update configuration with dictionaries or YAML files
 - **Forcing Management**: Load single files, lists of files, or DataFrames
+- **Checkpoint Restarts**: Continue YAML-based runs from typed checkpoint JSON
 - **Simple API**: Clean interface focused on essential functionality
 - **Format Support**: Save results in txt or parquet formats via OutputConfig
 
@@ -52,6 +53,8 @@ For spin-up runs, state continuation, and deep model inspection.
 
     ~SUEWSSimulation.state_init
     ~SUEWSSimulation.state_final
+    ~SUEWSSimulation.checkpoint
+    ~SUEWSSimulation.state_checkpoint
 
 .. _sim_setup_methods:
 
@@ -66,6 +69,8 @@ Configure simulations, load forcing data, and initialise from various sources.
     ~SUEWSSimulation.update_config
     ~SUEWSSimulation.update_forcing
     ~SUEWSSimulation.from_sample_data
+    ~SUEWSSimulation.from_checkpoint
+    ~SUEWSSimulation.continue_from
     ~SUEWSSimulation.from_state
 
 .. _sim_execution_methods:
@@ -94,6 +99,20 @@ Save results to files and extract specific variables from output groups.
     ~SUEWSSimulation.save
     ~SUEWSSimulation.get_variable
 
+Run Output
+^^^^^^^^^^
+
+``run()`` returns a :class:`SUEWSOutput` object. Use its ``checkpoint`` property
+as the restart artefact for continuation runs; ``state_final`` is retained as a
+legacy/developer DataFrame view.
+
+.. autosummary::
+    :nosignatures:
+
+    ~SUEWSOutput.checkpoint
+    ~SUEWSOutput.state_checkpoint
+    ~SUEWSOutput.state_final
+
 
 Full Class Reference
 ^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +134,7 @@ Quick Example
     # Create and run simulation
     sim = SUEWSSimulation('config.yml')
     sim.update_forcing('forcing_data.txt')
-    sim.run()
+    output = sim.run()
 
     # Access results - use get_variable() for safe extraction
     qh = sim.get_variable('QH')              # Sensible heat flux
@@ -126,6 +145,15 @@ Quick Example
 
     # Save results
     sim.save('output_dir/')
+
+    # Continue from the typed checkpoint and the next forcing period
+    output.checkpoint.to_file('output_dir/{site}_SUEWS_checkpoint.json')
+    sim_next = SUEWSSimulation.from_checkpoint(
+        'config.yml',
+        'output_dir/{site}_SUEWS_checkpoint.json',
+    )
+    sim_next.update_forcing('forcing_next_period.txt')
+    output_next = sim_next.run()
 
     # Update configuration and re-run
     sim.update_config({'model': {'control': {'tstep': 600}}})
@@ -147,5 +175,6 @@ Related Documentation
    - :doc:`dts` - DTS backend for performance-optimised execution
 
 - :doc:`/inputs/yaml/index` - YAML configuration guide
+- :ref:`suews_checkpoint` - Typed checkpoint restart artefact
 - :doc:`/data-structures/df_forcing` - Forcing data format
 - :doc:`/data-structures/df_output` - Output data format

--- a/docs/source/inputs/yaml/examples/output_config_parquet.yml
+++ b/docs/source/inputs/yaml/examples/output_config_parquet.yml
@@ -33,4 +33,4 @@ sites:
 
 # Output files created:
 # - {site}_SUEWS_output.parquet - All output data (all years, all groups)
-# - {site}_SUEWS_state_final.parquet - Final model state for restart runs
+# - {site}_SUEWS_checkpoint.json - Typed restart checkpoint

--- a/docs/source/outputs/index.rst
+++ b/docs/source/outputs/index.rst
@@ -30,19 +30,23 @@ See :doc:`../inputs/yaml/index` for configuration details.
    legacy_text_columns
 
 
-State Output
-------------
+Restart Checkpoint
+------------------
 
-df_state_SSss.csv
-^^^^^^^^^^^^^^^^^
+{site}_SUEWS_checkpoint.json
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-SUEWS automatically outputs a df_state_SSss.csv file containing:
+Object-oriented SUEWS runs save ``{site}_SUEWS_checkpoint.json`` as the
+preferred restart artefact. It contains typed runtime state from the backend,
+keyed by grid ID.
 
-- Model configuration parameters
-- Initial and final states
-- Simulation metadata (SUEWS version, timestamps, etc.)
+The checkpoint is intentionally only the typed runtime state. To continue a run,
+load the same YAML configuration, attach the next forcing period, and run from
+``SUEWSSimulation.from_checkpoint(...)``.
 
-This file preserves model state for analysis and restart purposes.
+Legacy ``df_state_SSss.csv`` and state parquet files remain documented for
+backwards compatibility and developer inspection, but they are not the preferred
+restart artefact for new object-oriented workflows.
 
 
 Temporal Information

--- a/docs/source/outputs/parquet_format.rst
+++ b/docs/source/outputs/parquet_format.rst
@@ -18,13 +18,18 @@ large-scale SUEWS simulations.
 Output Files
 ------------
 
-When using parquet format, SUEWS produces two output files:
+When using parquet format through the object-oriented API, SUEWS produces the
+analysis output parquet file and a checkpoint JSON restart artefact:
 
 - **SSss_SUEWS_output.parquet** - All simulation output in a single file, including
   all output groups and years. See :doc:`variables/index` for variable details.
 
-- **SSss_SUEWS_state_final.parquet** - Final model state for restart runs.
+- **{site}_SUEWS_checkpoint.json** - Typed runtime state for restart runs.
   See :ref:`State Persistence <state-persistence>` for details.
+
+Legacy and developer workflows may still produce
+``SSss_SUEWS_state_final.parquet`` for DataFrame state inspection, but it is not
+the preferred restart artefact for new object-oriented workflows.
 
 
 Reading Parquet Files

--- a/docs/source/outputs/text_format.rst
+++ b/docs/source/outputs/text_format.rst
@@ -3,14 +3,17 @@
 Text Format Output
 ==================
 
-Since version ``2025.10.15`` (see :ref:`release notes <new_2025.10.15>`), when using
-text format (default), SUEWS produces two types of output files:
+Since version ``2025.10.15`` (see :ref:`release notes <new_2025.10.15>`), text
+format output is organised as tab-delimited simulation files by output group and
+simulation year. Current object-oriented workflows also save a typed checkpoint
+JSON file for continuation runs:
 
-1. **Simulation output files** - Tab-delimited files organised by output group and
-   simulation year. See :ref:`Output Groups <output-groups>` for details.
+- **Simulation output files** - Tab-delimited files organised by output group and
+  simulation year. See :ref:`Output Groups <output-groups>` for details.
 
-2. **State persistence file** - A CSV file (``df_state_SSss.csv``) containing model
-   state for restart and analysis. See :ref:`State Persistence <state-persistence>`.
+- **Restart checkpoint** - A JSON file (``{site}_SUEWS_checkpoint.json``)
+  containing typed runtime state for continuation runs. See
+  :ref:`State Persistence <state-persistence>`.
 
 .. note::
 
@@ -18,8 +21,9 @@ text format (default), SUEWS produces two types of output files:
    Some features are retained in the modern format (e.g., output level control via
    ``groups``), while others have been adapted:
 
-   - **State persistence**: Legacy ``InitialConditionsSSss_YYYY.nml`` files replaced
-     by modern ``df_state_SSss.csv``
+   - **State persistence**: Legacy ``InitialConditionsSSss_YYYY.nml`` files are
+     replaced by typed checkpoint JSON in new object-oriented workflows.
+     ``df_state_SSss.csv`` remains available for legacy and developer workflows.
    - **Error/warning messages**: Legacy ``problems.txt`` and ``warnings.txt`` files
      are no longer written; diagnostics are emitted to stdout/stderr and handled by
      the Python runtime logger (SuPy).
@@ -213,22 +217,31 @@ Group Details
 State Persistence
 -----------------
 
-SUEWS automatically saves model state for restart and analysis purposes using the
-modern CSV-based state file format.
+SUEWS saves typed runtime state for continuation runs using checkpoint JSON.
 
-At the end of each simulation, SUEWS writes a ``df_state_SSss.csv`` file containing:
+At the end of each object-oriented simulation, ``sim.run()`` exposes
+``output.checkpoint`` and ``sim.save(...)`` writes
+``{site}_SUEWS_checkpoint.json``. The checkpoint contains:
 
-- Model configuration parameters
-- Initial and final states for all surface types
-- Simulation metadata (SUEWS version, timestamps, etc.)
+- Backend runtime state keyed by grid ID
+- SUEWS/SuPy version metadata
+- The last forcing timestamp represented by the checkpoint
 
 This file can be used to:
 
 1. **Restart simulations** - Continue from a saved state
-2. **Analyse model state** - Inspect internal variables
-3. **Chain simulations** - Use end state as input for subsequent runs
+2. **Chain simulations** - Use end state as input for subsequent runs
+3. **Preserve typed backend state** - Avoid lossy DataFrame restart conversion
 
-See `df_state_final: model final states <../api/io-data-structures.html#df-state-final>`_ for details on the state data structure.
+The checkpoint is intentionally only the typed runtime state. To continue a run,
+load the same YAML configuration, attach the next forcing period, and run from
+``SUEWSSimulation.from_checkpoint(...)``.
+
+``df_state_SSss.csv`` and ``df_state_final`` remain legacy/developer-facing
+DataFrame structures for backwards compatibility and state inspection. They are
+not the preferred restart artefact for new object-oriented workflows. See
+`SUEWSCheckpoint: typed restart state <../api/io-data-structures.html#suews-checkpoint>`_
+for details.
 
 
 .. _legacy-output-control:
@@ -274,7 +287,9 @@ Legacy Initial Conditions Output
 
 **InitialConditionsSSss_YYYY.nml**
    The legacy namelist-based initial conditions files are deprecated.
-   Use the modern ``df_state_SSss.csv`` files instead (see :ref:`State Persistence <state-persistence>`).
+   Use checkpoint JSON for new object-oriented restart workflows (see
+   :ref:`State Persistence <state-persistence>`). ``df_state_SSss.csv`` remains
+   a legacy/developer compatibility file.
 
 See :doc:`variables/index` for the complete list of output variables.
 

--- a/docs/source/tutorials/tutorial_03_initial_conditions.py
+++ b/docs/source/tutorials/tutorial_03_initial_conditions.py
@@ -12,6 +12,7 @@ You will learn:
 
 1. **Understanding state variables** - What SUEWS tracks and why it matters
 2. **Spin-up strategies** - Equilibrating the model before analysis
+   and carrying typed checkpoints forward
 3. **Seasonal adjustments** - Setting appropriate states for different start dates
 4. **Common pitfalls** - Avoiding unrealistic initial conditions
 
@@ -68,21 +69,21 @@ print(f"  Final soil moisture (mean): {sim.state_final.filter(like='soilstore').
 # Method 1: Full Year Spin-Up
 # ---------------------------
 #
-# Run one year before your analysis period and use the final state as
-# initial conditions. This is the most robust approach.
+# Run one year before your analysis period and use the typed checkpoint as
+# the restart artefact. This is the most robust approach.
 
 # Step 1: Run spin-up year
 sim_spinup = SUEWSSimulation.from_sample_data()
 _ = sim_spinup.run()
 
-# Step 2: Get equilibrated state
-state_equilibrated = sim_spinup.state_final.copy()
+# Step 2: Get equilibrated typed checkpoint
+checkpoint_equilibrated = sim_spinup.checkpoint
 
 print("Spin-up complete!")
-print("Equilibrated state ready for analysis period")
+print("Equilibrated checkpoint ready for analysis period")
 
 # Step 3: Use for analysis (in practice, you'd load new forcing data)
-# sim_analysis = SUEWSSimulation.from_state(state_equilibrated)
+# sim_analysis = SUEWSSimulation.from_checkpoint(sim_spinup.config, checkpoint_equilibrated)
 # sim_analysis.update_forcing('forcing_2015.txt')
 # sim_analysis.run()
 
@@ -104,12 +105,12 @@ soil_history.append(sim.state_final.filter(like="soilstore").mean().mean())
 # Capture forcing once -- it stays the same across all spin-up iterations.
 forcing_data = sim.forcing
 
-# Spin-up iterations: reuse the same forcing but transfer evolved state.
+# Spin-up iterations: reuse the same forcing but transfer evolved checkpoints.
 # Typically 2-3 iterations suffice for convergence (change < 1 mm).
 n_spinup = 3
 for i in range(n_spinup):
-    # Create new simulation from final state and re-attach forcing
-    sim_next = SUEWSSimulation.from_state(sim.state_final)
+    # Create new simulation from checkpoint and re-attach forcing
+    sim_next = SUEWSSimulation.from_checkpoint(sim.config, sim.checkpoint)
     sim_next.update_forcing(forcing_data)
     _ = sim_next.run()
     soil_history.append(sim_next.state_final.filter(like="soilstore").mean().mean())

--- a/docs/source/tutorials/tutorial_05_results_analysis.py
+++ b/docs/source/tutorials/tutorial_05_results_analysis.py
@@ -423,11 +423,11 @@ export_df = get_vars(output, export_vars)
 print(f"Export DataFrame shape: {export_df.shape}")
 print(f"Ready to save with: export_df.to_csv('suews_output.csv')")
 
-# Export final state for restart runs
-final_state = sim.state_final
-# final_state.to_csv('final_state.csv')  # Uncomment to save
-print(f"\nFinal state shape: {final_state.shape}")
-print("Ready to save with: final_state.to_csv('final_state.csv')")
+# Save typed checkpoint for restart runs
+checkpoint = output.checkpoint
+# checkpoint.to_file('Kc_SUEWS_checkpoint.json')  # Uncomment to save
+print("\nCheckpoint ready for restart runs")
+print("Ready to save with: checkpoint.to_file('Kc_SUEWS_checkpoint.json')")
 
 # %%
 # Summary

--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -332,13 +332,37 @@ Once you have a YAML configuration file, use the `SUEWSSimulation` class:
    sim = SUEWSSimulation("path/to/your/config_suews.yml")
 
    # Run simulation (forcing data loaded from config)
-   sim.run()
+   output = sim.run()
 
    # Access results
    print(sim.results)
 
    # Save outputs
    sim.save("output_directory/")
+
+   # Save the typed restart artefact explicitly
+   checkpoint_path = output.checkpoint.to_file(
+       "output_directory/{site}_SUEWS_checkpoint.json"
+   )
+
+To continue a simulation, pair the same YAML configuration with the checkpoint
+from the previous run and the next forcing period:
+
+.. code-block:: python
+
+   from supy import SUEWSSimulation
+
+   sim_next = SUEWSSimulation.from_checkpoint(
+       "path/to/your/config_suews.yml",
+       "output_directory/{site}_SUEWS_checkpoint.json",
+   )
+   sim_next.update_forcing("forcing_next_period.txt")
+   output_next = sim_next.run()
+
+The checkpoint is intentionally only the typed runtime state. To continue a
+run, load the same YAML configuration, attach the next forcing period, and run
+from ``SUEWSSimulation.from_checkpoint(...)``. Checkpoints are keyed by grid ID,
+so checkpoint/configuration grid mismatches are rejected by the runtime.
 
 For detailed examples, see :doc:`/sub-tutorials/suews-simulation-tutorial`.
 
@@ -381,8 +405,8 @@ Multi-Site and Comparative Studies
    def run_site(config_file):
        """Run SUEWS for a single site configuration"""
        sim = SUEWSSimulation(config_file)
-       sim.run()
-       return config_file, (sim.results, sim.state_final)
+       output = sim.run()
+       return config_file, output
 
    # Configuration files for different sites
    site_configs = [
@@ -395,19 +419,15 @@ Multi-Site and Comparative Studies
    with Pool() as pool:
        results = pool.map(run_site, site_configs)
 
-   # Note: Each result tuple contains (df_output, df_state_final)
-   # We need to access variables using the simulation object or helper
+   # Note: Each result tuple contains a SUEWSOutput object. Its checkpoint
+   # can be saved or passed to SUEWSSimulation.from_checkpoint(...) later.
 
-   # Create simulations from stored states to access get_variable()
    monthly_temps = {}
-   for name, (output, state) in results:
-       # Recreate sim with results for get_variable() access
-       sim_temp = SUEWSSimulation()
-       sim_temp._df_output = output
-       sim_temp._run_completed = True
-
-       t2 = sim_temp.get_variable('T2', group='SUEWS')
+   checkpoints = {}
+   for name, output in results:
+       t2 = output.get_variable('T2', group='SUEWS')
        monthly_temps[name] = t2.iloc[:, 0].groupby(t2.index.month).mean()
+       checkpoints[name] = output.checkpoint
 
    temp_comparison = pd.DataFrame(monthly_temps)
    temp_comparison.plot(kind='bar', title='Monthly Temperature Comparison')


### PR DESCRIPTION
## Summary

- Documents typed checkpoint JSON as the preferred object-oriented restart artefact.
- Adds the `config.yml + {site}_SUEWS_checkpoint.json + forcing_next_period.txt` continuation workflow.
- Updates output docs, API docs, tutorials, and parquet example comments so `df_state_*` restart wording is legacy/developer-facing.

## Dependency

Depends on #1344. This is intentionally stacked on `sunt05/gh1338-typed-checkpoint` while the runtime/API PR remains open.

Closes #1346.

## Validation

- `git diff --check` passed.
- `python3 -m py_compile docs/source/tutorials/tutorial_03_initial_conditions.py docs/source/tutorials/tutorial_05_results_analysis.py` passed.
- API import check passed for `SUEWSCheckpoint`, `SUEWSSimulation.from_checkpoint`, `SUEWSSimulation.continue_from`, and `SUEWSOutput.checkpoint`.
- `make docs` is currently blocked on the #1344 base: `make dev` fails in Fortran with `anthroemis_prm` expecting `startdls` but seeing `start_dls`; source-path docs then fail in Sphinx-Gallery because the Rust backend is unavailable.
- `make test-smoke` ran and failed two backend-dependent checks: Rust CLI `interp_z` failure and missing Rust Python bridge.
