### PR TITLE
Optimize SUEWS test tiers

### DIFF
--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -115,6 +115,19 @@ The tier axis composes with the nature axis. CI expressions like
 `-m "api and smoke"` and `-m "physics and not slow"` select the right
 subset per matrix cell.
 
+### PR/CR placement
+
+- `smoke`: minimal fail-fast checks only. Keep this tier small enough for quick
+  wheel validation.
+- `core`: essential guardrails that are fast enough for draft PRs and merge
+  queue. Do not mark a test `core` merely because the feature matters; use
+  `slow` if the regression is important but expensive.
+- `standard`: all non-slow tests for the relevant nature axis.
+- `slow`: long regressions and reproductions. These belong in `make test-all`,
+  scheduled/release builds, or explicit manual validation, not normal PR/CR.
+- `qgis`: UMEP/QGIS tests only. These are Windows + Python 3.12 specific and
+  should stay out of local `make test` unless selected explicitly.
+
 ---
 
 ## Test File Locations

--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -93,7 +93,9 @@ When unsure, pick `api` — it's the broader coverage axis and safer if
 the test is genuinely mixed.
 
 UMEP tests (`test/umep/*.py`) pick up `api` automatically via
-`test/umep/conftest.py`; no file-level declaration needed there.
+`test/umep/conftest.py`; no file-level declaration needed there. These remain
+needed with the Rust backend because they guard the UMEP/QGIS plugin-facing API
+contracts rather than model physics.
 
 **A static CI lint (`scripts/lint/check_test_markers.py`) and a
 `pytest_collection_finish` hook in `test/conftest.py` both fail any PR
@@ -125,8 +127,10 @@ subset per matrix cell.
 - `standard`: all non-slow tests for the relevant nature axis.
 - `slow`: long regressions and reproductions. These belong in `make test-all`,
   scheduled/release builds, or explicit manual validation, not normal PR/CR.
-- `qgis`: UMEP/QGIS tests only. These are Windows + Python 3.12 specific and
-  should stay out of local `make test` unless selected explicitly.
+- `qgis`: UMEP/QGIS tests only. These target Windows + Python 3.12, which
+  matches the current Windows runtime line for both QGIS 3 LTR and QGIS 4.
+  They should stay out of local `make test` and normal PR/CR tiers unless
+  selected explicitly.
 
 ---
 

--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -169,10 +169,10 @@ runs:
         CIBW_TEST_COMMAND: >-
           python {project}/scripts/suews/run_ci_tests.py {project}
           -v --tb=short --durations=10
