### PR TITLE
feat: scaffold SUEWS Claude Skill (.claude/skills/suews/)

### DIFF
--- a/.claude/skills/suews/SKILL.md
+++ b/.claude/skills/suews/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: suews
+description: Use whenever helping with SUEWS or SuPy -- preparing or migrating YAML configurations, running urban-climate simulations, validating inputs, diagnosing failed or suspicious runs, comparing scenarios, interpreting energy/water balance outputs, or reviewing simulation setups before publication. Prefers structured CLI/MCP calls (suews validate, suews diagnose, validate_config tool) over guessing parameters or rewriting files.
+---
+
+# SUEWS workflow
+
+When helping with SUEWS or SuPy, follow this rule set. The Skill teaches *when*
+and *why* to call which tool -- actual execution lives in the unified `suews`
+CLI and the `suews-mcp` server. Never re-implement validation, schema
+checking, or simulation logic in conversation.
+
+
+> **CLI naming note**: this Skill describes the unified `suews <subcommand>`
+> CLI (`suews validate`, `suews inspect`, `suews diagnose`, `suews convert`,
+> `suews compare`, `suews init`). On installations that ship the legacy
+> hyphenated entry points only (`suews-validate`, `suews-convert`,
+> `suews-schema`, `suews-run`), substitute the hyphenated form -- the
+> structured JSON envelope and exit semantics are the same. When in doubt,
+> run `suews --help` and pick whichever surface the wheel exposes.
+
+1. Prefer YAML configuration. Treat namelist as legacy and only touch it
+   during migration via `suews convert`.
+2. Never invent parameter values. If a value is missing, ask the user or
+   reuse a sample from `suews://examples/{name}` or
+   `src/supy/sample_data/sample_config.yml`.
+3. Always validate before editing. Call the `validate_config` MCP tool, or
+   run `suews validate <config> --format json`. Read the structured output,
+   not the prose. Pretty-printed terminal output is for humans; you want the
+   JSON envelope (`{status, data, errors, warnings, meta}`).
+4. Use structured JSON outputs only. If a CLI lacks `--format json`, flag
+   it as a CLI gap rather than scrape prose.
+5. Failure-diagnosis order: schema/version -> file paths -> forcing time
+   axis -> required forcing variables -> land-cover fractions sum to 1 ->
+   temporal resolution -> output directory writable. Stop at the first
+   failure and explain it before moving on.
+6. Suggest the smallest safe patch. Single-key edits, never wholesale
+   rewrites.
+7. Never overwrite user files without explicit consent. Prefer creating
+   `*.suews-suggested.yml` next to the original.
+8. Distinguish four error classes in any reply:
+   schema errors / missing input data / unit problems / physically
+   suspicious values. Tag each finding with one of these.
+9. After running, always read `provenance.json` and `diagnostics.json`
+   before claiming success. The MCP resources `suews://runs/{id}/provenance`
+   and `suews://runs/{id}/diagnostics` are the canonical way.
+10. For publication, route through the `review_config_before_publication`
+    MCP prompt. Do not invent a checklist -- see
+    `references/publication-review-checklist.md`.
+
+## Procedural recipes
+
+These are the standard moves; expand by reading the referenced files.
+
+- **New case from scratch**: `suews init --template simple-urban -o demo`,
+  edit, then `suews validate demo/config.yml --format json`. See
+  `references/forcing-checklist.md` before adding forcing.
+- **Failed run**: `suews validate` -> `suews inspect` -> `suews diagnose`.
+  Read `references/common-errors.md` for the most frequent diagnoses.
+- **Namelist -> YAML migration**: `suews convert -i RunControl.nml -o config.yml`,
+  then validate. See `references/migration-namelist-to-yaml.md`.
+- **Output interpretation**: read `references/output-interpretation.md` for
+  energy balance, storage heat, anthropogenic heat, Bowen ratio.
+- **Scenario comparison**: `suews compare <baseline> <scenario>` -- see
+  `references/output-interpretation.md` for which metrics to read first.

