### PR TITLE
Add parallel multi-grid tutorial

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -138,6 +138,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "docs/source/tutorials/tutorial_05_results_analysis.py" = ["D205", "D400"]
 "docs/source/tutorials/tutorial_06_external_coupling.py" = ["D205", "D301", "D400"]
 "docs/source/tutorials/tutorial_07_attribution.py" = ["D205", "D400"]
+"docs/source/tutorials/tutorial_08_parallel_multi_grid.py" = ["D205", "D400"]
 "docs/table.py" = ["D412"]
 "get_ver_git.py" = ["D103", "D400", "D406", "D407"]
 "scripts/lint/audit_docstrings.py" = ["D103"]

--- a/docs/source/tutorials/tutorial_04_impact_studies.py
+++ b/docs/source/tutorials/tutorial_04_impact_studies.py
@@ -40,7 +40,9 @@ sim = SUEWSSimulation.from_sample_data()
 forcing_sliced = sim.forcing["2012-01":"2012-03"].iloc[1:]
 
 print("Sample data loaded using SUEWSSimulation.from_sample_data()")
-print(f"Simulation period: {forcing_sliced.df.index[0]} to {forcing_sliced.df.index[-1]}")
+print(
+    f"Simulation period: {forcing_sliced.df.index[0]} to {forcing_sliced.df.index[-1]}"
+)
 
 # %%
 # Part 1: Surface Properties - Albedo Study
@@ -111,7 +113,9 @@ print(f"Completed {n_albedo} albedo simulations")
 # Examine the temperature response to albedo changes using the OOP output interface.
 
 # Combine T2 results from all scenarios
-dict_T2 = {alb: output.SUEWS.T2.droplevel("grid") for alb, output in dict_outputs.items()}
+dict_T2 = {
+    alb: output.SUEWS.T2.droplevel("grid") for alb, output in dict_outputs.items()
+}
 df_T2_all = pd.concat(dict_T2, axis=1, names=["albedo"])
 
 # Select last month for analysis
@@ -178,9 +182,11 @@ plt.tight_layout()
 #
 # .. note::
 #
-#    For larger studies, these simulations could be run in parallel using
-#    ``concurrent.futures.ThreadPoolExecutor``. We use a simple loop here
-#    for clarity.
+#    A loop over scenarios is the right tool when each scenario uses
+#    different forcing. When the *same* forcing applies across many sites
+#    (e.g. land-cover ensembles), populate ``config.sites`` instead and
+#    run the multi-site simulation with ``sim.run(n_jobs=-1)`` -- see
+#    :doc:`tutorial_08_parallel_multi_grid`.
 
 # Temperature offsets to test
 n_climate = 3
@@ -206,7 +212,9 @@ for temp_offset in list_temp_offset:
     list_outputs.append((temp_offset, output))
 
 print(f"Completed {n_climate} climate scenarios")
-print(f"Temperature offsets: {list_temp_offset[0]:.1f} to {list_temp_offset[-1]:.1f} deg C")
+print(
+    f"Temperature offsets: {list_temp_offset[0]:.1f} to {list_temp_offset[-1]:.1f} deg C"
+)
 
 # %%
 # Combine and Analyse Climate Results
@@ -249,7 +257,9 @@ df_temp_diff_stats.plot(ax=ax, marker="o")
 ax.set_ylabel(r"$\Delta T_2$ ($^\circ$C)")
 ax.set_xlabel(r"$\Delta T_{a}$ ($^\circ$C)")
 ax.set_aspect("equal")
-ax.set_title(f"Temperature Response to Background Climate Change ({last_month_climate})")
+ax.set_title(
+    f"Temperature Response to Background Climate Change ({last_month_climate})"
+)
 ax.legend(title="Statistic")
 plt.tight_layout()
 

--- a/docs/source/tutorials/tutorial_05_results_analysis.py
+++ b/docs/source/tutorials/tutorial_05_results_analysis.py
@@ -85,7 +85,8 @@ def get_var(out, name, group="SUEWS"):
         if n_grids != 1:
             raise ValueError(
                 f"Expected single-grid output, but found {n_grids} grids. "
-                "Use MultiIndex indexing directly for multi-grid runs."
+                "Use MultiIndex indexing directly for multi-grid runs "
+                "(see tutorial_08_parallel_multi_grid for a worked example)."
             )
         ser = ser.droplevel("grid")
     return ser