-          ${{ inputs.test_tier == 'smoke' && '-m "physics and smoke"' ||
-              inputs.test_tier == 'core' && '-m "physics and (smoke or core)"' ||
-              inputs.test_tier == 'cfg' && '-m "physics and (smoke or cfg)"' ||
-              inputs.test_tier == 'standard' && '-m "physics and (not slow or core)"' ||
+          ${{ inputs.test_tier == 'smoke' && '-m "physics and smoke and not slow"' ||
+              inputs.test_tier == 'core' && '-m "physics and (smoke or core) and not slow"' ||
+              inputs.test_tier == 'cfg' && '-m "physics and (smoke or cfg) and not slow"' ||
+              inputs.test_tier == 'standard' && '-m "physics and not slow"' ||
               inputs.test_tier == 'all' && '-m physics' ||
               '-m physics' }}
         MACOSX_DEPLOYMENT_TARGET: '15.0'

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -63,15 +63,20 @@ When triggering via Actions tab → "Run workflow", you can configure:
 - **deploy_target**: `none` (validation) or `testpypi` (PyPI restricted to tags)
 - **test_tier**: `smoke`, `core`, `cfg`, `standard`, or `all`
 
-Every cp39-abi3 wheel also covers QGIS 3 LTR (NumPy 1.26.4) — the runtime
-pin is `numpy>=1.22` and the Rust bridge has no NumPy C-ABI dependency.
+Every cp39-abi3 wheel also covers the current Windows QGIS 3 LTR and QGIS 4
+Python line. Both use Python 3.12 on Windows; the runtime pin is
+`numpy>=1.22` and the Rust bridge has no NumPy C-ABI dependency.
 
 **Test tier routing:**
 - Wheel-build jobs run `physics` tests once per selected platform/architecture.
 - API cross-CPython jobs install the built wheel and run `api` tests across the
   selected Python versions.
-- `smoke`, `core`, `cfg`, and `standard` all exclude `slow`; `all` is reserved
-  for scheduled builds, tagged releases, and explicit manual validation.
+- `smoke`, `core`, `cfg`, and `standard` all exclude `slow` and `qgis`; `all`
+  is reserved for scheduled builds, tagged releases, and explicit manual
+  validation.
+- UMEP/QGIS tests are `api + qgis`: they are not physics backend tests, and
+  run only when `all` reaches the Windows + Python 3.12 compatibility cell or
+  when selected explicitly.
 
 ### 4. GitHub Pages Deploy (`pages-deploy.yml`)
 Deploys static site content to GitHub Pages at suews.io:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -66,6 +66,13 @@ When triggering via Actions tab → "Run workflow", you can configure:
 Every cp39-abi3 wheel also covers QGIS 3 LTR (NumPy 1.26.4) — the runtime
 pin is `numpy>=1.22` and the Rust bridge has no NumPy C-ABI dependency.
 
+**Test tier routing:**
+- Wheel-build jobs run `physics` tests once per selected platform/architecture.
+- API cross-CPython jobs install the built wheel and run `api` tests across the
+  selected Python versions.
+- `smoke`, `core`, `cfg`, and `standard` all exclude `slow`; `all` is reserved
+  for scheduled builds, tagged releases, and explicit manual validation.
+
 ### 4. GitHub Pages Deploy (`pages-deploy.yml`)
 Deploys static site content to GitHub Pages at suews.io:
 - Deploys `site/` directory content on push to master

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -12,9 +12,12 @@ name: Build and Publish Python wheels to PyPI and TestPyPI
 # Build strategy:
 #   One cp39-abi3 wheel per (OS, arch). The Rust bridge (PyO3 abi3-py39)
 #   makes the binary ABI-stable, so a single wheel installs on cp39..cp3xx.
-#   Covers QGIS 3 LTR (NumPy 1.26.4), QGIS 4 (NumPy 2.x), and general users
-#   — the runtime pin is numpy>=1.22 (Rust bridge has no NumPy C-ABI
-#   dependency; pure-Python code uses only NumPy 1.22-compatible APIs).
+#   Covers current Windows QGIS 3 LTR, QGIS 4, and general users — the runtime
+#   pin is numpy>=1.22 (Rust bridge has no NumPy C-ABI dependency; pure-Python
+#   code uses only NumPy 1.22-compatible APIs).
+#   UMEP/QGIS tests are integration-contract tests, not physics tests; normal
+#   PR tiers exclude qgis and scheduled/release/manual `all` runs cover the
+#   Windows + Python 3.12 runtime shared by current QGIS 3 LTR and QGIS 4.
 #
 # Nightly version: Tag YYYY.M.D.dev created BEFORE build for version consistency.
 # See get_ver_git.py for version string logic, .github/path-filters.yml for categories.

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -69,9 +69,9 @@ jobs:
           TIER: ${{ inputs.test_tier }}
         run: |
           case "$TIER" in
-            smoke)    EXPR='api and smoke' ;;
-            core)     EXPR='api and (smoke or core)' ;;
-            cfg)      EXPR='api and (smoke or cfg)' ;;
+            smoke)    EXPR='api and smoke and not slow' ;;
+            core)     EXPR='api and (smoke or core) and not slow' ;;
+            cfg)      EXPR='api and (smoke or cfg) and not slow' ;;
             standard) EXPR='api and not slow' ;;
             all)      EXPR='api' ;;
             *)        echo "::error::Unknown test_tier: $TIER"; exit 1 ;;

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -1,5 +1,8 @@
 # Reusable workflow: install the cp39-abi3 wheel into each supported CPython
-# version and run `pytest -m "api and <tier>"`.
+# version and run `pytest -m "api and <tier>"`. Normal tiers exclude the
+# QGIS/UMEP integration lane; `all` keeps it for scheduled/release/manual
+# validation where the Windows + Python 3.12 cell matches current QGIS 3 LTR
+# and QGIS 4 Windows runtimes.
 #
 # Called by build-publish_to_pypi.yml. The `api` marker (gh#1300) covers the
 # Python wrapper surface — pandas/numpy/pydantic, CLI, SUEWSSimulation —
@@ -69,10 +72,10 @@ jobs:
           TIER: ${{ inputs.test_tier }}
         run: |
           case "$TIER" in
