### PR TITLE
Revise data model validation science fixes

### DIFF
--- a/docs/source/inputs/yaml/validation.rst
+++ b/docs/source/inputs/yaml/validation.rst
@@ -3,26 +3,41 @@
 Validation Tool Reference
 =========================
 
-The ``suews-validate`` command is a comprehensive validation system that automatically checks and updates SUEWS YAML configuration files. It ensures your configuration is complete, scientifically valid, and compatible with the SUEWS model.
+The ``suews-validate`` command checks SUEWS YAML configuration files and writes
+an updated YAML file plus a validation report. It is a validator first: structural
+updates are applied where they are mechanical, while scientific initialisation
+changes are only applied when explicitly requested.
 
 What the Validator Does
 -----------------------
 
-The validation system performs multiple checks on your configuration:
+The validation system performs three groups of checks:
 
-- **Completeness Check**: Detects missing parameters, updates deprecated parameter names to current standards and validates forcing data (see :doc:`/inputs/forcing-data` for detailed reference on forcing data validation)
-- **Scientific Validation**: Applies automatic scientific corrections and validates physics options compatibility
-- **Model Compatibility**: Ensures configuration compatibility with SUEWS computational engine
+- **Completeness check**: detects missing parameters, updates deprecated parameter
+  names to current snake_case names, and validates forcing data (see
+  :doc:`/inputs/forcing-data` for forcing data validation details).
+- **Scientific validation**: checks physics options, land-cover fractions,
+  geography, irrigation, STEBBS, radiation, albedo, emissivity, and forcing-height
+  consistency. Scientific initialisation transformations are suggestions by
+  default.
+- **Model compatibility**: validates the resulting configuration against the
+  SUEWS data model.
 
 Basic Usage
 -----------
 
 .. code-block:: bash
 
-    # Validate and fix configuration (creates corrected file)
+    # Validate configuration and write updated_config.yml plus report_config.txt
     suews-validate config.yml
 
-    # Check configuration without making changes
+    # Apply Phase B scientific initialisation updates to the output YAML
+    suews-validate --science-fixes apply config.yml
+
+    # Run Phase B scientific checks without suggestions or scientific updates
+    suews-validate --science-fixes off config.yml
+
+    # Check configuration without writing files
     suews-validate validate config.yml
 
     # Check without writing files (read-only validation)
@@ -32,27 +47,55 @@ For complete usage options and advanced features, use:
 
 .. code-block:: bash
 
-    # View all available options and commands
     suews-validate --help
-
-    # View help for specific subcommands
     suews-validate validate --help
     suews-validate migrate --help
     suews-validate version --help
+
+Phase B Scientific Fix Policy
+-----------------------------
+
+``--science-fixes`` controls transformations that can change scientific or
+user-provided values:
+
+- ``suggest`` (default): report CRU-derived initial temperatures, annual/monthly
+  temperature metrics, DLS/timezone, deciduous LAI seasonality, vegetation albedo,
+  snow albedo nullification, CO2/STEBBS nullification, setpoint/profile cleanup,
+  WWR-dependent nullification, and small land-cover fraction normalisation as
+  suggested updates. They are not written to YAML.
+- ``apply``: apply the same transformations to the output YAML and record each
+  change under **APPLIED UPDATES**.
+- ``off``: run scientific validation checks only. No scientific transformation
+  suggestions are collected or applied.
+
+Climatology-derived values are initialisation suggestions, not scientific truth.
+They may be inappropriate for observed initial states, spin-up workflows,
+historical timezone settings, or specialist case studies.
 
 Output Files
 ------------
 
 When you run ``suews-validate config.yml``, it creates:
 
-**Final Files (ready to use):**
-- ``updated_config.yml`` - Your corrected configuration (ready to use with SUEWS)
-- ``report_config.txt`` - Consolidated validation report showing all changes
+- ``updated_config.yml`` - the updated configuration from the last successful
+  validation phase
+- ``report_config.txt`` - the consolidated validation report
 
 Understanding Reports
 ---------------------
 
-The validation report provides comprehensive details about every change made to your configuration. 
+Reports use stable action sections:
+
+- **ACTION NEEDED**: blocking validation errors that must be fixed before the
+  configuration can be used.
+- **REVIEW ADVISED**: warnings that are not blockers but should be reviewed.
+- **SUGGESTED UPDATES**: scientific initialisation changes proposed by Phase B
+  when ``--science-fixes suggest`` is used.
+- **APPLIED UPDATES**: structural updates and any scientific transformations
+  applied because ``--science-fixes apply`` was selected.
+- **INFO**: non-blocking notes and successful validation summaries.
+
+Example excerpt:
 
 .. code-block:: text
 
@@ -62,60 +105,47 @@ The validation report provides comprehensive details about every change made to 
     # ==================================================
 
     ## ACTION NEEDED
-    - Found (3) forcing data validation error(s):
-    -- In 'forcing_data.txt': Wind speed (`U`) must be >= 0.01 m/s to avoid division by zero errors in atmospheric calculations. 1 values below 0.01 m/s found at line(s): [670]
-    -- In 'forcing_data.txt': `rh` should be between [0.0001, 105] but 25 outliers are found at line(s): [5, 118, 156, 157, ...]
-    -- In 'forcing_data.txt': `kdown` should be between [0, 1400] but 6 outliers are found at line(s): [176, 406, 655, 693, 847, 1558]
-       Required fix: Review and correct forcing data file.
-       Suggestion: You may want to plot the time series of your input data.
-
-    Note: Line numbers refer to actual lines in the forcing .txt file (including header)
-    Note: When multiple forcing files are provided, all files are validated and errors include the filename
-
     - Found (1) critical missing parameter(s):
-    -- netradiationmethod has been added to updated YAML and set to null
-       Location: model.physics.netradiationmethod
+    -- net_radiation has been added to updated YAML and set to null
+       Location: model.physics.net_radiation
 
-    ## NO ACTION NEEDED
-    - Updated (3) optional missing parameter(s) with null values:
-    -- holiday added to updated YAML and set to null
-    -- wetthresh added to updated YAML and set to null
-    -- roughlenmommethod added to updated YAML and set to null
+    ## REVIEW ADVISED
+    - Review (1) scientific warning(s):
+    -- forcing_height at site [1]: Measurement height is close to roof level.
 
-    - Updated (2) renamed parameter(s):
-    -- diagmethod changed to rslmethod
+    ## SUGGESTED UPDATES
+    - Suggested (3) scientific initialisation update(s).
+    - These suggestions were not written to YAML. They may be inappropriate for observed initial states, spin-up workflows, historical timezone settings, or specialist case studies.
+    -- initial_states.paved at site [1]: temperature, tsfc, tin -> 12.4 C (Set from CRU data for coordinates (51.51, -0.13) for month 1. Source: CRU TS climatology-derived initialisation heuristic.)
+    -- anthropogenic_emissions.startdls at site [1]: 0 -> 86 (Calculated DLS start for coordinates (51.51, -0.13). Source: Timezone and daylight-saving calculation from site coordinates.)
+
+    ## APPLIED UPDATES
+    - Updated (2) renamed parameter(s) to current standards:
+    -- diagmethod changed to roughness_sublayer
     -- cp changed to rho_cp
 
-    - Updated (7) parameter(s):
-    -- initial_states.paved: temperature, tsfc, tin → 12.4°C (Set from CRU data for coordinates (51.51, -0.13) for month 1)
-    -- initial_states.bldgs: temperature, tsfc, tin → 12.4°C (Set from CRU data for coordinates (51.51, -0.13) for month 1)
-    -- anthropogenic_emissions.startdls: 15.0 → 86 (Calculated DLS start for coordinates (51.51, -0.13))
-
     # ==================================================
-
-**Report Structure:**
-
-The report is organised into two main sections:
-
-- **NO ACTION NEEDED**: Changes that were automatically applied to your configuration and warnings. These are informational and require no further action from you. 
-
-- **ACTION NEEDED**: Critical issues that require your attention before the configuration can be used. 
-
 
 Exit Codes
 ----------
 
 For scripting and CI/CD:
 
-- ``0`` - Configuration is valid (or was successfully fixed)
-- ``1`` - Validation failed (manual fixes needed)
-- ``2`` - Invalid command or file not found
+- ``0`` - configuration is valid, including configurations with warnings or
+  suggestions
+- ``1`` - blocking validation errors were found
+- ``2`` - command usage or file errors
+
+JSON Output
+-----------
+
+JSON output exposes separate issue arrays with stable fields:
+``errors``, ``warnings``, ``suggestions``, ``applied_fixes``, and ``info``.
+Each issue includes ``code``, ``severity``, ``path``, ``site_gridid``,
+``message``, ``suggested_value``, and ``source`` where available.
 
 CI/CD Integration
 -----------------
-
-GitHub Actions Example
-~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
@@ -133,12 +163,11 @@ Batch Processing
 .. code-block:: bash
 
     #!/bin/bash
