### PR TITLE
refactor: rename Rust CLI binary suews -> suews-engine

### DIFF
--- a/.claude/rules/rust/conventions.md
+++ b/.claude/rules/rust/conventions.md
@@ -34,7 +34,7 @@ The Rust bridge (`src/suews_bridge/`) replaced f90wrap as the Fortran-Python int
 ```bash
 # Rust CLI binary (standalone, no Python)
 make bridge
-# Output: src/suews_bridge/target/release/suews
+# Output: src/suews_bridge/target/release/suews-engine
 
 # Python module (for development)
 cd src/suews_bridge && maturin develop --features python-extension,physics

--- a/Makefile
+++ b/Makefile
@@ -281,8 +281,8 @@ bridge:
 	fi
 	@echo "Building Rust bridge CLI..."
 	cd src/suews_bridge && cargo build --release
-	@echo "Binary at: src/suews_bridge/target/release/suews"
-	@echo "Run: src/suews_bridge/target/release/suews --help"
+	@echo "Binary at: src/suews_bridge/target/release/suews-engine"
+	@echo "Run: src/suews_bridge/target/release/suews-engine --help"
 
 # Format code
 format:

--- a/src/suews_bridge/Cargo.toml
+++ b/src/suews_bridge/Cargo.toml
@@ -11,7 +11,7 @@ name = "suews_bridge"
 crate-type = ["rlib", "cdylib"]
 
 [[bin]]
-name = "suews"
+name = "suews-engine"
 path = "src/main.rs"
 
 [features]

--- a/src/suews_bridge/README.md
+++ b/src/suews_bridge/README.md
@@ -4,7 +4,7 @@ This crate is a minimal end-to-end bridge for one SUEWS OHM timestep:
 
 - Fortran `bind(c)` facade in `src/suews_bridge/fortran/suews_c_api_ohm.f95`
 - Rust FFI + safe wrappers in `src/suews_bridge/src/`
-- CLI binary (`suews`)
+- CLI binary (`suews-engine`)
 - Optional Python module via PyO3 (`maturin develop`)
 
 It now includes a first derived-type bridge for `OHM_STATE` using explicit

--- a/src/suews_bridge/src/main.rs
+++ b/src/suews_bridge/src/main.rs
@@ -124,7 +124,7 @@ use suews_bridge::{
 };
 
 #[derive(Debug, Parser)]
-#[command(name = "suews", version = env!("SUEWS_VERSION"), about = "SUEWS — Surface Urban Energy and Water Balance Scheme")]
+#[command(name = "suews-engine", version = env!("SUEWS_VERSION"), about = "SUEWS engine — Rust runtime and schema introspection for the SUEWS Fortran physics core")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -731,9 +731,9 @@ enum FlatCommand {
 fn main() {
     // No subcommand: show prominent error + banner + help, then exit
     if std::env::args().len() == 1 {
-        eprintln!("\x1b[1;31merror:\x1b[0m no subcommand provided. Run \x1b[1msuews run <config>\x1b[0m or \x1b[1msuews --help\x1b[0m\n");
+        eprintln!("\x1b[1;31merror:\x1b[0m no subcommand provided. Run \x1b[1msuews-engine run <config>\x1b[0m or \x1b[1msuews-engine --help\x1b[0m\n");
         print_banner();
-        Cli::parse_from(["suews", "--help"]);
+        Cli::parse_from(["suews-engine", "--help"]);
     }
 
     let cli = Cli::parse();

--- a/src/supy/build_rust_bridge.py
+++ b/src/supy/build_rust_bridge.py
@@ -35,7 +35,7 @@ def _find_extension_artifact(target_dir: Path) -> Path:
 
 
 def _find_cli_artifact(target_dir: Path) -> Path:
-    binary = target_dir / ("suews.exe" if os.name == "nt" else "suews")
+    binary = target_dir / ("suews-engine.exe" if os.name == "nt" else "suews-engine")
     if not binary.exists():
         raise FileNotFoundError(f"Rust bridge CLI artifact not found: {binary}")
     return binary

--- a/src/supy/cmd/rust_bridge.py
+++ b/src/supy/cmd/rust_bridge.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 def _bridge_binary() -> Path:
-    binary_name = "suews.exe" if os.name == "nt" else "suews"
+    binary_name = "suews-engine.exe" if os.name == "nt" else "suews-engine"
     binary = files("supy").joinpath("bin").joinpath(binary_name)
     with as_file(binary) as path_obj:
         path = Path(path_obj)

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -211,10 +211,10 @@ if rust_bridge_enabled
     # wheel cp39-abi3-<plat> rather than cp313-cp313-<plat>.
     if host_machine.system() == 'windows'
         rust_bridge_ext_name = 'suews_bridge.pyd'
-        rust_bridge_cli_name = 'suews.exe'
+        rust_bridge_cli_name = 'suews-engine.exe'
     else
         rust_bridge_ext_name = 'suews_bridge.abi3.so'
-        rust_bridge_cli_name = 'suews'
+        rust_bridge_cli_name = 'suews-engine'
     endif
 
     rust_bridge_artifacts = custom_target(

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -412,7 +412,7 @@ class TestSampleOutput(TestCase):
         # installed package location (used by CI/cibuildwheel where the
         # binary is bundled inside supy/bin/).
         repo_root = Path(__file__).parent.parent.parent
-        dev_binary = repo_root / "src" / "suews_bridge" / "target" / "release" / "suews"
+        dev_binary = repo_root / "src" / "suews_bridge" / "target" / "release" / "suews-engine"
 
         if dev_binary.exists():
             rust_binary = dev_binary


### PR DESCRIPTION
Closes #1356.

The Rust bridge binary previously installed itself as `suews`, colliding with the Python CLI entry point of the same name registered in `pyproject.toml`. Rename the Rust binary to `suews-engine` so the names reflect their actual roles:

- `suews` — user-facing Python workflow CLI (validate, inspect, summarise, compare, ...) registered as a console script
- `suews-engine` — Rust runtime + schema introspection binary, called internally by `suews run` and bundled at `supy/bin/`

Touches `Cargo.toml`, `meson.build`, `build_rust_bridge.py`, `rust_bridge.py`, the Makefile bridge target, the dev test that locates the binary, plus matching docs/rules. Exactly 9 files, 13 lines net.

Part of #1355.