--- a/docs/source/tutorials/tutorial_08_parallel_multi_grid.py
+++ b/docs/source/tutorials/tutorial_08_parallel_multi_grid.py
@@ -212,9 +212,9 @@ plt.tight_layout()
 #    uses the Rust/Rayon default and is the normal choice for production
 #    runs. ``n_jobs=1`` forces serial execution for debugging or
 #    benchmarking, while values greater than 1 cap the Rayon worker count.
-# 4. **Windows fallback**. Parallel execution is a no-op on Windows; the
-#    run completes serially. Code written for the multi-site path remains
-#    portable -- only the wall-clock changes.
+#    The Rust/Rayon bridge runs in parallel on Windows the same as on
+#    macOS/Linux; the legacy ``supy.run_supy(serial_mode=...)`` functional
+#    API is the path that falls back to serial on Windows.
 #
 # **Next steps**:
 #

--- a/docs/source/tutorials/tutorial_08_parallel_multi_grid.py
+++ b/docs/source/tutorials/tutorial_08_parallel_multi_grid.py
@@ -1,0 +1,224 @@
+"""
+Parallel Multi-Grid Execution
+=============================
+
+Run an ensemble of sites in a single simulation, with parallelism controlled
+through ``n_jobs``.
+
+Many urban-climate workflows need more than one site at a time: comparing
+neighbourhoods that differ in land cover, evaluating climate scenarios over
+a city's grid cells, or producing a small sensitivity ensemble. SUEWS handles
+this natively. A configuration with multiple sites is dispatched through the
+Rust/Rayon bridge; you supply the sites, call ``sim.run(n_jobs=...)``, and
+choose whether to use the default thread pool, serial execution, or a capped
+number of worker threads.
+
+This tutorial covers two things:
+
+- Part 1 -- a four-site ensemble that varies surface composition, run in
+  one ``sim.run(n_jobs=-1)`` call.
+- Part 2 -- a short speed-up appendix measuring wall-clock time at
+  N = 1, 4, 8, 16 grids, so you can calibrate expectations on your own
+  machine.
+
+**API approach**: This tutorial uses the :class:`~supy.SUEWSSimulation` OOP
+interface and the :meth:`~supy.SUEWSSimulation.from_sample_data` factory's
+``n_sites`` parameter to populate the multi-site ensemble without writing a
+custom YAML. Multi-grid execution is controlled with
+``SUEWSSimulation.run(n_jobs=...)``.
+"""
+
+# %%
+# Setup
+# -----
+#
+# Load four sites from the bundled sample dataset. ``n_sites=4`` duplicates
+# the single sample site (``KCL``) into four entries with distinct names
+# (``KCL_01..KCL_04``) and unique grid IDs. The shared sample forcing is
+# reused for all four.
+
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from supy import SUEWSSimulation
+
+sim = SUEWSSimulation.from_sample_data(n_sites=4)
+
+# Slice the forcing to the first month for a fast tutorial run
+forcing_one_month = sim.forcing["2012-01":"2012-01"].iloc[1:]
+sim.update_forcing(forcing_one_month)
+
+print(f"Configured {len(sim.config.sites)} sites:")
+for site in sim.config.sites:
+    print(f"  name={site.name}  gridiv={site.gridiv}")
+
+# %%
+# Part 1: Four-Site Land-Cover Ensemble
+# -------------------------------------
+#
+# Vary surface composition across the four sites to build a small
+# land-cover gradient: from a paved-dominated site through to a
+# grass-dominated one. This is a stand-in for, e.g., comparing four
+# neighbourhoods or four idealised land-cover archetypes.
+
+# Each row is (paved, bldgs, grass) for one site; the remaining surface
+# fractions are zeroed for clarity. The four mixes span concrete-heavy
+# through to vegetation-heavy.
+land_cover_mix = [
+    (0.80, 0.10, 0.10),  # KCL_01: heavily paved
+    (0.50, 0.30, 0.20),  # KCL_02: mixed urban
+    (0.30, 0.20, 0.50),  # KCL_03: greener
+    (0.10, 0.10, 0.80),  # KCL_04: grass-dominated
+]
+
+for site, (paved, bldgs, grass) in zip(sim.config.sites, land_cover_mix):
+    lc = site.properties.land_cover
+    lc.paved.sfr = paved
+    lc.bldgs.sfr = bldgs
+    lc.grass.sfr = grass
+    lc.evetr.sfr = 0.0
+    lc.dectr.sfr = 0.0
+    lc.bsoil.sfr = 0.0
+    lc.water.sfr = 0.0
+
+# %%
+# Run All Four Sites in One Call
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# A single ``sim.run(n_jobs=-1)`` dispatches all four sites using the
+# Rust/Rayon default thread pool. The forcing is cloned per thread so
+# writes from the Fortran kernel stay isolated. Use ``n_jobs=1`` for a
+# serial run, or a positive value such as ``n_jobs=4`` to cap the Rayon
+# worker count.
+
+output = sim.run(n_jobs=-1)
+
+print(f"Output grids: {output.grids}")
+print(
+    f"Output shape: {output.df.shape}  # rows = grids x timesteps, columns = variables"
+)
+
+# %%
+# Plot Per-Site Air Temperature
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# ``output.SUEWS.T2`` returns a Series with a ``(grid, datetime)``
+# MultiIndex. ``unstack`` gives one column per grid, which plots cleanly.
+
+df_t2 = output.SUEWS.T2.unstack(level="grid")
+df_t2.columns = [
+    f"{site.name} ({pv:.0%} paved, {gr:.0%} grass)"
+    for site, (pv, _, gr) in zip(sim.config.sites, land_cover_mix)
+]
+
+# Daily mean for readability on a one-month plot
+df_t2_daily = df_t2.resample("1D").mean()
+
+fig, ax = plt.subplots(figsize=(9, 5))
+df_t2_daily.plot(ax=ax)
+ax.set_ylabel(r"Daily mean $T_2$ ($^\circ$C)")
+ax.set_xlabel("Date")
+ax.set_title("Air temperature across a four-site land-cover ensemble")
+ax.legend(title="Site", loc="best", fontsize=9)
+ax.grid(alpha=0.3)
+plt.tight_layout()
+
+# sphinx_gallery_thumbnail_number = 1
+
+# %%
+# The grass-dominated site (``KCL_04``) is consistently cooler than the
+# paved-dominated site (``KCL_01``) by daytime evapotranspiration --
+# exactly the contrast you would get from running four single-site
+# simulations in a loop, but without the loop.
+
+# %%
+# Part 2: Speed-up Appendix
+# -------------------------
+#
+# How much faster is multi-site execution as the number of grids grows?
+# We time the same forcing window at N = 1, 4, 8, 16 sites. The exact
+# numbers depend on your machine's core count and what else it is doing;
+# the shape of the curve is what matters.
+#
+# Each iteration recreates the simulation so the timing reflects a clean
+# end-to-end run rather than an in-place re-execution.
+
+
+def time_run(n_sites: int, n_steps: int = 576, n_jobs: int = -1) -> float:
+    """Measure wall-clock seconds for a fresh N-site run."""
+    sim_n = SUEWSSimulation.from_sample_data(n_sites=n_sites)
+    forcing_short = sim_n.forcing.iloc[1 : n_steps + 1]  # ~2 days at 5-min res
+    sim_n.update_forcing(forcing_short)
+
+    t0 = time.perf_counter()
+    sim_n.run(n_jobs=n_jobs)
+    return time.perf_counter() - t0
+
+
+grid_counts = [1, 4, 8, 16]
+wall_seconds = [time_run(n, n_jobs=-1) for n in grid_counts]
+
+for n, t in zip(grid_counts, wall_seconds):
+    print(f"  N={n:>3d} grids, n_jobs=-1: {t:6.2f}s  ({n / t:5.1f} grids/s)")
+
+# %%
+# Plot Wall-Clock vs Grid Count
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+fig, ax = plt.subplots(figsize=(7, 5))
+ax.plot(grid_counts, wall_seconds, marker="o")
+ax.set_xlabel("Number of grids")
+ax.set_ylabel("Wall-clock time (s)")
+ax.set_title("Multi-grid execution time (2-day forcing)")
+ax.set_xscale("log", base=2)
+ax.set_xticks(grid_counts)
+ax.set_xticklabels([str(n) for n in grid_counts])
+ax.grid(alpha=0.3, which="both")
+
+# Reference: linear scaling from the N=1 baseline
+linear_ref = np.array(wall_seconds[0]) * np.array(grid_counts)
+ax.plot(
+    grid_counts,
+    linear_ref,
+    linestyle="--",
+    alpha=0.5,
+    label="serial scaling (N x baseline)",
+)
+ax.legend()
+plt.tight_layout()
+
+# %%
+# On a typical multi-core laptop the curve sits well below the dashed
+# linear-scaling reference: doubling the grid count costs noticeably less
+# than double the wall-clock time, up to roughly your physical core
+# count. Beyond that the gains taper off as threads compete for cores.
+
+# %%
+# Caveats
+# -------
+#
+# A few things to keep in mind when scaling up:
+#
+# 1. **Memory scales with grid count**. The forcing array is cloned per
+#    thread (Fortran mutates it in place), so peak memory use grows
+#    roughly linearly with the number of sites in flight.
+# 2. **Each site needs its own config entry**. ``config.sites`` is the
+#    unit of parallelism; one entry per grid, with a unique ``gridiv``.
+#    The ``n_sites`` factory parameter handles this for the sample data,
+#    but for real workflows you supply the sites in your YAML.
+# 3. **``n_jobs`` controls the per-call worker policy**. ``n_jobs=-1``
+#    uses the Rust/Rayon default and is the normal choice for production
+#    runs. ``n_jobs=1`` forces serial execution for debugging or
+#    benchmarking, while values greater than 1 cap the Rayon worker count.
+# 4. **Windows fallback**. Parallel execution is a no-op on Windows; the
+#    run completes serially. Code written for the multi-site path remains
+#    portable -- only the wall-clock changes.
+#
+# **Next steps**:
+#
+# - :doc:`tutorial_04_impact_studies` -- scenario sweeps that combine
+#   naturally with multi-site setups.
+# - :doc:`tutorial_05_results_analysis` -- MultiIndex result handling
+#   (the ``unstack(level="grid")`` pattern used here).

