### PR TITLE
Fix STEBBS config aliases and smoke marker

### DIFF
--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -573,6 +573,14 @@ fn legacy_name_for(key: &str) -> Option<(&'static str, &'static str)> {
         .map(|(new_name, old_name)| (*new_name, *old_name))
 }
 
+fn should_rename_key_at_path(new_name: &str, path: &str) -> bool {
+    // `stebbs` is both a ModelPhysics option and a site-properties section.
+    // Only the physics option should be folded to `stebbsmethod`; the
+    // `sites[].properties.stebbs` section must keep its name so the STEBBS
+    // parser can read the parameter and initial-state overrides.
+    new_name != "stebbs" || path == "model.physics"
+}
+
 /// Recursively rewrite new snake_case keys to their legacy fused spellings
 /// so the downstream parser in `yaml_config.rs` keeps seeing the keys it
 /// has always read.
@@ -609,6 +617,7 @@ fn normalize_field_names_at(root: &mut Value, path: &str) -> Result<(), String> 
                 .iter()
                 .filter_map(|(key, _)| match key {
                     Value::String(k) => legacy_name_for(k.as_str())
+                        .filter(|(new_name, _)| should_rename_key_at_path(new_name, path))
                         .map(|(new_name, old_name)| (key.clone(), new_name, old_name)),
                     _ => None,
                 })
@@ -747,6 +756,29 @@ mod tests {
         let paved = &root["sites"][0]["properties"]["land_cover"]["paved"];
         assert!(paved.get("soildepth").is_some());
         assert!(paved.get("soil_depth").is_none());
+    }
+
+    #[test]
+    fn preserves_site_stebbs_section_name() {
+        let yaml = "\
+model:
+  physics:
+    stebbs: {value: 1}
+sites:
+  - properties:
+      stebbs:
+        annual_mean_air_temperature: {value: 10.0}
+";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+
+        let physics = &root["model"]["physics"];
+        assert!(physics.get("stebbsmethod").is_some());
+        assert!(physics.get("stebbs").is_none());
+
+        let properties = &root["sites"][0]["properties"];
+        assert!(properties.get("stebbs").is_some());
+        assert!(properties.get("stebbsmethod").is_none());
     }
 
     #[test]

--- a/src/suews_bridge/src/yaml_config.rs
+++ b/src/suews_bridge/src/yaml_config.rs
@@ -1701,17 +1701,6 @@ fn apply_state_overrides(state: &mut SuewsState, site_root: &Value) {
             "hot_water_heating_setpoint_temperature",
         );
 
-        eprintln!(
-            "DEBUG_STATE_MAP init_out={:?} init_in={:?} annual={:?} deep={:?} month_diffmax={:?} mains={:?} hwt_set={:?}",
-            init_out,
-            init_in,
-            annual_mean_air_temperature,
-            deep_soil,
-            month_mean_air_temperature_diffmax,
-            mains_water,
-            hot_water_setpoint
-        );
-
         if let Some(v) = init_out {
             state.stebbs_state.outdoor_air_start_temperature = v;
             state.stebbs_state.wall_outdoor_surface_temperature = v;
@@ -2219,6 +2208,22 @@ mod tests {
         assert!((run_cfg.site.stebbs.daylight_control - 1.0).abs() < 1.0e-12);
         assert!((run_cfg.site.stebbs.lighting_illuminance_threshold - 300.0).abs() < 1.0e-12);
         assert!((run_cfg.site.building_archtype.lightingpowerdensity - 2.0).abs() < 1.0e-12);
+
+        assert!((run_cfg.state.stebbs_state.deep_soil_temperature - 10.738).abs() < 1.0e-12);
+        assert!(
+            (run_cfg
+                .state
+                .stebbs_state
+                .month_mean_air_temperature_diffmax
+                - 12.947)
+                .abs()
+                < 1.0e-12
+        );
+        assert!(
+            (run_cfg.state.stebbs_state.indoor_air_start_temperature - 17.540002822875977).abs()
+                < 1.0e-12
+        );
+        assert!((run_cfg.state.stebbs_state.mains_water_temperature - 10.0).abs() < 1.0e-12);
     }
 
     #[test]

--- a/test/core/test_supy.py
+++ b/test/core/test_supy.py
@@ -40,6 +40,7 @@ pytestmark = pytest.mark.api
 
 class TestSuPy(TestCase):
     # test if single-tstep mode can run
+    @pytest.mark.physics
     @pytest.mark.smoke
     @pytest.mark.smoke_bridge
     def test_is_supy_running_single_step(self):


### PR DESCRIPTION
## Summary

- Preserve `sites[].properties.stebbs` during YAML field normalisation while still folding `model.physics.stebbs` to the legacy `stebbsmethod` key.
- Remove a temporary `DEBUG_STATE_MAP` stderr print and extend STEBBS config assertions for parsed state overrides.
- Keep the fast single-step SuPy smoke test in the physics smoke lane so the wheel smoke tier still exercises a short model run.

## CI failure analysis

The failed scheduled run was [24946815662](https://github.com/UMEP-dev/SUEWS/actions/runs/24946815662) on `master` at `ac202a7e3` from #1348. The wheels built far enough to run pytest, then all standard wheel jobs failed the same test:

- `test/core/test_sample_output.py::TestSTEBBSOutput::test_stebbs_building_energy_outputs`
- Failed output variables: `Twater_mains`, `Tair_ind`, `QHload_cooling_FA`, `QH_lighting_FA`

There are two separate pieces of history:

- **Root regression:** #1330 added the Rust alias `("stebbs", "stebbsmethod")` for `model.physics.stebbs`. Because the Rust YAML normaliser walks the whole YAML tree, it also rewrote `sites[].properties.stebbs` to `sites[].properties.stebbsmethod`. The STEBBS parser reads `properties.stebbs`, so site-level STEBBS parameter and initial-state overrides were silently skipped.
- **Exposure in CI:** #1348 changed the default STEBBS validation window from effectively zero day-2 rows to the full validation day. That made the existing mismatch visible in the scheduled wheel workflow. So #1348 made CI catch the issue; #1330 introduced the underlying alias bug.

#1335 sits between the last green scheduled run and the failing run, but it does not explain this failure path: the failing variables line up with the Rust STEBBS site-section aliasing problem rather than sparse-YAML validation.

## Why

STEBBS is both a model physics option and a site-properties section. Normalising every `stebbs` key to `stebbsmethod` prevented the site parser from reading STEBBS parameter and initial-state overrides. This PR scopes that rename to `model.physics` only and leaves `sites[].properties.stebbs` intact.

The smoke-marker follow-up keeps the new CI marker routing aligned with the intended minimal physics smoke coverage.

## Validation

- `git diff --check`
- PR CI: standard wheel jobs passed on `cp39-manylinux x86_64`, `cp39-macosx arm64`, and `cp39-win AMD64`.
- Attempted `cargo test preserves_site_stebbs_section_name` and `cargo test parses_stebbs_and_building_archetype_sections`; local build stopped before the Rust tests because `gfortran` could not find `module_type_hydro.mod`.
- Attempted `uv run python -m pytest --collect-only -q test/core/test_supy.py -m "physics and smoke and not slow"`; local dependency resolution stopped before pytest because the docs extra requires `sphinx-design>=0.7.0`, whose available version requires Python >=3.11 while the project metadata still includes Python 3.10.