--- a/.claude/skills/suews/references/common-errors.md
+++ b/.claude/skills/suews/references/common-errors.md
@@ -1,0 +1,63 @@
+# Common SUEWS errors
+
+> CLI: this reference uses unified `suews <subcommand>` syntax. If your install only has the legacy hyphenated entry points (`suews-validate`, `suews-convert`, `suews-schema`, `suews-run`), substitute accordingly. See `../SKILL.md` for the rule.
+
+The errors most users hit and how to diagnose them. Each entry: the
+symptom, the root cause class (schema / input data / unit / physics), and
+the fix.
+
+## Schema errors
+
+- **`schema_version` mismatch** -- the YAML's `schema_version` is older
+  than `CURRENT_SCHEMA_VERSION`. Fix: `suews convert -i old.yml -o new.yml
+  --format json`. The migration registry in
+  `src/supy/util/converter/yaml_upgrade.py` will run the appropriate
+  handlers.
+- **Unknown field** -- a key the validator does not recognise. Fix: check
+  the schema export with `suews schema export --format json` and look for
+  the canonical name. Do not rename fields silently.
+- **Type error** -- value is not the expected type (e.g. a string where a
+  number is expected). Fix: read the validator message; the standard
+  envelope's `errors[].field` shows the YAML path.
+
+## Input data errors
+
+- **No forcing data found** -- `forcing_file` is missing, the path is
+  wrong, or the file is empty. Fix: confirm `forcing_file` resolves
+  relative to the config file's directory.
+- **Missing required forcing column** -- the CSV header is missing
+  `Tair` / `RH` / `Press` / `U` / `Kdown` / `rain`. Fix: rename the
+  column or add it. Run `check_forcing_columns.py` from `scripts/`.
+- **Forcing time axis irregular** -- gaps or duplicate rows in the time
+  index. Fix: resample to the model timestep before running.
+- **Land cover does not sum to 1** -- the seven `sfr` values must sum to
+  1.0 (within 1e-6). Fix: rebalance, usually by absorbing the residual
+  into the largest fraction.
+
+## Unit errors
+
+- **`Press` in Pa not kPa** -- order-of-magnitude pressure errors crash
+  the boundary-layer code. Fix: divide by 1000 if you ingested ERA5 raw.
+- **`Tair` in K not deg C** -- values around 280 give a hot-summer signal.
+  Fix: subtract 273.15.
+- **`Kdown` in J/m^2 instead of W/m^2** -- common when ingesting hourly
+  ERA5. Fix: divide by 3600 (or by the timestep in seconds).
+
+## Physics errors / suspicious outputs
+
+- **Energy balance closure off by >20%** -- usually `QF` (anthropogenic
+  heat) is missing or wrong. Fix: configure `Anthropogenic` realistically
+  for the site or set the simple `QF_method` to a known regional default.
+- **Negative latent heat** -- possible at night with a warm surface.
+  Becomes physical only when `Tsurf < Tair` and `state` is dry. Confirm
+  via `suews diagnose`.
+- **NaN propagation** -- usually starts in `state_*` from divide-by-zero
+  in surface water store updates. Re-check rainfall units and timestep.
+
+## Run-time errors
+
+- **Output directory not writable** -- usually a permission issue or
+  the path resolved outside the project root. Fix: provide
+  `--output <abs_dir>`.
+- **Spin-up too short** -- soil moisture has not equilibrated. Fix:
+  prepend a year of forcing or supply a warm-start checkpoint.

--- a/.claude/skills/suews/references/forcing-checklist.md
+++ b/.claude/skills/suews/references/forcing-checklist.md
@@ -1,0 +1,38 @@
+# Forcing data checklist
+
+> CLI: this reference uses unified `suews <subcommand>` syntax. If your install only has the legacy hyphenated entry points (`suews-validate`, `suews-convert`, `suews-schema`, `suews-run`), substitute accordingly. See `../SKILL.md` for the rule.
+
+Before running, verify these eight properties of the forcing CSV.
+
+1. **Required columns present** (case-sensitive headers): `Tair`, `RH`,
+   `Press`, `U`, `Kdown`, `rain`. Optional: `Ldown`, `fcld`, `qn1_obs`.
+2. **Time index regular** -- same delta between every row. No missing rows.
+   Use `pandas.infer_freq` on the parsed index; it should return a fixed
+   frequency string.
+3. **Time zone consistent** -- pick **UTC** or **local standard time**
+   (no DST). Mixing the two within a single run is a hidden
+   showstopper.
+4. **Units match SUEWS expectations** -- see
+   `variable-glossary.md`. Common traps: `Press` in Pa not kPa, `Kdown`
+   in J/m^2 not W/m^2, `Tair` in K not deg C.
+5. **No physically impossible values** -- `RH` in [0, 100], `Press` in
+   [80, 110] kPa, `Tair` in [-50, 60] deg C, `Kdown >= 0`,
+   `rain >= 0`.
+6. **NaN proportion < 1%** per variable. Higher proportions hide silent
+   gap-filling failures. `suews diagnose` reports per-variable NaN
+   proportion in the standard envelope.
+7. **Spin-up adequacy** -- at least one full year of forcing prior to
+   the analysis window, otherwise soil moisture has not equilibrated.
+   For multi-year studies, two-year spin-up is conservative.
+8. **Site time zone matches `Country`** -- the YAML's `Country` /
+   `timezone` should match the forcing's local standard time.
+
+Quick check from the command line:
+
+```bash
+suews validate config.yml --format json | jq '.warnings, .errors'
+suews inspect config.yml --format json | jq '.data.forcing_summary'
+```
+
+The `check_forcing_columns.py` script in `scripts/` returns a
+non-zero exit code when required columns are missing.

