### PR TITLE
feat: unify public suews CLI dispatcher

### DIFF
--- a/docs/source/api/python-cli-equivalents/schema.rst
+++ b/docs/source/api/python-cli-equivalents/schema.rst
@@ -8,9 +8,9 @@ CLI Commands
 
 .. code-block:: bash
 
-    suews-schema export -o schema.json
-    suews-schema validate config.yml
-    suews-schema migrate old_config.yml --target-version 2.0
+    suews schema export -o schema.json
+    suews validate config.yml
+    suews schema migrate old_config.yml --target-version 2.0
 
 Python Equivalent (Schema Export)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/contributing/schema/schema-developer.rst
+++ b/docs/source/contributing/schema/schema-developer.rst
@@ -76,7 +76,7 @@ definitive checklist is in
 6. Sync user-facing documentation: update
    :ref:`schema_versioning` (version history and illustrative
    labels), add a per-release entry in :ref:`transition_guide`
-   (rename/drop summary + the ``suews-schema migrate`` command), and
+   (rename/drop summary + the ``suews schema migrate`` command), and
    if a release is involved, note the migration chain in the
    matching ``docs/source/version-history/v<release>.rst``.
 
@@ -114,15 +114,15 @@ past a missing bump.
 Schema Management Commands
 --------------------------
 
-For developers, the ``suews-schema`` command exposes schema
+For developers, the ``suews schema`` command exposes schema
 management operations:
 
 .. code-block:: bash
 