-    # Validate all configurations
     for config in configs/*.yml; do
         if suews-validate validate "$config" --quiet; then
-            echo "✓ $config"
+            echo "OK $config"
         else
-            echo "✗ $config - needs attention"
+            echo "FAILED $config - needs attention"
         fi
     done
 
@@ -149,16 +178,12 @@ Troubleshooting
    Install SuPy: ``pip install supy``
 
 **"File not found"**
-   Check the file path and ensure the file exists
+   Check the file path and ensure the file exists.
 
-**"Validation failed after fixes"**
-   Some issues need manual intervention. Check the **ACTION NEEDED** section in ``report_config.txt`` for specific issues requiring your attention.
+**"Validation failed after updates"**
+   Some issues need manual intervention. Check the **ACTION NEEDED** section in
+   ``report_config.txt``.
 
 **"Unknown parameter"**
-   You may have a typo or be using an outdated configuration format. The validator will suggest corrections for renamed parameters.
-
-For more detailed usage examples and advanced options, always refer to:
-
-.. code-block:: bash
-
-    suews-validate --help
+   You may have a typo or be using an outdated configuration format. The
+   validator reports renamed parameters using current snake_case names.

--- a/src/supy/cmd/json_output.py
+++ b/src/supy/cmd/json_output.py
@@ -63,7 +63,12 @@ class ValidationError:
         result = {
             "code": self.code.value,
             "code_name": self.code.name,
+            "severity": "ERROR",
+            "path": self.field or self.location,
+            "site_gridid": None,
             "message": self.message,
+            "suggested_value": self.details.get("suggested_value"),
+            "source": self.details.get("source", "suews-validate"),
         }
         if self.field:
             result["field"] = self.field
@@ -88,6 +93,35 @@ class JSONOutput:
         self.version = version
         self.start_time = datetime.utcnow()
 
+    @staticmethod
+    def _normalise_issue(issue: Any, severity: str) -> Dict[str, Any]:
+        """Return the stable validation issue shape used by JSON output."""
+        if isinstance(issue, str):
+            return {
+                "code": ErrorCode.VALIDATION_FAILED.value,
+                "code_name": ErrorCode.VALIDATION_FAILED.name,
+                "severity": severity,
+                "path": None,
+                "site_gridid": None,
+                "message": issue,
+                "suggested_value": None,
+                "source": "suews-validate",
+            }
+        if isinstance(issue, ValidationError):
+            result = issue.to_dict()
+        elif hasattr(issue, "to_dict"):
+            result = issue.to_dict()
+        else:
+            result = dict(issue)
+
+        result.setdefault("severity", severity)
+        result.setdefault("path", result.get("field") or result.get("location"))
+        result.setdefault("site_gridid", None)
+        result.setdefault("message", "")
+        result.setdefault("suggested_value", None)
+        result.setdefault("source", "suews-validate")
+        return result
+
     def validation_result(
         self,
         files: List[Dict[str, Any]],
@@ -107,26 +141,26 @@ class JSONOutput:
         # Calculate summary statistics
         total_files = len(files)
         valid_files = sum(1 for f in files if f.get("valid", False))
-        total_errors = sum(f.get("error_count", 0) for f in files)
+        total_errors = sum(f.get("error_count", len(f.get("errors", []))) for f in files)
+        total_warnings = sum(len(f.get("warnings", [])) for f in files)
+        total_suggestions = sum(len(f.get("suggestions", [])) for f in files)
+        total_applied = sum(len(f.get("applied_fixes", [])) for f in files)
 
-        # Structure errors properly
+        # Structure issue arrays properly and keep all expected arrays present.
         for file_result in files:
-            if "errors" in file_result and isinstance(file_result["errors"], list):
-                # Convert string errors to structured format
-                structured_errors = []
-                for error in file_result["errors"]:
-                    if isinstance(error, str):
-                        # Parse error string to extract field and message
-                        structured_errors.append({
-                            "code": ErrorCode.VALIDATION_FAILED.value,
-                            "code_name": ErrorCode.VALIDATION_FAILED.name,
-                            "message": error,
-                        })
-                    elif isinstance(error, ValidationError):
-                        structured_errors.append(error.to_dict())
-                    else:
-                        structured_errors.append(error)
-                file_result["errors"] = structured_errors
+            for field_name, severity in (
+                ("errors", "ERROR"),
+                ("warnings", "WARNING"),
+                ("suggestions", "SUGGESTION"),
+                ("applied_fixes", "APPLIED_FIX"),
+                ("info", "INFO"),
+            ):
+                issues = file_result.get(field_name, [])
+                if not isinstance(issues, list):
+                    issues = [issues]
+                file_result[field_name] = [
+                    self._normalise_issue(issue, severity) for issue in issues
+                ]
 
         return {
             "status": "success" if valid_files == total_files else "failure",
@@ -143,6 +177,9 @@ class JSONOutput:
                 "valid_files": valid_files,
                 "invalid_files": total_files - valid_files,
                 "total_errors": total_errors,
+                "total_warnings": total_warnings,
+                "total_suggestions": total_suggestions,
+                "total_applied_fixes": total_applied,
                 "success_rate": valid_files / total_files if total_files > 0 else 0.0,
             },
             "results": files,
@@ -157,6 +194,9 @@ class JSONOutput:
         report_file: Optional[str] = None,
         errors: Optional[List[Union[str, ValidationError]]] = None,
         warnings: Optional[List[str]] = None,
+        suggestions: Optional[List[Any]] = None,
+        applied_fixes: Optional[List[Any]] = None,
+        info: Optional[List[Any]] = None,
     ) -> Dict[str, Any]:
         """Format phase processing results for JSON output.
 
@@ -172,20 +212,23 @@ class JSONOutput:
         Returns:
             Structured JSON-serializable dictionary
         """
-        # Structure errors
-        structured_errors = []
-        if errors:
-            for error in errors:
-                if isinstance(error, str):
-                    structured_errors.append({
-                        "code": ErrorCode.PROCESSING_ERROR.value,
-                        "code_name": ErrorCode.PROCESSING_ERROR.name,
-                        "message": error,
-                    })
-                elif isinstance(error, ValidationError):
-                    structured_errors.append(error.to_dict())
-                else:
-                    structured_errors.append(error)
+        structured_errors = [
+            self._normalise_issue(error, "ERROR") for error in (errors or [])
+        ]
+        structured_warnings = [
+            self._normalise_issue(warning, "WARNING") for warning in (warnings or [])
+        ]
+        structured_suggestions = [
+            self._normalise_issue(suggestion, "SUGGESTION")
+            for suggestion in (suggestions or [])
+        ]
+        structured_applied = [
+            self._normalise_issue(applied, "APPLIED_FIX")
+            for applied in (applied_fixes or [])
+        ]
+        structured_info = [
+            self._normalise_issue(info_item, "INFO") for info_item in (info or [])
+        ]
 
         return {
             "status": "success" if success else "failure",
@@ -196,7 +239,9 @@ class JSONOutput:
             "summary": {
                 "success": success,
                 "error_count": len(structured_errors),
-                "warning_count": len(warnings) if warnings else 0,
+                "warning_count": len(structured_warnings),
+                "suggestion_count": len(structured_suggestions),
+                "applied_fix_count": len(structured_applied),
             },
             "files": {
                 "input": input_file,
@@ -204,7 +249,10 @@ class JSONOutput:
                 "report": report_file,
             },
             "errors": structured_errors if structured_errors else [],
-            "warnings": warnings if warnings else [],
+            "warnings": structured_warnings if structured_warnings else [],
+            "suggestions": structured_suggestions if structured_suggestions else [],
+            "applied_fixes": structured_applied if structured_applied else [],
+            "info": structured_info if structured_info else [],
         }
 
     def schema_operation_result(

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -238,8 +238,25 @@ def validate_single_file(
     default="on",
     help="Enable/disable forcing data validation (default: on)",
 )
+@click.option(
+    "--science-fixes",
+    type=click.Choice(["suggest", "apply", "off"]),
+    default="suggest",
+    show_default=True,
+    help="Handle Phase B scientific transformations: suggest, apply, or off",
+)
 @click.pass_context
-def cli(ctx, files, pipeline, mode, dry_run, out_format, schema_version, forcing):
+def cli(
+    ctx,
+    files,
+    pipeline,
+    mode,
+    dry_run,
+    out_format,
+    schema_version,
+    forcing,
+    science_fixes,
+):
     """SUEWS Configuration Validator.
 
     Default behavior: run the complete validation pipeline on FILE. Use subcommands
@@ -397,7 +414,11 @@ def cli(ctx, files, pipeline, mode, dry_run, out_format, schema_version, forcing
             )
             ctx.exit(2)
         code = _execute_pipeline(
-            file=files[0], pipeline=pipeline, mode=mode, forcing=forcing
+            file=files[0],
+            pipeline=pipeline,
+            mode=mode,
+            forcing=forcing,
+            science_fixes=science_fixes,
         )
         ctx.exit(code)
 
@@ -788,7 +809,7 @@ def _format_phase_output(
     return None
 
 
-def _execute_pipeline(file, pipeline, mode, forcing="on"):
+def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest"):
     """Run YAML validation pipeline to validate and generate reports/YAML.
 
     The validation system uses multiple internal phases:
@@ -804,6 +825,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on"):
         print(f"[DEBUG]   file: {file}", file=sys.stderr)
         print(f"[DEBUG]   pipeline: {pipeline}", file=sys.stderr)
         print(f"[DEBUG]   mode: {mode}", file=sys.stderr)
+        print(f"[DEBUG]   science_fixes: {science_fixes}", file=sys.stderr)
 
     # Ensure processor is importable
     if not all([
@@ -895,6 +917,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on"):
             mode=mode,
             phase="B",
             silent=True,
+            science_fixes=science_fixes,
         )
         console.print(
             "[green]✓ Validation completed[/green]"
@@ -969,6 +992,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on"):
             mode=mode,
             phase="AB",
             silent=True,
+            science_fixes=science_fixes,
         )
 
         if not b_ok:
@@ -1163,6 +1187,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on"):
             mode=mode,
             phase="BC",
             silent=True,
+            science_fixes=science_fixes,
         )
         if not b_ok:
             # Phase B failed in BC workflow - create final user files from Phase B outputs
@@ -1235,12 +1260,12 @@ def _execute_pipeline(file, pipeline, mode, forcing="on"):
                             lines.pop()
                         phase_c_content = "\n".join(lines)
 
-                        # Ensure proper spacing before NO ACTION NEEDED section
+                        # Ensure proper spacing before INFO section
                         if not phase_c_content.endswith("\n\n"):
                             phase_c_content += "\n"
 
-                        # Add NO ACTION NEEDED section
-                        phase_c_content += "\n## NO ACTION NEEDED"
+                        # Add INFO section
+                        phase_c_content += "\n## INFO"
 
                         # Add Phase B messages
                         for msg in phase_b_messages:
@@ -1360,6 +1385,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on"):
         mode=mode,
         phase="ABC",
         silent=True,
+        science_fixes=science_fixes,
     )
 
     if not b_ok:

--- a/src/supy/data_model/validation/README.md
+++ b/src/supy/data_model/validation/README.md
@@ -1,112 +1,114 @@
 # SUEWS Validation Module
 
-This module implements the three-phase validation system for SUEWS configuration files.
+This package implements the three-phase validation system used by
+`suews-validate`.
 
 ## Module Structure
 
-```
+```text
 validation/
-├── core/                       # Core validation infrastructure
-│   ├── config_validation.py   # Configuration validation logic
-│   ├── conditional_validation.py  # Physics-based conditional validation
-│   ├── controller.py          # ValidationController class
-│   ├── result.py              # ValidationResult class
-│   ├── utils.py               # Utility functions
-│   └── yaml_helpers.py        # YAML processing utilities
-└── pipeline/                   # Three-phase validation pipeline
-    ├── orchestrator.py        # Main pipeline orchestrator
-    ├── phase_a_uptodate.py    # Phase A: Parameter updates
-    ├── phase_b_science.py     # Phase B: Scientific validation
-    ├── phase_c_pydantic.py    # Phase C: Pydantic validation
-    └── phase_c_reports.py     # Phase C reporting
+├── core/
+│   ├── controller.py          # Deprecated compatibility controller
+│   ├── result.py              # Shared result helpers
+│   └── utils.py               # Utility functions
+└── pipeline/
+    ├── orchestrator.py        # Phase orchestration and report consolidation
+    ├── phase_a.py             # Structural completeness and rename checks
+    ├── phase_b.py             # Scientific validation and optional fixes
+    ├── phase_b_rules/         # Ordered Phase B validation rules
+    └── report_writer.py       # Report file I/O
 ```
 
 ## Three-Phase Validation System
 
 ### Phase A: Completeness Check
-- Adds missing parameters with sensible defaults
-- Updates deprecated parameter names
-- Ensures YAML structure compatibility
+
+- Adds missing optional parameters with null placeholders.
+- Updates deprecated parameter names to current snake_case names.
+- Validates forcing data unless `--forcing off` is selected.
+- Leaves blocking missing physics options for the report.
 
 ### Phase B: Scientific Validation
-- Applies scientific constraints
-- Performs automatic corrections (e.g., normalize fractions)
-- Integrates CRU climatological data for temperature initialization
+
+- Runs deterministic validation rules for physics parameters, option
+  dependencies, land cover, geography, irrigation, STEBBS, radiation/albedo,
+  emissivity, and forcing height.
+- Collects scientific initialisation suggestions by default.
+- Applies scientific transformations only when `--science-fixes apply` is used.
+
+Scientific transformations include CRU-derived initial temperatures, annual and
+monthly temperature metrics, DLS/timezone suggestions, deciduous LAI seasonality,
+vegetation albedo, snow albedo nullification, CO2/STEBBS nullification,
+setpoint/profile cleanup, WWR-dependent nullification, and small land-cover
+fraction normalisation within `1e-4`.
 
 ### Phase C: Model Compatibility
-- Validates against Pydantic models
-- Applies conditional validation rules
-- Ensures physics options compatibility
 
-## Public API
+- Validates the YAML against the SUEWS data model.
+- Checks runtime blockers and critical null physics parameters.
+- Produces the final YAML/report when used in a combined pipeline.
 
-The module exports its public API through `__init__.py`:
+## Public Interfaces
 
-```python
-from .core.conditional_validation import validate_suews_config_conditional
-from .core.controller import ValidationController
-from .core.result import ValidationResult
-```
-
-## CLI Integration
-
-The command-line interface in `src/supy/cmd/validate_config.py` uses the pipeline orchestrator functions:
+The preferred public interface is the package pipeline and CLI:
 
 ```python
-from ..data_model.validation.pipeline.orchestrator import (
-    validate_input_file,
-    setup_output_paths,
+from supy.data_model.validation.pipeline.orchestrator import (
     run_phase_a,
     run_phase_b,
     run_phase_c,
 )
 ```
 
+`src/supy/validation.py` is retained as a backward-compatible shim for one
+release and emits `DeprecationWarning`. New code should use
+`supy.data_model.validation`.
+
+## CLI Integration
+
+`suews-validate config.yml` runs the ABC pipeline and writes:
+
+- `updated_config.yml`
+- `report_config.txt`
+
+Phase B scientific transformations are controlled by:
+
+```bash
+suews-validate --science-fixes suggest config.yml  # default
+suews-validate --science-fixes apply config.yml
+suews-validate --science-fixes off config.yml
+```
+
+Reports use `ACTION NEEDED`, `REVIEW ADVISED`, `SUGGESTED UPDATES`,
+`APPLIED UPDATES`, and `INFO`.
+
 ## Development Guidelines
 
-### Adding New Validation Rules
+### Adding Phase B Rules
 
-1. **Parameter validation**: Add to `core/config_validation.py`
-2. **Scientific constraints**: Add to `pipeline/phase_b_science.py`
-3. **Conditional rules**: Add to `core/conditional_validation.py`
+1. Add the rule implementation to the appropriate file in `phase_b_rules/`.
+2. Register it with `RulesRegistry.add_rule("rule_id")`.
+3. Add the rule id to `DEFAULT_RULE_ORDER` in `phase_b_rules/__init__.py`.
+4. Return `ValidationResult` objects with stable severity values.
+
+### Adding Scientific Transformations
+
+Keep validation checks and transformations separate:
+
+- validation checks return `ValidationResult`;
+- transformations should be exposed through `collect_science_suggestions`;
+- YAML mutation belongs behind `apply_science_suggestions`.
 
 ### Testing
 
-Run validation tests:
+Run targeted validation tests first:
+
 ```bash
-pytest test/data_model/test_validation.py -v
+pytest test/data_model/test_validation.py test/data_model/test_yaml_processing.py test/umep/test_preprocessor.py -v
 ```
 
-### CRU Data Integration
+Finish with:
 
-The module includes CRU TS4.06 climatological data (1991-2020) for automatic temperature initialization based on location and season. Data files are in `ext_data/`.
-
-## Architecture Decisions
-
-### Why Separate Core and Pipeline?
-
-- **Core** contains reusable validation infrastructure
-- **Pipeline** implements the specific three-phase workflow
-- This separation allows for future alternative validation workflows
-
-### Why Three Phases?
-
-1. **Phase A**: Structural fixes can be done automatically
-2. **Phase B**: Scientific corrections require domain knowledge
-3. **Phase C**: Model compatibility must be checked last
-
-Each phase builds on the previous one, creating a robust validation pipeline.
-
-## Error Handling
-
-- Phase A never fails (always produces output)
-- Phase B fails on scientific violations
-- Phase C fails on model incompatibilities
-- Errors are accumulated and reported comprehensively
-
-## For More Details
-
-- See `pipeline/PHASE_A_DETAILED.md` for Phase A implementation
-- See `pipeline/PHASE_B_DETAILED.md` for Phase B implementation  
-- See `pipeline/PHASE_C_DETAILED.md` for Phase C implementation
-- See `pipeline/ORCHESTRATOR.md` for workflow coordination
+```bash
+make test-smoke
+```

--- a/src/supy/data_model/validation/core/controller.py
+++ b/src/supy/data_model/validation/core/controller.py
@@ -57,6 +57,12 @@ class ValidationController(BaseModel):
 
     def __init__(self, config_data: Dict[str, Any], **data):
         """Initialize controller with configuration data."""
+        warnings.warn(
+            "ValidationController is deprecated; use supy.data_model.validation "
+            "pipeline APIs for current validation behaviour.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(config_data=config_data, **data)
         self._analyze_config()
 
@@ -161,10 +167,12 @@ class ValidationController(BaseModel):
         # Validate advanced method parameters
         if self.netradiation_spartacus_enabled:
             if verbose:
-                print("SPARTACUS radiation is ON: checking SPARTACUS parameters")
-            spartacus_errors = self._validate_spartacus_parameters()
-            result.errors.extend(spartacus_errors)
-            result.validated_methods.add("SPARTACUS")
+                print("SPARTACUS radiation is ON: validation deferred")
+            result.warnings.append(
+                "SPARTACUS-specific checks are not implemented in "
+                "ValidationController; use supy.data_model.validation."
+            )
+            result.skipped_methods.add("SPARTACUS")
         else:
             result.skipped.append("SPARTACUS validation (NetRadiationMethod < 1000)")
             result.skipped_methods.add("SPARTACUS")
@@ -181,10 +189,12 @@ class ValidationController(BaseModel):
 
         if self.storage_estm_enabled:
             if verbose:
-                print("ESTM storage is ON: checking ESTM parameters")
-            estm_errors = self._validate_estm_parameters()
-            result.errors.extend(estm_errors)
-            result.validated_methods.add("ESTM")
+                print("ESTM storage is ON: validation deferred")
+            result.warnings.append(
+                "ESTM-specific checks are not implemented in ValidationController; "
+                "use supy.data_model.validation."
+            )
+            result.skipped_methods.add("ESTM")
         else:
             result.skipped.append("ESTM validation (StorageHeatMethod != ESTM)")
             result.skipped_methods.add("ESTM")
@@ -284,21 +294,14 @@ class ValidationController(BaseModel):
         return errors
 
     def _validate_spartacus_parameters(self) -> List[str]:
-        """Validate parameters for SPARTACUS radiation scheme."""
-        errors = []
-
-        sites = self.config_data.get("sites", [])
-        for i, site in enumerate(sites):
-            site_props = site.get("properties", {})
-
-            # SPARTACUS needs specific radiation parameters
-            spartacus_params = site_props.get("spartacus_params")
-            if spartacus_params is not None:
-                # Add specific SPARTACUS parameter validation here
-                # This is a placeholder for actual SPARTACUS parameter checks
-                pass
-
-        return errors
+        """Deprecated placeholder retained for import compatibility."""
+        warnings.warn(
+            "ValidationController SPARTACUS checks are deprecated and not used; "
+            "use supy.data_model.validation.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return []
 
     def _validate_advanced_emissions_parameters(self) -> List[str]:
         """Validate parameters for advanced emissions calculations."""
@@ -320,18 +323,14 @@ class ValidationController(BaseModel):
         return errors
 
     def _validate_estm_parameters(self) -> List[str]:
-        """Validate parameters for ESTM (Element Surface Temperature Method)."""
-        errors = []
-
-        sites = self.config_data.get("sites", [])
-        for i, site in enumerate(sites):
-            site_props = site.get("properties", {})
-
-            # ESTM needs thermal parameters
-            # This is a placeholder for actual ESTM parameter validation
-            pass
-
-        return errors
+        """Deprecated placeholder retained for import compatibility."""
+        warnings.warn(
+            "ValidationController ESTM checks are deprecated and not used; "
+            "use supy.data_model.validation.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return []
 
     def _validate_core_parameters(self) -> List[str]:
         """Validate core parameters that are always required."""
@@ -417,6 +416,12 @@ def validate_suews_config_conditional(
     Raises:
         ValueError: If strict=True and validation fails
     """
+    warnings.warn(
+        "validate_suews_config_conditional from validation.core.controller is "
+        "deprecated; use supy.data_model.validation.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     controller = ValidationController(config_data=config_data)
     result = controller.validate_config(verbose=verbose)
 

--- a/src/supy/data_model/validation/core/yaml_helpers.py
+++ b/src/supy/data_model/validation/core/yaml_helpers.py
@@ -66,6 +66,16 @@ except ImportError:
             UserWarning,
         )
 
+
+def _fallback_timezone_name(lat: float, lng: float) -> Optional[str]:
+    """Small deterministic timezone fallback for simple UTC and London cases."""
+    if 49.0 <= lat <= 61.0 and -8.5 <= lng <= 2.5:
+        return "Europe/London"
+    if -1.0 <= lat <= 1.0 and -1.0 <= lng <= 1.0:
+        return "Etc/GMT"
+    return None
+
+
 # Optional import - use standalone if supy not available
 try:
     from ...._env import logger_supy, trv_supy_module
@@ -225,12 +235,13 @@ class DLSCheck(BaseModel):
     def compute_dst_transitions(self):
         if not HAS_TIMEZONE_FINDER:
             logger_supy.debug(
-                "[DLS] No timezone finder available, skipping DST calculation."
+                "[DLS] No timezone finder available, using limited fallback."
             )
-            return None, None, None
+            tz_name = _fallback_timezone_name(self.lat, self.lng)
+        else:
+            tf = TimezoneFinder()
+            tz_name = tf.timezone_at(lat=self.lat, lng=self.lng)
 
-        tf = TimezoneFinder()
-        tz_name = tf.timezone_at(lat=self.lat, lng=self.lng)
 
         if not tz_name:
             logger_supy.debug(

--- a/src/supy/data_model/validation/pipeline/README.md
+++ b/src/supy/data_model/validation/pipeline/README.md
@@ -1,272 +1,132 @@
-# SUEWS YAML Processor
+# SUEWS Validation Pipeline
 
 ## Overview
 
-The SUEWS YAML Processor is a three-phase pipeline for validating and updating SUEWS configuration files. It transforms user-provided YAML configurations into validated, up-to-date formats ready for SUEWS model execution.
+The validation pipeline updates and checks SUEWS YAML files in three phases:
 
-## Architecture
-
-### Three-Phase Processing Pipeline
-
-```
-User YAML → Phase A → Phase B → Phase C → Valid YAML
+```text
+User YAML -> Phase A -> Phase B -> Phase C -> Valid YAML
 ```
 
-1. **Phase A: Configuration structure check** (`phase_a.py`)
-   - Detects missing parameters
-   - Renames outdated parameters
-   - Identifies non-standard parameters
-   - Validates forcing data files (enabled by default)
-   - Generates updated YAML with null placeholders
+`suews-validate config.yml` runs the full ABC pipeline by default.
 
-2. **Phase B: Physics validation check** (`phase_b.py`)
-   - Validates physics parameters
-   - Checks ALL model physics compatibility (rslmethod-stabilitymethod, StorageHeatMethod-OhmIncQf)
-   - Validates land cover fractions
-   - Updates initial temperatures from CRU data
-   - Updates STEBBS outdoor surface temperatures when `stebbsmethod == 1`
+## Phases
 
-3. **Phase C: Configuration consistency check** (`phase_c.py`)
-   - Validates data types and value ranges
-   - Checks parameter relationships and conditional rules
-   - Generates detailed error reports
-   - Provides actionable feedback
+### Phase A: Configuration Structure Check (`phase_a.py`)
 
-### Components
+- Detects missing parameters against the sample configuration.
+- Renames outdated keys to current snake_case names.
+- Identifies non-standard parameters.
+- Validates forcing data by default.
+- Writes structural updates and null placeholders.
 
-- **`orchestrator.py`**: Main entry point that coordinates the pipeline
-- **`validation_helpers.py`**: Shared validation utilities (legacy precheck functions)
-- **`__init__.py`**: Module exports
+### Phase B: Physics and Scientific Validation (`phase_b.py`)
 
-## Usage
+- Runs ordered validation rules from `phase_b_rules/`.
+- Checks physics parameters, option dependencies, land-cover fractions,
+  geography, irrigation, STEBBS, radiation/albedo/emissivity, and forcing height.
+- Collects scientific initialisation suggestions by default.
+- Applies those transformations only with `--science-fixes apply`.
 
-### Command Line Interface
+Scientific suggestions are not treated as scientific truth. They can be useful
+initialisation aids, but they may be inappropriate for observed initial states,
+spin-up workflows, historical timezone settings, or specialist case studies.
 
-The SUEWS validation system supports flexible pipeline and mode combinations:
+### Phase C: Configuration Consistency Check
 
-#### Basic Validation
+- Validates with the SUEWS data model.
+- Checks critical null physics parameters that would block model execution.
+- Produces a final report/YAML in combined pipelines.
+
+## CLI Usage
 
 ```bash
-# Complete validation (default: all checks)
+# Complete validation, default scientific policy is suggest
 suews-validate config.yml
 
-# Same as above, explicit syntax
-suews-validate --pipeline ABC config.yml
-```
+# Apply Phase B scientific transformations to output YAML
+suews-validate --science-fixes apply config.yml
 
-#### Pipeline Options
+# Disable Phase B scientific transformation suggestions
+suews-validate --science-fixes off config.yml
 
-```bash
-# Configuration structure check only
+# Run individual or combined phases
 suews-validate --pipeline A config.yml
-
-# Physics validation check only
 suews-validate --pipeline B config.yml
-
-# Configuration consistency check only
 suews-validate --pipeline C config.yml
-
-# Combined workflows
-suews-validate --pipeline AB config.yml   # Structure + Physics
-suews-validate --pipeline AC config.yml   # Structure + Consistency
-suews-validate --pipeline BC config.yml   # Physics + Consistency
+suews-validate --pipeline AB config.yml
+suews-validate --pipeline AC config.yml
+suews-validate --pipeline BC config.yml
 ```
 
-#### Mode Options
-
-```bash
-# Public mode (default) - restricted features disabled
-suews-validate --mode public config.yml
-
-# Developer mode - all features available including experimental options
-suews-validate --mode dev config.yml
-suews-validate --mode dev --pipeline ABC config.yml
-```
-
-#### Forcing Validation Control
-
-```bash
-# Default: forcing validation enabled
-suews-validate config.yml
-
-# Disable forcing validation
-suews-validate --forcing off config.yml
-# or shorthand:
-suews-validate -f off config.yml
-```
-
-#### Complete Examples
-
-```bash
-# Developer doing full validation with experimental features
-suews-validate --pipeline ABC --mode dev my_research_config.yml
-
-# Quick YAML structure check during development
-suews-validate --pipeline A --mode dev draft_config.yml
-
-# Physics validation for a specific site configuration
-suews-validate --pipeline B --mode public site_london.yml
-
-### Python API
+## Python Entry Points
 
 ```python
-from supy.data_model.yaml_processor import orchestrator
-
-# Run complete pipeline
-orchestrator.main([
-    'user_config.yml',
-    '--phase', 'ABC',
-    '--mode', 'public'
-])
-
-# Direct orchestrator usage (legacy)
-python -m supy.data_model.yaml_processor.orchestrator user_config.yml --phase ABC --mode public
+from supy.data_model.validation.pipeline.orchestrator import (
+    validate_input_file,
+    setup_output_paths,
+    run_phase_a,
+    run_phase_b,
+    run_phase_c,
+)
 ```
 
-### Phase and Mode Reference
+Direct module use:
 
-#### Pipeline Options
-- `A`: Configuration structure check only
-- `B`: Physics validation check only
-- `C`: Configuration consistency check only
-- `AB`: Structure + Physics checks
-- `AC`: Structure + Consistency checks
-- `BC`: Physics + Consistency checks
-- `ABC`: Complete validation pipeline (default)
+```bash
+python -m supy.data_model.validation.pipeline.orchestrator user_config.yml --phase ABC --mode public
+```
 
-#### Modes
-- `public`: Standard mode with restricted features disabled (default)
-- `dev`: Developer mode with all features including experimental options (STEBBS, snow models)
+## Report Sections
 
-### Output Files
+Reports use:
 
-All validation runs create standardised output files:
-- **Final files**: `updated_config.yml`, `report_config.txt`
+- `ACTION NEEDED`: blocking errors
+- `REVIEW ADVISED`: warnings
+- `SUGGESTED UPDATES`: scientific suggestions not applied to YAML
+- `APPLIED UPDATES`: applied structural or scientific updates
+- `INFO`: non-blocking notes
 
-The validator shows all created files and their purposes in terminal output.
+Warnings should never be placed under `NO ACTION NEEDED`.
 
 ## Development Notes
 
-### Phase A Details
+### Phase B Rule Order
 
-Phase A performs parameter detection and updating:
+Rule registration is global, but execution order is explicit in
+`phase_b_rules.DEFAULT_RULE_ORDER`:
 
-1. **Missing Parameter Detection**
-   - Compares user YAML against standard configuration
-   - Classifies as URGENT (physics options) or OPTIONAL
-   - Creates null placeholders for missing parameters
+1. physics parameters
+2. option dependencies
+3. land cover
+4. geography
+5. irrigation
+6. STEBBS and building rules
+7. radiation, albedo, emissivity, and forcing-height checks
 
-2. **Renamed Parameter Handling**
-   - Maps outdated names to current names
-   - Examples: `cp` → `rho_cp`, `diagmethod` → `rslmethod`
+### Scientific Transformations
 
-3. **Extra Parameter Detection**
-   - Identifies parameters not in standard
-   - Categorises based on Pydantic model constraints
+Keep checks and transformations separate:
 
-4. **Forcing Data Validation** (enabled by default)
-   - Validates meteorological forcing file existence
-   - Checks column names and order
-   - Validates timestamps (DatetimeIndex, no duplicates, monotonic, frequency)
-   - Checks physical ranges (pressure, rain, radiation, wind speed, etc.)
-   - Can be disabled with `--forcing off` flag
+```python
+suggestions = collect_science_suggestions(data, start_date, model_year)
+updated_data, applied = apply_science_suggestions(
+    data, suggestions, start_date, model_year
+)
+```
 
-### Phase B Details
+`collect_science_suggestions` must not mutate the input data.
 
-Phase B performs scientific validation:
+## Tests
 
-1. **Physics Parameter Validation**
-   - Ensures all required physics options are present
-   - Validates parameter value ranges
+Targeted validation tests:
 
-2. **Model Dependencies**
-   - Checks interdependencies (e.g., rslmethod ↔ stabilitymethod)
-   - Validates STEBBS requirements
-   - Checks vegetation parameters
-
-3. **CRU Temperature Integration**
-   - Updates initial temperatures from climate data
-   - Based on location and start date
-
-### Phase C Details
-
-Phase C performs configuration consistency validation:
-
-1. **Validation Execution**
-   - Validates data types and ranges
-   - Checks parameter relationships
-   - Ensures conditional rules are satisfied
-
-2. **Report Generation**
-   - Formats errors by category
-   - Provides fix suggestions
-   - Generates updated YAML
-
-## Testing
-
-Tests are located in `test/data_model/yaml_processor/`:
-
-- `test_uptodate_yaml.py`: Phase A tests
-- `test_suews_yaml_processor.py`: Integration tests
-- `test_precheck.py`: Validation helper tests
-
-Run tests:
 ```bash
-pytest test/data_model/yaml_processor/ -v
+pytest test/data_model/test_validation.py test/data_model/test_yaml_processing.py test/umep/test_preprocessor.py -v
 ```
 
-## Key Data Structures
+Smoke check:
 
-### Physics Options
-```python
-PHYSICS_OPTIONS = {
-    'netradiationmethod', 'emissionsmethod', 'storageheatmethod',
-    'ohmincqf', 'roughlenmommethod', 'roughlenheatmethod',
-    'stabilitymethod', 'smdmethod', 'waterusemethod',
-    'rslmethod', 'faimethod', 'rsllevel', 'gsmodel',
-    'snowuse', 'stebbsmethod', 'rcmethod'
-}
+```bash
+make test-smoke
 ```
-
-### Renamed Parameters
-```python
-RENAMED_PARAMS = {
-    'cp': 'rho_cp',
-    'diagmethod': 'rslmethod',
-    'localclimatemethod': 'rsllevel',
-    'chanohm': 'ch_anohm',
-    'cpanohm': 'rho_cp_anohm',
-    'kkanohm': 'k_anohm'
-}
-```
-
-## Output Files
-
-The processor generates standardised output files:
-
-1. **Updated YAML**: `updated_<input_name>.yml`
-   - Represents the last successful validation phase
-
-2. **Consolidated Report**: `report_<input_name>.txt`
-   - Single unified report combining all validation phases
-   - Action items categorised by priority (ACTION NEEDED / NO ACTION NEEDED)
-   - Fix suggestions with parameter locations
-
-## Detailed Documentation
-
-For comprehensive technical details about each component, see:
-
-- **[ORCHESTRATOR.md](ORCHESTRATOR.md)** - Complete orchestrator architecture, workflow coordination, file management, and integration patterns
-- **[PHASE_A_DETAILED.md](PHASE_A_DETAILED.md)** - In-depth configuration structure check: missing parameters, renamed parameters, extra parameters, mode differences
-- **[PHASE_B_DETAILED.md](PHASE_B_DETAILED.md)** - Comprehensive physics validation check: scientific parameter validation, CRU temperature integration, physics compatibility rules
-- **[PHASE_C_DETAILED.md](PHASE_C_DETAILED.md)** - Complete configuration consistency check: data type validation, parameter relationships, conditional validation rules
-
-These files provide exhaustive implementation details, troubleshooting guides, testing patterns, and advanced usage scenarios for developers working on or extending the validation system.
-
-## Future Enhancements
-
-- [ ] Add Phase D for post-processing optimisation
-- [ ] Implement parallel site processing
-- [ ] Add configuration caching
-- [ ] Create GUI interface
-- [ ] Add batch processing support

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -342,8 +342,18 @@ def setup_output_paths(
     )
 
 
+REPORT_SUMMARY_SECTIONS = (
+    "ACTION NEEDED",
+    "REVIEW ADVISED",
+    "SUGGESTED UPDATES",
+    "APPLIED UPDATES",
+    "INFO",
+    "NO ACTION NEEDED",
+)
+
+
 def extract_no_action_messages_from_report(report_file: str) -> list:
-    """Extract NO ACTION NEEDED messages from a report file."""
+    """Extract non-blocking summary messages from a validation report."""
     messages = []
 
     if not report_file or not os.path.exists(report_file):
@@ -352,21 +362,23 @@ def extract_no_action_messages_from_report(report_file: str) -> list:
     try:
         content = REPORT_WRITER.read(report_file)
 
-        # Extract NO ACTION NEEDED section
         lines = content.split("\n")
-        in_no_action = False
+        current_section = None
 
         for line in lines:
-            if line.strip().startswith("## NO ACTION NEEDED"):
-                in_no_action = True
+            stripped = line.strip()
+            if stripped.startswith("## "):
+                section = stripped[3:].strip()
+                if section in REPORT_SUMMARY_SECTIONS:
+                    current_section = "INFO" if section == "NO ACTION NEEDED" else section
+                    messages.append(f"## {current_section}")
+                else:
+                    current_section = None
                 continue
-            elif line.strip().startswith("##") and in_no_action:
-                # Hit another section, stop collecting
-                break
-            elif line.strip().startswith("#") and in_no_action:
+            elif stripped.startswith("#") and current_section:
                 # Skip any separator lines (like # ==================================================)
                 continue
-            elif in_no_action and line.strip():
+            elif current_section and stripped:
                 messages.append(line)
 
     except Exception:
@@ -381,7 +393,7 @@ def create_consolidated_report(
     final_report_file: str,
     mode: str = "public",
 ) -> None:
-    """Create final consolidated report with all NO ACTION NEEDED messages."""
+    """Create final consolidated report preserving non-blocking sections."""
     import sys
 
     debug = os.environ.get("SUEWS_DEBUG", "").lower() in ("1", "true", "yes")
@@ -396,53 +408,78 @@ def create_consolidated_report(
     # Use unified report title for all validation phases
     title = "SUEWS Validation Report"
 
-    # Deduplicate messages while preserving order
-    # Also filter out the generic "All validations passed" message if there are other messages
-    seen = set()
-    deduplicated_messages = []
-    for message in no_action_messages:
-        # Skip the generic "all passed" message - it will be added later if needed
-        if message.strip() == "- All validations passed with no issues detected":
-            continue
-        if message not in seen:
-            seen.add(message)
-            deduplicated_messages.append(message)
+    section_messages = {
+        "ACTION NEEDED": [],
+        "REVIEW ADVISED": [],
+        "SUGGESTED UPDATES": [],
+        "APPLIED UPDATES": [],
+        "INFO": [],
+    }
+    current_section = "INFO"
 
-    # Remove orphaned headers (headers ending with : that have no following detail lines starting with --)
-    filtered_messages = []
-    i = 0
-    while i < len(deduplicated_messages):
-        msg = deduplicated_messages[i]
-        # Check if this is a header line (starts with - but not --, ends with :)
-        if (
-            msg.strip().startswith("- ")
-            and not msg.strip().startswith("-- ")
-            and msg.strip().endswith(":")
-        ):
-            # Check if next line exists and is a detail line (starts with --)
-            if i + 1 < len(deduplicated_messages) and deduplicated_messages[
-                i + 1
-            ].strip().startswith("-- "):
-                # Has following details, keep it
+    for message in no_action_messages:
+        stripped = str(message).strip()
+        if stripped == "- All validations passed with no issues detected":
+            continue
+        if stripped.startswith("## "):
+            section = stripped[3:].strip()
+            current_section = "INFO" if section == "NO ACTION NEEDED" else section
+            if current_section not in section_messages:
+                current_section = "INFO"
+            continue
+        section_messages[current_section].append(message)
+
+    filtered_sections = {}
+    for section, messages in section_messages.items():
+        seen = set()
+        deduplicated_messages = []
+        for message in messages:
+            if message not in seen:
+                seen.add(message)
+                deduplicated_messages.append(message)
+
+        filtered_messages = []
+        i = 0
+        while i < len(deduplicated_messages):
+            msg = deduplicated_messages[i]
+            if (
+                msg.strip().startswith("- ")
+                and not msg.strip().startswith("-- ")
+                and msg.strip().endswith(":")
+            ):
+                if i + 1 < len(deduplicated_messages) and deduplicated_messages[
+                    i + 1
+                ].strip().startswith("-- "):
+                    filtered_messages.append(msg)
+            else:
                 filtered_messages.append(msg)
-            # else: orphaned header, skip it
-        else:
-            # Not a header, keep it
-            filtered_messages.append(msg)
-        i += 1
+            i += 1
+        filtered_sections[section] = filtered_messages
 
     # Build final report content
     report_content = f"""# {title}
 # {"=" * 50}
 # Mode: {"Public" if mode.lower() == "public" else mode.title()}
-# {"=" * 50}
+# {"=" * 50}"""
 
-## NO ACTION NEEDED"""
-
-    if filtered_messages:
-        for message in filtered_messages:
+    has_messages = False
+    for section in (
+        "ACTION NEEDED",
+        "REVIEW ADVISED",
+        "SUGGESTED UPDATES",
+        "APPLIED UPDATES",
+        "INFO",
+    ):
+        messages = filtered_sections.get(section, [])
+        if not messages:
+            continue
+        has_messages = True
+        report_content += f"\n\n## {section}"
+        for message in messages:
             report_content += f"\n{message}"
-    else:
+
+    if not has_messages:
+        report_content += "\n\n## INFO"
         report_content += "\n- All validations passed with no issues detected"
 
     report_content += f"\n\n# {'=' * 50}"
@@ -598,8 +635,9 @@ def run_phase_b(
     mode: str = "public",
     phase: str = "B",
     silent: bool = False,
+    science_fixes: str = "suggest",
 ) -> bool:
-    """Execute Phase B: Physics validation checks and automatic adjustments."""
+    """Execute Phase B: physics validation and optional scientific fixes."""
     try:
         with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
             science_checked_data = run_science_check(
@@ -612,6 +650,7 @@ def run_phase_b(
                 phase_a_performed=phase_a_performed,
                 mode=mode,
                 phase=phase,
+                science_fixes=science_fixes,
             )
 
         # Check if Phase B produced output files
@@ -781,10 +820,10 @@ def run_phase_c(
                         print(f"Updated YAML: {pydantic_yaml_file}")
                     return False
 
-                # Build NO ACTION NEEDED section if any defaults were detected
+                # Build INFO section if any defaults were detected
                 no_action_info = ""
                 if normal_defaults:
-                    no_action_info = "\n\n## NO ACTION NEEDED\n"
+                    no_action_info = "\n\n## INFO\n"
                     for default_app in normal_defaults:
                         field_name = default_app.get("field_name", "unknown")
                         default_value = default_app.get("default_value", "unknown")
@@ -803,7 +842,7 @@ def run_phase_c(
                 # Use unified report title for all validation phases
                 title = "SUEWS Validation Report"
 
-                # Extract NO ACTION NEEDED content from previous phases to consolidate properly
+                # Extract INFO content from previous phases to consolidate properly
                 consolidated_no_action = []
 
                 # Add any validation summary messages from Phase C (e.g., hemisphere warnings)
@@ -816,9 +855,9 @@ def run_phase_c(
                 if no_action_info:
                     # Remove the leading newlines and header, parse the content
                     no_action_content = no_action_info.strip()
-                    if no_action_content.startswith("## NO ACTION NEEDED"):
+                    if no_action_content.startswith("## INFO"):
                         no_action_content = no_action_content.replace(
-                            "## NO ACTION NEEDED", "", 1
+                            "## INFO", "", 1
                         )
 
                     consolidated_no_action.extend([
@@ -834,11 +873,11 @@ def run_phase_c(
                         "## PREVIOUS PHASES INFORMATION CONSOLIDATED\nSee below for prior phase results.\n",
                         "",
                     )
-                    # Remove redundant headers and extract only NO ACTION NEEDED content
+                    # Remove redundant headers and extract only non-blocking content
                     lines = phase_content.split("\n")
                     in_no_action = False
                     for line in lines:
-                        if line.strip().startswith("## NO ACTION NEEDED"):
+                        if line.strip().startswith("## INFO"):
                             in_no_action = True
                             continue
                         elif line.strip().startswith("##"):
@@ -851,14 +890,14 @@ def run_phase_c(
                         ):
                             consolidated_no_action.append(line.strip())
 
-                # Only add NO ACTION NEEDED section if there are items to show
+                # Only add INFO section if there are items to show
                 if consolidated_no_action:
                     success_report = f"""# {title}
 # ============================================
 # Mode: {"Public" if mode.lower() == "public" else mode.title()}
 # ============================================
 
-## NO ACTION NEEDED
+## INFO
 {chr(10).join(consolidated_no_action)}
 
 # =================================================="""
@@ -944,7 +983,7 @@ def run_phase_c(
 # Mode: {"Public" if mode.lower() == "public" else mode.title()}
 # ============================================
 
-## NO ACTION NEEDED
+## INFO
 {chr(10).join(consolidated_no_action)}
 
 # =================================================="""
@@ -1141,7 +1180,7 @@ Examples:
 
 Phases:
   Phase A: Configuration structure checks and parameter updates
-  Phase B: Physics validation checks and automatic adjustments
+  Phase B: Physics validation checks and optional scientific initialisation updates
   Phase C: Configuration consistency checks based on model physics options
 
 Modes:
@@ -1168,10 +1207,18 @@ Modes:
         help="Processing mode: public (standard validation mode, default) or dev (developer mode with extended options - available)",
     )
 
+    parser.add_argument(
+        "--science-fixes",
+        choices=["suggest", "apply", "off"],
+        default="suggest",
+        help="Handle Phase B scientific transformations: suggest, apply, or off (default: suggest)",
+    )
+
     args = parser.parse_args()
     user_yaml_file = args.yaml_file
     phase = args.phase
     mode = args.mode
+    science_fixes = args.science_fixes
 
     # Use mode directly - no mapping needed
     internal_mode = mode
@@ -1338,6 +1385,7 @@ Modes:
                 mode=internal_mode,
                 phase="B",
                 silent=True,  # Suppress phase function output, main function handles terminal output
+                science_fixes=science_fixes,
             )
 
             # Always create final user files with simple names
@@ -1412,6 +1460,7 @@ Modes:
                 mode=internal_mode,
                 phase="AB",
                 silent=True,
+                science_fixes=science_fixes,
             )
 
             if not phase_a_success:
@@ -1438,6 +1487,7 @@ Modes:
                 mode=internal_mode,
                 phase="AB",
                 silent=True,
+                science_fixes=science_fixes,
             )
 
             if not phase_b_success:
@@ -1633,6 +1683,7 @@ Modes:
                 mode=internal_mode,
                 phase="BC",
                 silent=True,
+                science_fixes=science_fixes,
             )
 
             if not phase_b_success:
@@ -1694,12 +1745,12 @@ Modes:
                                 lines.pop()
                             phase_c_content = "\n".join(lines)
 
-                            # Ensure proper spacing before NO ACTION NEEDED section
+                            # Ensure proper spacing before INFO section
                             if not phase_c_content.endswith("\n\n"):
                                 phase_c_content += "\n"
 
-                            # Add NO ACTION NEEDED section
-                            phase_c_content += "\n## NO ACTION NEEDED"
+                            # Add INFO section
+                            phase_c_content += "\n## INFO"
 
                             # Add Phase B messages
                             for msg in phase_b_messages:
@@ -1780,6 +1831,7 @@ Modes:
                 mode=internal_mode,
                 phase="ABC",
                 silent=True,
+                science_fixes=science_fixes,
             )
 
             if not phase_a_success:
@@ -1828,6 +1880,7 @@ Modes:
                 mode=internal_mode,
                 phase="ABC",
                 silent=True,
+                science_fixes=science_fixes,
             )
 
             if not phase_b_success:

--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -107,6 +107,24 @@ def handle_renamed_parameters(yaml_content: str):
     return "\n".join(lines), replacements
 
 
+def handle_renamed_parameters_in_parsed_yaml(obj):
+    """Rename deprecated keys in parsed YAML structures where line matching misses."""
+    replacements = []
+
+    if isinstance(obj, dict):
+        for old_key, new_key in list(RENAMED_PARAMS.items()):
+            if old_key in obj and new_key not in obj:
+                obj[new_key] = obj.pop(old_key)
+                replacements.append((old_key, new_key))
+        for value in obj.values():
+            replacements.extend(handle_renamed_parameters_in_parsed_yaml(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            replacements.extend(handle_renamed_parameters_in_parsed_yaml(item))
+
+    return replacements
+
+
 def is_physics_option(param_path):
     param_name = param_path.split(".")[-1]
     return "model.physics" in param_path and param_name in PHYSICS_OPTIONS
@@ -129,7 +147,6 @@ def get_allowed_nested_sections_in_properties():
         "model",
         "state",
         "site",
-        "core",
         "ohm",
         "profile",
         "surface",
@@ -143,7 +160,7 @@ def get_allowed_nested_sections_in_properties():
         try:
             # Import the module dynamically
             module = importlib.import_module(
-                f".{module_name}", package="supy.data_model"
+                f".{module_name}", package="supy.data_model.core"
             )
 
             # Find all classes in the module that are BaseModel subclasses
@@ -189,7 +206,7 @@ def get_allowed_nested_sections_in_properties():
 
         # Validate these exist in the actual models (best effort)
         try:
-            from .site import SiteProperties
+            from ...core.site import SiteProperties
 
             actual_fields = set(SiteProperties.model_fields.keys())
             validated_sections = static_sections.intersection(actual_fields)
@@ -1716,6 +1733,24 @@ def annotate_missing_parameters(
             original_yaml_content
         )
         user_data = yaml.safe_load(original_yaml_content)
+        parsed_renames = handle_renamed_parameters_in_parsed_yaml(user_data)
+        if parsed_renames:
+            seen_replacements = set(renamed_replacements)
+            for replacement in parsed_renames:
+                if replacement not in seen_replacements:
+                    renamed_replacements.append(replacement)
+                    seen_replacements.add(replacement)
+            import io
+
+            stream = io.StringIO()
+            yaml.dump(
+                user_data,
+                stream,
+                default_flow_style=False,
+                sort_keys=False,
+                allow_unicode=True,
+            )
+            original_yaml_content = stream.getvalue()
         with open(standard_file, "r") as f:
             standard_data = yaml.safe_load(f)
     except FileNotFoundError as e:

--- a/src/supy/data_model/validation/pipeline/phase_b.py
+++ b/src/supy/data_model/validation/pipeline/phase_b.py
@@ -7,10 +7,10 @@ that have already been processed by Phase A.
 Phase B focuses on:
 - Physics parameter validation
 - Geographic coordinate and timezone validation
-- Seasonal parameter adjustments (LAI, snowalb, surface temperatures)
+- Seasonal parameter checks (LAI, snowalb, surface temperatures)
 - Land cover fraction validation and consistency
 - Model physics option interdependency checks
-- Automatic physics-based corrections where appropriate
+- Optional scientific initialisation suggestions and corrections
 
 Phase B assumes Phase A has completed successfully and builds upon clean YAML output
 without duplicating parameter detection or YAML structure validation.
@@ -76,6 +76,133 @@ class ScientificAdjustment:
     old_value: Any = None
     new_value: Any = None
     reason: str = ""
+
+
+@dataclass
+class ScienceSuggestion:
+    """
+    Scientific transformation proposed by Phase B.
+
+    Suggestions describe values that can help initialise a SUEWS run, but they are
+    not treated as scientific truth. They are reported by default and only written
+    to YAML when the user explicitly selects apply mode.
+    """
+
+    parameter: str
+    site_index: Optional[int] = None
+    site_gridid: Optional[int] = None
+    old_value: Any = None
+    suggested_value: Any = None
+    message: str = ""
+    source: str = ""
+    code: Optional[str] = None
+    severity: str = "SUGGESTION"
+    path: Optional[str] = None
+
+    def __post_init__(self):
+        self.severity = self.severity.upper()
+        if self.code is None:
+            normalised_parameter = self.parameter.replace(".", "_").replace(" ", "_")
+            self.code = f"SCIENCE.{normalised_parameter}".upper()
+        if self.path is None:
+            self.path = self.parameter
+
+    def to_dict(self) -> dict:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "path": self.path,
+            "site_gridid": self.site_gridid,
+            "message": self.message,
+            "suggested_value": self.suggested_value,
+            "source": self.source,
+        }
+
+
+VALID_SCIENCE_FIX_MODES = {"suggest", "apply", "off"}
+
+
+def _normalise_science_fixes(science_fixes: str) -> str:
+    science_fixes = (science_fixes or "suggest").lower()
+    if science_fixes not in VALID_SCIENCE_FIX_MODES:
+        raise ValueError(
+            "science_fixes must be one of: suggest, apply, off"
+        )
+    return science_fixes
+
+
+def _science_source(parameter: str, reason: str) -> str:
+    parameter_lower = parameter.lower()
+    reason_lower = reason.lower()
+
+    if parameter_lower.startswith("initial_states") or "air_temperature" in parameter_lower:
+        return (
+            "CRU TS climatology-derived initialisation heuristic; may be inappropriate "
+            "for observed initial states, spin-up workflows, historical weather cases, "
+            "or specialist case studies."
+        )
+    if parameter_lower.startswith("stebbs.") and "temperature" in parameter_lower:
+        return (
+            "CRU TS climatology-derived STEBBS initialisation heuristic; review against "
+            "observed building states, spin-up workflows, and case-specific assumptions."
+        )
+    if parameter_lower in {"timezone", "anthropogenic_emissions.startdls", "anthropogenic_emissions.enddls"}:
+        return (
+            "Timezone and daylight-saving calculation from site coordinates; review for "
+            "historical timezone settings, policy changes, and local case-study choices."
+        )
+    if parameter_lower.endswith(".lai_id"):
+        return (
+            "Seasonal deciduous LAI initialisation based on start date and configured "
+            "LAI bounds; review for observed phenology or specialist vegetation studies."
+        )
+    if parameter_lower.endswith(".alb_id"):
+        return (
+            "Seasonal vegetation albedo initialisation based on configured albedo bounds; "
+            "review against observed surface state and site-specific calibration."
+        )
+    if parameter_lower == "snowalb":
+        return (
+            "Seasonal snow-albedo initialisation heuristic; review for observed snow cover, "
+            "cold-season spin-up, and unusual local conditions."
+        )
+    if parameter_lower.endswith(".sfr"):
+        return (
+            f"Land-cover fractions must sum to 1.0 for SUEWS runtime consistency; "
+            f"this suggestion only covers rounding drift within {SFR_FRACTION_TOL:g}."
+        )
+    if "stebbs" in parameter_lower or "wwr" in reason_lower:
+        return (
+            "Model-option dependency for STEBBS and window-to-wall-ratio parameters; "
+            "review before removing case-specific building physics inputs."
+        )
+    if "co2" in parameter_lower or "biogenic" in parameter_lower:
+        return (
+            "Model-option dependency for emissions and CO2/STEBBS coupling; review "
+            "before removing inputs needed by a specialist emissions workflow."
+        )
+    if parameter_lower.startswith("building_archetype"):
+        return (
+            "Model-option dependency for building archetype, setpoint, and RC settings; "
+            "review before replacing calibrated building parameters."
+        )
+    return (
+        "SUEWS option-dependent initialisation suggestion; review against the modelling "
+        "purpose before applying."
+    )
+
+
+def _adjustment_to_suggestion(adjustment: ScientificAdjustment) -> ScienceSuggestion:
+    source = _science_source(adjustment.parameter, adjustment.reason)
+    return ScienceSuggestion(
+        parameter=adjustment.parameter,
+        site_index=adjustment.site_index,
+        site_gridid=adjustment.site_gridid,
+        old_value=adjustment.old_value,
+        suggested_value=adjustment.new_value,
+        message=f"{adjustment.reason}. Current value: {adjustment.old_value}; suggested value: {adjustment.new_value}.",
+        source=source,
+    )
 
 
 def get_site_gridid(site_data: dict) -> int:
@@ -755,7 +882,7 @@ def get_mean_monthly_air_temperature(
     # Only catch availability errors, not validation errors
     try:
         return _get_mean_monthly_air_temperature(lat, lon, month, spatial_res)
-    except (FileNotFoundError, IOError, OSError) as e:
+    except (FileNotFoundError, IOError, OSError, ImportError) as e:
         logger_supy.warning(
             f"CRU data file not available: {e}. Temperature validation skipped."
         )
@@ -808,7 +935,7 @@ def get_monthly_air_temperature_diffmax(
 
     try:
         return _get_monthly_air_temperature_diffmax(lat, lon, spatial_res)
-    except (FileNotFoundError, IOError, OSError) as e:
+    except (FileNotFoundError, IOError, OSError, ImportError) as e:
         logger_supy.warning(
             f"CRU data file not available: {e}. Temperature diffmax validation skipped."
         )
@@ -860,7 +987,7 @@ def get_mean_annual_air_temperature(
     # Only catch availability errors, not validation errors
     try:
         return _get_mean_annual_air_temperature(lat, lon, spatial_res)
-    except (FileNotFoundError, IOError, OSError) as e:
+    except (FileNotFoundError, IOError, OSError, ImportError) as e:
         logger_supy.warning(
             f"CRU data file not available: {e}. Temperature validation skipped."
         )
@@ -2133,13 +2260,48 @@ def run_scientific_adjustment_pipeline(
     return updated_data, adjustments
 
 
+def collect_science_suggestions(
+    yaml_data: dict, start_date: str, model_year: int
+) -> List[ScienceSuggestion]:
+    """
+    Collect scientific initialisation suggestions without mutating the input data.
+
+    The underlying adjustment functions operate on a deep copy, so callers can use
+    this in the default validator path without silently overwriting user-provided
+    or scientifically curated values.
+    """
+    _, adjustments = run_scientific_adjustment_pipeline(
+        yaml_data, start_date, model_year
+    )
+    return [_adjustment_to_suggestion(adjustment) for adjustment in adjustments]
+
+
+def apply_science_suggestions(
+    yaml_data: dict,
+    suggestions: List[ScienceSuggestion],
+    start_date: str,
+    model_year: int,
+) -> Tuple[dict, List[ScientificAdjustment]]:
+    """
+    Apply the scientific transformation pipeline explicitly requested by the user.
+
+    The suggestions argument anchors the public API around the collect/apply split;
+    the transformations are recalculated from the same input data to avoid path
+    mutation code that would duplicate the existing domain logic.
+    """
+    del suggestions
+    return run_scientific_adjustment_pipeline(yaml_data, start_date, model_year)
+
+
 def create_science_report(
     validation_results: List[ValidationResult],
     adjustments: List[ScientificAdjustment],
+    suggestions: Optional[List[ScienceSuggestion]] = None,
     science_yaml_filename: str = None,
     phase_a_report_file: str = None,
     mode: str = "public",
     phase: str = "B",
+    science_fixes: str = "suggest",
 ) -> str:
     """
     Generate a comprehensive scientific validation report.
@@ -2170,6 +2332,8 @@ def create_science_report(
     - Integrates Phase A report highlights if available.
     - Designed for both human readability and traceability.
     """
+    suggestions = suggestions or []
+    science_fixes = _normalise_science_fixes(science_fixes)
     report_lines = []
 
     # Use unified report title for all validation phases
@@ -2212,9 +2376,15 @@ def create_science_report(
             # If we can't read Phase A report, continue without it
             pass
 
-    errors = [r for r in validation_results if r.status == "ERROR"]
-    warnings = [r for r in validation_results if r.status == "WARNING"]
-    passed = [r for r in validation_results if r.status == "PASS"]
+    errors = [
+        r for r in validation_results if getattr(r, "severity", r.status) == "ERROR"
+    ]
+    warnings = [
+        r for r in validation_results if getattr(r, "severity", r.status) == "WARNING"
+    ]
+    infos = [
+        r for r in validation_results if getattr(r, "severity", r.status) == "INFO"
+    ]
 
     if errors:
         report_lines.append("## ACTION NEEDED")
@@ -2232,12 +2402,54 @@ def create_science_report(
                 report_lines.append(f"   Suggested fix: {error.suggested_value}")
         report_lines.append("")
 
-    report_lines.append("## NO ACTION NEEDED")
+    if warnings:
+        report_lines.append("## REVIEW ADVISED")
+        report_lines.append(f"- Review ({len(warnings)}) scientific warning(s):")
+        for warning in warnings:
+            site_ref = (
+                f" at site [{warning.site_gridid}]"
+                if warning.site_gridid is not None
+                else ""
+            )
+            report_lines.append(
+                f"-- {warning.parameter}{site_ref}: {warning.message}"
+            )
+        report_lines.append("")
 
+    if suggestions:
+        report_lines.append("## SUGGESTED UPDATES")
+        report_lines.append(
+            f"- Suggested ({len(suggestions)}) scientific initialisation update(s)."
+        )
+        report_lines.append(
+            "- These suggestions were not written to YAML. They may be inappropriate "
+            "for observed initial states, spin-up workflows, historical timezone "
+            "settings, or specialist case studies."
+        )
+        if science_fixes == "suggest":
+            report_lines.append(
+                "- Re-run with --science-fixes apply to apply them, or "
+                "--science-fixes off to suppress scientific transformation suggestions."
+            )
+        for suggestion in suggestions:
+            site_ref = (
+                f" at site [{suggestion.site_gridid}]"
+                if suggestion.site_gridid is not None
+                else ""
+            )
+            report_lines.append(
+                f"-- {suggestion.parameter}{site_ref}: {suggestion.old_value} -> "
+                f"{suggestion.suggested_value} ({suggestion.message} Source: "
+                f"{suggestion.source})"
+            )
+        report_lines.append("")
+
+    applied_lines = []
     if adjustments:
         total_params_changed = 0
         for adjustment in adjustments:
-            if "temperature, tsfc, tin" in adjustment.old_value:
+            old_value_text = str(adjustment.old_value)
+            if "temperature, tsfc, tin" in old_value_text:
                 total_params_changed += 3
             elif adjustment.parameter == "stebbs" and "nullified" in adjustment.reason:
                 import re
@@ -2255,14 +2467,16 @@ def create_science_report(
             else:
                 total_params_changed += 1
 
-        report_lines.append(f"- Updated ({total_params_changed}) parameter(s):")
+        applied_lines.append(
+            f"- Applied ({total_params_changed}) scientific update(s):"
+        )
         for adjustment in adjustments:
             site_ref = (
                 f" at site [{adjustment.site_gridid}]"
                 if adjustment.site_gridid is not None
                 else ""
             )
-            report_lines.append(
+            applied_lines.append(
                 f"-- {adjustment.parameter}{site_ref}: {adjustment.old_value} -> {adjustment.new_value} ({adjustment.reason})"
             )
 
@@ -2289,32 +2503,15 @@ def create_science_report(
             phase_a_items.append(f"-- {param}")
 
     if phase_a_items:
-        report_lines.extend(phase_a_items)
-        if warnings or (not adjustments and not errors):
-            report_lines.append("")
+        applied_lines.extend(phase_a_items)
 
-    infos = [r for r in validation_results if r.status == "INFO"]
-
-    if warnings:
-        report_lines.append(f"- Revise ({len(warnings)}) warnings:")
-        for warning in warnings:
-            site_ref = (
-                f" at site [{warning.site_gridid}]"
-                if warning.site_gridid is not None
-                else ""
-            )
-            report_lines.append(f"-- {warning.parameter}{site_ref}: {warning.message}")
-        # Skip adding generic "passed" message when there are warnings
-    else:
-        if not adjustments and not errors:
-            if not phase_a_items:
-                report_lines.append("- All scientific validations passed")
-                report_lines.append("- Model physics parameters are consistent")
-                report_lines.append("- Geographic parameters are valid")
-            # Skip generic messages when phase A items exist
-        # Skip generic messages when there are no errors
+    if applied_lines:
+        report_lines.append("## APPLIED UPDATES")
+        report_lines.extend(applied_lines)
+        report_lines.append("")
 
     if infos:
+        report_lines.append("## INFO")
         report_lines.append(f"- Note ({len(infos)}):")
         for info in infos:
             site_ref = (
@@ -2323,6 +2520,15 @@ def create_science_report(
                 else ""
             )
             report_lines.append(f"-- {info.parameter}{site_ref}: {info.message}")
+        report_lines.append("")
+
+    if not errors and not warnings and not suggestions and not applied_lines and not infos:
+        report_lines.append("## INFO")
+        report_lines.append("- All scientific validation checks passed.")
+        if science_fixes == "off":
+            report_lines.append("- Scientific transformation suggestions were disabled.")
+        report_lines.append("- Model physics parameters are consistent.")
+        report_lines.append("- Geographic parameters are valid.")
 
     report_lines.append("")
 
@@ -2377,7 +2583,10 @@ def print_critical_halt_message(critical_errors: List[ValidationResult]):
 
 
 def print_science_check_results(
-    validation_results: List[ValidationResult], adjustments: List[ScientificAdjustment]
+    validation_results: List[ValidationResult],
+    adjustments: List[ScientificAdjustment],
+    suggestions: Optional[List[ScienceSuggestion]] = None,
+    science_fixes: str = "suggest",
 ):
     """
     Print concise terminal output for Phase B scientific validation results.
@@ -2399,6 +2608,7 @@ def print_science_check_results(
     errors = [r for r in validation_results if r.status == "ERROR"]
     warnings = [r for r in validation_results if r.status == "WARNING"]
     infos = [r for r in validation_results if r.status == "INFO"]
+    suggestions = suggestions or []
 
     if errors:
         print("PHASE B -- SCIENTIFIC ERRORS FOUND:")
@@ -2416,11 +2626,17 @@ def print_science_check_results(
         print(f"PHASE B -- SCIENTIFIC WARNINGS ({len(warnings)} found)")
         if adjustments:
             print(f"Applied {len(adjustments)} automatic scientific adjustments")
+        if suggestions and science_fixes == "suggest":
+            print(f"Suggested {len(suggestions)} scientific initialisation updates")
         print("Check science_report_user.txt for details")
     else:
         print("PHASE B -- PASSED")
         if adjustments:
             print(f"Applied {len(adjustments)} automatic scientific adjustments")
+        if suggestions and science_fixes == "suggest":
+            print(f"Suggested {len(suggestions)} scientific initialisation updates")
+        elif science_fixes == "off":
+            print("Scientific transformation suggestions were disabled")
 
     if infos:
         for info in infos:
@@ -2475,6 +2691,7 @@ def run_science_check(
     phase_a_performed: bool = True,
     mode: str = "public",
     phase: str = "B",
+    science_fixes: str = "suggest",
 ) -> dict:
     """
     Main Phase B workflow: perform scientific validation and scientific adjustments.
@@ -2518,6 +2735,7 @@ def run_science_check(
     - Writes a detailed report and optionally the updated YAML file.
     - Halts with a clear message if critical scientific errors are detected.
     """
+    science_fixes = _normalise_science_fixes(science_fixes)
     try:
         uptodate_data, user_data, standard_data = validate_phase_b_inputs(
             uptodate_yaml_file, user_yaml_file, standard_yaml_file
@@ -2571,12 +2789,14 @@ def run_science_check(
             os.path.basename(science_yaml_file) if science_yaml_file else None
         )
         report_content = create_science_report(
-            validation_results,
-            [],  # No adjustments since we failed early
-            science_yaml_filename,
-            phase_a_report_file,
-            mode,
-            phase,
+            validation_results=validation_results,
+            adjustments=[],  # No adjustments since we failed early
+            suggestions=[],
+            science_yaml_filename=science_yaml_filename,
+            phase_a_report_file=phase_a_report_file,
+            mode=mode,
+            phase=phase,
+            science_fixes=science_fixes,
         )
 
         # Write error report file
@@ -2587,24 +2807,38 @@ def run_science_check(
         raise e
 
     critical_errors = [r for r in validation_results if r.status == "ERROR"]
+    suggestions = []
+    adjustments = []
     if not critical_errors:
-        science_checked_data, adjustments = run_scientific_adjustment_pipeline(
-            uptodate_data, start_date, model_year
-        )
+        if science_fixes == "apply":
+            suggestions = collect_science_suggestions(
+                uptodate_data, start_date, model_year
+            )
+            science_checked_data, adjustments = apply_science_suggestions(
+                uptodate_data, suggestions, start_date, model_year
+            )
+        elif science_fixes == "suggest":
+            suggestions = collect_science_suggestions(
+                uptodate_data, start_date, model_year
+            )
+            science_checked_data = deepcopy(uptodate_data)
+        else:
+            science_checked_data = deepcopy(uptodate_data)
     else:
         science_checked_data = deepcopy(uptodate_data)
-        adjustments = []
 
     science_yaml_filename = (
         os.path.basename(science_yaml_file) if science_yaml_file else None
     )
     report_content = create_science_report(
-        validation_results,
-        adjustments,
-        science_yaml_filename,
-        phase_a_report_file,
-        mode,
-        phase,
+        validation_results=validation_results,
+        adjustments=adjustments,
+        suggestions=suggestions if science_fixes == "suggest" else [],
+        science_yaml_filename=science_yaml_filename,
+        phase_a_report_file=phase_a_report_file,
+        mode=mode,
+        phase=phase,
+        science_fixes=science_fixes,
     )
 
     if science_report_file:
@@ -2614,7 +2848,9 @@ def run_science_check(
         print_critical_halt_message(critical_errors)
         raise ValueError("Critical scientific errors detected - Phase B halted")
 
-    print_science_check_results(validation_results, adjustments)
+    print_science_check_results(
+        validation_results, adjustments, suggestions, science_fixes
+    )
 
     if science_yaml_file and not critical_errors:
         header = create_science_yaml_header(phase_a_performed)

--- a/src/supy/data_model/validation/pipeline/phase_b_rules/__init__.py
+++ b/src/supy/data_model/validation/pipeline/phase_b_rules/__init__.py
@@ -1,9 +1,54 @@
+"""Phase B rule registration.
+
+Rules are imported explicitly for their registration side effects. The execution
+order is kept in one place so scientific validation reports stay deterministic.
+"""
+
 from .rules_core import (
     RulesRegistry,
     ValidationContext,
     ValidationResult,
 )
 
-from .stebbs_rules import *
-from .physics_rules import *
-from .other_rules import *
+from . import physics_rules as _physics_rules
+from . import other_rules as _other_rules
+from . import stebbs_rules as _stebbs_rules
+from .other_rules import validate_irrigation_doy
+from .physics_rules import (
+    validate_rslmethod_dependency,
+    validate_smdmethod_dependency,
+    validate_storageheatmethod_dependency,
+)
+
+
+DEFAULT_RULE_ORDER = (
+    "physics_params",
+    "option_dependencies",
+    "land_cover",
+    "geographic",
+    "irrigation",
+    "archetype_properties",
+    "occupants_metabolism",
+    "daylight_control",
+    "stebbs_props",
+    "setpoint",
+    "rcmethod",
+    "same_albedo",
+    "same_emissivity",
+    "forcing_height",
+    "veg_albedo",
+)
+
+SFR_FRACTION_TOL = _other_rules.SFR_FRACTION_TOL
+
+__all__ = (
+    "DEFAULT_RULE_ORDER",
+    "RulesRegistry",
+    "SFR_FRACTION_TOL",
+    "ValidationContext",
+    "ValidationResult",
+    "validate_irrigation_doy",
+    "validate_rslmethod_dependency",
+    "validate_smdmethod_dependency",
+    "validate_storageheatmethod_dependency",
+)

--- a/src/supy/data_model/validation/pipeline/phase_b_rules/rules_core.py
+++ b/src/supy/data_model/validation/pipeline/phase_b_rules/rules_core.py
@@ -21,16 +21,26 @@ def function_name(context):
     return errors
 """
 
-from dataclasses import dataclass, fields
+from dataclasses import asdict, dataclass, fields
 from types import MappingProxyType
 from typing import Any, Mapping, Tuple, Optional
+
+
+VALID_SEVERITIES = {
+    "ERROR",
+    "WARNING",
+    "SUGGESTION",
+    "APPLIED_FIX",
+    "INFO",
+    "PASS",
+}
 
 
 @dataclass
 class ValidationResult:
     """Structured result from scientific validation checks."""
 
-    status: str  # 'PASS', 'WARNING', 'ERROR'
+    status: str  # 'ERROR', 'WARNING', 'SUGGESTION', 'APPLIED_FIX', 'INFO', 'PASS'
     category: str  # 'PHYSICS', 'GEOGRAPHY', 'SEASONAL', 'LAND_COVER', 'MODEL_OPTIONS'
     parameter: str
     site_index: Optional[int] = None  # Array index (for internal use)
@@ -38,6 +48,37 @@ class ValidationResult:
     message: str = ""
     suggested_value: Any = None
     applied_fix: bool = False
+    code: Optional[str] = None
+    severity: Optional[str] = None
+    path: Optional[str] = None
+    source: str = "phase_b"
+
+    def __setattr__(self, name, value):
+        if name == "status" and isinstance(value, str):
+            value = value.upper()
+            object.__setattr__(self, name, value)
+            if "severity" in self.__dict__:
+                object.__setattr__(self, "severity", value)
+            return
+        object.__setattr__(self, name, value)
+
+    def __post_init__(self):
+        self.status = (self.status or "INFO").upper()
+        self.severity = (self.severity or self.status).upper()
+        if self.severity not in VALID_SEVERITIES:
+            raise ValueError(
+                f"Invalid validation severity '{self.severity}'. "
+                f"Expected one of {sorted(VALID_SEVERITIES)}."
+            )
+        if self.code is None:
+            normalised_parameter = self.parameter.replace(".", "_").replace(" ", "_")
+            self.code = f"{self.category}.{normalised_parameter}".upper()
+        if self.path is None:
+            self.path = self.parameter
+
+    def to_dict(self) -> dict:
+        """Return a stable serialisable representation for reports and JSON."""
+        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -71,14 +112,37 @@ class RulesRegistry:
 
     rules = {}
 
-    def __init__(self, context:ValidationContext=None):
+    def __init__(self, context:ValidationContext=None, rule_order=None):
         self.context = context
+        self.rule_order = tuple(rule_order) if rule_order is not None else None
 
     def __getitem__(self, item):
         return self.rules[item]
 
     def get(self, key):
         return self.rules.get(key)
+
+    def ordered_rule_items(self):
+        rule_order = self.rule_order
+        if rule_order is None:
+            try:
+                from . import DEFAULT_RULE_ORDER
+
+                rule_order = DEFAULT_RULE_ORDER
+            except ImportError:
+                rule_order = tuple(self.rules.keys())
+
+        seen = set()
+        for rule_id in rule_order:
+            rule_fn = self.rules.get(rule_id)
+            if rule_fn is None:
+                continue
+            seen.add(rule_id)
+            yield rule_id, rule_fn
+
+        for rule_id, rule_fn in self.rules.items():
+            if rule_id not in seen:
+                yield rule_id, rule_fn
 
 
     @classmethod
@@ -96,7 +160,7 @@ class RulesRegistry:
                 raise ValueError("Must provide context of type ValidationContext to run validation registry.")
             context = self.context
 
-        for rule_id, rule_fn in self.rules.items():
+        for rule_id, rule_fn in self.ordered_rule_items():
             validation_results.extend(
                 rule_fn(context)
             )

--- a/src/supy/validation.py
+++ b/src/supy/validation.py
@@ -14,6 +14,15 @@ from .data_model.core.field_renames import read_physics_key
 logger = logging.getLogger(__name__)
 
 
+def _warn_deprecated():
+    warnings.warn(
+        "supy.validation is deprecated and will be removed in a future release; "
+        "use supy.data_model.validation instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 class ValidationResult:
     """Simple validation result class."""
 
@@ -33,6 +42,19 @@ class ValidationResult:
         self.validated_methods = validated_methods or set()
         self.skipped_methods = skipped_methods or set()
 
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+    def to_dict(self):
+        return {
+            "status": self.status,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "skipped": self.skipped,
+            "validated_methods": sorted(self.validated_methods),
+            "skipped_methods": sorted(self.skipped_methods),
+        }
+
 
 def analyze_config_methods(config_data: Dict[str, Any]) -> Dict[str, bool]:
     """
@@ -44,6 +66,7 @@ def analyze_config_methods(config_data: Dict[str, Any]) -> Dict[str, bool]:
     Returns:
         Dictionary of method flags
     """
+    _warn_deprecated()
     try:
         physics = config_data.get("model", {}).get("physics", {})
 
@@ -293,6 +316,7 @@ def validate_suews_config_conditional(
     Returns:
         ValidationResult object
     """
+    _warn_deprecated()
     if verbose:
         print("=== SUEWS Conditional Validation ===")
 
@@ -430,11 +454,11 @@ def enhanced_from_yaml_validation(
     """Enhanced YAML validation for SUEWSConfig.from_yaml integration."""
     result = validate_suews_config_conditional(config_data, verbose=True)
 
-    if result["errors"]:
+    if result.errors:
         error_msg = (
-            f"SUEWS Configuration Validation Failed: {len(result['errors'])} errors\n"
+            f"SUEWS Configuration Validation Failed: {len(result.errors)} errors\n"
         )
-        error_msg += "\n".join(f"  - {err}" for err in result["errors"])
+        error_msg += "\n".join(f"  - {err}" for err in result.errors)
 
         if strict:
             raise ValueError(error_msg)
@@ -450,12 +474,15 @@ def enhanced_to_df_state_validation(
     """Enhanced validation for to_df_state integration."""
     result = validate_suews_config_conditional(config_data, verbose=False)
 
-    if result["errors"]:
-        error_msg = f"Configuration validation found {len(result['errors'])} issues before to_df_state conversion"
+    if result.errors:
+        error_msg = (
+            f"Configuration validation found {len(result.errors)} issues before "
+            "to_df_state conversion"
+        )
 
         if strict:
             detailed_msg = f"\n{error_msg}:\n" + "\n".join(
-                f"  - {err}" for err in result["errors"]
+                f"  - {err}" for err in result.errors
             )
             raise ValueError(detailed_msg)
         else:

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -19,6 +19,7 @@ import types
 import copy
 
 import pytest
+import yaml
 
 import supy as sp
 from supy._env import trv_supy_module
@@ -4303,3 +4304,239 @@ sites:
 
         config = SUEWSConfig.from_yaml(str(config_path))
         assert config is not None
+
+
+def _phase_b_science_fixture():
+    return {
+        "model": {
+            "physics": {
+                "emissions": {"value": 5},
+                "stebbs": {"value": 1},
+                "outer_cap_fraction": {"value": 1},
+                "setpoint": {"value": 0},
+            }
+        },
+        "sites": [
+            {
+                "gridiv": {"value": 101},
+                "properties": {
+                    "lat": {"value": 51.5},
+                    "lng": {"value": -0.1},
+                    "land_cover": {
+                        "paved": {"sfr": {"value": 0.99995}},
+                    },
+                    "stebbs": {
+                        "initial_outdoor_temperature": {"value": 0.0},
+                        "annual_mean_air_temperature": {"value": 0.0},
+                    },
+                },
+                "initial_states": {
+                    "paved": {
+                        "temperature": {"value": [0.0] * 5},
+                        "tsfc": {"value": 0.0},
+                        "tin": {"value": 0.0},
+                    },
+                    "snowalb": {"value": 0.8},
+                },
+            }
+        ],
+    }
+
+
+def test_phase_b_collect_science_suggestions_does_not_mutate(monkeypatch):
+    from supy.data_model.validation.pipeline import phase_b
+
+    monkeypatch.setattr(
+        phase_b, "get_mean_monthly_air_temperature", lambda *args: 15.5
+    )
+    monkeypatch.setattr(
+        phase_b, "get_monthly_air_temperature_diffmax", lambda *args: 9.0
+    )
+    monkeypatch.setattr(
+        phase_b, "get_mean_annual_air_temperature", lambda *args: 11.2
+    )
+
+    yaml_data = _phase_b_science_fixture()
+    original = copy.deepcopy(yaml_data)
+
+    suggestions = phase_b.collect_science_suggestions(
+        yaml_data, start_date="2020-07-01", model_year=2020
+    )
+
+    assert yaml_data == original
+    assert any(s.parameter == "initial_states.paved" for s in suggestions)
+    assert any(s.parameter == "paved.sfr" for s in suggestions)
+    assert any(s.parameter == "snowalb" for s in suggestions)
+    assert all(s.severity == "SUGGESTION" for s in suggestions)
+    assert all(s.source for s in suggestions)
+
+
+def test_phase_b_apply_science_suggestions_mutates_copy(monkeypatch):
+    from supy.data_model.validation.pipeline import phase_b
+
+    monkeypatch.setattr(
+        phase_b, "get_mean_monthly_air_temperature", lambda *args: 15.5
+    )
+    monkeypatch.setattr(
+        phase_b, "get_monthly_air_temperature_diffmax", lambda *args: 9.0
+    )
+    monkeypatch.setattr(
+        phase_b, "get_mean_annual_air_temperature", lambda *args: 11.2
+    )
+
+    yaml_data = _phase_b_science_fixture()
+    suggestions = phase_b.collect_science_suggestions(
+        yaml_data, start_date="2020-07-01", model_year=2020
+    )
+    updated, adjustments = phase_b.apply_science_suggestions(
+        yaml_data, suggestions, start_date="2020-07-01", model_year=2020
+    )
+
+    paved_state = updated["sites"][0]["initial_states"]["paved"]
+    paved_sfr = updated["sites"][0]["properties"]["land_cover"]["paved"]["sfr"]
+
+    assert paved_state["tsfc"]["value"] == 15.5
+    assert paved_sfr["value"] == pytest.approx(1.0)
+    assert updated["sites"][0]["initial_states"]["snowalb"]["value"] is None
+    assert len(adjustments) == len(suggestions)
+    assert yaml_data["sites"][0]["initial_states"]["paved"]["tsfc"]["value"] == 0.0
+
+
+@pytest.mark.parametrize(
+    ("science_fixes", "expect_mutation", "expected_section", "unexpected_section"),
+    [
+        ("suggest", False, "## SUGGESTED UPDATES", "## APPLIED UPDATES"),
+        ("apply", True, "## APPLIED UPDATES", "## SUGGESTED UPDATES"),
+        ("off", False, "## INFO", "## SUGGESTED UPDATES"),
+    ],
+)
+def test_phase_b_run_science_check_science_fixes_modes(
+    tmp_path,
+    monkeypatch,
+    science_fixes,
+    expect_mutation,
+    expected_section,
+    unexpected_section,
+):
+    from supy.data_model.validation.pipeline import phase_b
+
+    monkeypatch.setattr(
+        phase_b, "get_mean_monthly_air_temperature", lambda *args: 15.5
+    )
+    monkeypatch.setattr(
+        phase_b, "get_monthly_air_temperature_diffmax", lambda *args: 9.0
+    )
+    monkeypatch.setattr(
+        phase_b, "get_mean_annual_air_temperature", lambda *args: 11.2
+    )
+    monkeypatch.setattr(phase_b.RulesRegistry, "run_validation", lambda self: [])
+
+    yaml_data = _phase_b_science_fixture()
+    yaml_data["model"]["control"] = {
+        "start_time": "2020-07-01",
+        "end_time": "2020-07-02",
+    }
+
+    input_file = tmp_path / "config.yml"
+    output_file = tmp_path / "updated_config.yml"
+    report_file = tmp_path / "report_config.txt"
+    input_file.write_text(yaml.safe_dump(yaml_data), encoding="utf-8")
+
+    phase_b.run_science_check(
+        uptodate_yaml_file=str(input_file),
+        user_yaml_file=str(input_file),
+        standard_yaml_file=str(input_file),
+        science_yaml_file=str(output_file),
+        science_report_file=str(report_file),
+        science_fixes=science_fixes,
+    )
+
+    updated = yaml.safe_load(output_file.read_text(encoding="utf-8"))
+    report = report_file.read_text(encoding="utf-8")
+
+    updated_tsfc = updated["sites"][0]["initial_states"]["paved"]["tsfc"]["value"]
+    expected_tsfc = 15.5 if expect_mutation else 0.0
+
+    assert updated_tsfc == expected_tsfc
+    assert expected_section in report
+    assert unexpected_section not in report
+
+
+def test_phase_b_report_uses_review_and_suggestion_sections():
+    from supy.data_model.validation.pipeline.phase_b import (
+        ScienceSuggestion,
+        ValidationResult,
+        create_science_report,
+    )
+
+    report = create_science_report(
+        validation_results=[
+            ValidationResult(
+                status="WARNING",
+                category="GEOGRAPHY",
+                parameter="timezone",
+                message="Review timezone choice",
+            )
+        ],
+        adjustments=[],
+        suggestions=[
+            ScienceSuggestion(
+                parameter="snowalb",
+                old_value=0.8,
+                suggested_value=None,
+                message="Seasonal initialisation suggestion",
+                source="Seasonal snow-albedo initialisation heuristic.",
+            )
+        ],
+    )
+
+    assert "## REVIEW ADVISED" in report
+    assert "## SUGGESTED UPDATES" in report
+    assert "## NO ACTION NEEDED" not in report
+
+
+def test_phase_b_structured_result_and_rule_order():
+    from supy.data_model.validation.pipeline.phase_b_rules import (
+        DEFAULT_RULE_ORDER,
+        RulesRegistry,
+        ValidationResult,
+    )
+
+    result = ValidationResult(
+        status="warning",
+        category="LAND_COVER",
+        parameter="land_cover.paved.sfr",
+        message="Review surface fractions",
+    )
+    payload = result.to_dict()
+
+    assert payload["severity"] == "WARNING"
+    assert payload["path"] == "land_cover.paved.sfr"
+    assert payload["code"] == "LAND_COVER.LAND_COVER_PAVED_SFR"
+
+    ordered_rule_names = [name for name, _ in RulesRegistry().ordered_rule_items()]
+    expected_prefix = [
+        name for name in DEFAULT_RULE_ORDER if name in RulesRegistry.rules
+    ]
+    assert ordered_rule_names[: len(expected_prefix)] == expected_prefix
+
+
+def test_supy_validation_backward_compatibility_warns():
+    import supy.validation as legacy_validation
+
+    with pytest.warns(DeprecationWarning):
+        result = legacy_validation.validate_suews_config_conditional(
+            {"model": {"physics": {}}, "sites": []}
+        )
+
+    assert result["errors"] == result.errors
+    assert "errors" in result.to_dict()
+
+
+def test_suews_validate_help_exposes_science_fixes(cli_runner):
+    from supy.cmd.validate_config import cli as validate_cli
+
+    result = cli_runner.invoke(validate_cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "--science-fixes" in result.output


### PR DESCRIPTION
## Summary

Revise the data model validation flow so Phase B scientific initialisation changes are suggestions by default rather than silent YAML mutations.

## What changed

- Added `suews-validate --science-fixes {suggest,apply,off}` with `suggest` as the default.
- Split Phase B scientific transformations into collection and explicit application paths.
- Added structured suggestion/applied-fix reporting and stable JSON arrays for `errors`, `warnings`, `suggestions`, `applied_fixes`, and `info`.
- Reworked report sections to use `ACTION NEEDED`, `REVIEW ADVISED`, `SUGGESTED UPDATES`, `APPLIED UPDATES`, and `INFO`.
- Replaced wildcard Phase B rule registration with an explicit deterministic order.
- Kept legacy `supy.validation` and `ValidationController` imports compatible while marking them deprecated.
- Fixed fragile Phase A rename/introspection paths and refreshed validation documentation.

## Impact

By default, validation remains conservative: climatology-derived CRU, DLS/timezone, LAI, albedo, snow, STEBBS, and land-cover normalisation changes are reported as initialisation suggestions rather than written back to user configuration. Users who need the previous mutation behaviour can opt in with `--science-fixes apply`.

## Validation

- `uv run --no-sync python -m py_compile` on changed Python files: passed
- `PYTHONPATH=src uv run --no-sync pytest test/data_model/test_validation.py -k "science_fixes_modes or science_suggestions or science_fixes or report_uses_review or structured_result or backward_compatibility_warns" -v`: passed
- `PYTHONPATH=src uv run --no-sync pytest test/data_model/test_validation.py test/data_model/test_yaml_processing.py test/umep/test_preprocessor.py -v`: `308 passed, 16 skipped`
- `source .venv/bin/activate && make dev`: passed
- `source .venv/bin/activate && make test-smoke`: `9 passed, 960 deselected, 8 warnings`
- `git diff --check`: passed