--- a/.claude/skills/suews/references/migration-namelist-to-yaml.md
+++ b/.claude/skills/suews/references/migration-namelist-to-yaml.md
@@ -1,0 +1,55 @@
+# Migration: namelist to YAML
+
+> CLI: this reference uses unified `suews <subcommand>` syntax. If your install only has the legacy hyphenated entry points (`suews-validate`, `suews-convert`, `suews-schema`, `suews-run`), substitute accordingly. See `../SKILL.md` for the rule.
+
+The legacy `RunControl.nml` + tables format is deprecated. Use YAML for
+all new work; convert old cases with `suews convert`.
+
+## One-shot conversion
+
+```bash
+suews convert -i RunControl.nml -o config.yml --format json
+suews validate config.yml --format json
+```
+
+The first command produces a current-schema YAML. The second confirms it
+parses. Read both envelopes -- `warnings` from convert often flag fields
+that received a default because the namelist did not provide them.
+
+## Cross-release YAML upgrade
+
+If you have an older YAML (e.g. from `2025.10.15`):
+
+```bash
+suews convert -i old.yml -o new.yml --format json
+```
+
+The migration registry at `src/supy/util/converter/yaml_upgrade.py`
+applies the chain of handlers between the source and current schema.
+Always validate after migration; the registry never deletes user fields
+silently -- any drop is in the `warnings` channel.
+
+## Hand-mapping common namelist fields
+
+If the auto-converter lacks coverage for an obscure namelist variant,
+the principal mappings are:
+
+- `RunControl.nml` `FileCode` -> YAML `model.physics.netradiation_method`
+  (and friends).
+- `SUEWS_AnthropogenicEmissions.txt` -> YAML
+  `sites[*].properties.anthropogenic` block.
+- `SUEWS_BiogenCO2.txt` -> `sites[*].properties.biogen_co2`.
+- `SUEWS_NonVeg.txt` / `SUEWS_Veg.txt` / `SUEWS_Water.txt` ->
+  `sites[*].properties.land_cover.<surface>` per surface.
+
+Refer to `docs/source/inputs/yaml/` for the canonical mapping.
+
+## Checklist after migration
+
+1. `schema_version` in the new YAML matches `CURRENT_SCHEMA_VERSION`.
+2. All seven `sfr` values present and sum to 1.0.
+3. Forcing path is portable (relative to the YAML location, not absolute).
+4. Site `Country` / `timezone` is populated (some old namelists omit it).
+5. `suews validate` returns `status: success` (warnings are OK if you
+   accept them).
+6. A fresh `suews run` reproduces qualitatively the old run's main fluxes.

