### PR TITLE
Expose n_jobs parallelism control on SUEWSSimulation.run() (gh#1365)

### DIFF
--- a/src/suews_bridge/src/lib.rs
+++ b/src/suews_bridge/src/lib.rs
@@ -4108,29 +4108,117 @@ mod python_bindings {
     /// Returns a list of `(grid_index, output_block, state_json, len_sim)`.
     #[cfg(feature = "physics")]
     #[pyfunction(name = "run_suews_multi")]
+    #[pyo3(signature = (config_jsons, forcing_block, len_sim, max_workers=None))]
     fn run_suews_multi_py(
         config_jsons: Vec<String>,
         forcing_block: Vec<f64>,
         len_sim: usize,
+        max_workers: Option<usize>,
     ) -> PyResult<Vec<(usize, Vec<f64>, String, usize)>> {
         use rayon::prelude::*;
 
-        let results: Vec<Result<(usize, Vec<f64>, String, usize), _>> = config_jsons
-            .par_iter()
-            .enumerate()
-            .map(|(idx, config_json)| {
-                // Each thread gets its own copy of forcing (Fortran mutates it)
-                let forcing_copy = forcing_block.clone();
-                let (output_block, state, actual_len) =
-                    run_from_config_str_and_forcing(config_json, forcing_copy, len_sim)
+        if max_workers == Some(0) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "max_workers must be a positive integer",
+            ));
+        }
+
+        let run_parallel = || {
+            config_jsons
+                .par_iter()
+                .enumerate()
+                .map(|(idx, config_json)| {
+                    // Each thread gets its own copy of forcing (Fortran mutates it)
+                    let forcing_copy = forcing_block.clone();
+                    let (output_block, state, actual_len) =
+                        run_from_config_str_and_forcing(config_json, forcing_copy, len_sim)
+                            .map_err(|e| e.to_string())?;
+                    let state_json = serde_json::to_string(&suews_state_to_nested_payload(&state))
                         .map_err(|e| e.to_string())?;
-                let state_json = serde_json::to_string(&suews_state_to_nested_payload(&state))
-                    .map_err(|e| e.to_string())?;
-                Ok((idx, output_block, state_json, actual_len))
-            })
-            .collect();
+                    Ok((idx, output_block, state_json, actual_len))
+                })
+                .collect()
+        };
+
+        let results: Vec<Result<(usize, Vec<f64>, String, usize), _>> =
+            if let Some(workers) = max_workers {
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(workers)
+                    .build()
+                    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?
+                    .install(run_parallel)
+            } else {
+                run_parallel()
+            };
 
         // Convert errors to PyResult
+        results
+            .into_iter()
+            .collect::<Result<Vec<_>, String>>()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
+    }
+
+    /// Run multiple grid cells in parallel using injected previous states.
+    ///
+    /// Each element of `state_jsons` must match the config at the same index.
+    /// Returns a list of `(grid_index, output_block, state_json, len_sim)`.
+    #[cfg(feature = "physics")]
+    #[pyfunction(name = "run_suews_multi_with_state")]
+    #[pyo3(signature = (config_jsons, forcing_block, len_sim, state_jsons, max_workers=None))]
+    fn run_suews_multi_with_state_py(
+        config_jsons: Vec<String>,
+        forcing_block: Vec<f64>,
+        len_sim: usize,
+        state_jsons: Vec<String>,
+        max_workers: Option<usize>,
+    ) -> PyResult<Vec<(usize, Vec<f64>, String, usize)>> {
+        use rayon::prelude::*;
+
+        if max_workers == Some(0) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "max_workers must be a positive integer",
+            ));
+        }
+        if config_jsons.len() != state_jsons.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "config_jsons and state_jsons must have the same length",
+            ));
+        }
+
+        let run_parallel = || {
+            config_jsons
+                .par_iter()
+                .zip(state_jsons.par_iter())
+                .enumerate()
+                .map(|(idx, (config_json, state_json_in))| {
+                    // Each thread gets its own copy of forcing (Fortran mutates it)
+                    let forcing_copy = forcing_block.clone();
+                    let (output_block, state, actual_len) =
+                        run_from_config_str_and_forcing_with_state(
+                            config_json,
+                            forcing_copy,
+                            len_sim,
+                            state_json_in,
+                        )
+                        .map_err(|e| e.to_string())?;
+                    let state_json = serde_json::to_string(&suews_state_to_nested_payload(&state))
+                        .map_err(|e| e.to_string())?;
+                    Ok((idx, output_block, state_json, actual_len))
+                })
+                .collect()
+        };
+
+        let results: Vec<Result<(usize, Vec<f64>, String, usize), _>> =
+            if let Some(workers) = max_workers {
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(workers)
+                    .build()
+                    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?
+                    .install(run_parallel)
+            } else {
+                run_parallel()
+            };
+
         results
             .into_iter()
             .collect::<Result<Vec<_>, String>>()