-            smoke)    EXPR='api and smoke and not slow' ;;
-            core)     EXPR='api and (smoke or core) and not slow' ;;
-            cfg)      EXPR='api and (smoke or cfg) and not slow' ;;
-            standard) EXPR='api and not slow' ;;
+            smoke)    EXPR='api and smoke and not slow and not qgis' ;;
+            core)     EXPR='api and (smoke or core) and not slow and not qgis' ;;
+            cfg)      EXPR='api and (smoke or cfg) and not slow and not qgis' ;;
+            standard) EXPR='api and not slow and not qgis' ;;
             all)      EXPR='api' ;;
             *)        echo "::error::Unknown test_tier: $TIER"; exit 1 ;;
           esac

--- a/Makefile
+++ b/Makefile
@@ -199,14 +199,14 @@ test:
 	@echo "NOTE: Slow tests (e.g., Fortran state persistence ~3-4 min) are skipped."
 	@echo "      Run 'make test-all' for comprehensive testing."
 	@echo ""
-	$(PYTHON) -m pytest test -m "not slow" -v --tb=short --durations=10
+	$(PYTHON) -m pytest test -m "not slow and not qgis" -v --tb=short --durations=10
 
 # Smoke tests - fast critical path tests for CI
 test-smoke:
 	@echo "Running smoke tests (critical path only)..."
 	@echo "This is the fastest test tier for CI wheel validation."
 	@echo ""
-	$(PYTHON) -m pytest test -m "smoke" -v --tb=short --durations=10
+	$(PYTHON) -m pytest test -m "smoke and not slow and not qgis" -v --tb=short --durations=10
 
 # All tests including slow tests
 test-all:

--- a/Makefile
+++ b/Makefile
@@ -190,10 +190,11 @@ rebuild-meson:
 		fi; \
 	fi
 
-# Run tests - Three tiers available:
+# Run tests - Four local entry points available:
 # - test-smoke: Fast critical tests (~30-60 sec) - used in CI wheel validation
 # - test: Standard tests excluding slow (~2-3 min) - default for development
 # - test-all: All tests including slow (~4-5 min) - comprehensive validation
+# - test-qgis: UMEP/QGIS compatibility tests (Windows + Python 3.12 target)
 test:
 	@echo "Running standard tests (excluding slow tests)..."
 	@echo "NOTE: Slow tests (e.g., Fortran state persistence ~3-4 min) are skipped."
@@ -214,6 +215,14 @@ test-all:
 	@echo "This may take 4-5 minutes."
 	@echo ""
 	$(PYTHON) -m pytest test -v --tb=short --durations=10