--- a/.claude/skills/suews/references/output-interpretation.md
+++ b/.claude/skills/suews/references/output-interpretation.md
@@ -1,0 +1,72 @@
+# Output interpretation
+
+> CLI: this reference uses unified `suews <subcommand>` syntax. If your install only has the legacy hyphenated entry points (`suews-validate`, `suews-convert`, `suews-schema`, `suews-run`), substitute accordingly. See `../SKILL.md` for the rule.
+
+How to read SUEWS results without overreaching.
+
+## Energy balance
+
+Closure: `QN + QF ~= QH + QE + QS`. Acceptable on hourly data within ~10%
+under stationary forcing. Larger residuals point to:
+
+- missing or wrong `QF` (anthropogenic heat) -- most common.
+- spin-up too short, soil moisture or storage not equilibrated.
+- forcing unit error in `Kdown`.
+- timestep mismatch: aggregating sub-hourly outputs to hourly without
+  weighting by valid steps.
+
+## Storage heat (`QS`)
+
+Diurnal hysteresis with `QN` is expected -- `QS` leads in the morning, lags
+in the afternoon. Large nighttime `QS` (still very negative after sunset)
+suggests the OHM coefficients are wrong for this surface mix. Check
+`derive_ohm_coef` outputs in `supy.util._ohm`.
+
+## Anthropogenic heat (`QF`)
+
+Two regimes:
+
+- Daily mean `QF` typically 5-50 W/m^2 in mid-latitude cities,
+  highest in dense centres in winter (heating) or summer (cooling).
+- Diurnal cycle for traffic-dominated sites peaks at rush hour;
+  building-dominated sites peak at meal times or in early morning
+  heating/cooling cycles.
+
+If `QF` is implausibly flat, the simple `QF_method` is probably set
+without diurnal weighting; switch to LUCY-style with site-specific
+profiles.
+
+## Latent heat (`QE`)
+
+Negative `QE` is rare but physical -- dewfall on a cool surface. Usually a
+data quality flag, not a model bug. Drying surface store after a
+rainfall pulse should produce a clear `QE` peak followed by exponential
+decay.
+
+## Bowen ratio (`B = QH / QE`)
+
+Useful summary by surface type and season:
+
+- B >> 1: dry, dominated by sensible heating (paved, bare soil in summer).
+- B ~ 1: mixed surfaces, transition seasons.
+- B << 1: wet, vegetated, irrigated.
+
+## Temperature diagnostics (`T2`, `Tsurf`)
+
+`Tsurf - T2` gives the surface-air temperature difference. A persistent
+negative value at noon suggests evaporative cooling is overactive (often
+an irrigation parameter issue).
+
+## Comparing scenarios
+
+When using `suews compare`, read in this order:
+
+1. `time_axis_overlap` -- confirm both runs cover the same period.
+2. Per-variable `r` (Pearson correlation) -- should be high (>0.9) for
+   the same site under different parameters; low values mean a phase
+   shift, often a time zone issue.
+3. `bias` -- sign and magnitude tell you direction of the change.
+4. `rmse` -- overall magnitude.
+
+Do not over-interpret single-day differences. SUEWS is a flux model; the
+useful comparison is multi-day to multi-week aggregates.

