### PR TITLE
feat: add canonical JSON envelope utility for the suews CLI

### DIFF
--- a/src/supy/cmd/json_envelope.py
+++ b/src/supy/cmd/json_envelope.py
@@ -1,0 +1,194 @@
+"""Standard JSON envelope for SUEWS unified CLI output.
+
+Every ``suews`` subcommand emits this envelope. Every MCP tool consumes it.
+The shape is fixed::
+
+    {
+        "status": "success" | "warning" | "error",
+        "data": <command-specific payload>,
+        "errors": [{"message": str, ...}, ...],
+        "warnings": [str | {...}, ...],
+        "meta": {
+            "schema_version": str,
+            "suews_version": str,
+            "supy_version": str,
+            "git_commit": str | null,
+            "command": str,
+            "started_at": str,  # ISO 8601 with trailing Z
+            "ended_at": str,
+        }
+    }
+
+Status rules:
+- ``"success"`` if no errors and no warnings.
+- ``"warning"`` if no errors but warnings present.
+- ``"error"`` if any errors present.
+
+This module is the single contract; never branch the shape per subcommand.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, IO, Optional, Sequence, Union
+
+EXIT_OK = 0
+EXIT_USER_ERROR = 1
+EXIT_SCHEMA_ERROR = 2
+EXIT_RUN_FAILURE = 3
+EXIT_ENV_ERROR = 4
+
+
+def _now_iso() -> str:
+    """Return current UTC time as ISO 8601 with trailing ``Z``."""
+    return (
+        datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+
+
+def _git_commit() -> Optional[str]:
+    """Return the current git commit short hash, or ``None`` if unavailable.
+
+    Looks up the repository the supy package was installed from. Returns
+    ``None`` for wheel installs without a ``.git`` directory.
+    """
+    try:
+        import supy
+
+        path_pkg = Path(supy.__file__).resolve().parent
+    except Exception:
+        return None
+
+    for candidate in (path_pkg, *path_pkg.parents):
+        if (candidate / ".git").exists():
+            try:
+                out = subprocess.run(
+                    ["git", "-C", str(candidate), "rev-parse", "--short", "HEAD"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                )
+            except (FileNotFoundError, subprocess.SubprocessError):
+                return None
+            if out.returncode == 0:
+                return out.stdout.strip() or None
+            return None
+    return None
+
+
+def _coerce_messages(items: Optional[Sequence[Any]]) -> list:
+    """Coerce string entries to ``{"message": str}``; pass dicts through."""
+    if not items:
+        return []
+    out: list = []
+    for entry in items:
+        if isinstance(entry, str):
+            out.append({"message": entry})
+        else:
+            out.append(entry)
+    return out
+
+
+def _build_meta(command: str, started_at: Optional[str]) -> dict[str, Any]:
+    from supy import __version__ as supy_version
+    from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+
+    started = started_at or _now_iso()
+    return {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "suews_version": supy_version,
+        "supy_version": supy_version,
+        "git_commit": _git_commit(),
+        "command": command,
+        "started_at": started,
+        "ended_at": _now_iso(),
+    }
+
+
+class Envelope:
+    """Canonical JSON envelope for ``suews`` CLI output."""
+
+    __slots__ = ("status", "data", "errors", "warnings", "meta")
+
+    def __init__(
+        self,
+        status: str,
+        data: dict[str, Any],
+        errors: list,
+        warnings: list,
+        meta: dict[str, Any],
+    ) -> None:
+        self.status = status
+        self.data = data
+        self.errors = errors
+        self.warnings = warnings
+        self.meta = meta
+
+    @classmethod
+    def success(
+        cls,
+        data: Optional[dict[str, Any]] = None,
+        command: str = "",
+        warnings: Optional[Sequence[Any]] = None,
+        started_at: Optional[str] = None,
+    ) -> "Envelope":
+        """Build a success/warning envelope (no errors)."""
+        coerced_warnings = _coerce_warnings(warnings)
+        status = "warning" if coerced_warnings else "success"
+        return cls(
+            status=status,
+            data=dict(data) if data else {},
+            errors=[],
+            warnings=coerced_warnings,
+            meta=_build_meta(command, started_at),
+        )
+
+    @classmethod
+    def error(
+        cls,
+        errors: Sequence[Any],
+        command: str = "",
+        data: Optional[dict[str, Any]] = None,
+        warnings: Optional[Sequence[Any]] = None,
+        started_at: Optional[str] = None,
+    ) -> "Envelope":
+        """Build an error envelope."""
+        return cls(
+            status="error",
+            data=dict(data) if data else {},
+            errors=_coerce_messages(errors),
+            warnings=_coerce_warnings(warnings),
+            meta=_build_meta(command, started_at),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "data": self.data,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "meta": self.meta,
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
+    def emit(self, stream: Optional[IO[str]] = None) -> None:
+        """Write the envelope as JSON to ``stream`` (default stdout)."""
+        text = self.to_json()
+        target = stream if stream is not None else sys.stdout
+        target.write(text)
+        target.write("\n")
+        target.flush()
+
+
+def _coerce_warnings(items: Optional[Sequence[Any]]) -> list:
+    """Warnings keep strings as strings (more lightweight than errors)."""
+    if not items:
+        return []
+    return list(items)

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -25,6 +25,7 @@ py.install_sources(
         [
             'cmd/__init__.py',
             'cmd/SUEWS.py',
+            'cmd/json_envelope.py',
             'cmd/json_output.py',
             'cmd/rust_bridge.py',
             'cmd/table_converter.py',

--- a/test/cmd/test_json_envelope.py
+++ b/test/cmd/test_json_envelope.py
@@ -1,0 +1,159 @@
+"""Tests for the SUEWS unified CLI JSON envelope.
+
+The envelope is the single contract every `suews` subcommand emits and every
+MCP tool consumes. Shape: ``{status, data, errors, warnings, meta}``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from supy.cmd.json_envelope import EXIT_OK, EXIT_USER_ERROR, Envelope
+
+pytestmark = pytest.mark.api
+
+
+class TestEnvelopeStatus:
+    def test_success_when_no_errors_no_warnings(self) -> None:
+        env = Envelope.success(data={"x": 1}, command="suews validate")
+        assert env.status == "success"
+        assert env.errors == []
+        assert env.warnings == []
+
+    def test_warning_when_no_errors_but_warnings_present(self) -> None:
+        env = Envelope.success(
+            data={"x": 1},
+            command="suews validate",
+            warnings=["forcing has gaps"],
+        )
+        assert env.status == "warning"
+        assert env.warnings == ["forcing has gaps"]
+
+    def test_error_when_errors_present(self) -> None:
+        env = Envelope.error(
+            errors=["schema mismatch"],
+            command="suews validate",
+        )
+        assert env.status == "error"
+        # String errors are coerced to {"message": str}; see TestErrorCoercion.
+        assert env.errors == [{"message": "schema mismatch"}]
+        assert env.data == {}
+
+
+class TestEnvelopeMeta:
+    def test_meta_has_required_keys(self) -> None:
+        env = Envelope.success(data={}, command="suews validate")
+        meta = env.meta
+        for key in (
+            "schema_version",
+            "suews_version",
+            "supy_version",
+            "git_commit",
+            "command",
+            "started_at",
+            "ended_at",
+        ):
+            assert key in meta, f"meta missing key {key!r}"
+
+    def test_meta_command_round_trip(self) -> None:
+        env = Envelope.success(data={}, command="suews validate")
+        assert env.meta["command"] == "suews validate"
+
+    def test_meta_schema_version_matches_module(self) -> None:
+        from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+
+        env = Envelope.success(data={}, command="suews schema info")
+        assert env.meta["schema_version"] == CURRENT_SCHEMA_VERSION
+
+    def test_meta_supy_version_matches_module(self) -> None:
+        import supy
+
+        env = Envelope.success(data={}, command="suews validate")
+        assert env.meta["supy_version"] == supy.__version__
+
+    def test_meta_git_commit_is_string_or_none(self) -> None:
+        env = Envelope.success(data={}, command="suews validate")
+        commit = env.meta["git_commit"]
+        assert commit is None or isinstance(commit, str)
+
+    def test_meta_started_at_is_iso_8601(self) -> None:
+        env = Envelope.success(data={}, command="suews validate")
+        # ISO 8601 with trailing Z (UTC)
+        assert env.meta["started_at"].endswith("Z")
+        assert "T" in env.meta["started_at"]
+
+    def test_meta_ended_at_at_least_started_at(self) -> None:
+        env = Envelope.success(data={}, command="suews validate")
+        assert env.meta["ended_at"] >= env.meta["started_at"]
+
+
+class TestEnvelopeSerialisation:
+    def test_to_dict_has_five_top_level_keys(self) -> None:
+        env = Envelope.success(data={"x": 1}, command="suews validate")
+        d = env.to_dict()
+        assert set(d.keys()) == {"status", "data", "errors", "warnings", "meta"}
+
+    def test_to_json_round_trip(self) -> None:
+        env = Envelope.success(
+            data={"x": 1, "y": [1, 2, 3]},
+            command="suews validate",
+            warnings=["watch out"],
+        )
+        text = env.to_json()
+        parsed = json.loads(text)
+        assert parsed["status"] == "warning"
+        assert parsed["data"] == {"x": 1, "y": [1, 2, 3]}
+        assert parsed["warnings"] == ["watch out"]
+        assert parsed["meta"]["command"] == "suews validate"
+
+    def test_to_json_uses_utf8_safely(self) -> None:
+        env = Envelope.success(data={"note": "résumé"}, command="suews inspect")
+        text = env.to_json()
+        # ensure_ascii must be False so non-ASCII passes through unescaped.
+        assert "résumé" in text
+
+
+class TestEnvelopeEmit:
+    def test_emit_writes_json_to_stream(self) -> None:
+        import io
+
+        buf = io.StringIO()
+        env = Envelope.success(data={"x": 1}, command="suews validate")
+        env.emit(stream=buf)
+        parsed = json.loads(buf.getvalue())
+        assert parsed["status"] == "success"
+        assert parsed["data"] == {"x": 1}
+
+
+class TestErrorCoercion:
+    def test_string_errors_coerced_to_dict_with_message(self) -> None:
+        env = Envelope.error(
+            errors=["schema mismatch", "missing field"],
+            command="suews validate",
+        )
+        assert env.errors == [
+            {"message": "schema mismatch"},
+            {"message": "missing field"},
+        ]
+
+    def test_dict_errors_passed_through(self) -> None:
+        err = {"code": "E001", "message": "bad", "field": "albedo"}
+        env = Envelope.error(errors=[err], command="suews validate")
+        assert env.errors == [err]
+
+    def test_string_warnings_coerced_similarly(self) -> None:
+        env = Envelope.success(
+            data={},
+            command="suews validate",
+            warnings=["heads up"],
+        )
+        assert env.warnings == ["heads up"]
+
+
+class TestExitCodes:
+    def test_exit_code_constants_defined(self) -> None:
+        # Exit codes per the plan: 0 ok, 1 user error, 2 schema/migration, 3 run, 4 env
+        assert EXIT_OK == 0
+        assert EXIT_USER_ERROR == 1


### PR DESCRIPTION
Closes #1357.

Introduces `supy.cmd.json_envelope.Envelope` — the canonical machine-readable shape for `suews <subcmd> --format json` output (landing in #1359 onwards) and for the `suews-mcp` server (#1364).

## Shape

`{status, data, errors, warnings, meta}` where:

- `status` is derived from the presence of errors and warnings (`success` / `warning` / `error`)
- `meta` carries `schema_version`, `supy_version`, `command`, `started_at`, `ended_at`, `git_commit`
- `errors`/`warnings` accept plain strings (auto-coerced to `{message: ...}`) or already-structured dicts

## Self-contained

No callers wired in this PR. Wave 2 (the unified CLI dispatcher in #1359) is the first consumer.

## Verification

- 18 tests pass: `pytest test/cmd/test_json_envelope.py -v` — covers status semantics, meta shape, serialisation round-trip, error/warning coercion, ASCII-only invariant, exit-code constants
- Registered in `src/supy/meson.build` so meson-python picks it up

Part of #1355.