-   suews-schema info                 # Display schema information
-   suews-schema version files/*.yml  # Check schema versions
-   suews-schema migrate old.yml      # Migrate between versions
-   suews-schema export               # Export JSON Schema
+   suews schema info                 # Display schema information
+   suews schema version files/*.yml  # Check schema versions
+   suews schema migrate old.yml      # Migrate between versions
+   suews schema export               # Export JSON Schema
 
 See :ref:`schema_cli` for the full command reference.
 
@@ -166,5 +166,5 @@ Implementation Map
 - ``src/supy/util/converter/__init__.py`` — unified ``suews-convert``
   entry point covering both legacy table conversion and schema
   migration.
-- ``src/supy/cmd/validate_config.py`` — ``suews-schema`` CLI entry
+- ``src/supy/cmd/schema_cli.py`` — ``suews schema`` CLI entry
   point.

--- a/docs/source/contributing/schema/schema_cli.rst
+++ b/docs/source/contributing/schema/schema_cli.rst
@@ -3,7 +3,7 @@
 Schema Management CLI
 =====================
 
-The ``suews-schema`` command provides a comprehensive command-line interface for managing SUEWS YAML configuration schemas. This unified tool addresses the needs for schema version checking, validation, and migration between different schema versions.
+The ``suews schema`` command provides a comprehensive command-line interface for managing SUEWS YAML configuration schemas. This unified tool addresses the needs for schema version checking, migration, and schema export.
 
 .. note::
    This CLI consolidates functionality from GitHub issues #612 and #613, providing a single entry point for all schema-related operations that will integrate with the future suews-wizard (#544).
@@ -11,7 +11,7 @@ The ``suews-schema`` command provides a comprehensive command-line interface for
 Installation
 ------------
 
-The ``suews-schema`` command is automatically installed with SuPy:
+The ``suews schema`` command is automatically installed with SuPy:
 
 .. code-block:: bash
 
@@ -22,16 +22,17 @@ Once installed, the command is available system-wide.
 Available Commands
 ------------------
 
-The ``suews-schema`` CLI provides the following subcommands:
+The ``suews schema`` CLI provides the following subcommands:
 
 .. code-block:: bash
 
-   suews-schema --help              # Show help and available commands
-   suews-schema info                 # Display schema version information
-   suews-schema version              # Check or update schema versions
-   suews-schema validate             # Validate configuration files
-   suews-schema migrate              # Migrate between schema versions
-   suews-schema export               # Export JSON Schema
+   suews schema --help              # Show help and available commands
+   suews schema info                 # Display schema version information
+   suews schema version              # Check or update schema versions
+   suews schema migrate              # Migrate between schema versions
+   suews schema export               # Export JSON Schema
+
+Configuration validation is handled by ``suews validate``.
 
 Command Reference
 -----------------
@@ -43,7 +44,7 @@ Display information about available schema versions and the current version.
 
 .. code-block:: bash
 
-   suews-schema info
+   suews schema info
 
 This command shows:
 
@@ -61,64 +62,29 @@ Check or update schema versions in configuration files.
 .. code-block:: bash
 
    # Check schema version
-   suews-schema version config.yml
+   suews schema version config.yml
 
    # Check multiple files
-   suews-schema version configs/*.yml
+   suews schema version configs/*.yml
 
 **Update schema versions:**
 
 .. code-block:: bash
 
    # Update to current version
-   suews-schema version config.yml --update
+   suews schema version config.yml --update
 
    # Update to specific version
-   suews-schema version config.yml --update --target-version 2026.4
+   suews schema version config.yml --update --target-version 2026.4
 
    # Update without backup (not recommended)
-   suews-schema version config.yml --update --no-backup
+   suews schema version config.yml --update --no-backup
 
 **Options:**
 
 - ``--update, -u``: Update schema version in files
 - ``--target-version``: Target version for update (default: current)
 - ``--backup, -b``: Create backup before updating (default: true)
-
-validate
-~~~~~~~~
-
-Validate configuration files against their schema.
-
-**Basic usage:**
-
-.. code-block:: bash
-
-   # Validate single file
-   suews-schema validate config.yml
-
-   # Validate multiple files
-   suews-schema validate configs/*.yml
-
-**Advanced options:**
-
-.. code-block:: bash
-
-   # Validate against specific schema version
-   suews-schema validate config.yml --schema-version 2026.4
-
-   # Strict mode (exit with error code on failure)
-   suews-schema validate config.yml --strict
-
-   # Different output formats
-   suews-schema validate config.yml --format json
-   suews-schema validate config.yml --format yaml
-
-**Options:**
-
-- ``--schema-version``: Schema version to validate against
-- ``--strict, -s``: Exit with error on validation failure
-- ``--format``: Output format (table, json, yaml)
 
 migrate
 ~~~~~~~
@@ -130,20 +96,20 @@ Migrate configuration files between schema versions.
 .. code-block:: bash
 
    # Migrate to current version
-   suews-schema migrate old_config.yml
+   suews schema migrate old_config.yml
 
    # Migrate to specific version
-   suews-schema migrate config.yml --target-version 2026.4
+   suews schema migrate config.yml --target-version 2026.4
 
 **Batch migration:**
 
 .. code-block:: bash
 
    # Migrate multiple files to output directory
-   suews-schema migrate configs/*.yml --output-dir migrated/
+   suews schema migrate configs/*.yml --output-dir migrated/
 
    # Dry run to preview changes
-   suews-schema migrate config.yml --dry-run
+   suews schema migrate config.yml --dry-run
 
 **Options:**
 
@@ -162,13 +128,13 @@ Export the JSON Schema for SUEWS configurations.
 .. code-block:: bash
 
    # Export to file
-   suews-schema export -o schema.json
+   suews schema export -o schema.json
 
    # Export specific version
-   suews-schema export --version 2026.4 -o schema-2026.4.json
+   suews schema export --version 2026.4 -o schema-2026.4.json
 
    # Export as YAML
-   suews-schema export --format yaml -o schema.yaml
+   suews schema export --format yaml -o schema.yaml
 
 **Options:**
 
@@ -192,46 +158,46 @@ Examples
 .. code-block:: bash
 
    # Check current versions
-   suews-schema version configs/*.yml
+   suews schema version configs/*.yml
 
    # Update all to current version
-   suews-schema version configs/*.yml --update
+   suews schema version configs/*.yml --update
 
 **Example 2: CI/CD validation**
 
 .. code-block:: bash
 
    # Validate all configs in CI pipeline
-   suews-schema validate configs/*.yml --strict
+   suews validate -p C --dry-run configs/*.yml
 
    # Output validation results as JSON for processing
-   suews-schema validate configs/*.yml --format json > validation.json
+   suews validate -p C --dry-run configs/*.yml --format json > validation.json
 
 **Example 3: Migration workflow**
 
 .. code-block:: bash
 
    # Check what needs migration
-   suews-schema version old_configs/*.yml
+   suews schema version old_configs/*.yml
 
    # Dry run migration
-   suews-schema migrate old_configs/*.yml --dry-run
+   suews schema migrate old_configs/*.yml --dry-run
 
    # Perform migration
-   suews-schema migrate old_configs/*.yml --output-dir updated_configs/
+   suews schema migrate old_configs/*.yml --output-dir updated_configs/
 
    # Validate migrated files
-   suews-schema validate updated_configs/*.yml --strict
+   suews validate -p C --dry-run updated_configs/*.yml
 
 **Example 4: Schema documentation**
 
 .. code-block:: bash
 
    # Export current schema for documentation
-   suews-schema export -o docs/schema.json
+   suews schema export -o docs/schema.json
 
    # Generate human-readable YAML version
-   suews-schema export --format yaml -o docs/schema.yaml
+   suews schema export --format yaml -o docs/schema.yaml
 
 Integration with Other Tools
 ----------------------------
@@ -248,14 +214,14 @@ The schema CLI can be called from Python scripts:
 
    # Validate configuration
    result = subprocess.run(
-       ['suews-schema', 'validate', 'config.yml', '--format', 'json'],
+       ['suews', 'validate', '-p', 'C', '--dry-run', 'config.yml', '--format', 'json'],
        capture_output=True, text=True
    )
    validation = json.loads(result.stdout)
 
    # Check schema version
    result = subprocess.run(
-       ['suews-schema', 'version', 'config.yml', '--quiet'],
+       ['suews', 'schema', 'version', 'config.yml', '--quiet'],
        capture_output=True, text=True
    )
 
@@ -268,11 +234,11 @@ Using in CI/CD
 
    - name: Validate SUEWS configs
      run: |
-       suews-schema validate configs/*.yml --strict
+       suews validate -p C --dry-run configs/*.yml
 
    - name: Check schema versions
      run: |
-       suews-schema version configs/*.yml
+       suews schema version configs/*.yml
 
 **Pre-commit hook example:**
 
@@ -283,16 +249,16 @@ Using in CI/CD
        hooks:
          - id: validate-suews-config
            name: Validate SUEWS configs
-           entry: suews-schema validate
-           language: system
-           files: '\.yml$'
-           pass_filenames: true
-           args: ['--strict']
+          entry: suews validate
+          language: system
+          files: '\.yml$'
+          pass_filenames: true
+          args: ['-p', 'C', '--dry-run']
 
 Future Integration with suews-wizard
 ------------------------------------
 
-The ``suews-schema`` CLI is designed to integrate seamlessly with the upcoming ``suews-wizard`` (issue #544):
+The ``suews schema`` CLI is designed to integrate seamlessly with the upcoming ``suews-wizard`` (issue #544):
 
 - The wizard will use the validation logic to ensure created configurations are valid
 - Migration utilities can be called from within the wizard for upgrading existing configs
@@ -303,7 +269,7 @@ CLI Best Practices
 ------------------
 
 1. **Always specify schema version**: Include ``schema_version`` in your YAML files
-2. **Validate before running**: Use ``suews-schema validate`` before running simulations
+2. **Validate before running**: Use ``suews validate`` before running simulations
 3. **Keep backups**: Always backup configurations before migration
 4. **Use CI/CD validation**: Integrate validation into your automated workflows
 5. **Document versions**: Keep track of which schema version your configs use
@@ -325,8 +291,8 @@ Check if you're validating against the correct schema version:
 
 .. code-block:: bash
 
-   suews-schema version config.yml
-   suews-schema validate config.yml --schema-version <correct_version>
+   suews schema version config.yml
+   suews validate -p C --dry-run --schema-version <correct_version> config.yml
 
 **Issue: Migration fails**
 
@@ -335,8 +301,8 @@ Try step-by-step migration if jumping multiple versions:
 .. code-block:: bash
 
    # Instead of 2025.12 -> 2026.4 directly
-   suews-schema migrate config.yml --target-version 2026.1
-   suews-schema migrate config.migrated.yml --target-version 2026.4
+   suews schema migrate config.yml --target-version 2026.1
+   suews schema migrate config.migrated.yml --target-version 2026.4
 
 See Also
 --------

--- a/docs/source/contributing/schema/schema_versioning.rst
+++ b/docs/source/contributing/schema/schema_versioning.rst
@@ -138,13 +138,13 @@ Command-line migration (preferred entry point)
 .. code-block:: bash
 
    # Upgrade a YAML to the current schema in place-safely (creates a .bak)
-   suews-schema migrate old_config.yml
+   suews schema migrate old_config.yml
 
    # Migrate to a specific target schema
-   suews-schema migrate config.yml --target-version 2026.5
+   suews schema migrate config.yml --target-version 2026.5
 
    # Dry-run to preview the rename/drop deltas
-   suews-schema migrate config.yml --dry-run
+   suews schema migrate config.yml --dry-run
 
 Python API
 ~~~~~~~~~~
@@ -423,10 +423,10 @@ Versioning Best Practices
 
 1. **Pin** ``schema_version`` in shared configurations so the target
    shape is explicit.
-2. **Upgrade via ``suews-schema migrate``** rather than hand-editing;
+2. **Upgrade via ``suews schema migrate``** rather than hand-editing;
    the tool preserves user-supplied values through rename chains and
    logs dropped fields so you can recover intent.
-3. **Re-validate after migration**: ``suews-schema validate
+3. **Re-validate after migration**: ``suews validate
    new_config.yml`` catches any downstream field that tightened at the
    same time.
 4. **Quote the SUEWS release** when sharing a config — the release

--- a/docs/source/inputs/transition_guide.rst
+++ b/docs/source/inputs/transition_guide.rst
@@ -171,7 +171,7 @@ YAML Schema Migrations
 Once your configuration is in YAML, subsequent SUEWS releases may bump
 the YAML *schema* — the structure of the file itself. Each bump is
 backed by a registered migration handler, so ``suews-convert`` (for
-combined legacy+schema upgrades) and ``suews-schema migrate`` (for
+combined legacy+schema upgrades) and ``suews schema migrate`` (for
 schema-only upgrades) will move old YAMLs onto the current shape
 without losing data. Every drop is logged with a human-readable
 reason so you can reconstruct intent if needed.
@@ -217,13 +217,13 @@ the user omitted them are skipped, so programmatic
 docs YAMLs that only exercise unrelated aspects (timezone, output
 configuration, ...) remain permissive.
 
-Because the YAML shape is unchanged, no ``suews-schema migrate`` run
+Because the YAML shape is unchanged, no ``suews schema migrate`` run
 is strictly required to move to ``2026.5.dev6``. Run the migrator
 only to refresh the ``schema_version`` stamp if you pin the field:
 
 .. code-block:: bash
 
-   suews-schema migrate your_config.yml --target-version 2026.5.dev6
+   suews schema migrate your_config.yml --target-version 2026.5.dev6
 
 Users hitting the new raise should either (a) fill in the missing
 fields the error message names, or (b) remove the offending surface
@@ -246,7 +246,7 @@ Because the change is accept-only, the ``2026.5.dev4 ->
 
 .. code-block:: bash
 
-   suews-schema migrate your_config.yml --target-version 2026.5.dev5
+   suews schema migrate your_config.yml --target-version 2026.5.dev5
 
 Upgrading to Schema 2026.5.dev4 (gh#1334 follow-through via PR #1337: STEBBS hot-water prefix unification)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -276,7 +276,7 @@ component qualifiers; only the prefix becomes consistent.
 
 Legacy ``dhw_*`` and ``water_tank_*`` spellings continue to load
 via the Pydantic shim with a ``DeprecationWarning``. Run
-``suews-schema migrate --target-version 2026.5.dev4 <your.yml>``
+``suews schema migrate --target-version 2026.5.dev4 <your.yml>``
 to rewrite them in place. Rust struct fields and the c_api shadow
 keep ``dhw_*`` internally — cross-layer work is tracked in #1324.
 
@@ -343,7 +343,7 @@ cluster) continue to load under a ``DeprecationWarning``. Run:
 
 .. code-block:: bash
 
-   suews-schema migrate your_config.yml --target-version 2026.5.dev3
+   suews schema migrate your_config.yml --target-version 2026.5.dev3
 
 Use this historical target when you specifically want the pre-hot-water
 unification ``2026.5.dev3`` spellings. To land on the current schema
@@ -388,7 +388,7 @@ under a ``DeprecationWarning``. Run:
 
 .. code-block:: bash
 
-   suews-schema migrate your_config.yml --target-version 2026.5.dev2
+   suews schema migrate your_config.yml --target-version 2026.5.dev2
 
 The migrator accepts any registered intermediate (``2025.12``,
 ``2026.1``, ``2026.4``, ``2026.5``, ``2026.5.dev1``) and walks the
@@ -428,7 +428,7 @@ persisted YAMLs should be migrated. Run:
 
 .. code-block:: bash
 
-   suews-schema migrate your_config.yml --target-version 2026.5.dev1
+   suews schema migrate your_config.yml --target-version 2026.5.dev1
 
 The migrator accepts any registered intermediate (for example
 ``2025.12``, ``2026.1``, ``2026.4`` or ``2026.5``) and walks the
@@ -470,7 +470,7 @@ top.
 
    The standalone Rust CLI (``suews run config.yml``) accepts both the
    new ``snake_case`` spellings and the legacy fused spellings
-   transparently (gh#1322). You do not need to run ``suews-schema
+   transparently (gh#1322). You do not need to run ``suews schema
    migrate`` purely to use the CLI — migration is only required when
    persisting a canonical 2026.5-shaped YAML, for example alongside a
    release fixture or before sharing a config with collaborators.
@@ -499,7 +499,7 @@ Run:
 
 .. code-block:: bash
 
-   suews-schema migrate your_config.yml --target-version 2026.4
+   suews schema migrate your_config.yml --target-version 2026.4
 
 The migrator accepts any registered intermediate (for example
 ``2025.12``) and walks the chain to the 2026.4 schema. To upgrade
@@ -529,7 +529,7 @@ If you are targeting 2026.1.28 exactly:
 
 .. code-block:: bash
 
-   suews-schema migrate your_config.yml --target-version 2026.1
+   suews schema migrate your_config.yml --target-version 2026.1
 
 Otherwise the 2026.4 -> 2026.5 chain above is applied in one pass.
 
@@ -546,7 +546,7 @@ upgraded file, pass ``--dry-run``:
 
 .. code-block:: bash
 
-   suews-schema migrate your_config.yml --dry-run
+   suews schema migrate your_config.yml --dry-run
 
 Troubleshooting
 ~~~~~~~~~~~~~~~
@@ -617,7 +617,7 @@ Accept-only widening — no schema version bump. Every previously
 valid YAML continues to validate and round-trips byte-identically.
 Writing in the nested form is optional and serves as in-file
 documentation of intent; YAMLs that round-trip through
-``suews-schema migrate`` or ``SUEWSConfig.to_yaml`` are always
+``suews schema migrate`` or ``SUEWSConfig.to_yaml`` are always
 emitted in the flat form.
 
 The Rust CLI (``suews run``) accepts the same two shapes via the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,11 +125,15 @@ docs = [
 ]
 
 [project.scripts]
-suews = "supy.cmd.rust_bridge:main"
-suews-run = "supy.cmd.SUEWS:SUEWS"
-suews-convert = "supy.cmd.table_converter:convert_table_cmd"
-suews-validate = "supy.cmd.validate_config:main"
-suews-schema = "supy.cmd.schema_cli:main"
+# Unified CLI dispatcher. `suews <subcmd>` is the canonical entry point;
+# the hyphenated scripts below are deprecated aliases that print a notice
+# and forward to the matching subcommand. The Rust engine binary is
+# exposed as `suews rust ...` (was previously the bare `suews` invocation).
+suews = "supy.cmd.suews_cli:main"
+suews-run = "supy.cmd.suews_cli:run_alias"
+suews-convert = "supy.cmd.suews_cli:convert_alias"
+suews-validate = "supy.cmd.suews_cli:validate_alias"
+suews-schema = "supy.cmd.suews_cli:schema_alias"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,7 @@ docs = [
 [project.scripts]
 # Unified CLI dispatcher. `suews <subcmd>` is the canonical entry point;
 # the hyphenated scripts below are deprecated aliases that print a notice
-# and forward to the matching subcommand. The Rust engine binary is
-# exposed as `suews rust ...` (was previously the bare `suews` invocation).
+# and forward to the matching subcommand.
 suews = "supy.cmd.suews_cli:main"
 suews-run = "supy.cmd.suews_cli:run_alias"
 suews-convert = "supy.cmd.suews_cli:convert_alias"

--- a/src/suews_bridge/README.md
+++ b/src/suews_bridge/README.md
@@ -16,6 +16,10 @@ the flat payload layout.
 
 ## Build and test (Rust only)
 
+The public SUEWS CLI does not expose a Rust subcommand. For bridge debugging,
+run the engine directly from this crate or from the installed
+`supy/bin/suews-engine` binary.
+
 ```bash
 cd src/suews_bridge
 cargo test

--- a/src/supy/cmd/__init__.py
+++ b/src/supy/cmd/__init__.py
@@ -1,9 +1,17 @@
 # Lazy imports for fast CLI startup
 # Only import specific CLI tools when actually accessed
 
+import importlib as _importlib
+
 __all__ = ["SUEWS", "convert_table_cmd", "validate_config_main", "schema_cli_main"]
 
 _lazy_cache = {}
+
+# Submodules exposed through ``from supy.cmd import <name>``. Listed
+# explicitly so static checks (e.g. test_api_surface.py's hasattr probe)
+# resolve them without requiring the consumer to first import the
+# fully-qualified module path.
+_LAZY_SUBMODULES = frozenset({"rust_bridge", "suews_cli"})
 
 
 def __getattr__(name):
@@ -38,6 +46,11 @@ def __getattr__(name):
         except Exception:
             _lazy_cache[name] = None
             return None
+
+    if name in _LAZY_SUBMODULES:
+        module = _importlib.import_module(f"{__name__}.{name}")
+        _lazy_cache[name] = module
+        return module
 
     raise AttributeError(f"module 'supy.cmd' has no attribute {name!r}")
 

--- a/src/supy/cmd/rust_bridge.py
+++ b/src/supy/cmd/rust_bridge.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from importlib.resources import as_file, files
 import os
+from pathlib import Path
 import subprocess
 import sys
-from importlib.resources import as_file, files
-from pathlib import Path
 
 
 def _bridge_binary() -> Path:
@@ -19,7 +20,7 @@ def _bridge_binary() -> Path:
         return path
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     """Run the bundled Rust CLI, forwarding command-line arguments."""
     try:
         bridge_path = _bridge_binary()
@@ -28,6 +29,7 @@ def main() -> None:
             "Bundled Rust bridge CLI not found. Rebuild/install SuPy with Meson Rust bridge enabled."
         ) from exc
 
-    cmd = [str(bridge_path), *sys.argv[1:]]
+    args = sys.argv[1:] if argv is None else list(argv)
+    cmd = [str(bridge_path), *args]
     result = subprocess.run(cmd, check=False)
     raise SystemExit(result.returncode)

--- a/src/supy/cmd/schema_cli.py
+++ b/src/supy/cmd/schema_cli.py
@@ -3,7 +3,7 @@
 SUEWS Schema Management CLI
 
 Unified command-line interface for managing SUEWS YAML configuration schemas.
-This consolidates schema version checking, migration, and validation operations.
+This consolidates schema version checking, migration, and export operations.
 
 This module addresses GitHub issues #612 and #613, providing a single entry point
 for all schema-related operations that will integrate with the future suews-wizard (#544).
@@ -134,7 +134,7 @@ def cli(ctx, verbose, quiet):
     SUEWS Schema Management - Manage YAML configuration schemas.
 
     This tool provides utilities for managing SUEWS YAML configuration schemas,
-    including version checking, validation, and migration between versions.
+    including version checking, migration between versions, and schema export.
     """
     ctx.ensure_object(dict)
     ctx.obj["verbose"] = verbose
@@ -162,8 +162,8 @@ def version(ctx, files, update, target_version, backup):
     Check or update schema versions in configuration files.
 
     Examples:
-        suews-schema version config.yml
-        suews-schema version *.yml --update --target-version 1.0
+        suews schema version config.yml
+        suews schema version *.yml --update --target-version 1.0
     """
     verbose = ctx.obj.get("verbose", False)
     quiet = ctx.obj.get("quiet", False)
@@ -257,8 +257,8 @@ def migrate(ctx, files, target_version, output_dir, backup, dry_run):
     Migrate configuration files between schema versions.
 
     Examples:
-        suews-schema migrate old_config.yml
-        suews-schema migrate configs/*.yml --target-version 2.0 --output-dir migrated/
+        suews schema migrate old_config.yml
+        suews schema migrate configs/*.yml --target-version 2.0 --output-dir migrated/
     """
     verbose = ctx.obj.get("verbose", False)
     quiet = ctx.obj.get("quiet", False)
@@ -349,97 +349,6 @@ def migrate(ctx, files, target_version, output_dir, backup, dry_run):
 
 
 @cli.command()
-@click.argument("files", nargs=-1, type=click.Path(exists=True), required=True)
-@click.option("--schema-version", help="Schema version to validate against")
-@click.option(
-    "--strict", "-s", is_flag=True, help="Exit with error on validation failure"
-)
-@click.option(
-    "--format",
-    type=click.Choice(["table", "json", "yaml"]),
-    default="table",
-    help="Output format",
-)
-@click.pass_context
-def validate(ctx, files, schema_version, strict, format):
-    """
-    Validate configuration files against their schema.
-
-    Examples:
-        suews-schema validate config.yml
-        suews-schema validate configs/*.yml --schema-version 1.0 --strict
-    """
-    verbose = ctx.obj.get("verbose", False)
-    quiet = ctx.obj.get("quiet", False)
-
-    version = schema_version or CURRENT_SCHEMA_VERSION
-
-    if not quiet and format == "table":
-        console.print(f"[bold blue]Validating against schema v{version}[/bold blue]\n")
-
-    results = []
-    all_valid = True
-
-    for file_path in files:
-        path = Path(file_path)
-        is_valid, errors = validate_file_against_schema(
-            path, schema_version=schema_version, show_details=verbose
-        )
-
-        if not is_valid:
-            all_valid = False
-
-        results.append({
-            "file": str(path),
-            "valid": is_valid,
-            "errors": errors if not is_valid else [],
-            "error_count": len(errors) if not is_valid else 0,
-        })
-
-    # Output results based on format
-    if format == "json":
-        import json
-
-        console.print(json.dumps(results, indent=2))
-    elif format == "yaml":
-        console.print(yaml.dump(results, default_flow_style=False))
-    else:  # table format
-        if not quiet:
-            table = Table(title="Validation Results")
-            table.add_column("File", style="cyan")
-            table.add_column("Status", justify="center")
-            table.add_column("Issues", style="yellow")
-
-            for result in results:
-                path = Path(result["file"])
-                if result["valid"]:
-                    status = "[green]✓ Valid[/green]"
-                    issues = ""
-                else:
-                    status = "[red]✗ Invalid[/red]"
-                    if verbose and result["errors"]:
-                        issues = "\n".join(result["errors"][:3])
-                        if len(result["errors"]) > 3:
-                            issues += f"\n... and {len(result['errors']) - 3} more"
-                    else:
-                        issues = f"{result['error_count']} issue(s)"
-
-                table.add_row(path.name, status, issues)
-
-            console.print(table)
-
-            valid_count = sum(1 for r in results if r["valid"])
-            total_count = len(results)
-            console.print(
-                f"\n[bold]Summary:[/bold] {valid_count}/{total_count} files valid"
-            )
-
-    # Exit with error if strict mode and validation failed
-    if strict and not all_valid:
-        sys.exit(1)
-
-
-@cli.command()
 @click.option("--output", "-o", type=click.Path(), help="Output file for schema")
 @click.option("--version", help="Schema version to export")
 @click.option(
@@ -454,8 +363,8 @@ def export(ctx, output, version, format):
     Export the JSON Schema for SUEWS configurations.
 
     Examples:
-        suews-schema export -o schema.json
-        suews-schema export --version 1.0 --format yaml
+        suews schema export -o schema.json
+        suews schema export --version 1.0 --format yaml
     """
     verbose = ctx.obj.get("verbose", False)
     quiet = ctx.obj.get("quiet", False)
@@ -528,19 +437,19 @@ def info(ctx):
         console.print(f"  {marker} v{version}: {description}")
 
     console.print("\n[bold]CLI Commands:[/bold]")
-    console.print("  • Check version: [cyan]suews-schema version config.yml[/cyan]")
-    console.print("  • Validate: [cyan]suews-schema validate config.yml[/cyan]")
+    console.print("  • Check version: [cyan]suews schema version config.yml[/cyan]")
+    console.print("  • Validate configs: [cyan]suews validate config.yml[/cyan]")
     console.print(
-        "  • Migrate: [cyan]suews-schema migrate old.yml --target-version 2.0[/cyan]"
+        "  • Migrate: [cyan]suews schema migrate old.yml --target-version 2.0[/cyan]"
     )
-    console.print("  • Export schema: [cyan]suews-schema export -o schema.json[/cyan]")
+    console.print("  • Export schema: [cyan]suews schema export -o schema.json[/cyan]")
 
     console.print("\n[bold]Integration:[/bold]")
     console.print(
-        "  • Use with CI/CD: [cyan]suews-schema validate *.yml --strict[/cyan]"
+        "  • Use with CI/CD: [cyan]suews validate *.yml --dry-run --format json[/cyan]"
     )
     console.print(
-        "  • Batch operations: [cyan]suews-schema version configs/*.yml --update[/cyan]"
+        "  • Batch operations: [cyan]suews schema version configs/*.yml --update[/cyan]"
     )
     console.print("  • Future wizard: Will use these utilities for validation")
 

--- a/src/supy/cmd/suews_cli.py
+++ b/src/supy/cmd/suews_cli.py
@@ -7,13 +7,14 @@ console scripts (``suews-run``, ``suews-convert``, ``suews-validate``,
 ``suews-schema``) remain as deprecated thin aliases.
 
 Hard rule: this module never reimplements physics, validation, schema, or
-run logic. It only routes.
+run logic. It only routes. Backend implementation details such as the Rust
+bridge are deliberately kept out of the public command surface.
 
-Phase-1 dispatcher: ``run``, ``validate``, ``schema``, ``convert``, ``rust``
-are wired here. The Phase-1 gap-fill commands (``init``, ``inspect``,
-``diagnose``, ``compare``, ``summarise``, ``skill``) attach in the Wave 3
-sub-issues (#1360-#1363) and the standalone ``suews-mcp`` package lands in
-Wave 4 (#1364).
+Phase-1 dispatcher: ``run``, ``validate``, ``schema``, and ``convert`` are
+wired here. The Phase-1 gap-fill commands (``init``, ``inspect``,
+``diagnose``, ``compare``, ``summarise``, ``skill``) remain future work in the
+Wave 3 sub-issues (#1360-#1363), and the standalone ``suews-mcp`` package
+lands in Wave 4 (#1364).
 """
 
 from __future__ import annotations
@@ -52,23 +53,6 @@ cli.add_command(_validate_cli, name="validate")
 cli.add_command(_schema_cli, name="schema")
 cli.add_command(_convert_cmd, name="convert")
 cli.add_command(_run_cmd, name="run")
-
-
-@cli.command(
-    name="rust",
-    context_settings={
-        "ignore_unknown_options": True,
-        "allow_extra_args": True,
-        "help_option_names": [],  # let -h / --help fall through to the Rust binary
-    },
-    help="Forward arguments to the bundled SUEWS Rust engine binary.",
-)
-@click.pass_context
-def _rust(ctx: click.Context) -> None:
-    """Pass-through to the bundled Rust binary (``supy.bin.suews-engine``)."""
-    from . import rust_bridge
-
-    rust_bridge.main(argv=list(ctx.args))
 
 
 # ---------------------------------------------------------------------------

--- a/src/supy/cmd/suews_cli.py
+++ b/src/supy/cmd/suews_cli.py
@@ -1,0 +1,128 @@
+"""Unified ``suews`` CLI dispatcher.
+
+Wires the existing per-command Click implementations as subcommands of a
+single ``suews`` Click group. This is the canonical entry point that the
+SUEWS MCP server and downstream tooling depend on; the legacy hyphenated
+console scripts (``suews-run``, ``suews-convert``, ``suews-validate``,
+``suews-schema``) remain as deprecated thin aliases.
+
+Hard rule: this module never reimplements physics, validation, schema, or
+run logic. It only routes.
+
+Phase-1 dispatcher: ``run``, ``validate``, ``schema``, ``convert``, ``rust``
+are wired here. The Phase-1 gap-fill commands (``init``, ``inspect``,
+``diagnose``, ``compare``, ``summarise``, ``skill``) attach in the Wave 3
+sub-issues (#1360-#1363) and the standalone ``suews-mcp`` package lands in
+Wave 4 (#1364).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+# Each existing entry point is reused unchanged. Importing the Click commands
+# here keeps the dispatcher small and ensures behaviour is identical across
+# the new and legacy invocation styles.
+from .SUEWS import SUEWS as _run_cmd
+from .schema_cli import cli as _schema_cli
+from .table_converter import convert_table_cmd as _convert_cmd
+from .validate_config import cli as _validate_cli
+
+
+@click.group(
+    help=(
+        "SUEWS unified command-line interface.\n\n"
+        "Use `suews <subcommand> --help` to see options for each subcommand.\n"
+        "All subcommands emit a standard JSON envelope when invoked with "
+        "`--format json` (where supported)."
+    ),
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+def cli() -> None:
+    """Top-level ``suews`` group."""
+
+
+# ---------------------------------------------------------------------------
+# Subcommands: register the existing Click implementations under stable names.
+# ---------------------------------------------------------------------------
+
+cli.add_command(_validate_cli, name="validate")
+cli.add_command(_schema_cli, name="schema")
+cli.add_command(_convert_cmd, name="convert")
+cli.add_command(_run_cmd, name="run")
+
+
+@cli.command(
+    name="rust",
+    context_settings={
+        "ignore_unknown_options": True,
+        "allow_extra_args": True,
+        "help_option_names": [],  # let -h / --help fall through to the Rust binary
+    },
+    help="Forward arguments to the bundled SUEWS Rust engine binary.",
+)
+@click.pass_context
+def _rust(ctx: click.Context) -> None:
+    """Pass-through to the bundled Rust binary (``supy.bin.suews-engine``)."""
+    from . import rust_bridge
+
+    rust_bridge.main(argv=list(ctx.args))
+
+
+# ---------------------------------------------------------------------------
+# Back-compat aliases for the legacy hyphenated entry points.
+#
+# Each shim writes a single deprecation line to stderr and forwards to the
+# underlying Click command. We deliberately do NOT use the project-wide
+# ``_warn_functional_deprecation`` helper here -- that one targets Python
+# function deprecations and the warnings filter system. CLI entry points
+# need a hard, always-visible stderr line because shells redirect stdout
+# for piping into tools like ``jq``.
+# ---------------------------------------------------------------------------
+
+
+_DEPRECATION_TEMPLATE = (
+    "DEPRECATED: '{legacy}' is deprecated and will be removed in a future release. "
+    "Use '{replacement}' instead."
+)
+
+
+def _emit_deprecation(legacy: str, replacement: str) -> None:
+    sys.stderr.write(_DEPRECATION_TEMPLATE.format(legacy=legacy, replacement=replacement))
+    sys.stderr.write("\n")
+    sys.stderr.flush()
+
+
+def run_alias() -> None:
+    """Deprecated alias for ``suews run``."""
+    _emit_deprecation("suews-run", "suews run")
+    _run_cmd()
+
+
+def convert_alias() -> None:
+    """Deprecated alias for ``suews convert``."""
+    _emit_deprecation("suews-convert", "suews convert")
+    _convert_cmd()
+
+
+def validate_alias() -> None:
+    """Deprecated alias for ``suews validate``."""
+    _emit_deprecation("suews-validate", "suews validate")
+    _validate_cli()
+
+
+def schema_alias() -> None:
+    """Deprecated alias for ``suews schema``."""
+    _emit_deprecation("suews-schema", "suews schema")
+    _schema_cli()
+
+
+def main() -> None:
+    """Console-script entry point for ``suews``."""
+    cli()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -259,8 +259,9 @@ def cli(
 ):
     """SUEWS Configuration Validator.
 
-    Default behavior: run the complete validation pipeline on FILE. Use subcommands
-    for specific operations (validate, schema, migrate, export).
+    Default behavior: run the complete validation pipeline on FILE. Use the
+    validate subcommand for batch schema checks; use `suews schema` for schema
+    lifecycle operations.
     """
     # If invoked without a subcommand, run the pipeline workflow
     if ctx.invoked_subcommand is None:
@@ -522,7 +523,7 @@ def validate(files, schema_version, verbose, quiet, format):
 ## Removed `check` subcommand to avoid redundancy with `validate`.
 
 
-@cli.command()
+@cli.command(hidden=True)
 @click.argument("file", type=click.Path(exists=True))
 @click.option("--output", "-o", help="Output file for migrated configuration")
 @click.option("--to-version", help="Target schema version")
@@ -606,14 +607,14 @@ def _print_schema_info():
     console.print("  • Documentation: docs/source/inputs/yaml/schema_versioning.rst")
 
     console.print("\n[bold]Validation Commands:[/bold]")
-    console.print("  • Full validation: suews-validate config.yml")
+    console.print("  • Full validation: suews validate config.yml")
     console.print(
-        "  • Read-only check: suews-validate -p C --dry-run configs/*.yml --format json"
+        "  • Read-only check: suews validate -p C --dry-run configs/*.yml --format json"
     )
-    console.print("  • Migrate: suews-validate schema migrate old_config.yml")
+    console.print("  • Migrate: suews schema migrate old_config.yml")
 
 
-@cli.command()
+@cli.command(hidden=True)
 @click.argument("files", nargs=-1, type=click.Path(exists=True), required=True)
 @click.option(
     "--update", "-u", is_flag=True, help="Update schema_version field in files"
@@ -688,7 +689,7 @@ def version(files, update, target_version, backup):
     console.print(table)
 
 
-@cli.command()
+@cli.command(hidden=True)
 @click.option(
     "--output",
     "-o",
@@ -1557,7 +1558,7 @@ if __name__ == "__main__":
     main()
 
 
-@cli.group(name="schema", invoke_without_command=True)
+@cli.group(name="schema", invoke_without_command=True, hidden=True)
 @click.pass_context
 def schema_group(ctx):
     """Schema operations: status, update, migrate, export, info.

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -28,6 +28,7 @@ py.install_sources(
             'cmd/json_envelope.py',
             'cmd/json_output.py',
             'cmd/rust_bridge.py',
+            'cmd/suews_cli.py',
             'cmd/table_converter.py',
             'cmd/to_yaml.py',
             'cmd/validate_config.py',

--- a/test/cmd/test_suews_cli.py
+++ b/test/cmd/test_suews_cli.py
@@ -1,7 +1,7 @@
 """Tests for the unified ``suews`` CLI dispatcher.
 
 Validates:
-- `suews --help` lists the 5 expected subcommands (validate/schema/convert/run/rust).
+- `suews --help` lists the 4 public subcommands (validate/schema/convert/run).
 - Each subcommand resolves to its existing Click implementation.
 - The legacy hyphenated entry points (`suews-run`, `-convert`, `-validate`,
   `-schema`) print a deprecation notice and forward to the underlying command.
@@ -29,8 +29,9 @@ def test_top_level_help_lists_subcommands() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0, result.output
-    for sub in ("validate", "schema", "convert", "run", "rust"):
+    for sub in ("validate", "schema", "convert", "run"):
         assert sub in result.output, f"subcommand {sub!r} missing from help output"
+    assert "rust" not in result.output
 
 
 def test_validate_subcommand_help() -> None:
@@ -66,10 +67,10 @@ def test_run_subcommand_help() -> None:
     assert result.exit_code == 0, result.output
 
 
-def test_rust_subcommand_registered() -> None:
+def test_rust_subcommand_is_not_registered() -> None:
     from supy.cmd.suews_cli import cli
 
-    assert "rust" in cli.commands
+    assert "rust" not in cli.commands
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +104,31 @@ def test_run_subcommand_is_suews_cmd() -> None:
     from supy.cmd.SUEWS import SUEWS as suews_run
 
     assert cli.commands["run"] is suews_run
+
+
+@pytest.mark.parametrize("subcommand", ["info", "version", "migrate", "export"])
+def test_schema_public_subcommands_have_help(subcommand: str) -> None:
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", subcommand, "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_schema_validate_is_not_public() -> None:
+    from supy.cmd.suews_cli import cli
+
+    assert "validate" not in cli.commands["schema"].commands
+
+
+def test_validate_help_keeps_schema_lifecycle_hidden() -> None:
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", "--help"])
+    assert result.exit_code == 0, result.output
+    for hidden_subcommand in ("migrate", "export"):
+        assert hidden_subcommand not in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -155,32 +181,6 @@ def test_back_compat_alias_emits_deprecation(
     assert expected_legacy_name in captured.err
     assert expected_replacement in captured.err
     assert invoked["called"], "alias did not forward to underlying command"
-
-
-# ---------------------------------------------------------------------------
-# Rust subcommand passthrough
-# ---------------------------------------------------------------------------
-
-
-def test_rust_subcommand_passes_argv_through(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from supy.cmd import rust_bridge, suews_cli
-
-    captured: dict[str, list[str] | None] = {"argv": None}
-
-    def fake_rust_main(argv: list[str] | None = None) -> None:
-        captured["argv"] = argv
-
-    monkeypatch.setattr(rust_bridge, "main", fake_rust_main)
-
-    runner = CliRunner()
-    result = runner.invoke(
-        suews_cli.cli,
-        ["rust", "--input", "config.yml", "--verbose"],
-    )
-    assert result.exit_code == 0, result.output
-    assert captured["argv"] == ["--input", "config.yml", "--verbose"]
 
 
 def test_rust_bridge_main_accepts_explicit_argv(

--- a/test/cmd/test_suews_cli.py
+++ b/test/cmd/test_suews_cli.py
@@ -198,12 +198,16 @@ def test_rust_bridge_main_accepts_explicit_argv(
         captured["check"] = check
         return Result()
 
-    monkeypatch.setattr(rust_bridge, "_bridge_binary", lambda: Path("/tmp/suews-engine"))
+    fake_binary = Path("/tmp/suews-engine")
+    monkeypatch.setattr(rust_bridge, "_bridge_binary", lambda: fake_binary)
     monkeypatch.setattr(rust_bridge.subprocess, "run", fake_run)
 
     with pytest.raises(SystemExit) as excinfo:
         rust_bridge.main(argv=["--version"])
 
     assert excinfo.value.code == 7
-    assert captured["cmd"] == ["/tmp/suews-engine", "--version"]
+    # Compare against the platform-appropriate string form so Windows (where
+    # ``str(Path("/tmp/suews-engine"))`` becomes ``\\tmp\\suews-engine``) and
+    # POSIX both pass; ``rust_bridge.main`` stringifies the Path before exec.
+    assert captured["cmd"] == [str(fake_binary), "--version"]
     assert captured["check"] is False

--- a/test/cmd/test_suews_cli.py
+++ b/test/cmd/test_suews_cli.py
@@ -1,0 +1,182 @@
+"""Tests for the unified ``suews`` CLI dispatcher.
+
+Validates:
+- `suews --help` lists the 5 expected subcommands (validate/schema/convert/run/rust).
+- Each subcommand resolves to its existing Click implementation.
+- The legacy hyphenated entry points (`suews-run`, `-convert`, `-validate`,
+  `-schema`) print a deprecation notice and forward to the underlying command.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.api
+
+
+# ---------------------------------------------------------------------------
+# Top-level group
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_help_lists_subcommands() -> None:
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0, result.output
+    for sub in ("validate", "schema", "convert", "run", "rust"):
+        assert sub in result.output, f"subcommand {sub!r} missing from help output"
+
+
+def test_validate_subcommand_help() -> None:
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "validate" in result.output.lower()
+
+
+def test_schema_subcommand_help() -> None:
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_convert_subcommand_help() -> None:
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["convert", "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_run_subcommand_help() -> None:
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run", "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_rust_subcommand_registered() -> None:
+    from supy.cmd.suews_cli import cli
+
+    assert "rust" in cli.commands
+
+
+# ---------------------------------------------------------------------------
+# Subcommand registry preserves the underlying Click commands
+# ---------------------------------------------------------------------------
+
+
+def test_validate_subcommand_is_validate_cli() -> None:
+    from supy.cmd.suews_cli import cli
+    from supy.cmd.validate_config import cli as validate_cli
+
+    assert cli.commands["validate"] is validate_cli
+
+
+def test_schema_subcommand_is_schema_cli() -> None:
+    from supy.cmd.suews_cli import cli
+    from supy.cmd.schema_cli import cli as schema_cli
+
+    assert cli.commands["schema"] is schema_cli
+
+
+def test_convert_subcommand_is_convert_cmd() -> None:
+    from supy.cmd.suews_cli import cli
+    from supy.cmd.table_converter import convert_table_cmd
+
+    assert cli.commands["convert"] is convert_table_cmd
+
+
+def test_run_subcommand_is_suews_cmd() -> None:
+    from supy.cmd.suews_cli import cli
+    from supy.cmd.SUEWS import SUEWS as suews_run
+
+    assert cli.commands["run"] is suews_run
+
+
+# ---------------------------------------------------------------------------
+# Back-compat aliases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "alias_func_name, expected_legacy_name, expected_replacement",
+    [
+        ("run_alias", "suews-run", "suews run"),
+        ("convert_alias", "suews-convert", "suews convert"),
+        ("validate_alias", "suews-validate", "suews validate"),
+        ("schema_alias", "suews-schema", "suews schema"),
+    ],
+)
+def test_back_compat_alias_emits_deprecation(
+    alias_func_name: str,
+    expected_legacy_name: str,
+    expected_replacement: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from supy.cmd import suews_cli
+
+    invoked = {"called": False}
+
+    def fake_command(*args, **kwargs):
+        invoked["called"] = True
+
+    # Force the underlying Click command to be a no-op so we only test the shim.
+    if alias_func_name == "run_alias":
+        monkeypatch.setattr(suews_cli, "_run_cmd", fake_command)
+    elif alias_func_name == "convert_alias":
+        monkeypatch.setattr(suews_cli, "_convert_cmd", fake_command)
+    elif alias_func_name == "validate_alias":
+        monkeypatch.setattr(suews_cli, "_validate_cli", fake_command)
+    elif alias_func_name == "schema_alias":
+        monkeypatch.setattr(suews_cli, "_schema_cli", fake_command)
+    else:  # pragma: no cover
+        pytest.fail(f"unknown alias {alias_func_name!r}")
+
+    monkeypatch.setattr(sys, "argv", [expected_legacy_name])
+
+    alias = getattr(suews_cli, alias_func_name)
+    alias()
+
+    captured = capsys.readouterr()
+    assert "DEPRECATED" in captured.err
+    assert expected_legacy_name in captured.err
+    assert expected_replacement in captured.err
+    assert invoked["called"], "alias did not forward to underlying command"
+
+
+# ---------------------------------------------------------------------------
+# Rust subcommand passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_rust_subcommand_passes_argv_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from supy.cmd import rust_bridge, suews_cli
+
+    captured: dict[str, list[str] | None] = {"argv": None}
+
+    def fake_rust_main(argv: list[str] | None = None) -> None:
+        captured["argv"] = argv
+
+    monkeypatch.setattr(rust_bridge, "main", fake_rust_main)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        suews_cli.cli,
+        ["rust", "--input", "config.yml", "--verbose"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["argv"] == ["--input", "config.yml", "--verbose"]

--- a/test/cmd/test_suews_cli.py
+++ b/test/cmd/test_suews_cli.py
@@ -10,6 +10,7 @@ Validates:
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -180,3 +181,29 @@ def test_rust_subcommand_passes_argv_through(
     )
     assert result.exit_code == 0, result.output
     assert captured["argv"] == ["--input", "config.yml", "--verbose"]
+
+
+def test_rust_bridge_main_accepts_explicit_argv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from supy.cmd import rust_bridge
+
+    captured: dict[str, object] = {}
+
+    class Result:
+        returncode = 7
+
+    def fake_run(cmd, check):
+        captured["cmd"] = cmd
+        captured["check"] = check
+        return Result()
+
+    monkeypatch.setattr(rust_bridge, "_bridge_binary", lambda: Path("/tmp/suews-engine"))
+    monkeypatch.setattr(rust_bridge.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        rust_bridge.main(argv=["--version"])
+
+    assert excinfo.value.code == 7
+    assert captured["cmd"] == ["/tmp/suews-engine", "--version"]
+    assert captured["check"] is False


### PR DESCRIPTION
Closes #1359.

Introduces `supy.cmd.suews_cli` as the canonical Click group for the public SUEWS command-line interface. The bare `suews` console script now routes through a compact `suews <subcommand>` namespace, while backend details such as the Rust bridge stay internal to the implementation.

## Public CLI surface

The public top-level commands are now:

- `suews run` — forwards to the existing simulation command
- `suews validate` — owns runnable configuration/forcing validation and pipeline checks
- `suews convert` — converts legacy tables, `df_state`, or older YAML into current-schema YAML
- `suews schema` — owns schema lifecycle tooling only

The `suews schema` namespace now exposes only:

- `suews schema info`
- `suews schema version`
- `suews schema migrate`
- `suews schema export`

`SUEWS` validation belongs under `suews validate`, so `suews schema validate` is not part of the public schema namespace. The former `suews rust` pass-through has also been removed from the public CLI; developers can still debug the bundled engine directly when needed.

## Backwards compatibility

The existing hyphenated console scripts remain as deprecated aliases that emit one stderr notice and forward to the corresponding public command:

- `suews-run` -> `suews run`
- `suews-validate` -> `suews validate`
- `suews-convert` -> `suews convert`
- `suews-schema` -> `suews schema`

## MCP contract

This PR keeps the MCP-facing surface aligned with user-level SUEWS concepts rather than backend implementation details. MCP tools should map to `run`, `validate`, `convert`, and `schema` actions, with JSON output continuing to use the shared `{status, data, errors, warnings, meta}` envelope shape.

## Verification

- `.venv/bin/python -m pytest test/cmd/test_suews_cli.py test/cmd/test_json_envelope.py` — 39 passed
- Confirmed top-level registry is exactly `convert`, `run`, `schema`, `validate`
- Confirmed `suews schema` exposes only `export`, `info`, `migrate`, `version`
- Confirmed `suews rust` is no longer registered

Part of #1355.