+
+# UMEP/QGIS compatibility tests
+test-qgis:
+	@echo "Running UMEP/QGIS compatibility tests..."
+	@echo "Target runtime is Windows + Python 3.12 (current QGIS 3 LTR / QGIS 4)."
+	@echo "Other platforms/interpreters collect these tests as skipped."
+	@echo ""
+	$(PYTHON) -m pytest test/umep -m "qgis and api" -v --tb=short --durations=10
 
 # Audit installed dependency hooks and declared dependency advisories
 audit-deps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 dependencies = [
     # Data processing
     "pandas",
-    "numpy>=1.22",  # NumPy 1.22+ covers QGIS 3.40 LTR (1.26.4) through 2.x; no ABI constraint (Rust bridge is NumPy-free)
+    "numpy>=1.22",  # Covers current QGIS 3 LTR / QGIS 4 NumPy stacks; no ABI constraint (Rust bridge is NumPy-free)
     "scipy<1.15; python_version >= '3.11' and python_version < '3.13' and platform_system == 'Linux'",  # manylinux2014 wheels
     "scipy; python_version < '3.11' or python_version >= '3.13' or platform_system != 'Linux'",  # Others use latest
     # xarray removed - only needed for gridded ERA5 (install separately)
@@ -153,7 +153,7 @@ markers = [
     "util: Utility function tests (non-critical)",
     "cfg: Config/schema validation tests",
     "slow: Tests taking >30s individually",
-    "qgis: UMEP plugin tests in test/umep/ (Windows + Python 3.12 only)",
+    "qgis: UMEP plugin integration tests in test/umep/ (Windows + Python 3.12 target)",
 ]
 
 [tool.ruff]

--- a/test/README.md
+++ b/test/README.md
@@ -119,6 +119,20 @@ pytest -m "api and not slow"       # wrapper surface, skip slow tests
 pytest -m "physics and api"        # files that straddle both axes
 ```
 
+### PR/CR placement rules
+
+- Put numerical guardrails in `test/physics/` or a clearly named physics file
+  under `test/core/`, mark them `physics`, and add `core` only when they are
+  fast enough for draft PRs and merge-queue checks.
+- Put pandas / numpy / pydantic / CLI / wrapper behaviour in `api` tests. These
+  run across the CPython bookends because the dependency surface varies by
+  interpreter.
+- Mark long regression or reproduction tests `slow`. Slow tests run in
+  `test-all`, scheduled builds, release builds, or explicit manual validation;
+  they are excluded from smoke, core, cfg, standard, and local `make test`.
+- Keep `smoke` tiny: imports, one short model run, and the minimum output
+  validation needed to fail fast.
+
 ### Adding a new test file
 
 Decide which axis the file belongs on, then add one of:

--- a/test/README.md
+++ b/test/README.md
@@ -36,12 +36,19 @@ Input/output and data handling tests:
 - **test_yaml_annotation.py** - YAML annotation features
 
 ### UMEP/QGIS Tests (`umep/`)
-UMEP plugin compatibility tests (Windows + Python 3.12 only, GH-901):
+UMEP plugin compatibility tests (Windows + Python 3.12 target, GH-901):
 - **test_preprocessor.py** - Database Manager, Database Prepare, ERA5 Download APIs
 - **test_processor.py** - SUEWS model runs (init, run, save)
 - **test_postprocessor.py** - Output path handling
 - **test_environment.py** - QGIS-specific environment (None stdout/stderr)
 - **test_imports.py** - Import path verification
+
+These tests are still needed with the Rust backend. They do not duplicate the
+physics guardrails; they protect the UMEP/QGIS integration surface: import
+paths, YAML-backed runtime construction, output path handling, `run_supy`
+calling patterns, and QGIS stdout/stderr behaviour. Current Windows QGIS 3 LTR
+and QGIS 4 runtimes both use Python 3.12, so a single Windows + Python 3.12
+lane is enough for this repository's plugin-facing compatibility checks.
 
 ### Test Fixtures (`fixtures/`)
 Test data and resources:
@@ -60,7 +67,8 @@ pytest test/core/ -v              # Core functionality
 pytest test/data_model/ -v        # Data model tests
 pytest test/physics/ -v           # Physics validation
 pytest test/io_tests/ -v          # I/O tests
-pytest test/umep/ -v -m qgis      # UMEP/QGIS tests (Windows + Python 3.12 only)
+pytest test/umep/ -v -m qgis      # UMEP/QGIS tests (Windows + Python 3.12 target)
+make test-qgis                    # Same QGIS/UMEP lane via Makefile
 
 # Run specific key tests
 pytest test/core/test_sample_output.py -v    # Fast validation
@@ -92,7 +100,9 @@ pytestmark = [pytest.mark.physics, pytest.mark.api]
 ```
 
 UMEP tests pick up `api` automatically via `test/umep/conftest.py`; they
-are gated to Windows + Python 3.12 by the existing `qgis` marker.
+are gated to Windows + Python 3.12 by the existing `qgis` marker. This matches
+the current Windows runtime for both QGIS 3 LTR and QGIS 4; the Qt/PyQt
+difference is outside this repository's direct test surface.
 
 ### Tier axis — how fast or expensive is the test?
 
@@ -107,7 +117,7 @@ are gated to Windows + Python 3.12 by the existing `qgis` marker.
 - `util` — utility function tests (non-critical).
 - `cfg` — config / schema validation tests.
 - `slow` — tests taking more than 30s individually.
-- `qgis` — UMEP plugin tests in `test/umep/` (Windows + Python 3.12).
+- `qgis` — UMEP plugin tests in `test/umep/` (Windows + Python 3.12 target).
 
 ### Selecting a subset
 
@@ -130,6 +140,10 @@ pytest -m "physics and api"        # files that straddle both axes
 - Mark long regression or reproduction tests `slow`. Slow tests run in
   `test-all`, scheduled builds, release builds, or explicit manual validation;
   they are excluded from smoke, core, cfg, standard, and local `make test`.
+- Keep UMEP/QGIS tests under `test/umep/` with the auto-applied `api` + `qgis`
+  markers. They run in `all` validation on the Windows + Python 3.12 cell or
+  through `make test-qgis`; keep them out of normal PR/CR tiers unless a change
+  directly touches the UMEP/QGIS integration contract.
 - Keep `smoke` tiny: imports, one short model run, and the minimum output
   validation needed to fail fast.
 

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -52,7 +52,7 @@ def _get_fail_fast_steps(default_steps: int = DEFAULT_FAIL_FAST_STEPS) -> int:
     """Return validation timesteps for fail-fast execution."""
     raw = os.environ.get(FAIL_FAST_STEPS_ENV)
     if raw is None or raw == "":
-        return default_steps
+        return TIMESTEPS_PER_DAY if default_steps <= 0 else default_steps
     try:
         steps = int(raw)
     except ValueError as exc:
@@ -60,7 +60,7 @@ def _get_fail_fast_steps(default_steps: int = DEFAULT_FAIL_FAST_STEPS) -> int:
             f"{FAIL_FAST_STEPS_ENV} must be an integer, got: {raw!r}"
         ) from exc
 