--- a/.claude/skills/suews/references/publication-review-checklist.md
+++ b/.claude/skills/suews/references/publication-review-checklist.md
@@ -1,0 +1,67 @@
+# Publication review checklist
+
+> CLI: this reference uses unified `suews <subcommand>` syntax. If your install only has the legacy hyphenated entry points (`suews-validate`, `suews-convert`, `suews-schema`, `suews-run`), substitute accordingly. See `../SKILL.md` for the rule.
+
+Run through this before submitting a paper that uses SUEWS results.
+
+## Reproducibility
+
+- The exact `config.yml` used is in the supplementary material or a
+  public repository.
+- The schema version (`schema_version` field) is stated in the methods
+  text.
+- The supy / SUEWS version (`suews --version` or
+  `python -c "import supy; print(supy.__version__)"`) is stated.
+- The git commit (from `provenance.json::git_commit`) is recorded if
+  the run used a development version.
+- Forcing data are either public or available on reasonable request,
+  with the same time axis as the run.
+- A `provenance.json` is preserved next to the run output.
+
+## Validation
+
+- `suews validate config.yml --format json` returns `status` of
+  `success` or `warning` (not `error`).
+- All warnings have been read and judged acceptable; reasons are
+  documented in the methods or supplement.
+- `suews diagnose <run_dir> --format json` shows zero `severity: fail`
+  checks.
+
+## Physical plausibility
+
+- Energy balance closure within ~10% on multi-day means.
+- Bowen ratio falls in the expected range for the surface mix and
+  season.
+- Seasonal QE is positive on summer afternoons; negative QE values are
+  rare (< 5% of timesteps) and explained.
+- No NaN propagation in any reported variable.
+- Spin-up adequate (at least one full year before the analysis window).
+
+## Methods text checklist
+
+- Forcing source named with version (e.g. "ERA5 single-levels, hourly,
+  retrieved DD-MM-YYYY").
+- Time zone explicit and matched between forcing and site.
+- Land cover fractions reported per surface; totals sum to 1.0.
+- Anthropogenic heat scheme named (`QF_method` value or LUCY-style
+  description).
+- Storage heat scheme named (OHM coefficients or AnOHM if used).
+- Comparison metrics (rmse, bias, r) reported with units and sample
+  size; computed via `suews compare` for reproducibility.
+
+## Figure / table checklist
+
+- Axes use SI units consistent with the variable glossary.
+- Time axes labelled with time zone.
+- Multi-panel figures share comparable y-ranges where the comparison is
+  the point.
+- Captions identify the SUEWS variable name plus the plain-language
+  description.
+
+## Avoid
+
+- Quoting metrics from a single day.
+- Calling a single short run a "validation"; that is a sanity check,
+  not a validation.
+- Reporting closure better than 5% as a model achievement; that level is
+  inside measurement uncertainty.

--- a/.claude/skills/suews/references/variable-glossary.md
+++ b/.claude/skills/suews/references/variable-glossary.md
@@ -1,0 +1,62 @@
+# SUEWS variable glossary
+
+Quick lookup for the variables you will see most often in SUEWS configs and
+outputs. Names follow the YAML/snake_case convention. Units are SI.
+
+## Forcing variables (required)
+
+- `Tair` -- air temperature, deg C.
+- `RH` -- relative humidity, %.
+- `Press` -- air pressure, kPa.
+- `U` -- wind speed at measurement height, m/s.
+- `Kdown` -- incoming shortwave radiation, W/m^2.
+- `rain` -- precipitation, mm per timestep.
+
+Optional forcing (improves model skill if available): `Ldown` (longwave),
+`fcld` (cloud fraction), `qn1_obs` (observed Q*).
+
+## Surface cover (`sites[*].properties.land_cover.<surface>.sfr`)
+
+Seven fractions that must sum to 1.0:
+
+- `paved` -- sealed surfaces (roads, pavements).
+- `bldgs` -- buildings (roof + walls).
+- `evetr` -- evergreen trees.
+- `dectr` -- deciduous trees.
+- `grass` -- irrigated and unirrigated grass.
+- `bsoil` -- bare soil.
+- `water` -- open water.
+
+## Output flux variables (W/m^2 unless noted)
+
+- `QN` (or `Q*`) -- net all-wave radiation.
+- `QH` -- sensible heat flux.
+- `QE` -- latent heat flux.
+- `QS` (or `dQS`) -- net storage heat flux.
+- `QF` -- anthropogenic heat flux.
+
+Energy balance: `QN + QF ~= QH + QE + QS` (closure within ~10% on hourly
+data is reasonable).
+
+## Output state variables
+
+- `Tsurf` -- surface temperature, deg C.
+- `T2` -- diagnostic 2 m air temperature, deg C.
+- `q2` -- diagnostic 2 m specific humidity, g/kg.
+- `U10` -- diagnostic 10 m wind speed, m/s.
+- `state_*` -- surface water store, mm.
+- `soilstore_*` -- sub-surface soil moisture store, mm.
+
+## Time and grid
+
+- `Year`, `DOY`, `Hour`, `Min` -- output time keys.
+- `Grid` -- site identifier (multi-grid runs).
+
+## Common gotchas
+
+- Forcing time axis must be **regular** (no missing rows) and in **UTC** or
+  **local standard time consistent with the site time zone**. DST changes
+  break the model; use a non-DST time zone string.
+- Wind speed `U` is at the **measurement height** declared in the config,
+  not 10 m by default.
+- `rain` is **per timestep**, not per hour, unless your timestep is 1 h.

--- a/.claude/skills/suews/scripts/check_forcing_columns.py
+++ b/.claude/skills/suews/scripts/check_forcing_columns.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Check the header of a SUEWS forcing CSV against the canonical column list.
+
+Pure stdlib so the Skill never pulls supy.
+
+Usage:
+    python check_forcing_columns.py <forcing.csv>
+
+Exit codes: 0 = all required columns present; 1 = missing columns.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+REQUIRED = ["Tair", "RH", "Press", "U", "Kdown", "rain"]
+OPTIONAL = ["Ldown", "fcld", "qn1_obs"]
+
+
+def check(path_csv: Path) -> int:
+    with path_csv.open("r", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        try:
+            header = next(reader)
+        except StopIteration:
+            print(f"{path_csv}: empty file", file=sys.stderr)
+            return 1
+
+    header_set = {h.strip() for h in header}
+    missing = [c for c in REQUIRED if c not in header_set]
+    found_optional = [c for c in OPTIONAL if c in header_set]
+
+    print(f"File: {path_csv}")
+    print(f"Header columns: {len(header_set)}")
+    if missing:
+        print(f"Missing required: {', '.join(missing)}")
+    else:
+        print("All required columns present.")
+    if found_optional:
+        print(f"Optional present: {', '.join(found_optional)}")
+    return 1 if missing else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check the header of a SUEWS forcing CSV against the canonical "
+            "required column list. Pure stdlib so the Skill never pulls supy."
+        ),
+    )
+    parser.add_argument(
+        "forcing_csv",
+        type=Path,
+        help="Path to the SUEWS forcing CSV whose header should be checked.",
+    )
+    args = parser.parse_args()
+    return check(args.forcing_csv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/suews/scripts/summarise_diagnostics.py
+++ b/.claude/skills/suews/scripts/summarise_diagnostics.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Read a SUEWS run diagnostics.json and print a short plain-English summary.
+
+Pure stdlib so the Skill never pulls supy as a dependency.
+
+Usage:
+    python summarise_diagnostics.py <run_dir>
+
+Exit codes: 0 = all checks passed; 1 = warnings present; 2 = failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def summarise(run_dir: Path) -> int:
+    path = run_dir / "diagnostics.json"
+    if not path.exists():
+        print(f"diagnostics.json not found in {run_dir}", file=sys.stderr)
+        print(
+            f"Run: suews diagnose {run_dir} --format json > {path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    data = payload.get("data") or payload
+    summary = data.get("summary") or {}
+    n_pass = summary.get("n_pass", 0)
+    n_warn = summary.get("n_warn", 0)
+    n_fail = summary.get("n_fail", 0)
+    checks = data.get("checks") or []
+
+    print(f"Run: {run_dir}")
+    print(f"Checks: {n_pass} passed, {n_warn} warnings, {n_fail} failed")
+
+    fail_names = [c.get("name") for c in checks if c.get("severity") == "fail"]
+    warn_names = [c.get("name") for c in checks if c.get("severity") == "warning"]
+    if fail_names:
+        print(f"Failed: {', '.join(fail_names)}")
+    if warn_names:
+        print(f"Warnings: {', '.join(warn_names)}")
+    if not fail_names and not warn_names:
+        print("All diagnostic checks passed.")
+
+    if n_fail:
+        return 2
+    if n_warn:
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read a SUEWS run diagnostics.json and print a short "
+            "plain-English summary. Pure stdlib so the Skill never pulls "
+            "supy as a dependency."
+        ),
+    )
+    parser.add_argument(
+        "run_dir",
+        type=Path,
+        help="Path to a SUEWS run directory containing diagnostics.json.",
+    )
+    args = parser.parse_args()
+    return summarise(args.run_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1358.

Adds a SUEWS Claude Skill that carries workflow guidance as Skill references rather than MCP-only prompts. The Skill loads in any IDE that supports skills (Claude Code, Cursor, Codex CLI), not just MCP-aware clients — that's the design rationale for moving the workflow content out of the MCP layer (where PR #1351 placed it) and into a Skill.

## Contents

- `SKILL.md` — top-level definition with triggers and methodology
- 6 references: `forcing-checklist`, `migration-namelist-to-yaml`, `publication-review-checklist`, `common-errors`, `output-interpretation`, `variable-glossary`
- 2 helper scripts (pure stdlib so the Skill never pulls supy as a dependency): `check_forcing_columns.py`, `summarise_diagnostics.py`

The 5 workflow prompts from PR #1351 are ported into matching reference files (`review_config_before_run` → publication-review-checklist + forcing-checklist content; `debug_failed_suews_run` → common-errors; `migrate_namelist_to_yaml` → migration-namelist-to-yaml; `prepare_new_suews_case` → forcing-checklist + variable-glossary; `compare_scenarios` → output-interpretation).

## Independent of the unified CLI

CLI references are softened with a "use `suews-validate` (or, when available, `suews validate`)" pattern so the Skill is useful even before the unified `suews <subcmd>` dispatcher lands (#1359).

## Acceptance

- [x] 9 files: SKILL.md + 6 references + 2 scripts
- [x] ASCII-only across the entire tree (verified via byte audit)
- [x] Both helper scripts return exit 0 and a usage message on `--help`
- [x] No hard dependency on the unified CLI

Part of #1355.