--- a/src/supy/_supy_module.py
+++ b/src/supy/_supy_module.py
@@ -754,8 +754,7 @@ def _run_supy(
         lai_issues = []
         if _check_observed_lai_nonneg(df_forcing, lai_issues):
             logger_supy.critical(
-                "`df_forcing` violates the observed-LAI contract under "
-                "`laimethod=0`."
+                "`df_forcing` violates the observed-LAI contract under `laimethod=0`."
             )
             raise RuntimeError(lai_issues[0])
 
@@ -838,6 +837,11 @@ def run_supy(
         If set to `True`, SuPy simulation will be conducted in serial mode;
         a `False` flag will try parallel simulation if possible (Windows not supported, i.e., always serial).
         (the default is `False`).
+        See :doc:`/auto_examples/tutorial_08_parallel_multi_grid` for a worked
+        example of multi-grid execution. The modern OOP entry point
+        :meth:`~supy.SUEWSSimulation.run` exposes ``n_jobs`` instead:
+        ``n_jobs=-1`` keeps the default Rayon thread pool, ``n_jobs=1`` forces
+        serial execution, and values greater than 1 cap the Rayon worker count.
     debug_mode : bool, optional
         If set to `True`, SuPy simulation will be conducted in debug mode, which will write out additional information for debugging purposes.
 

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -472,6 +472,17 @@ class SUEWSSimulation:
         RuntimeError
             If configuration or forcing data is missing.
 
+        Notes
+        -----
+        Configurations with more than one entry in ``config.sites`` are
+        executed with the Rust/Rayon backend. Use ``n_jobs=-1`` for the
+        default Rayon thread pool, ``n_jobs=1`` for serial execution, or a
+        positive value greater than 1 to cap the Rayon worker count. The
+        forcing array is cloned per thread so Fortran kernel writes stay
+        isolated.
+        See :doc:`/auto_examples/tutorial_08_parallel_multi_grid` for a
+        worked example.
+
         Examples
         --------
         >>> sim = SUEWSSimulation.from_sample_data()
@@ -744,12 +755,24 @@ class SUEWSSimulation:
         return self
 
     @classmethod
-    def from_sample_data(cls):
+    def from_sample_data(cls, n_sites: int = 1):
         """Create SUEWSSimulation instance with built-in sample data.
 
         This factory method provides a quick way to create a simulation object
         pre-loaded with sample configuration and forcing data, ideal for tutorials,
         testing, and learning the SUEWS workflow.
+
+        Parameters
+        ----------
+        n_sites : int, optional
+            Number of sites to populate in the returned simulation. The default
+            of ``1`` returns the single-site sample (existing behaviour). Values
+            greater than 1 duplicate the sample site to produce ``n_sites``
+            entries with distinct names (e.g. ``KCL_01``, ``KCL_02``, ...) and
+            unique ``gridiv`` IDs. The shared sample forcing is reused for all
+            sites. Useful for exploring multi-grid execution controlled by the
+            ``n_jobs`` parameter on :meth:`~supy.SUEWSSimulation.run` (see
+            :doc:`/auto_examples/tutorial_08_parallel_multi_grid`).
 
         Returns
         -------
@@ -762,10 +785,19 @@ class SUEWSSimulation:
 
         >>> from supy import SUEWSSimulation
         >>> sim = SUEWSSimulation.from_sample_data()
-        >>> sim.run()
-        >>> results = sim.results
+        >>> output = sim.run()
+
+        Multi-site ensemble (runs with the default Rayon thread pool):
+
+        >>> sim = SUEWSSimulation.from_sample_data(n_sites=4)
+        >>> len(sim.config.sites)
+        4
+        >>> output = sim.run(n_jobs=-1)
 
         """
+        if n_sites < 1:
+            raise ValueError(f"n_sites must be >= 1, got {n_sites}")
+
         from ._env import trv_supy_module
         from ._supy_module import _load_sample_data
 
@@ -799,7 +831,41 @@ class SUEWSSimulation:
         # Set core simulation data (overrides any config-derived state)
         sim._df_state_init = df_state_init
         sim._df_forcing = df_forcing
+
+        if n_sites > 1:
+            sim._expand_to_multi_site(n_sites)
+
         return sim
+
+    def _expand_to_multi_site(self, n_sites: int) -> None:
+        """Replicate the first configured site into ``n_sites`` entries.
+
+        Each replica gets a distinct name (``<base>_NN``) and a unique
+        ``gridiv`` derived from the template site's ``gridiv``. The
+        ``df_state_init`` DataFrame is regenerated from the expanded config
+        so it stays consistent with ``config.sites``.
+        """
+        if self._config is None or not getattr(self._config, "sites", None):
+            raise RuntimeError(
+                "Cannot expand to multiple sites: configuration has no sites loaded."
+            )
+
+        template = self._config.sites[0]
+        base_name = template.name
+        base_gridiv = template.gridiv
+
+        new_sites = []
+        for i in range(n_sites):
+            replica = copy.deepcopy(template)
+            replica.name = f"{base_name}_{i + 1:02d}"
+            replica.gridiv = base_gridiv + i
+            new_sites.append(replica)
+
+        self._config.sites = new_sites
+        # Regenerate state DataFrame from the expanded config so the row index
+        # carries one entry per gridiv (downstream code that inspects
+        # ``sim.state_init`` sees the multi-grid shape).
+        self._df_state_init = self._config.to_df_state()
 
     @staticmethod
     def _coerce_checkpoint(

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -45,6 +45,15 @@ def _validate_n_jobs(n_jobs: int) -> Optional[int]:
     return None if n_jobs == -1 else n_jobs
 
 
+def _validate_n_sites(n_sites: int) -> int:
+    """Return a validated positive integer site count."""
+    if isinstance(n_sites, bool) or not isinstance(n_sites, int):
+        raise ValueError("n_sites must be a positive integer")
+    if n_sites < 1:
+        raise ValueError(f"n_sites must be >= 1, got {n_sites}")
+    return n_sites
+
+
 class SUEWSSimulation:
     """
     Simplified SUEWS simulation class for urban climate modelling.
@@ -795,8 +804,7 @@ class SUEWSSimulation:
         >>> output = sim.run(n_jobs=-1)
 
         """
-        if n_sites < 1:
-            raise ValueError(f"n_sites must be >= 1, got {n_sites}")
+        n_sites = _validate_n_sites(n_sites)
 
         from ._env import trv_supy_module
         from ._supy_module import _load_sample_data

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -113,10 +113,11 @@ class TestInit:
         assert len(sim_explicit.config.sites) == 1
         assert sim_default._df_state_init.shape == sim_explicit._df_state_init.shape
 
-    def test_from_sample_data_invalid_n_sites(self):
-        """`n_sites < 1` is rejected with a clear message."""
-        with pytest.raises(ValueError, match="n_sites must be >= 1"):
-            SUEWSSimulation.from_sample_data(n_sites=0)
+    @pytest.mark.parametrize("n_sites", [True, False, 0, -1, 1.5, "2"])
+    def test_from_sample_data_invalid_n_sites(self, n_sites):
+        """Invalid `n_sites` values are rejected with a clear message."""
+        with pytest.raises(ValueError, match="n_sites must be"):
+            SUEWSSimulation.from_sample_data(n_sites=n_sites)
 
 
 class TestConfig:

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -75,6 +75,49 @@ class TestInit:
         assert len(results) == 24
         assert sim._run_completed is True
 
+    @pytest.mark.core
+    def test_from_sample_data_multi_site_shape(self):
+        """`n_sites=N` populates N sites with distinct names and gridivs."""
+        sim = SUEWSSimulation.from_sample_data(n_sites=4)
+
+        # Config layer
+        assert len(sim.config.sites) == 4
+        names = [s.name for s in sim.config.sites]
+        gridivs = [s.gridiv for s in sim.config.sites]
+        assert len(set(names)) == 4, f"Site names not unique: {names}"
+        assert len(set(gridivs)) == 4, f"gridiv values not unique: {gridivs}"
+
+        # State DataFrame layer (one row per site, indexed by grid)
+        assert sim._df_state_init.shape[0] == 4
+        assert set(sim._df_state_init.index) == set(gridivs)
+
+    def test_from_sample_data_multi_site_can_run(self):
+        """`n_sites=N` produces a runnable simulation with output rows per grid."""
+        sim = SUEWSSimulation.from_sample_data(n_sites=4)
+
+        # Short run to keep the test fast
+        results = sim.run(end_date=sim._df_forcing.index[23], n_jobs=2)
+
+        assert results is not None
+        # SUEWSOutput exposes the grid level via the underlying DataFrame index
+        df = results.df
+        grids_in_output = df.index.get_level_values("grid").unique()
+        assert len(grids_in_output) == 4
+
+    def test_from_sample_data_default_unchanged(self):
+        """Calling without `n_sites` keeps single-site behaviour."""
+        sim_default = SUEWSSimulation.from_sample_data()
+        sim_explicit = SUEWSSimulation.from_sample_data(n_sites=1)
+
+        assert len(sim_default.config.sites) == 1
+        assert len(sim_explicit.config.sites) == 1
+        assert sim_default._df_state_init.shape == sim_explicit._df_state_init.shape
+
+    def test_from_sample_data_invalid_n_sites(self):
+        """`n_sites < 1` is rejected with a clear message."""
+        with pytest.raises(ValueError, match="n_sites must be >= 1"):
+            SUEWSSimulation.from_sample_data(n_sites=0)
+
 
 class TestConfig:
     """Test configuration updates."""


### PR DESCRIPTION
## Summary
Adds a new Sphinx Gallery tutorial for multi-grid execution using `SUEWSSimulation.from_sample_data(n_sites=...)` and the new `SUEWSSimulation.run(n_jobs=...)` API from #1375.
Updates related tutorial/API references and adds regression coverage for the multi-site sample-data path with an explicit worker cap.
Fixes #1315.

## Status
Stacked on the current #1375 head because `origin/master` still lacks the `SUEWSSimulation.run(n_jobs=...)` API; after #1375 merges, retarget this PR to `master`.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" make test-smoke`
- `.venv/bin/pytest test/core/test_suews_simulation.py::TestInit::test_from_sample_data_multi_site_shape test/core/test_suews_simulation.py::TestInit::test_from_sample_data_multi_site_can_run test/core/test_suews_simulation.py::TestInit::test_from_sample_data_default_unchanged test/core/test_suews_simulation.py::TestInit::test_from_sample_data_invalid_n_sites test/core/test_suews_simulation.py::TestRun::test_run_n_jobs_defaults_to_rayon_default test/core/test_suews_simulation.py::TestRun::test_run_n_jobs_one_forces_serial test/core/test_suews_simulation.py::TestRun::test_run_n_jobs_positive_caps_workers test/core/test_suews_simulation.py::TestRun::test_run_n_jobs_rejects_invalid_values -q`
- `.venv/bin/ruff check --select D docs/source/tutorials/tutorial_08_parallel_multi_grid.py`
- `.venv/bin/ruff format --check docs/source/tutorials/tutorial_08_parallel_multi_grid.py docs/source/tutorials/tutorial_04_impact_studies.py src/supy/_supy_module.py src/supy/suews_sim.py test/core/test_suews_simulation.py`