-    # Non-positive value means "disable fail-fast", use full day window.
+    # Non-positive value means "disable fail-fast", use the full validation day.
     if steps <= 0:
         return TIMESTEPS_PER_DAY
     return steps
@@ -302,7 +302,6 @@ def compare_arrays_with_tolerance(actual, expected, rtol, atol, var_name=""):
 # ============================================================================
 
 
-@pytest.mark.smoke
 class TestSampleOutput(TestCase):
     """Dedicated test class for validating SUEWS outputs against reference data."""
 
@@ -391,6 +390,7 @@ class TestSampleOutput(TestCase):
 
     @pytest.mark.core
     @pytest.mark.rust
+    @pytest.mark.smoke
     def test_sample_output_validation(self):
         """
         Test SUEWS output against reference data with appropriate tolerances.
@@ -572,7 +572,7 @@ if __name__ == "__main__":
 
 
 @pytest.mark.core
-@pytest.mark.slow  # Runs in wheel CI core/standard tiers to catch SPARTACUS/STEBBS regressions early.
+@pytest.mark.slow  # Runs in test-all, scheduled builds, release builds, or manual all-tier validation.
 class TestSTEBBSOutput(TestCase):
     """Test class for validating STEBBS building energy outputs."""
 

--- a/test/core/test_supy.py
+++ b/test/core/test_supy.py
@@ -35,7 +35,7 @@ flag_full_test = True
 # Note: Sample data loading moved to individual test methods to avoid test interference
 # This prevents caching issues when tests run in sequence
 
-pytestmark = [pytest.mark.physics, pytest.mark.api]
+pytestmark = pytest.mark.api
 
 
 class TestSuPy(TestCase):

--- a/test/physics/test_core_physics.py
+++ b/test/physics/test_core_physics.py
@@ -28,20 +28,19 @@ import pytest
 import supy as sp
 from conftest import TIMESTEPS_PER_DAY
 
-pytestmark = pytest.mark.physics
+pytestmark = [pytest.mark.physics, pytest.mark.core]
 
 
 class TestPhysicalValidation(TestCase):
     """Test physical validity of SUEWS outputs."""
 
-    def setUp(self):
-        """Set up test data."""
-        # Load and run a short simulation for testing
-        self.df_state_init, self.df_forcing = sp.load_SampleData()
-        # Run for 7 days to get meaningful statistics
-        self.df_forcing_week = self.df_forcing.iloc[: TIMESTEPS_PER_DAY * 7]
-        self.df_output, self.df_state_final = sp.run_supy(
-            self.df_forcing_week, self.df_state_init
+    @classmethod
+    def setUpClass(cls):
+        """Run the shared weekly simulation once for all physical checks."""
+        cls.df_state_init, cls.df_forcing = sp.load_SampleData()
+        cls.df_forcing_week = cls.df_forcing.iloc[: TIMESTEPS_PER_DAY * 7]
+        cls.df_output, cls.df_state_final = sp.run_supy(
+            cls.df_forcing_week, cls.df_state_init
         )
 
     def test_physical_bounds(self):

--- a/test/umep/__init__.py
+++ b/test/umep/__init__.py
@@ -1,7 +1,9 @@
 """UMEP/QGIS compatibility tests (GH-901).
 
 This package tests SUEWS compatibility with UMEP plugins in QGIS environment.