@@ -5375,6 +5463,8 @@ mod python_bindings {
         m.add_function(wrap_pyfunction!(run_suews_with_state_py, m)?)?;
         #[cfg(feature = "physics")]
         m.add_function(wrap_pyfunction!(run_suews_multi_py, m)?)?;
+        #[cfg(feature = "physics")]
+        m.add_function(wrap_pyfunction!(run_suews_multi_with_state_py, m)?)?;
         #[cfg(feature = "physics")]
         m.add_function(wrap_pyfunction!(output_group_layout_py, m)?)?;
         #[cfg(feature = "physics")]

--- a/src/supy/_run_rust.py
+++ b/src/supy/_run_rust.py
@@ -352,9 +352,8 @@ def run_suews_rust_multi(
     copies and YAML serialisation.
 
     When *serial_mode* is False and there are multiple sites, grids are
-    run in parallel using ``multiprocessing.Pool`` with the ``spawn``
-    context (safe for Fortran SAVE variables — each process gets its
-    own address space).
+    run in parallel using Rust/Rayon.  If *max_workers* is provided, the
+    Rayon call is capped to that many threads.
 
     Returns ``(df_output, dict_state_json)`` where *dict_state_json* maps
     each grid ID to its post-simulation state JSON string.
@@ -371,15 +370,19 @@ def run_suews_rust_multi(
     _validate_output_layout(rust_module)
     if df_forcing.empty:
         raise ValueError("forcing data is empty")
+    if max_workers is not None and (
+        isinstance(max_workers, bool)
+        or not isinstance(max_workers, int)
+        or max_workers < 1
+    ):
+        raise ValueError("max_workers must be a positive integer or None")
 
     # --- Prepare shared data once ---
     # The Rust bridge's YAML preprocessor accepts both new snake_case and
     # legacy fused spellings (gh#1322), so the Pydantic dump is submitted
     # verbatim.
     config_dict = config.model_dump(exclude_none=True, mode="json")
-    list_site_dict = [
-        s.model_dump(exclude_none=True, mode="json") for s in sites
-    ]
+    list_site_dict = [s.model_dump(exclude_none=True, mode="json") for s in sites]
     forcing_block = _prepare_forcing_block(df_forcing)
     forcing_flat = forcing_block.ravel(order="C").tolist()
     len_forcing = len(df_forcing)
@@ -400,14 +403,19 @@ def run_suews_rust_multi(
     has_rayon = hasattr(rust_module, "run_suews_multi")
 
     if use_rayon and has_rayon:
-        logger_supy.info(
-            "Running %d grids in parallel (Rust/Rayon)",
-            len(sites),
-        )
+        if max_workers is None:
+            logger_supy.info("Running %d grids in parallel (Rust/Rayon)", len(sites))
+        else:
+            logger_supy.info(
+                "Running %d grids in parallel (Rust/Rayon, max_workers=%d)",
+                len(sites),
+                max_workers,
+            )
         raw_results = rust_module.run_suews_multi(
             list_config_jsons,
             forcing_flat,
             len_forcing,
+            max_workers,
         )
         # raw_results: list of (grid_index, output_flat, state_json, len_sim)
         # Sort by original index to preserve grid ordering
@@ -427,6 +435,122 @@ def run_suews_rust_multi(
             results.append((list_grid_ids[idx], output_flat, state_json, len_sim))
 
     # --- Collect results ---
+    list_df_output = []
+    dict_state_json: dict[int, str] = {}
+
+    for grid_id, output_flat, state_json, len_sim in results:
+        if len_sim != len_forcing:
+            raise RuntimeError(
+                f"Rust backend length mismatch: forcing={len_forcing}, output={len_sim}"
+            )
+        df_output = _parse_output_block(output_flat, len_sim, grid_id)
+        list_df_output.append(df_output)
+        if state_json is not None:
+            dict_state_json[grid_id] = state_json
+
+    df_output_all = pd.concat(list_df_output).sort_index()
+
+    return df_output_all, dict_state_json or None
+
+
+def run_suews_rust_multi_with_state(
+    config: SUEWSConfig,
+    df_forcing: pd.DataFrame,
+    dict_state_json_by_grid: dict[int, str],
+    serial_mode: bool = False,
+    max_workers: int | None = None,
+) -> tuple[pd.DataFrame, dict[int, str] | None]:
+    """Run SUEWS via Rust bridge for all sites with injected states."""
+    sites = config.sites
+
+    list_gridiv = [_normalise_grid_id(s.gridiv) for s in sites]
+    list_dupes = [g for g in list_gridiv if list_gridiv.count(g) > 1]
+    if list_dupes:
+        raise ValueError(f"Duplicate gridiv values in config.sites: {set(list_dupes)}")
+
+    dict_state_json_by_grid = {
+        _normalise_grid_id(grid_id): state_json
+        for grid_id, state_json in dict_state_json_by_grid.items()
+    }
+    config_grid_ids = set(list_gridiv)
+    state_grid_ids = set(dict_state_json_by_grid)
+    if state_grid_ids != config_grid_ids:
+        parts = []
+        missing = sorted(config_grid_ids - state_grid_ids)
+        unexpected = sorted(state_grid_ids - config_grid_ids)
+        if missing:
+            parts.append(f"missing states for grids {missing}")
+        if unexpected:
+            parts.append(f"unexpected states for grids {unexpected}")
+        raise ValueError(
+            "State grid IDs do not match config.sites: " + "; ".join(parts)
+        )
+
+    rust_module = _check_rust_available()
+    _validate_output_layout(rust_module)
+    if df_forcing.empty:
+        raise ValueError("forcing data is empty")
+    if max_workers is not None and (
+        isinstance(max_workers, bool)
+        or not isinstance(max_workers, int)
+        or max_workers < 1
+    ):
+        raise ValueError("max_workers must be a positive integer or None")
+
+    config_dict = config.model_dump(exclude_none=True, mode="json")
+    list_site_dict = [s.model_dump(exclude_none=True, mode="json") for s in sites]
+    forcing_block = _prepare_forcing_block(df_forcing)
+    forcing_flat = forcing_block.ravel(order="C").tolist()
+    len_forcing = len(df_forcing)
+
+    list_grid_ids = []
+    list_config_jsons = []
+    list_state_jsons = []
+    for idx, site_dict in enumerate(list_site_dict):
+        grid_id = list_gridiv[idx]
+        list_grid_ids.append(grid_id)
+        config_dict["sites"] = [site_dict]
+        list_config_jsons.append(json.dumps(config_dict))
+        list_state_jsons.append(dict_state_json_by_grid[grid_id])
+
+    use_rayon = not serial_mode and len(sites) > 1
+    has_rayon = hasattr(rust_module, "run_suews_multi_with_state")
+
+    if use_rayon and has_rayon:
+        if max_workers is None:
+            logger_supy.info(
+                "Running %d checkpointed grids in parallel (Rust/Rayon)", len(sites)
+            )
+        else:
+            logger_supy.info(
+                "Running %d checkpointed grids in parallel "
+                "(Rust/Rayon, max_workers=%d)",
+                len(sites),
+                max_workers,
+            )
+        raw_results = rust_module.run_suews_multi_with_state(
+            list_config_jsons,
+            forcing_flat,
+            len_forcing,
+            list_state_jsons,
+            max_workers,
+        )
+        raw_results.sort(key=lambda r: r[0])
+        results = [
+            (list_grid_ids[idx], output_flat, state_json, len_sim)
+            for idx, output_flat, state_json, len_sim in raw_results
+        ]
+    else:
+        results = []
+        for idx, config_json in enumerate(list_config_jsons):
+            output_flat, state_json, len_sim = rust_module.run_suews_with_state(
+                config_json,
+                forcing_flat,
+                len_forcing,
+                list_state_jsons[idx],
+            )
+            results.append((list_grid_ids[idx], output_flat, state_json, len_sim))
+
     list_df_output = []
     dict_state_json: dict[int, str] = {}
 
@@ -487,6 +611,7 @@ def run_suews_rust_chunked(
     df_forcing: pd.DataFrame,
     chunk_day: int = 366,
     serial_mode: bool = False,
+    max_workers: int | None = None,
     initial_state_json_by_grid: dict[int, str] | None = None,
 ) -> tuple[pd.DataFrame, dict[int, str] | None]:
     """Run SUEWS via Rust bridge with multi-chunk state chaining.
@@ -511,7 +636,7 @@ def run_suews_rust_chunked(
     n_chunk = len(grp_forcing_chunk)
     if n_chunk <= 1 and not initial_state_json_by_grid:
         return run_suews_rust_multi(
-            config, df_forcing, serial_mode=serial_mode
+            config, df_forcing, serial_mode=serial_mode, max_workers=max_workers
         )
 
     if n_chunk > 1:
@@ -539,8 +664,7 @@ def run_suews_rust_chunked(
             if unexpected:
                 parts.append(f"unexpected checkpoint states for grids {unexpected}")
             raise ValueError(
-                "Checkpoint grid IDs do not match config.sites: "
-                + "; ".join(parts)
+                "Checkpoint grid IDs do not match config.sites: " + "; ".join(parts)
             )
 
     dict_state_json: dict[int, str] = dict(initial_state_json_by_grid)
@@ -557,33 +681,25 @@ def run_suews_rust_chunked(
             len(df_forcing_chunk),
         )
 
-        list_df_chunk: list[pd.DataFrame] = []
+        if dict_state_json:
+            df_output_chunk, dict_state_json_chunk = run_suews_rust_multi_with_state(
+                config=config,
+                df_forcing=df_forcing_chunk,
+                dict_state_json_by_grid=dict_state_json,
+                serial_mode=serial_mode,
+                max_workers=max_workers,
+            )
+        else:
+            df_output_chunk, dict_state_json_chunk = run_suews_rust_multi(
+                config=config,
+                df_forcing=df_forcing_chunk,
+                serial_mode=serial_mode,
+                max_workers=max_workers,
+            )
 
-        for site in sites:
-            grid_id = _normalise_grid_id(site.gridiv)
-            config_single = config.model_copy(deep=True)
-            config_single.sites = [site.model_copy(deep=True)]
-
-            prev_state = dict_state_json.get(grid_id)
-            if prev_state is not None:
-                df_out, new_state = run_suews_rust_with_state(
-                    config=config_single,
-                    df_forcing=df_forcing_chunk,
-                    grid_id=grid_id,
-                    state_json=prev_state,
-                )
-            else:
-                df_out, new_state = run_suews_rust(
-                    config=config_single,
-                    df_forcing=df_forcing_chunk,
-                    grid_id=grid_id,
-                )
-
-            list_df_chunk.append(df_out)
-            if new_state is not None:
-                dict_state_json[grid_id] = new_state
-
-        list_df_output.append(pd.concat(list_df_chunk))
+        list_df_output.append(df_output_chunk)
+        if dict_state_json_chunk:
+            dict_state_json.update(dict_state_json_chunk)
 
     df_output_all = pd.concat(list_df_output).sort_index()
     return df_output_all, dict_state_json or None

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -36,6 +36,15 @@ DEFAULT_FORCING_FILE_PATTERNS = [
 ]  # Valid forcing file extensions
 
 
+def _validate_n_jobs(n_jobs: int) -> int | None:
+    """Return a Rust worker cap for a public ``n_jobs`` value."""
+    if isinstance(n_jobs, bool) or not isinstance(n_jobs, int):
+        raise ValueError("n_jobs must be an integer: -1, 1, or a positive value")
+    if n_jobs == 0 or n_jobs < -1:
+        raise ValueError("n_jobs must be -1, 1, or a positive integer")
+    return None if n_jobs == -1 else n_jobs
+
+
 class SUEWSSimulation:
     """
     Simplified SUEWS simulation class for urban climate modelling.
@@ -251,7 +260,9 @@ class SUEWSSimulation:
         if self._config is not None:
             try:
                 tstep_val = self._config.model.control.tstep
-                tstep_mod = tstep_val.value if hasattr(tstep_val, "value") else tstep_val
+                tstep_mod = (
+                    tstep_val.value if hasattr(tstep_val, "value") else tstep_val
+                )
             except AttributeError:
                 logger_supy.debug(
                     "Could not extract tstep from config; using default %ds",
@@ -428,6 +439,7 @@ class SUEWSSimulation:
         start_date=None,
         end_date=None,
         chunk_day: int = 3660,
+        n_jobs: int = -1,
         **run_kwargs,
     ) -> SUEWSOutput:
         """
@@ -443,6 +455,10 @@ class SUEWSSimulation:
             Chunk size in days for splitting long simulations, by default 3660
             (~10 years). Smaller values reduce peak memory at a small overhead
             cost.
+        n_jobs : int, optional
+            Parallel worker control for multi-grid runs. ``-1`` (default) uses
+            Rayon default parallelism, ``1`` forces serial execution, and
+            values greater than ``1`` cap Rayon to that many threads.
 
         Returns
         -------
@@ -472,6 +488,9 @@ class SUEWSSimulation:
                 f"Only the 'rust' backend is available. "
                 f"Remove the backend parameter or use backend='rust'."
             )
+
+        max_workers = _validate_n_jobs(n_jobs)
+        serial_mode = n_jobs == 1
 
         _check_rust_available()
 
@@ -549,6 +568,8 @@ class SUEWSSimulation:
             config=self._config,
             df_forcing=df_forcing_slice,
             chunk_day=chunk_day,
+            serial_mode=serial_mode,
+            max_workers=max_workers,
             initial_state_json_by_grid=initial_state_json_by_grid,
         )
         self._df_output = df_output

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -36,7 +36,7 @@ DEFAULT_FORCING_FILE_PATTERNS = [
 ]  # Valid forcing file extensions
 
 
-def _validate_n_jobs(n_jobs: int) -> int | None:
+def _validate_n_jobs(n_jobs: int) -> Optional[int]:
     """Return a Rust worker cap for a public ``n_jobs`` value."""
     if isinstance(n_jobs, bool) or not isinstance(n_jobs, int):
         raise ValueError("n_jobs must be an integer: -1, 1, or a positive value")

--- a/test/core/test_checkpoint.py
+++ b/test/core/test_checkpoint.py
@@ -1,5 +1,6 @@
 """Tests for typed SUEWS restart checkpoints."""
 
+import importlib
 import json
 from pathlib import Path
 
@@ -50,25 +51,25 @@ def test_run_stores_non_empty_checkpoint():
 
 
 def test_checkpoint_continuation_calls_rust_state_path(monkeypatch):
-    """Continuation from checkpoint uses run_suews_with_state."""
-    import supy._run_rust as rust_module
-
+    """Continuation from checkpoint uses the Rust state bridge API."""
+    rust_module = importlib.import_module("supy._run_rust")
     sim1 = SUEWSSimulation.from_sample_data()
     forcing = sim1.forcing.df.iloc[:24]
     sim1.update_forcing(forcing.iloc[:12])
     sim1.run()
 
     calls = {"count": 0}
-    original = rust_module.run_suews_rust_with_state
+    bridge_module = rust_module._check_rust_available()
+    original = bridge_module.run_suews_with_state
 
-    def wrapped_run_suews_rust_with_state(*args, **kwargs):
+    def wrapped_run_suews_with_state(*args, **kwargs):
         calls["count"] += 1
         return original(*args, **kwargs)
 
     monkeypatch.setattr(
-        rust_module,
-        "run_suews_rust_with_state",
-        wrapped_run_suews_rust_with_state,
+        bridge_module,
+        "run_suews_with_state",
+        wrapped_run_suews_with_state,
     )
 
     sim2 = SUEWSSimulation.from_checkpoint(sim1.config, sim1.checkpoint)
@@ -123,9 +124,9 @@ def test_split_run_matches_continuous_run_with_checkpoint():
 
 def test_from_checkpoint_requires_config():
     """A checkpoint alone is not enough to continue a run."""
-    checkpoint = SUEWSCheckpoint.from_grid_states(
-        {1: {"schema_version": 1, "members": {}}}
-    )
+    checkpoint = SUEWSCheckpoint.from_grid_states({
+        1: {"schema_version": 1, "members": {}}
+    })
 
     with pytest.raises(ValueError, match="requires a YAML/SUEWSConfig"):
         SUEWSSimulation.from_checkpoint(None, checkpoint)
@@ -140,12 +141,12 @@ def test_checkpoint_grid_ids_must_match_config():
     sim = SUEWSSimulation(str(config_path))
     forcing = sim.forcing.df.iloc[:12]
     sim.update_forcing(forcing)
-    checkpoint = SUEWSCheckpoint.from_grid_states(
-        {2: {"schema_version": 1, "members": {}}}
-    )
+    checkpoint = SUEWSCheckpoint.from_grid_states({
+        2: {"schema_version": 1, "members": {}}
+    })
     sim.continue_from(checkpoint)
 
-    with pytest.raises(ValueError, match="missing checkpoint states.*unexpected"):
+    with pytest.raises(ValueError, match=r"missing checkpoint states.*unexpected"):
         sim.run()
 
 

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -2,8 +2,9 @@
 
 from pathlib import Path
 
-import pytest
 from conftest import TIMESTEPS_PER_DAY
+import pandas as pd
+import pytest
 
 try:
     from importlib.resources import files
@@ -11,7 +12,9 @@ except ImportError:
     from importlib_resources import files
 
 import supy as sp
+import supy._run_rust as run_rust_module
 from supy.suews_checkpoint import SUEWSCheckpoint
+import supy.suews_sim as suews_sim_module
 from supy.suews_sim import SUEWSSimulation
 
 pytestmark = pytest.mark.api
@@ -404,6 +407,255 @@ class TestForcing:
 
 class TestRun:
     """Test simulation execution."""
+
+    @staticmethod
+    def _multi_site_config():
+        """Return a sample config with two distinct grids."""
+        config = SUEWSSimulation.from_sample_data().config.model_copy(deep=True)
+        site2 = config.sites[0].model_copy(deep=True)
+        site2.gridiv = 2
+        site2.name = "Grid 2"
+        config.sites.append(site2)
+        return config
+
+    @staticmethod
+    def _fake_output_for_config(config, df_forcing):
+        """Return a minimal multi-grid output frame for chunking tests."""
+        list_df_output = []
+        for site in config.sites:
+            grid_id = run_rust_module._normalise_grid_id(site.gridiv)
+            index = pd.MultiIndex.from_product(
+                [[grid_id], df_forcing.index],
+                names=["grid", "datetime"],
+            )
+            list_df_output.append(pd.DataFrame({"QH": 0.0}, index=index))
+        return pd.concat(list_df_output)
+
+    @staticmethod
+    def _patch_run_suews_rust_chunked(monkeypatch):
+        """Patch the Rust runner and return captured parallelism kwargs."""
+        captured = {}
+
+        def fake_check_rust_available():
+            return object()
+
+        def fake_check_forcing(*args, **kwargs):
+            return []
+
+        def fake_run_suews_rust_chunked(
+            config,
+            df_forcing,
+            chunk_day,
+            serial_mode=False,
+            max_workers=None,
+            initial_state_json_by_grid=None,
+        ):
+            captured["serial_mode"] = serial_mode
+            captured["max_workers"] = max_workers
+            captured["initial_state_json_by_grid"] = initial_state_json_by_grid
+            return pd.DataFrame(index=df_forcing.index), None
+
+        monkeypatch.setattr(
+            suews_sim_module, "_check_rust_available", fake_check_rust_available
+        )
+        monkeypatch.setattr(suews_sim_module, "check_forcing", fake_check_forcing)
+        monkeypatch.setattr(
+            suews_sim_module,
+            "run_suews_rust_chunked",
+            fake_run_suews_rust_chunked,
+        )
+        return captured
+
+    def test_run_n_jobs_defaults_to_rayon_default(self, monkeypatch):
+        """Test default n_jobs preserves uncapped parallel execution."""
+        sim = SUEWSSimulation.from_sample_data()
+        sim._df_forcing = sim._df_forcing.iloc[:2]
+        captured = self._patch_run_suews_rust_chunked(monkeypatch)
+
+        sim.run()
+
+        assert captured["serial_mode"] is False
+        assert captured["max_workers"] is None
+
+    def test_run_n_jobs_one_forces_serial(self, monkeypatch):
+        """Test n_jobs=1 disables the multi-grid Rayon path."""
+        sim = SUEWSSimulation.from_sample_data()
+        sim._df_forcing = sim._df_forcing.iloc[:2]
+        captured = self._patch_run_suews_rust_chunked(monkeypatch)
+
+        sim.run(n_jobs=1)
+
+        assert captured["serial_mode"] is True
+        assert captured["max_workers"] == 1
+
+    def test_run_n_jobs_positive_caps_workers(self, monkeypatch):
+        """Test positive n_jobs reaches the Rust bridge as max_workers."""
+        sim = SUEWSSimulation.from_sample_data()
+        sim._df_forcing = sim._df_forcing.iloc[:2]
+        captured = self._patch_run_suews_rust_chunked(monkeypatch)
+
+        sim.run(n_jobs=3)
+
+        assert captured["serial_mode"] is False
+        assert captured["max_workers"] == 3
+
+    @pytest.mark.parametrize("n_jobs", [True, False, 0, -2, 1.5, "2"])
+    def test_run_n_jobs_rejects_invalid_values(self, n_jobs):
+        """Test n_jobs validation rejects ambiguous worker controls."""
+        sim = SUEWSSimulation()
+
+        with pytest.raises(ValueError, match="n_jobs must be"):
+            sim.run(n_jobs=n_jobs)
+
+    def test_chunked_run_forwards_worker_cap_per_chunk(self, monkeypatch):
+        """Test chunked multi-grid runs keep n_jobs after the first chunk."""
+        config = self._multi_site_config()
+        df_forcing = SUEWSSimulation.from_sample_data()._df_forcing.iloc[
+            : TIMESTEPS_PER_DAY + 1
+        ]
+        calls = []
+
+        def fake_run_suews_rust_multi(
+            config, df_forcing, serial_mode=False, max_workers=None
+        ):
+            calls.append(("fresh", serial_mode, max_workers))
+            dict_state_json = {
+                run_rust_module._normalise_grid_id(site.gridiv): "state"
+                for site in config.sites
+            }
+            return self._fake_output_for_config(config, df_forcing), dict_state_json
+
+        def fake_run_suews_rust_multi_with_state(
+            config,
+            df_forcing,
+            dict_state_json_by_grid,
+            serial_mode=False,
+            max_workers=None,
+        ):
+            calls.append(("state", serial_mode, max_workers))
+            assert sorted(dict_state_json_by_grid) == [1, 2]
+            return (
+                self._fake_output_for_config(config, df_forcing),
+                dict_state_json_by_grid,
+            )
+
+        monkeypatch.setattr(
+            run_rust_module, "run_suews_rust_multi", fake_run_suews_rust_multi
+        )
+        monkeypatch.setattr(
+            run_rust_module,
+            "run_suews_rust_multi_with_state",
+            fake_run_suews_rust_multi_with_state,
+        )
+
+        run_rust_module.run_suews_rust_chunked(
+            config=config,
+            df_forcing=df_forcing,
+            chunk_day=1,
+            serial_mode=False,
+            max_workers=3,
+        )
+
+        assert calls == [("fresh", False, 3), ("state", False, 3)]
+
+    def test_checkpointed_run_forwards_worker_cap(self, monkeypatch):
+        """Test resumed multi-grid runs keep n_jobs on the first chunk."""
+        config = self._multi_site_config()
+        df_forcing = SUEWSSimulation.from_sample_data()._df_forcing.iloc[:2]
+        calls = []
+
+        def fail_run_suews_rust_multi(*args, **kwargs):
+            raise AssertionError("checkpointed runs should use the state-aware path")
+
+        def fake_run_suews_rust_multi_with_state(
+            config,
+            df_forcing,
+            dict_state_json_by_grid,
+            serial_mode=False,
+            max_workers=None,
+        ):
+            calls.append(("state", serial_mode, max_workers))
+            assert sorted(dict_state_json_by_grid) == [1, 2]
+            return (
+                self._fake_output_for_config(config, df_forcing),
+                dict_state_json_by_grid,
+            )
+
+        monkeypatch.setattr(
+            run_rust_module, "run_suews_rust_multi", fail_run_suews_rust_multi
+        )
+        monkeypatch.setattr(
+            run_rust_module,
+            "run_suews_rust_multi_with_state",
+            fake_run_suews_rust_multi_with_state,
+        )
+
+        run_rust_module.run_suews_rust_chunked(
+            config=config,
+            df_forcing=df_forcing,
+            chunk_day=3660,
+            serial_mode=False,
+            max_workers=4,
+            initial_state_json_by_grid={1: "state-1", 2: "state-2"},
+        )
+
+        assert calls == [("state", False, 4)]
+
+    def test_multi_with_state_passes_worker_cap_to_rust(self, monkeypatch):
+        """Test state-aware multi-grid wrapper forwards max_workers."""
+        config = self._multi_site_config()
+        df_forcing = SUEWSSimulation.from_sample_data()._df_forcing.iloc[:2]
+        captured = {}
+
+        class FakeRustModule:
+            def run_suews_multi_with_state(
+                self,
+                list_config_jsons,
+                forcing_flat,
+                len_forcing,
+                list_state_jsons,
+                max_workers,
+            ):
+                captured["n_config"] = len(list_config_jsons)
+                captured["len_forcing"] = len_forcing
+                captured["list_state_jsons"] = list_state_jsons
+                captured["max_workers"] = max_workers
+                return [
+                    (idx, [], f"new-state-{idx}", len_forcing)
+                    for idx in range(len(list_config_jsons))
+                ]
+
+        def fake_parse_output_block(output_flat, len_sim, grid_id):
+            index = pd.MultiIndex.from_product(
+                [[grid_id], df_forcing.index[:len_sim]],
+                names=["grid", "datetime"],
+            )
+            return pd.DataFrame({"QH": 0.0}, index=index)
+
+        monkeypatch.setattr(
+            run_rust_module, "_check_rust_available", lambda: FakeRustModule()
+        )
+        monkeypatch.setattr(
+            run_rust_module, "_validate_output_layout", lambda rust_module: None
+        )
+        monkeypatch.setattr(
+            run_rust_module, "_parse_output_block", fake_parse_output_block
+        )
+
+        _, dict_state_json = run_rust_module.run_suews_rust_multi_with_state(
+            config=config,
+            df_forcing=df_forcing,
+            dict_state_json_by_grid={1: "state-1", 2: "state-2"},
+            max_workers=5,
+        )
+
+        assert captured == {
+            "n_config": 2,
+            "len_forcing": 2,
+            "list_state_jsons": ["state-1", "state-2"],
+            "max_workers": 5,
+        }
+        assert dict_state_json == {1: "new-state-0", 2: "new-state-1"}
 
     def test_basic_run(self):
         """Test basic simulation run."""


### PR DESCRIPTION
## Summary

- Add joblib-style `n_jobs` to `SUEWSSimulation.run()`: `-1` = Rayon default (current behaviour), `1` = serial, `N>1` = cap Rayon to N threads. Validation via `_validate_n_jobs` rejects `bool`, non-int, `0`, and values `< -1`.
- Plumb `max_workers` through the Rust bridge (`run_suews_multi_py`) and add a new `run_suews_multi_with_state_py` entrypoint plus its Python wrapper `run_suews_rust_multi_with_state`, used by checkpointed multi-grid chunks.
- Refactor `run_suews_rust_chunked` to call the multi-grid Rayon path once per chunk (replacing the per-site sequential loop), so multi-grid chunked runs now actually run grids in parallel.

## Test plan

- [x] New unit tests in `test/core/test_suews_simulation.py` cover `n_jobs` defaults, `n_jobs=1` serial, `n_jobs=N` worker cap, invalid inputs, and `max_workers` forwarding through the chunked + checkpointed paths
- [ ] `make test-smoke`
- [ ] Multi-grid sample run with `n_jobs=1`, `n_jobs=-1`, `n_jobs=2`

Closes #1365