-Target environment: Windows + Python 3.12 (QGIS 3.40 LTR bundled Python).
+Target environment: Windows + Python 3.12. Current Windows QGIS 3 LTR and
+QGIS 4 runtimes share this CPython line; these tests guard plugin-facing API
+contracts rather than Rust backend physics.
 
 Test modules:
 - test_preprocessor.py: Database Manager, Database Prepare, ERA5 Download

--- a/test/umep/conftest.py
+++ b/test/umep/conftest.py
@@ -1,7 +1,8 @@
 """Pytest configuration for UMEP/QGIS compatibility tests.
 
 Shared markers and constants for all test modules in this directory.
-Target environment: Windows + Python 3.12 (QGIS 3.40 LTR bundled Python).
+Target environment: Windows + Python 3.12. Current Windows QGIS 3 LTR and
+QGIS 4 runtimes both use this CPython line, while differing mainly in Qt/PyQt.
 
 See: https://github.com/UMEP-dev/SUEWS/issues/901
 """
@@ -10,14 +11,14 @@ import sys
 
 import pytest
 
-# Target environment: Windows + Python 3.12 (QGIS 3.40 LTR)
+# Target environment: Windows + Python 3.12 (current QGIS 3 LTR / QGIS 4)
 _IS_WINDOWS = sys.platform == "win32"
 _IS_PY312 = sys.version_info[:2] == (3, 12)
 _IS_QGIS_TARGET = _IS_WINDOWS and _IS_PY312
 
 # Check if safe_stdout_stderr is available (added in PR #903)
 try:
-    from supy.util._era5 import safe_stdout_stderr  # noqa: F401
+    from supy.util._era5 import safe_stdout_stderr  # noqa: F401, PLC2701
 
     _HAS_SAFE_STDOUT_STDERR = True
 except ImportError:
@@ -28,8 +29,10 @@ def pytest_collection_modifyitems(items):
     """Auto-apply qgis + api markers and skip condition to all tests in this directory.
 
     UMEP tests are Python wrapper tests (pydantic/pandas/QGIS plugin glue), so they
-    carry the `api` nature marker (gh#1300). The `qgis` tier gates them to Windows +
-    Python 3.12; the platform skip below enforces that at runtime.
+    carry the `api` nature marker (gh#1300). They still matter with the Rust backend:
+    physics coverage lives elsewhere, while this lane guards plugin-facing API,
+    output-path, import, and QGIS stdout/stderr contracts. The `qgis` tier gates them
+    to Windows + Python 3.12; the platform skip below enforces that at runtime.
     """
     for item in items:
         # Only apply to tests in test/umep/
@@ -39,6 +42,9 @@ def pytest_collection_modifyitems(items):
             if not _IS_QGIS_TARGET:
                 item.add_marker(
                     pytest.mark.skip(
-                        reason="QGIS compatibility tests only run on Windows + Python 3.12 (QGIS 3.40 LTR)"
+                        reason=(
+                            "QGIS compatibility tests only run on Windows + Python 3.12 "
+                            "(current QGIS 3 LTR / QGIS 4 runtime)"
+                        )
                     )
                 )


### PR DESCRIPTION
## Summary
- tighten smoke/core/cfg/standard marker expressions so normal PR/CR paths exclude slow and QGIS-specific tests
- keep `test_supy.py` on the API axis and move only the reference-output check into smoke
- reuse the weekly core-physics simulation across physical validation tests and document tier placement rules
- clarify the QGIS/UMEP strategy: these tests guard plugin-facing API contracts, stay out of normal PR tiers, and run in `all` or explicit `make test-qgis` on the Windows + Python 3.12 target shared by current QGIS 3 LTR and QGIS 4

## Validation
- `python3 scripts/lint/check_test_markers.py`
- `git diff --check`
- `.venv/bin/python -m ruff check test/umep/conftest.py test/umep/__init__.py`
- `PYTHON=.venv/bin/python PATH="$PWD/.venv/bin:$PATH" make test-smoke`
- `PYTHON=.venv/bin/python PATH="$PWD/.venv/bin:$PATH" make test-qgis` (31 skipped locally on macOS/Python 3.13, as expected)
- `.venv/bin/python -m pytest test/physics/test_core_physics.py -q --tb=short --durations=10`
- pytest collection checks for smoke, physics core, physics standard, and API core marker expressions

## Notes
- Code review found no additional issues to fix before publishing this draft PR.