### PR TITLE
feat: suews summarise/compare/diagnose + diagnostics & metrics modules

### DIFF
--- a/src/supy/_run_output.py
+++ b/src/supy/_run_output.py
@@ -1,0 +1,132 @@
+"""Helpers for loading saved SUEWS run outputs.
+
+The command-line diagnostics operate on files written by ``suews run`` /
+``SUEWSSimulation.save``. Those files may be legacy text outputs, synthetic
+``df_output`` fixtures used in tests, or the current parquet artefacts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+_COMMON_OUTPUT_VARIABLES = frozenset({
+    "QH",
+    "QE",
+    "QN",
+    "QS",
+    "QF",
+    "Tair",
+    "RH",
+    "Kdown",
+    "UStar",
+    "Lob",
+})
+
+_PARQUET_PATTERNS = ("df_output*.parquet", "*SUEWS_output.parquet")
+_CSV_PATTERNS = ("df_output*.csv",)
+_TEXT_PATTERNS = ("*_SUEWS_*.txt",)
+
+
+def _candidate_patterns(include_text: bool = True) -> tuple[str, ...]:
+    patterns = (*_PARQUET_PATTERNS, *_CSV_PATTERNS)
+    if include_text:
+        patterns = (*patterns, *_TEXT_PATTERNS)
+    return patterns
+
+
+def _list_run_output_files(
+    path_run_dir: Path, *, include_text: bool = True
+) -> list[Path]:
+    path_run_dir = Path(path_run_dir)
+    if not path_run_dir.exists() or not path_run_dir.is_dir():
+        return []
+
+    list_ranked: list[tuple[int, str, Path]] = []
+    set_seen: set[Path] = set()
+    for priority, pattern in enumerate(_candidate_patterns(include_text)):
+        for path in path_run_dir.rglob(pattern):
+            path_resolved = path.resolve()
+            if not path.is_file() or path_resolved in set_seen:
+                continue
+            set_seen.add(path_resolved)
+            list_ranked.append((priority, path.as_posix(), path))
+
+    return [path for _, _, path in sorted(list_ranked)]
+
+
+def _read_output_file(path_output: Path) -> pd.DataFrame:
+    suffix = path_output.suffix.lower()
+    if suffix == ".parquet":
+        return pd.read_parquet(path_output)
+    if suffix == ".txt":
+        return pd.read_csv(path_output, sep=r"\s+", engine="python")
+    return pd.read_csv(path_output)
+
+
+def _pick_variable_level(columns: pd.MultiIndex) -> int:
+    names = [str(name).lower() if name is not None else "" for name in columns.names]
+    list_candidates: list[int] = []
+
+    for target in ("var", "variable"):
+        if target in names:
+            list_candidates.append(names.index(target))
+
+    list_candidates.extend(range(columns.nlevels))
+
+    set_seen: set[int] = set()
+    for level in list_candidates:
+        if level in set_seen:
+            continue
+        set_seen.add(level)
+        values = columns.get_level_values(level)
+        if any(value in _COMMON_OUTPUT_VARIABLES for value in values):
+            return level
+
+    for target in ("var", "variable"):
+        if target in names:
+            return names.index(target)
+
+    return 0
+
+
+def _flatten_tuple_label(label: Any) -> Any:
+    if not isinstance(label, tuple):
+        return label
+    for value in label:
+        if value in _COMMON_OUTPUT_VARIABLES:
+            return value
+    return label[0] if label else label
+
+
+def _flatten_output_columns(df_output: pd.DataFrame) -> pd.DataFrame:
+    if isinstance(df_output.columns, pd.MultiIndex):
+        level = _pick_variable_level(df_output.columns)
+        df_output = df_output.copy()
+        df_output.columns = df_output.columns.get_level_values(level)
+        return df_output
+
+    if any(isinstance(col, tuple) for col in df_output.columns):
+        df_output = df_output.copy()
+        df_output.columns = [_flatten_tuple_label(col) for col in df_output.columns]
+    return df_output
+
+
+def _load_run_output_dataframe(
+    path: Path,
+    *,
+    include_text: bool = True,
+) -> pd.DataFrame:
+    path = Path(path)
+    if path.is_dir():
+        list_paths = _list_run_output_files(path, include_text=include_text)
+        if not list_paths:
+            patterns = " / ".join(_candidate_patterns(include_text))
+            raise FileNotFoundError(
+                f"No recognised SUEWS output ({patterns}) under {path}"
+            )
+        path = list_paths[0]
+
+    return _flatten_output_columns(_read_output_file(path))

--- a/src/supy/cmd/__init__.py
+++ b/src/supy/cmd/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F822, RUF067
 # Lazy imports for fast CLI startup
 # Only import specific CLI tools when actually accessed
 
@@ -15,6 +16,16 @@ __all__ = [
 
 _lazy_cache = {}
 
+_LAZY_ATTRS = {
+    "SUEWS": ("SUEWS", "SUEWS"),
+    "compare_runs_cmd": ("compare_runs", "compare_runs_cmd"),
+    "convert_table_cmd": ("table_converter", "convert_table_cmd"),
+    "diagnose_run_cmd": ("diagnose_run", "diagnose_run_cmd"),
+    "schema_cli_main": ("schema_cli", "main"),
+    "summarise_output_cmd": ("summarise_output", "summarise_output_cmd"),
+    "validate_config_main": ("validate_config", "main"),
+}
+
 # Submodules exposed through ``from supy.cmd import <name>``. Listed
 # explicitly so static checks (e.g. test_api_surface.py's hasattr probe)
 # resolve them without requiring the consumer to first import the
@@ -27,50 +38,16 @@ def __getattr__(name):
     if name in _lazy_cache:
         return _lazy_cache[name]
 
-    if name == "SUEWS":
-        from .SUEWS import SUEWS
-
-        _lazy_cache[name] = SUEWS
-        return _lazy_cache[name]
-
-    if name == "convert_table_cmd":
-        from .table_converter import convert_table_cmd
-
-        _lazy_cache[name] = convert_table_cmd
-        return _lazy_cache[name]
-
-    if name == "validate_config_main":
-        from .validate_config import main as validate_config_main
-
-        _lazy_cache[name] = validate_config_main
-        return _lazy_cache[name]
-
-    if name == "schema_cli_main":
+    if name in _LAZY_ATTRS:
+        module_name, attr_name = _LAZY_ATTRS[name]
         try:
-            from .schema_cli import main as schema_cli_main
-
-            _lazy_cache[name] = schema_cli_main
-            return _lazy_cache[name]
+            module = _importlib.import_module(f"{__name__}.{module_name}")
+            value = getattr(module, attr_name)
         except Exception:
-            _lazy_cache[name] = None
-            return None
-
-    if name == "summarise_output_cmd":
-        from .summarise_output import summarise_output_cmd
-
-        _lazy_cache[name] = summarise_output_cmd
-        return _lazy_cache[name]
-
-    if name == "compare_runs_cmd":
-        from .compare_runs import compare_runs_cmd
-
-        _lazy_cache[name] = compare_runs_cmd
-        return _lazy_cache[name]
-
-    if name == "diagnose_run_cmd":
-        from .diagnose_run import diagnose_run_cmd
-
-        _lazy_cache[name] = diagnose_run_cmd
+            if name != "schema_cli_main":
+                raise
+            value = None
+        _lazy_cache[name] = value
         return _lazy_cache[name]
 
     if name in _LAZY_SUBMODULES:

--- a/src/supy/cmd/__init__.py
+++ b/src/supy/cmd/__init__.py
@@ -3,7 +3,15 @@
 
 import importlib as _importlib
 
-__all__ = ["SUEWS", "convert_table_cmd", "validate_config_main", "schema_cli_main"]
+__all__ = [
+    "SUEWS",
+    "compare_runs_cmd",
+    "convert_table_cmd",
+    "diagnose_run_cmd",
+    "schema_cli_main",
+    "summarise_output_cmd",
+    "validate_config_main",
+]
 
 _lazy_cache = {}
 
@@ -46,6 +54,24 @@ def __getattr__(name):
         except Exception:
             _lazy_cache[name] = None
             return None
+
+    if name == "summarise_output_cmd":
+        from .summarise_output import summarise_output_cmd
+
+        _lazy_cache[name] = summarise_output_cmd
+        return _lazy_cache[name]
+
+    if name == "compare_runs_cmd":
+        from .compare_runs import compare_runs_cmd
+
+        _lazy_cache[name] = compare_runs_cmd
+        return _lazy_cache[name]
+
+    if name == "diagnose_run_cmd":
+        from .diagnose_run import diagnose_run_cmd
+
+        _lazy_cache[name] = diagnose_run_cmd
+        return _lazy_cache[name]
 
     if name in _LAZY_SUBMODULES:
         module = _importlib.import_module(f"{__name__}.{name}")

--- a/src/supy/cmd/compare_runs.py
+++ b/src/supy/cmd/compare_runs.py
@@ -1,0 +1,295 @@
+"""``suews compare`` — compare two SUEWS runs (or run vs observations).
+
+Loads the run output (or observation CSV) at each of two positional paths
+and computes per-variable RMSE / bias / Pearson r. Time-axis overlap
+(start / end / number of joint timestamps) is reported alongside so the
+caller can sanity-check the alignment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+import click
+import pandas as pd
+
+from .json_envelope import EXIT_USER_ERROR, Envelope, _now_iso
+
+
+def _load_run_or_observations(path: Path) -> pd.DataFrame:
+    """Best-effort load of a run output dir or an observations file.
+
+    - If ``path`` is a directory: scans for ``df_output*.csv`` /
+      ``df_output*.parquet`` and loads the first hit.
+    - If ``path`` is a file: loads it as CSV (parquet detection by suffix).
+
+    The returned DataFrame is column-flattened: tuple columns from a
+    canonical SUEWS MultiIndex are reduced to their first level.
+    """
+    if path.is_dir():
+        list_paths: list[Path] = []
+        for pattern in ("df_output*.parquet", "df_output*.csv"):
+            list_paths.extend(path.rglob(pattern))
+        if not list_paths:
+            raise FileNotFoundError(
+                f"No df_output*.parquet / df_output*.csv under {path}"
+            )
+        # Prefer parquet for speed and dtype fidelity.
+        list_paths.sort(key=lambda p: 0 if p.suffix == ".parquet" else 1)
+        path_first = list_paths[0]
+        if path_first.suffix == ".parquet":
+            df = pd.read_parquet(path_first)
+        else:
+            df = pd.read_csv(path_first)
+    elif path.suffix == ".parquet":
+        df = pd.read_parquet(path)
+    else:
+        df = pd.read_csv(path)
+
+    # Flatten MultiIndex columns to their first level so callers can ask
+    # for "QH" without having to thread a tuple key through.
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = [
+            col[0] if isinstance(col, tuple) else col for col in df.columns
+        ]
+    else:
+        df.columns = [
+            col[0] if isinstance(col, tuple) else col for col in df.columns
+        ]
+    return df
+
+
+def _coerce_datetime_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure the DataFrame has a DatetimeIndex when one is recoverable.
+
+    The canonical SUEWS save path produces a (grid, datetime) MultiIndex.
+    For metric computation we drop the grid level (taking the first grid)
+    so the comparison happens on a single time series. If neither index
+    is datetime-like, we leave the index as-is and rely on row-order
+    alignment in ``_align_pair``.
+    """
+    if isinstance(df.index, pd.MultiIndex):
+        # Pick the first grid present; comparing across grids is out of
+        # scope for the Phase-1 compare command.
+        try:
+            df = df.xs(df.index.get_level_values(0).unique()[0], level=0)
+        except (IndexError, KeyError):
+            pass
+    if not isinstance(df.index, pd.DatetimeIndex):
+        # Try the first column or a 'datetime' column.
+        for cand in ("datetime", "Datetime", "DateTime"):
+            if cand in df.columns:
+                df = df.set_index(pd.DatetimeIndex(df[cand]))
+                break
+    return df
+
+
+def _align_pair(
+    df_a: pd.DataFrame, df_b: pd.DataFrame, variable: str
+) -> tuple[pd.Series, pd.Series, dict[str, Any]]:
+    """Align two series on the DataFrames' shared index.
+
+    Returns ``(series_a, series_b, overlap_meta)``. When neither input has
+    a DatetimeIndex, alignment falls back to row order on the shorter
+    length.
+    """
+    if variable not in df_a.columns or variable not in df_b.columns:
+        raise KeyError(f"Variable {variable!r} missing from one or both inputs.")
+
+    ser_a = pd.to_numeric(df_a[variable], errors="coerce")
+    ser_b = pd.to_numeric(df_b[variable], errors="coerce")
+
+    if isinstance(ser_a.index, pd.DatetimeIndex) and isinstance(
+        ser_b.index, pd.DatetimeIndex
+    ):
+        df_pair = pd.concat({"a": ser_a, "b": ser_b}, axis=1, join="inner")
+        idx = df_pair.index
+        overlap = {
+            "start": idx.min().isoformat() if len(idx) else None,
+            "end": idx.max().isoformat() if len(idx) else None,
+            "n": len(idx),
+        }
+        return df_pair["a"], df_pair["b"], overlap
+
+    n = min(len(ser_a), len(ser_b))
+    overlap = {"start": None, "end": None, "n": int(n)}
+    return ser_a.iloc[:n].reset_index(drop=True), ser_b.iloc[:n].reset_index(drop=True), overlap
+
+
+def _build_text_message(data: dict[str, Any]) -> str:
+    lines = [
+        "Comparison",
+        "  baseline: {}".format(data["baseline"]),
+        "  scenario: {}".format(data["scenario"]),
+        "  overlap : start={} end={} n={}".format(
+            data["time_axis_overlap"]["start"],
+            data["time_axis_overlap"]["end"],
+            data["time_axis_overlap"]["n"],
+        ),
+        "",
+        "Per-variable metrics:",
+    ]
+    for var, metrics in (data.get("per_variable") or {}).items():
+        lines.append(
+            f"  {var:<6} rmse={metrics['rmse']:.4g} "
+            f"bias={metrics['bias']:.4g} r={metrics['r']:.4g} "
+            f"n={metrics['n']}"
+        )
+    return "\n".join(lines)
+
+
+@click.command(
+    name="compare",
+    short_help="Compare two SUEWS runs or run vs observations.",
+    help=(
+        "Compare two SUEWS run directories (or a run and an observations CSV) "
+        "by computing per-variable RMSE / bias / Pearson r. The second "
+        "argument is treated as a directory if it is one and as an "
+        "observations file otherwise. Time-axis overlap is reported alongside."
+    ),
+)
+@click.argument(
+    "run_a",
+    type=click.Path(exists=True),
+)
+@click.argument(
+    "run_b_or_obs",
+    type=click.Path(exists=True),
+)
+@click.option(
+    "--metrics",
+    default="rmse,bias,r",
+    show_default=True,
+    help="Comma-separated metric names. Subset of {rmse,bias,r}.",
+)
+@click.option(
+    "--variables",
+    default="QH,QE,QN",
+    show_default=True,
+    help="Comma-separated variable names to compare.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format. 'json' emits the standard SUEWS envelope on stdout.",
+)
+def compare_runs_cmd(
+    run_a: str,
+    run_b_or_obs: str,
+    metrics: str,
+    variables: str,
+    output_format: str,
+) -> None:
+    """Implementation of ``suews compare``."""
+    started_at = _now_iso()
+    json_mode = output_format.lower() == "json"
+    command = " ".join(["suews", "compare", *sys.argv[1:]])
+
+    path_a = Path(run_a)
+    path_b = Path(run_b_or_obs)
+
+    list_metrics = [m.strip() for m in metrics.split(",") if m.strip()]
+    list_variables = [v.strip() for v in variables.split(",") if v.strip()]
+
+    valid_metrics = {"rmse", "bias", "r"}
+    list_unknown = [m for m in list_metrics if m not in valid_metrics]
+    if list_unknown:
+        message = "Unknown metric(s): {}. Valid: {}".format(
+            ", ".join(list_unknown),
+            ", ".join(sorted(valid_metrics)),
+        )
+        if json_mode:
+            Envelope.error(
+                errors=[message],
+                command=command,
+                data={"baseline": str(path_a), "scenario": str(path_b)},
+                started_at=started_at,
+            ).emit()
+        else:
+            click.secho(message, fg="red", err=True)
+        sys.exit(EXIT_USER_ERROR)
+
+    try:
+        from ..metrics import bias as metric_bias, pearson_r, rmse as metric_rmse
+
+        df_a = _load_run_or_observations(path_a)
+        df_b = _load_run_or_observations(path_b)
+        df_a = _coerce_datetime_index(df_a)
+        df_b = _coerce_datetime_index(df_b)
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        message = f"Failed to load inputs: {exc}"
+        if json_mode:
+            Envelope.error(
+                errors=[message],
+                command=command,
+                data={"baseline": str(path_a), "scenario": str(path_b)},
+                started_at=started_at,
+            ).emit()
+        else:
+            click.secho(message, fg="red", err=True)
+        sys.exit(EXIT_USER_ERROR)
+
+    list_warnings: list[str] = []
+    per_variable: dict[str, dict[str, Any]] = {}
+    overlap: dict[str, Any] | None = None
+    aggregate: dict[str, float] = {}
+
+    for var in list_variables:
+        try:
+            ser_a, ser_b, var_overlap = _align_pair(df_a, df_b, var)
+        except KeyError as exc:
+            list_warnings.append(f"variable {var!r} skipped: {exc}")
+            continue
+        # First successful overlap is recorded as the run-level overlap.
+        if overlap is None:
+            overlap = var_overlap
+        try:
+            entry: dict[str, Any] = {"n": int(min(len(ser_a), len(ser_b)))}
+            if "rmse" in list_metrics:
+                entry["rmse"] = metric_rmse(ser_a, ser_b)
+            if "bias" in list_metrics:
+                entry["bias"] = metric_bias(ser_a, ser_b)
+            if "r" in list_metrics:
+                entry["r"] = pearson_r(ser_a, ser_b)
+            per_variable[var] = entry
+        except ValueError as exc:
+            list_warnings.append(f"variable {var!r} skipped: {exc}")
+
+    # Aggregate metrics: simple unweighted mean across variables. This is
+    # a useful single-number summary for triage; per-variable detail is
+    # available in ``per_variable``.
+    for metric_name in list_metrics:
+        list_values = [
+            entry[metric_name]
+            for entry in per_variable.values()
+            if metric_name in entry
+            and entry[metric_name] is not None
+            and entry[metric_name] == entry[metric_name]  # filter NaN
+        ]
+        if list_values:
+            aggregate[metric_name] = float(sum(list_values) / len(list_values))
+
+    data: dict[str, Any] = {
+        "baseline": str(path_a),
+        "scenario": str(path_b),
+        "metrics": aggregate,
+        "per_variable": per_variable,
+        "time_axis_overlap": overlap or {"start": None, "end": None, "n": 0},
+    }
+
+    if json_mode:
+        Envelope.success(
+            data=data,
+            command=command,
+            warnings=list_warnings or None,
+            started_at=started_at,
+        ).emit()
+    else:
+        click.echo(_build_text_message(data))
+        for warn in list_warnings:
+            click.echo(f"warning: {warn}", err=True)

--- a/src/supy/cmd/compare_runs.py
+++ b/src/supy/cmd/compare_runs.py
@@ -8,6 +8,7 @@ caller can sanity-check the alignment.
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 import sys
 from typing import Any
@@ -15,50 +16,11 @@ from typing import Any
 import click
 import pandas as pd
 
+from .._run_output import _load_run_output_dataframe
+from ..metrics import bias as metric_bias, pearson_r, rmse as metric_rmse
 from .json_envelope import EXIT_USER_ERROR, Envelope, _now_iso
 
-
-def _load_run_or_observations(path: Path) -> pd.DataFrame:
-    """Best-effort load of a run output dir or an observations file.
-
-    - If ``path`` is a directory: scans for ``df_output*.csv`` /
-      ``df_output*.parquet`` and loads the first hit.
-    - If ``path`` is a file: loads it as CSV (parquet detection by suffix).
-
-    The returned DataFrame is column-flattened: tuple columns from a
-    canonical SUEWS MultiIndex are reduced to their first level.
-    """
-    if path.is_dir():
-        list_paths: list[Path] = []
-        for pattern in ("df_output*.parquet", "df_output*.csv"):
-            list_paths.extend(path.rglob(pattern))
-        if not list_paths:
-            raise FileNotFoundError(
-                f"No df_output*.parquet / df_output*.csv under {path}"
-            )
-        # Prefer parquet for speed and dtype fidelity.
-        list_paths.sort(key=lambda p: 0 if p.suffix == ".parquet" else 1)
-        path_first = list_paths[0]
-        if path_first.suffix == ".parquet":
-            df = pd.read_parquet(path_first)
-        else:
-            df = pd.read_csv(path_first)
-    elif path.suffix == ".parquet":
-        df = pd.read_parquet(path)
-    else:
-        df = pd.read_csv(path)
-
-    # Flatten MultiIndex columns to their first level so callers can ask
-    # for "QH" without having to thread a tuple key through.
-    if isinstance(df.columns, pd.MultiIndex):
-        df.columns = [
-            col[0] if isinstance(col, tuple) else col for col in df.columns
-        ]
-    else:
-        df.columns = [
-            col[0] if isinstance(col, tuple) else col for col in df.columns
-        ]
-    return df
+_VALID_METRICS = {"rmse", "bias", "r"}
 
 
 def _coerce_datetime_index(df: pd.DataFrame) -> pd.DataFrame:
@@ -70,13 +32,10 @@ def _coerce_datetime_index(df: pd.DataFrame) -> pd.DataFrame:
     is datetime-like, we leave the index as-is and rely on row-order
     alignment in ``_align_pair``.
     """
-    if isinstance(df.index, pd.MultiIndex):
-        # Pick the first grid present; comparing across grids is out of
-        # scope for the Phase-1 compare command.
-        try:
-            df = df.xs(df.index.get_level_values(0).unique()[0], level=0)
-        except (IndexError, KeyError):
-            pass
+    # Pick the first grid present; comparing across grids is out of scope for
+    # the Phase-1 compare command.
+    if isinstance(df.index, pd.MultiIndex) and len(df.index):
+        df = df.xs(df.index.get_level_values(0).unique()[0], level=0)
     if not isinstance(df.index, pd.DatetimeIndex):
         # Try the first column or a 'datetime' column.
         for cand in ("datetime", "Datetime", "DateTime"):
@@ -115,7 +74,15 @@ def _align_pair(
 
     n = min(len(ser_a), len(ser_b))
     overlap = {"start": None, "end": None, "n": int(n)}
-    return ser_a.iloc[:n].reset_index(drop=True), ser_b.iloc[:n].reset_index(drop=True), overlap
+    return (
+        ser_a.iloc[:n].reset_index(drop=True),
+        ser_b.iloc[:n].reset_index(drop=True),
+        overlap,
+    )
+
+
+def _fmt_metric(value: float) -> str:
+    return "nan" if math.isnan(value) else f"{value:.4g}"
 
 
 def _build_text_message(data: dict[str, Any]) -> str:
@@ -131,13 +98,100 @@ def _build_text_message(data: dict[str, Any]) -> str:
         "",
         "Per-variable metrics:",
     ]
+    list_metrics = data.get("requested_metrics") or ("rmse", "bias", "r")
     for var, metrics in (data.get("per_variable") or {}).items():
-        lines.append(
-            f"  {var:<6} rmse={metrics['rmse']:.4g} "
-            f"bias={metrics['bias']:.4g} r={metrics['r']:.4g} "
-            f"n={metrics['n']}"
-        )
+        parts = [f"  {var:<6}"]
+        for metric_name in list_metrics:
+            if metric_name in metrics:
+                parts.append(f"{metric_name}={_fmt_metric(metrics[metric_name])}")
+        parts.append(f"n={metrics['n']}")
+        lines.append(" ".join(parts))
     return "\n".join(lines)
+
+
+def _emit_user_error(
+    message: str,
+    *,
+    json_mode: bool,
+    command: str,
+    data: dict[str, Any],
+    started_at: str,
+) -> None:
+    if json_mode:
+        Envelope.error(
+            errors=[message],
+            command=command,
+            data=data,
+            started_at=started_at,
+        ).emit()
+    else:
+        click.secho(message, fg="red", err=True)
+    sys.exit(EXIT_USER_ERROR)
+
+
+def _parse_requested_metrics(metrics: str) -> list[str]:
+    list_metrics = [metric.strip() for metric in metrics.split(",") if metric.strip()]
+    list_unknown = [metric for metric in list_metrics if metric not in _VALID_METRICS]
+    if list_unknown:
+        valid = ", ".join(sorted(_VALID_METRICS))
+        unknown = ", ".join(list_unknown)
+        raise ValueError(f"Unknown metric(s): {unknown}. Valid: {valid}")
+    return list_metrics
+
+
+def _metric_entry(
+    ser_a: pd.Series,
+    ser_b: pd.Series,
+    list_metrics: list[str],
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {"n": int(min(len(ser_a), len(ser_b)))}
+    if "rmse" in list_metrics:
+        entry["rmse"] = metric_rmse(ser_a, ser_b)
+    if "bias" in list_metrics:
+        entry["bias"] = metric_bias(ser_a, ser_b)
+    if "r" in list_metrics:
+        entry["r"] = pearson_r(ser_a, ser_b)
+    return entry
+
+
+def _compare_variables(
+    df_a: pd.DataFrame,
+    df_b: pd.DataFrame,
+    list_variables: list[str],
+    list_metrics: list[str],
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any] | None, list[str]]:
+    list_warnings: list[str] = []
+    per_variable: dict[str, dict[str, Any]] = {}
+    overlap: dict[str, Any] | None = None
+
+    for var in list_variables:
+        try:
+            ser_a, ser_b, var_overlap = _align_pair(df_a, df_b, var)
+            per_variable[var] = _metric_entry(ser_a, ser_b, list_metrics)
+        except (KeyError, ValueError) as exc:
+            list_warnings.append(f"variable {var!r} skipped: {exc}")
+            continue
+
+        if overlap is None:
+            overlap = var_overlap
+
+    return per_variable, overlap, list_warnings
+
+
+def _aggregate_metrics(
+    per_variable: dict[str, dict[str, Any]],
+    list_metrics: list[str],
+) -> dict[str, float]:
+    aggregate: dict[str, float] = {}
+    for metric_name in list_metrics:
+        list_values: list[float] = []
+        for entry in per_variable.values():
+            value = entry.get(metric_name)
+            if value is not None and not math.isnan(value):
+                list_values.append(value)
+        if list_values:
+            aggregate[metric_name] = float(sum(list_values) / len(list_values))
+    return aggregate
 
 
 @click.command(
@@ -185,100 +239,54 @@ def compare_runs_cmd(
     variables: str,
     output_format: str,
 ) -> None:
-    """Implementation of ``suews compare``."""
+    """Compare two saved SUEWS outputs."""
     started_at = _now_iso()
     json_mode = output_format.lower() == "json"
     command = " ".join(["suews", "compare", *sys.argv[1:]])
 
     path_a = Path(run_a)
     path_b = Path(run_b_or_obs)
-
-    list_metrics = [m.strip() for m in metrics.split(",") if m.strip()]
-    list_variables = [v.strip() for v in variables.split(",") if v.strip()]
-
-    valid_metrics = {"rmse", "bias", "r"}
-    list_unknown = [m for m in list_metrics if m not in valid_metrics]
-    if list_unknown:
-        message = "Unknown metric(s): {}. Valid: {}".format(
-            ", ".join(list_unknown),
-            ", ".join(sorted(valid_metrics)),
-        )
-        if json_mode:
-            Envelope.error(
-                errors=[message],
-                command=command,
-                data={"baseline": str(path_a), "scenario": str(path_b)},
-                started_at=started_at,
-            ).emit()
-        else:
-            click.secho(message, fg="red", err=True)
-        sys.exit(EXIT_USER_ERROR)
+    paths_data = {"baseline": str(path_a), "scenario": str(path_b)}
 
     try:
-        from ..metrics import bias as metric_bias, pearson_r, rmse as metric_rmse
+        list_metrics = _parse_requested_metrics(metrics)
+    except ValueError as exc:
+        _emit_user_error(
+            str(exc),
+            json_mode=json_mode,
+            command=command,
+            data=paths_data,
+            started_at=started_at,
+        )
 
-        df_a = _load_run_or_observations(path_a)
-        df_b = _load_run_or_observations(path_b)
+    try:
+        df_a = _load_run_output_dataframe(path_a)
+        df_b = _load_run_output_dataframe(path_b)
         df_a = _coerce_datetime_index(df_a)
         df_b = _coerce_datetime_index(df_b)
     except (FileNotFoundError, OSError, ValueError) as exc:
-        message = f"Failed to load inputs: {exc}"
-        if json_mode:
-            Envelope.error(
-                errors=[message],
-                command=command,
-                data={"baseline": str(path_a), "scenario": str(path_b)},
-                started_at=started_at,
-            ).emit()
-        else:
-            click.secho(message, fg="red", err=True)
-        sys.exit(EXIT_USER_ERROR)
+        _emit_user_error(
+            f"Failed to load inputs: {exc}",
+            json_mode=json_mode,
+            command=command,
+            data=paths_data,
+            started_at=started_at,
+        )
 
-    list_warnings: list[str] = []
-    per_variable: dict[str, dict[str, Any]] = {}
-    overlap: dict[str, Any] | None = None
-    aggregate: dict[str, float] = {}
-
-    for var in list_variables:
-        try:
-            ser_a, ser_b, var_overlap = _align_pair(df_a, df_b, var)
-        except KeyError as exc:
-            list_warnings.append(f"variable {var!r} skipped: {exc}")
-            continue
-        # First successful overlap is recorded as the run-level overlap.
-        if overlap is None:
-            overlap = var_overlap
-        try:
-            entry: dict[str, Any] = {"n": int(min(len(ser_a), len(ser_b)))}
-            if "rmse" in list_metrics:
-                entry["rmse"] = metric_rmse(ser_a, ser_b)
-            if "bias" in list_metrics:
-                entry["bias"] = metric_bias(ser_a, ser_b)
-            if "r" in list_metrics:
-                entry["r"] = pearson_r(ser_a, ser_b)
-            per_variable[var] = entry
-        except ValueError as exc:
-            list_warnings.append(f"variable {var!r} skipped: {exc}")
-
-    # Aggregate metrics: simple unweighted mean across variables. This is
-    # a useful single-number summary for triage; per-variable detail is
-    # available in ``per_variable``.
-    for metric_name in list_metrics:
-        list_values = [
-            entry[metric_name]
-            for entry in per_variable.values()
-            if metric_name in entry
-            and entry[metric_name] is not None
-            and entry[metric_name] == entry[metric_name]  # filter NaN
-        ]
-        if list_values:
-            aggregate[metric_name] = float(sum(list_values) / len(list_values))
+    list_variables = [v.strip() for v in variables.split(",") if v.strip()]
+    per_variable, overlap, list_warnings = _compare_variables(
+        df_a,
+        df_b,
+        list_variables,
+        list_metrics,
+    )
 
     data: dict[str, Any] = {
         "baseline": str(path_a),
         "scenario": str(path_b),
-        "metrics": aggregate,
+        "metrics": _aggregate_metrics(per_variable, list_metrics),
         "per_variable": per_variable,
+        "requested_metrics": list_metrics,
         "time_axis_overlap": overlap or {"start": None, "end": None, "n": 0},
     }
 

--- a/src/supy/cmd/diagnose_run.py
+++ b/src/supy/cmd/diagnose_run.py
@@ -14,7 +14,8 @@ from typing import Any
 
 import click
 
-from .json_envelope import EXIT_USER_ERROR, Envelope, _now_iso
+from ..diagnostics import check_run
+from .json_envelope import Envelope, _now_iso
 
 
 def _summarise(list_results: list[Any]) -> dict[str, int]:
@@ -38,8 +39,8 @@ def _build_recommendations(list_results: list[Any]) -> list[str]:
             continue
         if res.name == "provenance_present":
             list_recommendations.append(
-                "Re-run with 'suews run --format json --output <dir>' to "
-                "produce a provenance.json sidecar."
+                "Preserve the run command, configuration path, and git commit "
+                "in a provenance.json sidecar before archiving the run."
             )
         elif res.name == "output_files_present":
             list_recommendations.append(
@@ -71,7 +72,7 @@ def _build_text_message(data: dict[str, Any]) -> str:
     ]
     for check in data["checks"]:
         lines.append(
-            f"  [{check['severity'].upper()}] {check['name']} — {check['message']}"
+            f"  [{check['severity'].upper()}] {check['name']} - {check['message']}"
         )
     if data.get("recommendations"):
         lines.append("")
@@ -104,27 +105,12 @@ def _build_text_message(data: dict[str, Any]) -> str:
     help="Output format. 'json' emits the standard SUEWS envelope on stdout.",
 )
 def diagnose_run_cmd(run_dir: str, output_format: str) -> None:
-    """Implementation of ``suews diagnose``."""
+    """Diagnose a saved SUEWS run directory."""
     started_at = _now_iso()
     json_mode = output_format.lower() == "json"
     command = " ".join(["suews", "diagnose", *sys.argv[1:]])
 
     path_run_dir = Path(run_dir)
-
-    try:
-        from ..diagnostics import check_run
-    except ImportError as exc:  # pragma: no cover - dev-env edge case
-        message = f"Failed to import supy.diagnostics: {exc}"
-        if json_mode:
-            Envelope.error(
-                errors=[message],
-                command=command,
-                data={"run_dir": str(path_run_dir)},
-                started_at=started_at,
-            ).emit()
-        else:
-            click.secho(message, fg="red", err=True)
-        sys.exit(EXIT_USER_ERROR)
 
     list_results = check_run(path_run_dir)
     list_check_dicts = [res.to_dict() for res in list_results]
@@ -152,9 +138,7 @@ def diagnose_run_cmd(run_dir: str, output_format: str) -> None:
                 encoding="utf-8",
             )
         except OSError as exc:
-            list_warnings.append(
-                f"could not write diagnostics.json sidecar: {exc}"
-            )
+            list_warnings.append(f"could not write diagnostics.json sidecar: {exc}")
 
     if json_mode:
         # Map a hard 'fail' onto the envelope error channel so MCP tooling can

--- a/src/supy/cmd/diagnose_run.py
+++ b/src/supy/cmd/diagnose_run.py
@@ -1,0 +1,179 @@
+"""``suews diagnose`` — run diagnostic checks against a finished SUEWS run.
+
+This subcommand is a thin CLI wrapper over ``supy.diagnostics.check_run``;
+the heavy lifting lives there so that MCP tools and downstream callers
+can use the same checks without re-implementing them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import click
+
+from .json_envelope import EXIT_USER_ERROR, Envelope, _now_iso
+
+
+def _summarise(list_results: list[Any]) -> dict[str, int]:
+    counts = {"n_pass": 0, "n_warn": 0, "n_fail": 0}
+    for res in list_results:
+        sev = res.severity
+        if sev == "pass":
+            counts["n_pass"] += 1
+        elif sev == "warning":
+            counts["n_warn"] += 1
+        elif sev == "fail":
+            counts["n_fail"] += 1
+    return counts
+
+
+def _build_recommendations(list_results: list[Any]) -> list[str]:
+    """Map check failures to short, actionable recommendations."""
+    list_recommendations: list[str] = []
+    for res in list_results:
+        if res.passed:
+            continue
+        if res.name == "provenance_present":
+            list_recommendations.append(
+                "Re-run with 'suews run --format json --output <dir>' to "
+                "produce a provenance.json sidecar."
+            )
+        elif res.name == "output_files_present":
+            list_recommendations.append(
+                "Confirm the run actually finished: check stderr / Fortran log "
+                "for errors before diagnosing."
+            )
+        elif res.name == "nan_proportion":
+            list_recommendations.append(
+                "Inspect forcing-file gaps (Tair / Kdown / RH) and rerun once "
+                "gaps are filled."
+            )
+        elif res.name == "energy_balance_closure":
+            list_recommendations.append(
+                "Review storage_heat / emissions physics options and check "
+                "land-cover fractions sum to 1.0."
+            )
+    return list_recommendations
+
+
+def _build_text_message(data: dict[str, Any]) -> str:
+    summary = data["summary"]
+    lines = [
+        f"Run directory: {data['run_dir']}",
+        "",
+        (
+            f"Checks: {summary['n_pass']} pass / "
+            f"{summary['n_warn']} warn / {summary['n_fail']} fail"
+        ),
+    ]
+    for check in data["checks"]:
+        lines.append(
+            f"  [{check['severity'].upper()}] {check['name']} — {check['message']}"
+        )
+    if data.get("recommendations"):
+        lines.append("")
+        lines.append("Recommendations:")
+        for rec in data["recommendations"]:
+            lines.append(f"  - {rec}")
+    return "\n".join(lines)
+
+
+@click.command(
+    name="diagnose",
+    short_help="Diagnose a finished SUEWS run directory.",
+    help=(
+        "Read the contents of a SUEWS run directory and run a battery of "
+        "Phase-1 checks (provenance present, output files present, NaN "
+        "proportion in QH/QE/QN, energy-balance closure). Use --format json "
+        "for structured output consumable by MCP tooling."
+    ),
+)
+@click.argument(
+    "run_dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format. 'json' emits the standard SUEWS envelope on stdout.",
+)
+def diagnose_run_cmd(run_dir: str, output_format: str) -> None:
+    """Implementation of ``suews diagnose``."""
+    started_at = _now_iso()
+    json_mode = output_format.lower() == "json"
+    command = " ".join(["suews", "diagnose", *sys.argv[1:]])
+
+    path_run_dir = Path(run_dir)
+
+    try:
+        from ..diagnostics import check_run
+    except ImportError as exc:  # pragma: no cover - dev-env edge case
+        message = f"Failed to import supy.diagnostics: {exc}"
+        if json_mode:
+            Envelope.error(
+                errors=[message],
+                command=command,
+                data={"run_dir": str(path_run_dir)},
+                started_at=started_at,
+            ).emit()
+        else:
+            click.secho(message, fg="red", err=True)
+        sys.exit(EXIT_USER_ERROR)
+
+    list_results = check_run(path_run_dir)
+    list_check_dicts = [res.to_dict() for res in list_results]
+    summary = _summarise(list_results)
+    list_recommendations = _build_recommendations(list_results)
+
+    data: dict[str, Any] = {
+        "run_dir": str(path_run_dir),
+        "checks": list_check_dicts,
+        "summary": summary,
+        "recommendations": list_recommendations,
+    }
+
+    list_warnings = [res.message for res in list_results if res.severity == "warning"]
+
+    # Sidecar: write diagnostics.json next to the run output. Required by the
+    # gh#1361 acceptance criteria. Failure to write (e.g. read-only mount)
+    # degrades to an envelope warning rather than a hard error so 'diagnose'
+    # remains usable on CI artefact trees.
+    if path_run_dir.is_dir():
+        path_sidecar = path_run_dir / "diagnostics.json"
+        try:
+            path_sidecar.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            list_warnings.append(
+                f"could not write diagnostics.json sidecar: {exc}"
+            )
+
+    if json_mode:
+        # Map a hard 'fail' onto the envelope error channel so MCP tooling can
+        # short-circuit; warnings remain structured but non-fatal.
+        list_errors = [res.message for res in list_results if res.severity == "fail"]
+        if list_errors:
+            Envelope.error(
+                errors=list_errors,
+                command=command,
+                data=data,
+                warnings=list_warnings or None,
+                started_at=started_at,
+            ).emit()
+        else:
+            Envelope.success(
+                data=data,
+                command=command,
+                warnings=list_warnings or None,
+                started_at=started_at,
+            ).emit()
+    else:
+        click.echo(_build_text_message(data))

--- a/src/supy/cmd/suews_cli.py
+++ b/src/supy/cmd/suews_cli.py
@@ -81,31 +81,33 @@ _DEPRECATION_TEMPLATE = (
 
 
 def _emit_deprecation(legacy: str, replacement: str) -> None:
-    sys.stderr.write(_DEPRECATION_TEMPLATE.format(legacy=legacy, replacement=replacement))
+    sys.stderr.write(
+        _DEPRECATION_TEMPLATE.format(legacy=legacy, replacement=replacement)
+    )
     sys.stderr.write("\n")
     sys.stderr.flush()
 
 
 def run_alias() -> None:
-    """Deprecated alias for ``suews run``."""
+    """Forward the deprecated ``suews-run`` alias."""
     _emit_deprecation("suews-run", "suews run")
     _run_cmd()
 
 
 def convert_alias() -> None:
-    """Deprecated alias for ``suews convert``."""
+    """Forward the deprecated ``suews-convert`` alias."""
     _emit_deprecation("suews-convert", "suews convert")
     _convert_cmd()
 
 
 def validate_alias() -> None:
-    """Deprecated alias for ``suews validate``."""
+    """Forward the deprecated ``suews-validate`` alias."""
     _emit_deprecation("suews-validate", "suews validate")
     _validate_cli()
 
 
 def schema_alias() -> None:
-    """Deprecated alias for ``suews schema``."""
+    """Forward the deprecated ``suews-schema`` alias."""
     _emit_deprecation("suews-schema", "suews schema")
     _schema_cli()
 

--- a/src/supy/cmd/suews_cli.py
+++ b/src/supy/cmd/suews_cli.py
@@ -11,10 +11,10 @@ run logic. It only routes. Backend implementation details such as the Rust
 bridge are deliberately kept out of the public command surface.
 
 Phase-1 dispatcher: ``run``, ``validate``, ``schema``, and ``convert`` are
-wired here. The Phase-1 gap-fill commands (``init``, ``inspect``,
-``diagnose``, ``compare``, ``summarise``, ``skill``) remain future work in the
-Wave 3 sub-issues (#1360-#1363), and the standalone ``suews-mcp`` package
-lands in Wave 4 (#1364).
+wired here. The Wave-3 post-run triage commands (``diagnose``, ``compare``,
+``summarise``) are added by gh#1361. ``init``, ``inspect`` and ``skill``
+remain future work in the other Wave 3 sub-issues, and the standalone
+``suews-mcp`` package lands in Wave 4 (#1364).
 """
 
 from __future__ import annotations
@@ -23,11 +23,15 @@ import sys
 
 import click
 
+from .compare_runs import compare_runs_cmd as _compare_cmd
+from .diagnose_run import diagnose_run_cmd as _diagnose_cmd
+from .schema_cli import cli as _schema_cli
+
 # Each existing entry point is reused unchanged. Importing the Click commands
 # here keeps the dispatcher small and ensures behaviour is identical across
 # the new and legacy invocation styles.
 from .SUEWS import SUEWS as _run_cmd
-from .schema_cli import cli as _schema_cli
+from .summarise_output import summarise_output_cmd as _summarise_cmd
 from .table_converter import convert_table_cmd as _convert_cmd
 from .validate_config import cli as _validate_cli
 
@@ -53,6 +57,9 @@ cli.add_command(_validate_cli, name="validate")
 cli.add_command(_schema_cli, name="schema")
 cli.add_command(_convert_cmd, name="convert")
 cli.add_command(_run_cmd, name="run")
+cli.add_command(_summarise_cmd, name="summarise")
+cli.add_command(_compare_cmd, name="compare")
+cli.add_command(_diagnose_cmd, name="diagnose")
 
 
 # ---------------------------------------------------------------------------

--- a/src/supy/cmd/summarise_output.py
+++ b/src/supy/cmd/summarise_output.py
@@ -15,35 +15,8 @@ import click
 import numpy as np
 import pandas as pd
 
+from .._run_output import _load_run_output_dataframe
 from .json_envelope import EXIT_USER_ERROR, Envelope, _now_iso
-
-
-def _load_run_dataframe(path_run_dir: Path) -> pd.DataFrame:
-    """Load the canonical run output from ``path_run_dir``.
-
-    Raises ``FileNotFoundError`` when no recognised output file is present.
-    """
-    list_paths: list[Path] = []
-    for pattern in ("df_output*.parquet", "df_output*.csv", "*_SUEWS_*.txt"):
-        list_paths.extend(path_run_dir.rglob(pattern))
-    if not list_paths:
-        raise FileNotFoundError(
-            f"No df_output*.parquet / *.csv / *_SUEWS_*.txt under {path_run_dir}"
-        )
-    list_paths.sort(key=lambda p: 0 if p.suffix == ".parquet" else 1)
-    path_first = list_paths[0]
-    if path_first.suffix == ".parquet":
-        df = pd.read_parquet(path_first)
-    elif path_first.suffix == ".csv":
-        df = pd.read_csv(path_first)
-    else:
-        df = pd.read_csv(path_first, sep=r"\s+", engine="python")
-
-    if isinstance(df.columns, pd.MultiIndex):
-        df.columns = [
-            col[0] if isinstance(col, tuple) else col for col in df.columns
-        ]
-    return df
 
 
 def _period_and_n_steps(df: pd.DataFrame) -> dict[str, Any]:
@@ -170,7 +143,7 @@ def _build_text_message(data: dict[str, Any]) -> str:
     help="Output format. 'json' emits the standard SUEWS envelope on stdout.",
 )
 def summarise_output_cmd(run_dir: str, variables: str, output_format: str) -> None:
-    """Implementation of ``suews summarise``."""
+    """Summarise a saved SUEWS run output."""
     started_at = _now_iso()
     json_mode = output_format.lower() == "json"
     command = " ".join(["suews", "summarise", *sys.argv[1:]])
@@ -178,7 +151,7 @@ def summarise_output_cmd(run_dir: str, variables: str, output_format: str) -> No
     path_run_dir = Path(run_dir)
 
     try:
-        df_output = _load_run_dataframe(path_run_dir)
+        df_output = _load_run_output_dataframe(path_run_dir)
     except (FileNotFoundError, OSError, ValueError) as exc:
         message = f"Failed to load run output: {exc}"
         if json_mode:
@@ -206,9 +179,7 @@ def summarise_output_cmd(run_dir: str, variables: str, output_format: str) -> No
         if df_subset.shape[1] == 0:
             list_notes.append("no numeric columns detected in run output")
 
-    list_summaries = [
-        _summarise_variable(df_subset[col]) for col in df_subset.columns
-    ]
+    list_summaries = [_summarise_variable(df_subset[col]) for col in df_subset.columns]
 
     period_data = _period_and_n_steps(df_output)
 

--- a/src/supy/cmd/summarise_output.py
+++ b/src/supy/cmd/summarise_output.py
@@ -1,0 +1,231 @@
+"""``suews summarise`` — produce a per-variable summary of a SUEWS run.
+
+For each requested variable (or every numeric column when ``--variables``
+is empty) the command reports the mean / min / max / NaN-percentage
+alongside the overall time period and step count.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+import click
+import numpy as np
+import pandas as pd
+
+from .json_envelope import EXIT_USER_ERROR, Envelope, _now_iso
+
+
+def _load_run_dataframe(path_run_dir: Path) -> pd.DataFrame:
+    """Load the canonical run output from ``path_run_dir``.
+
+    Raises ``FileNotFoundError`` when no recognised output file is present.
+    """
+    list_paths: list[Path] = []
+    for pattern in ("df_output*.parquet", "df_output*.csv", "*_SUEWS_*.txt"):
+        list_paths.extend(path_run_dir.rglob(pattern))
+    if not list_paths:
+        raise FileNotFoundError(
+            f"No df_output*.parquet / *.csv / *_SUEWS_*.txt under {path_run_dir}"
+        )
+    list_paths.sort(key=lambda p: 0 if p.suffix == ".parquet" else 1)
+    path_first = list_paths[0]
+    if path_first.suffix == ".parquet":
+        df = pd.read_parquet(path_first)
+    elif path_first.suffix == ".csv":
+        df = pd.read_csv(path_first)
+    else:
+        df = pd.read_csv(path_first, sep=r"\s+", engine="python")
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = [
+            col[0] if isinstance(col, tuple) else col for col in df.columns
+        ]
+    return df
+
+
+def _period_and_n_steps(df: pd.DataFrame) -> dict[str, Any]:
+    """Extract period start/end and step count from the DataFrame."""
+    n_steps = len(df)
+    if isinstance(df.index, pd.MultiIndex):
+        # Unique datetimes across grids.
+        idx_levels = [
+            level for level in df.index.names if level and "time" in level.lower()
+        ]
+        if idx_levels:
+            try:
+                values = df.index.get_level_values(idx_levels[0])
+                return {
+                    "period": {
+                        "start": str(values.min()),
+                        "end": str(values.max()),
+                    },
+                    "n_steps": n_steps,
+                }
+            except (KeyError, ValueError):
+                pass
+    if isinstance(df.index, pd.DatetimeIndex):
+        return {
+            "period": {
+                "start": df.index.min().isoformat(),
+                "end": df.index.max().isoformat(),
+            },
+            "n_steps": n_steps,
+        }
+    for cand in ("datetime", "Datetime", "DateTime"):
+        if cand in df.columns:
+            ser = pd.to_datetime(df[cand], errors="coerce").dropna()
+            if len(ser):
+                return {
+                    "period": {
+                        "start": ser.min().isoformat(),
+                        "end": ser.max().isoformat(),
+                    },
+                    "n_steps": n_steps,
+                }
+    return {"period": {"start": None, "end": None}, "n_steps": n_steps}
+
+
+def _summarise_variable(ser: pd.Series) -> dict[str, Any]:
+    """Summary stats for a single column. NaN-aware."""
+    arr = pd.to_numeric(ser, errors="coerce")
+    nan_pct = float(arr.isna().mean() * 100.0)
+    arr_finite = arr[np.isfinite(arr)]
+    if len(arr_finite) == 0:
+        return {
+            "name": ser.name,
+            "mean": None,
+            "min": None,
+            "max": None,
+            "nan_pct": nan_pct,
+        }
+    return {
+        "name": ser.name,
+        "mean": float(arr_finite.mean()),
+        "min": float(arr_finite.min()),
+        "max": float(arr_finite.max()),
+        "nan_pct": nan_pct,
+    }
+
+
+def _fmt_or_na(value: Any) -> str:
+    return f"{value:.4g}" if value is not None else "n/a"
+
+
+def _build_text_message(data: dict[str, Any]) -> str:
+    period = data["period"]
+    lines = [
+        f"Run directory: {data['run_dir']}",
+        f"Period: {period.get('start')} -> {period.get('end')} ({data['n_steps']} steps)",
+        "",
+        "Variable summary:",
+        f"  {'name':<20} {'mean':>12} {'min':>12} {'max':>12} {'nan_pct':>8}",
+    ]
+    for var in data["variables"]:
+        lines.append(
+            f"  {var['name']:<20} "
+            f"{_fmt_or_na(var['mean']):>12} "
+            f"{_fmt_or_na(var['min']):>12} "
+            f"{_fmt_or_na(var['max']):>12} "
+            f"{var['nan_pct']:>7.1f}%"
+        )
+    if data.get("notes"):
+        lines.append("")
+        lines.append("Notes:")
+        for note in data["notes"]:
+            lines.append(f"  - {note}")
+    return "\n".join(lines)
+
+
+@click.command(
+    name="summarise",
+    short_help="Summarise a SUEWS run output.",
+    help=(
+        "Print a per-variable summary (mean / min / max / NaN-percentage) of "
+        "a SUEWS run output. Pass --variables to restrict the columns; the "
+        "default is every numeric column."
+    ),
+)
+@click.argument(
+    "run_dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+)
+@click.option(
+    "--variables",
+    default="",
+    show_default=False,
+    help=(
+        "Comma-separated variable names to summarise. Empty (default) "
+        "means every numeric column."
+    ),
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format. 'json' emits the standard SUEWS envelope on stdout.",
+)
+def summarise_output_cmd(run_dir: str, variables: str, output_format: str) -> None:
+    """Implementation of ``suews summarise``."""
+    started_at = _now_iso()
+    json_mode = output_format.lower() == "json"
+    command = " ".join(["suews", "summarise", *sys.argv[1:]])
+
+    path_run_dir = Path(run_dir)
+
+    try:
+        df_output = _load_run_dataframe(path_run_dir)
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        message = f"Failed to load run output: {exc}"
+        if json_mode:
+            Envelope.error(
+                errors=[message],
+                command=command,
+                data={"run_dir": str(path_run_dir)},
+                started_at=started_at,
+            ).emit()
+        else:
+            click.secho(message, fg="red", err=True)
+        sys.exit(EXIT_USER_ERROR)
+
+    list_notes: list[str] = []
+
+    list_variables = [v.strip() for v in variables.split(",") if v.strip()]
+    if list_variables:
+        list_missing = [v for v in list_variables if v not in df_output.columns]
+        list_present = [v for v in list_variables if v in df_output.columns]
+        for missing in list_missing:
+            list_notes.append(f"variable {missing!r} not found in output")
+        df_subset = df_output[list_present]
+    else:
+        df_subset = df_output.select_dtypes(include=[np.number])
+        if df_subset.shape[1] == 0:
+            list_notes.append("no numeric columns detected in run output")
+
+    list_summaries = [
+        _summarise_variable(df_subset[col]) for col in df_subset.columns
+    ]
+
+    period_data = _period_and_n_steps(df_output)
+
+    data: dict[str, Any] = {
+        "run_dir": str(path_run_dir),
+        "period": period_data["period"],
+        "n_steps": period_data["n_steps"],
+        "variables": list_summaries,
+        "notes": list_notes,
+    }
+
+    if json_mode:
+        Envelope.success(
+            data=data,
+            command=command,
+            warnings=list_notes or None,
+            started_at=started_at,
+        ).emit()
+    else:
+        click.echo(_build_text_message(data))

--- a/src/supy/diagnostics/__init__.py
+++ b/src/supy/diagnostics/__init__.py
@@ -1,0 +1,37 @@
+"""Diagnostic checks for completed SUEWS run directories.
+
+The aggregator :func:`check_run` runs every Phase-1 check and returns a
+list of :class:`CheckResult` records. Each check is a small pure
+function that takes a ``Path`` and returns one ``CheckResult``; this
+keeps the checks individually testable and the aggregator trivial.
+
+Phase-1 checks (intentionally minimal):
+
+- :func:`check_provenance_present` -- ``provenance.json`` sidecar exists.
+- :func:`check_output_files_present` -- at least one ``df_output*.csv``
+  or ``*.parquet`` produced by ``suews run`` is present.
+- :func:`check_nan_proportion` -- NaN fraction in QH/QE/QN below 5%.
+- :func:`check_energy_balance_closure` -- mean
+  ``|QN - (QH + QE + QS + QF)| / |QN| < 0.10``.
+
+Severity ladder: ``pass`` (passed=True), ``warning`` (passed=False but
+non-fatal), ``fail`` (passed=False and the run is unusable).
+"""
+
+from ._checks import (
+    CheckResult,
+    check_energy_balance_closure,
+    check_nan_proportion,
+    check_output_files_present,
+    check_provenance_present,
+    check_run,
+)
+
+__all__ = [
+    "CheckResult",
+    "check_energy_balance_closure",
+    "check_nan_proportion",
+    "check_output_files_present",
+    "check_provenance_present",
+    "check_run",
+]

--- a/src/supy/diagnostics/_checks.py
+++ b/src/supy/diagnostics/_checks.py
@@ -1,0 +1,359 @@
+"""Diagnostic checks for completed SUEWS run directories.
+
+The aggregator ``check_run(run_dir)`` runs every Phase-1 check and returns
+a list of ``CheckResult`` records. Each check is a small pure function
+that takes a ``Path`` and returns one ``CheckResult``; this keeps the
+checks individually testable and the aggregator trivial.
+
+Phase-1 checks (intentionally minimal):
+
+- ``check_provenance_present`` — ``provenance.json`` sidecar exists.
+- ``check_output_files_present`` — at least one ``df_output*.csv`` or
+  ``*.parquet`` produced by ``suews run`` is present.
+- ``check_nan_proportion`` — NaN fraction in QH/QE/QN below 5%.
+- ``check_energy_balance_closure`` — mean
+  ``|QN - (QH + QE + QS + QF)| / |QN| < 0.10``.
+
+Severity ladder: ``pass`` (passed=True), ``warning`` (passed=False but
+non-fatal), ``fail`` (passed=False and the run is unusable).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+__all__ = [
+    "CheckResult",
+    "check_energy_balance_closure",
+    "check_nan_proportion",
+    "check_output_files_present",
+    "check_provenance_present",
+    "check_run",
+]
+
+# Tunables for Phase-1 checks. Conservative defaults; tighten in later
+# phases once the user-base has reported real-world distributions.
+_NAN_THRESHOLD_FRACTION = 0.05
+_ENERGY_BALANCE_THRESHOLD = 0.10
+_FLUX_VARIABLES = ("QH", "QE", "QN")
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single diagnostic check.
+
+    Attributes
+    ----------
+    name : str
+        Stable check identifier (snake_case).
+    severity : str
+        One of ``"pass"``, ``"warning"``, ``"fail"``.
+    passed : bool
+        ``True`` when the check completed without flagging an issue.
+    message : str
+        Short human-readable summary.
+    details : dict
+        Free-form structured payload (counts, paths, percentages, etc.).
+    """
+
+    name: str
+    severity: str
+    passed: bool
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (private)
+# ---------------------------------------------------------------------------
+
+
+def _list_output_files(path_run_dir: Path) -> list[Path]:
+    """Return all candidate output files under ``path_run_dir``.
+
+    Recognises CSV and parquet output produced by ``suews run`` /
+    ``SUEWSSimulation.save``. The current ``save`` implementation may write
+    files at the run-dir root or under a subdirectory keyed by site name —
+    we accept both.
+    """
+    if not path_run_dir.exists() or not path_run_dir.is_dir():
+        return []
+    list_paths: list[Path] = []
+    for pattern in ("df_output*.csv", "df_output*.parquet", "*_SUEWS_*.txt"):
+        list_paths.extend(path_run_dir.rglob(pattern))
+    return list_paths
+
+
+def _load_output_dataframe(path_run_dir: Path) -> pd.DataFrame | None:
+    """Best-effort load of run output into a single DataFrame.
+
+    Returns ``None`` when no recognisable output file is present. Errors
+    during read are deliberately propagated to the caller — the caller
+    decides whether to mark the check as ``fail`` or ``warning``.
+    """
+    list_paths = _list_output_files(path_run_dir)
+    if not list_paths:
+        return None
+    # Prefer parquet (fast + typed) when both are available.
+    list_paths.sort(key=lambda p: 0 if p.suffix == ".parquet" else 1)
+    path_first = list_paths[0]
+    if path_first.suffix == ".parquet":
+        return pd.read_parquet(path_first)
+    if path_first.suffix == ".csv":
+        return pd.read_csv(path_first)
+    # SUEWS legacy text format — whitespace-delimited.
+    return pd.read_csv(path_first, sep=r"\s+", engine="python")
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def check_provenance_present(path_run_dir: Path) -> CheckResult:
+    """Verify ``provenance.json`` is present in the run directory."""
+    path_provenance = path_run_dir / "provenance.json"
+    if path_provenance.exists():
+        return CheckResult(
+            name="provenance_present",
+            severity="pass",
+            passed=True,
+            message="provenance.json present.",
+            details={"path": str(path_provenance)},
+        )
+    return CheckResult(
+        name="provenance_present",
+        severity="warning",
+        passed=False,
+        message=(
+            "provenance.json missing — run was not produced by 'suews run "
+            "--format json' or the sidecar was deleted."
+        ),
+        details={"expected": str(path_provenance)},
+    )
+
+
+def check_output_files_present(path_run_dir: Path) -> CheckResult:
+    """Verify at least one recognisable output file is present."""
+    list_paths = _list_output_files(path_run_dir)
+    if list_paths:
+        return CheckResult(
+            name="output_files_present",
+            severity="pass",
+            passed=True,
+            message=f"Found {len(list_paths)} output file(s).",
+            details={"files": [str(p) for p in list_paths[:10]]},
+        )
+    return CheckResult(
+        name="output_files_present",
+        severity="fail",
+        passed=False,
+        message="No df_output*.csv / *.parquet / *_SUEWS_*.txt files found.",
+        details={"run_dir": str(path_run_dir)},
+    )
+
+
+def check_nan_proportion(path_run_dir: Path) -> CheckResult:
+    """Check NaN proportion in QH / QE / QN flux columns.
+
+    Severity:
+    - ``pass`` when all three flux columns have NaN fraction below 5%.
+    - ``warning`` when any flux column exceeds the threshold.
+    - ``fail`` when none of the flux columns are present (cannot judge).
+    """
+    try:
+        df_output = _load_output_dataframe(path_run_dir)
+    except (OSError, ValueError, pd.errors.ParserError) as exc:
+        return CheckResult(
+            name="nan_proportion",
+            severity="warning",
+            passed=False,
+            message=f"Could not read run output to compute NaN proportions: {exc}",
+            details={"run_dir": str(path_run_dir)},
+        )
+
+    if df_output is None:
+        return CheckResult(
+            name="nan_proportion",
+            severity="warning",
+            passed=False,
+            message="No output dataframe to inspect.",
+            details={"run_dir": str(path_run_dir)},
+        )
+
+    # Tolerate MultiIndex columns from the canonical SUEWS output.
+    list_columns = [
+        col[0] if isinstance(col, tuple) else col for col in df_output.columns
+    ]
+    df_output = df_output.copy()
+    df_output.columns = list_columns
+
+    found = {var: var in df_output.columns for var in _FLUX_VARIABLES}
+    if not any(found.values()):
+        return CheckResult(
+            name="nan_proportion",
+            severity="fail",
+            passed=False,
+            message="None of QH / QE / QN present in output.",
+            details={"available_columns": list_columns[:30]},
+        )
+
+    dict_fractions = {
+        var: float(df_output[var].isna().mean()) for var in _FLUX_VARIABLES if found[var]
+    }
+    list_offenders = [
+        f"{var}={frac:.3%}"
+        for var, frac in dict_fractions.items()
+        if frac > _NAN_THRESHOLD_FRACTION
+    ]
+    if list_offenders:
+        return CheckResult(
+            name="nan_proportion",
+            severity="warning",
+            passed=False,
+            message=(
+                f"NaN fraction exceeds {_NAN_THRESHOLD_FRACTION * 100:.0f}% "
+                f"in: {', '.join(list_offenders)}"
+            ),
+            details={
+                "threshold_fraction": _NAN_THRESHOLD_FRACTION,
+                "fractions": dict_fractions,
+            },
+        )
+    return CheckResult(
+        name="nan_proportion",
+        severity="pass",
+        passed=True,
+        message=f"NaN fractions within {_NAN_THRESHOLD_FRACTION * 100:.0f}% on QH/QE/QN.",
+        details={"fractions": dict_fractions},
+    )
+
+
+def check_energy_balance_closure(path_run_dir: Path) -> CheckResult:
+    """Approximate energy balance closure check.
+
+    Computes ``mean(|QN - (QH + QE + QS + QF)| / |QN|)`` over rows where
+    ``QN`` is finite and non-zero, then flags the run when the ratio
+    exceeds 10%. ``QF`` and ``QS`` may be missing for very simple
+    configurations — the check treats them as zero in that case rather
+    than refusing to run.
+    """
+    try:
+        df_output = _load_output_dataframe(path_run_dir)
+    except (OSError, ValueError, pd.errors.ParserError) as exc:
+        return CheckResult(
+            name="energy_balance_closure",
+            severity="warning",
+            passed=False,
+            message=f"Could not read run output to compute energy balance: {exc}",
+            details={"run_dir": str(path_run_dir)},
+        )
+
+    if df_output is None:
+        return CheckResult(
+            name="energy_balance_closure",
+            severity="warning",
+            passed=False,
+            message="No output dataframe to inspect.",
+            details={"run_dir": str(path_run_dir)},
+        )
+
+    list_columns = [
+        col[0] if isinstance(col, tuple) else col for col in df_output.columns
+    ]
+    df_output = df_output.copy()
+    df_output.columns = list_columns
+
+    if "QN" not in df_output.columns:
+        return CheckResult(
+            name="energy_balance_closure",
+            severity="fail",
+            passed=False,
+            message="QN missing — cannot compute energy balance closure.",
+            details={"available_columns": list_columns[:30]},
+        )
+
+    ser_qn = pd.to_numeric(df_output["QN"], errors="coerce")
+    ser_qh = pd.to_numeric(df_output.get("QH", 0.0), errors="coerce").fillna(0.0)
+    ser_qe = pd.to_numeric(df_output.get("QE", 0.0), errors="coerce").fillna(0.0)
+    ser_qs = pd.to_numeric(df_output.get("QS", 0.0), errors="coerce").fillna(0.0)
+    ser_qf = pd.to_numeric(df_output.get("QF", 0.0), errors="coerce").fillna(0.0)
+
+    mask_valid = ser_qn.notna() & (ser_qn.abs() > 1.0)
+    if not mask_valid.any():
+        return CheckResult(
+            name="energy_balance_closure",
+            severity="warning",
+            passed=False,
+            message="QN has no finite, non-trivial values to evaluate closure.",
+            details={"n_rows": len(df_output)},
+        )
+
+    ser_residual = (ser_qn - (ser_qh + ser_qe + ser_qs + ser_qf)).abs()
+    ser_ratio = ser_residual[mask_valid] / ser_qn[mask_valid].abs()
+    ratio_mean = float(ser_ratio.mean())
+
+    if ratio_mean < _ENERGY_BALANCE_THRESHOLD:
+        return CheckResult(
+            name="energy_balance_closure",
+            severity="pass",
+            passed=True,
+            message=f"Mean closure residual {ratio_mean:.3f} < {_ENERGY_BALANCE_THRESHOLD:.2f}.",
+            details={"ratio_mean": ratio_mean, "n_rows": int(mask_valid.sum())},
+        )
+    return CheckResult(
+        name="energy_balance_closure",
+        severity="warning",
+        passed=False,
+        message=(
+            f"Mean closure residual {ratio_mean:.3f} exceeds "
+            f"{_ENERGY_BALANCE_THRESHOLD:.2f}."
+        ),
+        details={"ratio_mean": ratio_mean, "n_rows": int(mask_valid.sum())},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+_REGISTERED_CHECKS: tuple[Callable[[Path], CheckResult], ...] = (
+    check_provenance_present,
+    check_output_files_present,
+    check_nan_proportion,
+    check_energy_balance_closure,
+)
+
+
+def check_run(run_dir: Path) -> list[CheckResult]:
+    """Run every registered check against ``run_dir`` and return the list.
+
+    Each check is wrapped in a defensive try/except so that one buggy
+    check cannot mask the others. A check that raises is recorded as a
+    ``fail`` with the exception message.
+    """
+    path_run_dir = Path(run_dir)
+    list_results: list[CheckResult] = []
+    for check_fn in _REGISTERED_CHECKS:
+        try:
+            list_results.append(check_fn(path_run_dir))
+        except Exception as exc:
+            list_results.append(
+                CheckResult(
+                    name=check_fn.__name__,
+                    severity="fail",
+                    passed=False,
+                    message=f"Check raised {type(exc).__name__}: {exc}",
+                    details={"run_dir": str(path_run_dir)},
+                )
+            )
+    return list_results

--- a/src/supy/diagnostics/_checks.py
+++ b/src/supy/diagnostics/_checks.py
@@ -27,6 +27,8 @@ from typing import Any
 
 import pandas as pd
 
+from .._run_output import _list_run_output_files, _load_run_output_dataframe
+
 __all__ = [
     "CheckResult",
     "check_energy_balance_closure",
@@ -84,12 +86,7 @@ def _list_output_files(path_run_dir: Path) -> list[Path]:
     files at the run-dir root or under a subdirectory keyed by site name —
     we accept both.
     """
-    if not path_run_dir.exists() or not path_run_dir.is_dir():
-        return []
-    list_paths: list[Path] = []
-    for pattern in ("df_output*.csv", "df_output*.parquet", "*_SUEWS_*.txt"):
-        list_paths.extend(path_run_dir.rglob(pattern))
-    return list_paths
+    return _list_run_output_files(path_run_dir)
 
 
 def _load_output_dataframe(path_run_dir: Path) -> pd.DataFrame | None:
@@ -99,18 +96,9 @@ def _load_output_dataframe(path_run_dir: Path) -> pd.DataFrame | None:
     during read are deliberately propagated to the caller — the caller
     decides whether to mark the check as ``fail`` or ``warning``.
     """
-    list_paths = _list_output_files(path_run_dir)
-    if not list_paths:
+    if not _list_output_files(path_run_dir):
         return None
-    # Prefer parquet (fast + typed) when both are available.
-    list_paths.sort(key=lambda p: 0 if p.suffix == ".parquet" else 1)
-    path_first = list_paths[0]
-    if path_first.suffix == ".parquet":
-        return pd.read_parquet(path_first)
-    if path_first.suffix == ".csv":
-        return pd.read_csv(path_first)
-    # SUEWS legacy text format — whitespace-delimited.
-    return pd.read_csv(path_first, sep=r"\s+", engine="python")
+    return _load_run_output_dataframe(path_run_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -134,8 +122,7 @@ def check_provenance_present(path_run_dir: Path) -> CheckResult:
         severity="warning",
         passed=False,
         message=(
-            "provenance.json missing — run was not produced by 'suews run "
-            "--format json' or the sidecar was deleted."
+            "provenance.json missing; this run directory has no provenance sidecar."
         ),
         details={"expected": str(path_provenance)},
     )
@@ -207,7 +194,9 @@ def check_nan_proportion(path_run_dir: Path) -> CheckResult:
         )
 
     dict_fractions = {
-        var: float(df_output[var].isna().mean()) for var in _FLUX_VARIABLES if found[var]
+        var: float(df_output[var].isna().mean())
+        for var in _FLUX_VARIABLES
+        if found[var]
     }
     list_offenders = [
         f"{var}={frac:.3%}"

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -8,6 +8,7 @@ py.install_sources(
         '_post.py',
         '_run.py',
         '_run_rust.py',
+        '_run_output.py',
         '_save.py',
         '_supy_module.py',
         '_var_metadata.py',

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -25,14 +25,25 @@ py.install_sources(
         [
             'cmd/__init__.py',
             'cmd/SUEWS.py',
+            'cmd/compare_runs.py',
+            'cmd/diagnose_run.py',
             'cmd/json_envelope.py',
             'cmd/json_output.py',
             'cmd/rust_bridge.py',
             'cmd/suews_cli.py',
+            'cmd/summarise_output.py',
             'cmd/table_converter.py',
             'cmd/to_yaml.py',
             'cmd/validate_config.py',
             'cmd/schema_cli.py',
+        ],
+        [
+            'diagnostics/__init__.py',
+            'diagnostics/_checks.py',
+        ],
+        [
+            'metrics/__init__.py',
+            'metrics/_core.py',
         ],
         [
             'util/_UMEP2epw.py',

--- a/src/supy/metrics/__init__.py
+++ b/src/supy/metrics/__init__.py
@@ -1,0 +1,17 @@
+"""Lightweight metric helpers for SUEWS run / observation comparison.
+
+NaN-aware wrappers around numpy / pandas primitives. Public API:
+
+- :func:`rmse` -- root mean square error.
+- :func:`bias` -- signed mean bias (``mean(y_pred - y_true)``).
+- :func:`pearson_r` -- Pearson correlation coefficient.
+
+Each function aligns the inputs by their pandas index when both are
+``pd.Series`` (or coerces them to ``pd.Series``), drops pairs where
+either member is NaN, and raises ``ValueError`` if fewer than 3 valid
+pairs remain.
+"""
+
+from ._core import bias, pearson_r, rmse
+
+__all__ = ["bias", "pearson_r", "rmse"]

--- a/src/supy/metrics/_core.py
+++ b/src/supy/metrics/_core.py
@@ -1,0 +1,103 @@
+"""Lightweight metric helpers for SUEWS run / observation comparison.
+
+These are NaN-aware wrappers around numpy / pandas primitives. Public API:
+
+- ``rmse(y_true, y_pred) -> float``
+- ``bias(y_true, y_pred) -> float`` (signed, ``mean(y_pred - y_true)``)
+- ``pearson_r(y_true, y_pred) -> float``
+
+Each function aligns the inputs by their pandas index when both are
+``pd.Series`` (or coerces them to ``pd.Series``), drops pairs where either
+member is NaN, and raises ``ValueError`` if fewer than 3 valid pairs remain.
+The minimum-pair guard avoids silently returning a metric computed from
+two-or-fewer points (Pearson r is undefined for n<2 and unreliable for n<3).
+
+Pure dependency-free in the supy build (numpy / pandas already required).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["bias", "pearson_r", "rmse"]
+
+_MIN_VALID_PAIRS = 3
+
+
+def _coerce_pair(
+    y_true: pd.Series | np.ndarray | list,
+    y_pred: pd.Series | np.ndarray | list,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Align inputs and drop pairs where either side is NaN.
+
+    Parameters
+    ----------
+    y_true : pd.Series, np.ndarray, or list
+        Reference / observed values.
+    y_pred : pd.Series, np.ndarray, or list
+        Modelled / scenario values.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        ``(arr_true, arr_pred)`` with NaN pairs dropped.
+
+    Raises
+    ------
+    ValueError
+        If fewer than 3 finite pairs remain after alignment.
+    """
+    ser_true = y_true if isinstance(y_true, pd.Series) else pd.Series(y_true)
+    ser_pred = y_pred if isinstance(y_pred, pd.Series) else pd.Series(y_pred)
+    df_pair = pd.concat({"a": ser_true, "b": ser_pred}, axis=1, join="inner")
+    df_pair = df_pair.replace([np.inf, -np.inf], np.nan).dropna()
+    if len(df_pair) < _MIN_VALID_PAIRS:
+        raise ValueError(
+            f"Need at least {_MIN_VALID_PAIRS} non-NaN aligned pairs for a "
+            f"metric; got {len(df_pair)}."
+        )
+    return df_pair["a"].to_numpy(dtype=float), df_pair["b"].to_numpy(dtype=float)
+
+
+def rmse(
+    y_true: pd.Series | np.ndarray | list,
+    y_pred: pd.Series | np.ndarray | list,
+) -> float:
+    """Root mean square error between two aligned series.
+
+    NaN pairs are dropped before computation.
+    """
+    arr_true, arr_pred = _coerce_pair(y_true, y_pred)
+    return float(np.sqrt(np.mean((arr_pred - arr_true) ** 2)))
+
+
+def bias(
+    y_true: pd.Series | np.ndarray | list,
+    y_pred: pd.Series | np.ndarray | list,
+) -> float:
+    """Signed mean bias (``mean(y_pred - y_true)``).
+
+    NaN pairs are dropped before computation.
+    """
+    arr_true, arr_pred = _coerce_pair(y_true, y_pred)
+    return float(np.mean(arr_pred - arr_true))
+
+
+def pearson_r(
+    y_true: pd.Series | np.ndarray | list,
+    y_pred: pd.Series | np.ndarray | list,
+) -> float:
+    """Pearson correlation coefficient between two aligned series.
+
+    NaN pairs are dropped before computation. Returns ``nan`` if either
+    series has zero variance after pairing — undefined correlation rather
+    than a misleading number.
+    """
+    arr_true, arr_pred = _coerce_pair(y_true, y_pred)
+    # Exact-zero variance is the test we want here — corrcoef returns nan
+    # in that case anyway and we want to short-circuit deterministically.
+    if np.std(arr_true) == 0.0 or np.std(arr_pred) == 0.0:  # noqa: RUF069
+        return float("nan")
+    matrix = np.corrcoef(arr_true, arr_pred)
+    return float(matrix[0, 1])

--- a/test/cmd/test_agent_flow.py
+++ b/test/cmd/test_agent_flow.py
@@ -1,0 +1,200 @@
+"""End-to-end agent-flow demos for the gh#1361 wave-3 commands.
+
+Each test simulates one branch of a typical MCP / AI-agent decision tree
+that consumes the unified ``suews`` CLI envelope. The point is to
+demonstrate (and lock in) that ``status`` + ``data.recommendations`` +
+``data.per_variable`` are sufficient inputs for an agent to chain
+``diagnose`` -> ``summarise`` / ``compare`` without ever loading a
+DataFrame on its own.
+
+Tests invoke the **dispatcher** ``supy.cmd.suews_cli.cli`` rather than
+the per-command Click functions directly, so wiring at the
+``suews <subcommand>`` level is exercised here too — the same surface
+the future MCP server will call through.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.api
+
+
+def _make_run_dir(
+    base: Path,
+    name: str,
+    *,
+    seed: int = 1,
+    nan_fraction: float = 0.0,
+    n: int = 144,
+    bias_offset: float = 0.0,
+) -> Path:
+    """Synthetic run directory with provenance + parquet output.
+
+    Parameters
+    ----------
+    base : Path
+        Parent tmp_path.
+    name : str
+        Subdirectory name.
+    seed : int
+        RNG seed for reproducible per-variable ordering.
+    nan_fraction : float
+        Fraction of QH samples to set to NaN.
+    n : int
+        Number of synthetic timesteps (5-min cadence).
+    bias_offset : float
+        Additive offset applied to QH (used by the comparison demo to
+        guarantee a deterministic worst-bias variable).
+    """
+    run_dir = base / name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2024-06-01", periods=n, freq="5min", name="datetime")
+    qn = rng.normal(loc=200.0, scale=50.0, size=n)
+    qh = 0.4 * qn + rng.normal(scale=2.0, size=n) + bias_offset
+    qe = 0.3 * qn + rng.normal(scale=2.0, size=n)
+    qs = 0.2 * qn + rng.normal(scale=2.0, size=n)
+    qf = 0.1 * qn + rng.normal(scale=2.0, size=n)
+
+    if nan_fraction > 0.0:
+        n_nan = int(n * nan_fraction)
+        qh[:n_nan] = np.nan
+
+    df = pd.DataFrame(
+        {"QN": qn, "QH": qh, "QE": qe, "QS": qs, "QF": qf}, index=idx
+    )
+    df.to_parquet(run_dir / "df_output.parquet")
+    (run_dir / "provenance.json").write_text(
+        json.dumps({"command": "suews run --format json"}), encoding="utf-8"
+    )
+    return run_dir
+
+
+def _invoke(args: list[str]) -> dict:
+    """Invoke ``suews`` dispatcher and return the parsed envelope."""
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, args)
+    assert result.stdout, "expected envelope on stdout, got: %r" % result.output
+    return json.loads(result.stdout)
+
+
+def test_demo_1_happy_path_chains_diagnose_to_summarise(tmp_path: Path) -> None:
+    """Agent step 1: diagnose passes -> step 2: summarise the same run."""
+    run_dir = _make_run_dir(tmp_path, "happy")
+
+    # Step 1 — triage.
+    diag = _invoke(["diagnose", str(run_dir), "--format", "json"])
+    assert diag["status"] in {"success", "warning"}
+    assert diag["data"]["summary"]["n_fail"] == 0
+
+    # Step 2 — drill into descriptive stats. An agent would only reach
+    # this branch if step 1 did not return status="error".
+    summary = _invoke(["summarise", str(run_dir), "--format", "json"])
+    assert summary["status"] in {"success", "warning"}
+    list_names = {var["name"] for var in summary["data"]["variables"]}
+    assert {"QH", "QE", "QN"} <= list_names
+    for var in summary["data"]["variables"]:
+        if var["name"] in {"QH", "QE", "QN"}:
+            assert var["mean"] is not None and not np.isnan(var["mean"])
+
+
+def test_demo_2_warning_branch_exposes_structured_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Warning-severity check must surface a structured recommendation.
+
+    The agent contract: read ``data.recommendations`` to decide the next
+    step instead of NL-parsing the human-readable message.
+    """
+    run_dir = _make_run_dir(tmp_path, "noisy", nan_fraction=0.10)
+
+    diag = _invoke(["diagnose", str(run_dir), "--format", "json"])
+    assert diag["status"] == "warning"
+
+    list_names = {check["name"] for check in diag["data"]["checks"]}
+    assert "nan_proportion" in list_names
+
+    # The recommendation channel is what the agent reads next.
+    list_recs = diag["data"]["recommendations"]
+    assert any("forcing-file" in rec for rec in list_recs), (
+        "nan_proportion warning must surface the forcing-gap recommendation; "
+        "got %r" % list_recs
+    )
+
+
+def test_demo_3_error_short_circuits_agent(tmp_path: Path) -> None:
+    """An empty run dir yields status=error from BOTH diagnose and summarise.
+
+    Encodes the agent's "if status=error, stop" rule: the contract is
+    consistent across post-run commands so the agent never falls through
+    to a downstream command when an upstream one already failed.
+    """
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir(parents=True)
+
+    diag = _invoke(["diagnose", str(empty_dir), "--format", "json"])
+    assert diag["status"] == "error"
+    assert diag["errors"]
+
+    summary = _invoke(["summarise", str(empty_dir), "--format", "json"])
+    assert summary["status"] == "error"
+    assert summary["errors"]
+
+
+def test_demo_4_compare_drives_drill_down_into_summarise(tmp_path: Path) -> None:
+    """Agent picks the variable with worst bias from compare, drills into it.
+
+    The bias is engineered (``bias_offset=20`` on QH for run B only) so
+    the worst-biased variable is deterministically QH; the test then
+    asserts the agent's drill-down returns exactly QH from summarise.
+    """
+    run_a = _make_run_dir(tmp_path, "runA", seed=1)
+    # Identical seed for runB so QE/QN match exactly between the two runs;
+    # the bias_offset on QH guarantees QH is the worst variable.
+    run_b = _make_run_dir(tmp_path, "runB", seed=1, bias_offset=20.0)
+
+    cmp = _invoke([
+        "compare",
+        str(run_a),
+        str(run_b),
+        "--format",
+        "json",
+    ])
+    assert cmp["status"] in {"success", "warning"}
+
+    per_var = cmp["data"]["per_variable"]
+    assert {"QH", "QE", "QN"} <= set(per_var.keys())
+
+    # Agent picks the worst-biased variable (deterministic given fixed seeds).
+    list_ranked = sorted(
+        per_var.items(),
+        key=lambda kv: (-abs(kv[1]["bias"]), kv[0]),
+    )
+    name_worst = list_ranked[0][0]
+    assert name_worst == "QH", (
+        "expected QH to be the worst-biased variable given the engineered "
+        "bias_offset, got ordering %r" % [k for k, _ in list_ranked]
+    )
+
+    # Agent drills into the worst variable on the scenario run.
+    summary = _invoke([
+        "summarise",
+        str(run_b),
+        "--variables",
+        name_worst,
+        "--format",
+        "json",
+    ])
+    assert summary["status"] in {"success", "warning"}
+    list_names = [var["name"] for var in summary["data"]["variables"]]
+    assert list_names == [name_worst]

--- a/test/cmd/test_agent_flow.py
+++ b/test/cmd/test_agent_flow.py
@@ -18,10 +18,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from click.testing import CliRunner
 import numpy as np
 import pandas as pd
 import pytest
-from click.testing import CliRunner
+
+from supy.cmd.suews_cli import cli
 
 pytestmark = pytest.mark.api
 
@@ -68,9 +70,7 @@ def _make_run_dir(
         n_nan = int(n * nan_fraction)
         qh[:n_nan] = np.nan
 
-    df = pd.DataFrame(
-        {"QN": qn, "QH": qh, "QE": qe, "QS": qs, "QF": qf}, index=idx
-    )
+    df = pd.DataFrame({"QN": qn, "QH": qh, "QE": qe, "QS": qs, "QF": qf}, index=idx)
     df.to_parquet(run_dir / "df_output.parquet")
     (run_dir / "provenance.json").write_text(
         json.dumps({"command": "suews run --format json"}), encoding="utf-8"
@@ -80,11 +80,9 @@ def _make_run_dir(
 
 def _invoke(args: list[str]) -> dict:
     """Invoke ``suews`` dispatcher and return the parsed envelope."""
-    from supy.cmd.suews_cli import cli
-
     runner = CliRunner()
     result = runner.invoke(cli, args)
-    assert result.stdout, "expected envelope on stdout, got: %r" % result.output
+    assert result.stdout, f"expected envelope on stdout, got: {result.output!r}"
     return json.loads(result.stdout)
 
 
@@ -128,7 +126,7 @@ def test_demo_2_warning_branch_exposes_structured_recommendations(
     list_recs = diag["data"]["recommendations"]
     assert any("forcing-file" in rec for rec in list_recs), (
         "nan_proportion warning must surface the forcing-gap recommendation; "
-        "got %r" % list_recs
+        f"got {list_recs!r}"
     )
 
 

--- a/test/cmd/test_compare_runs.py
+++ b/test/cmd/test_compare_runs.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from click.testing import CliRunner
 import numpy as np
 import pandas as pd
 import pytest
-from click.testing import CliRunner
+
+from supy.cmd.compare_runs import compare_runs_cmd
 
 pytestmark = pytest.mark.api
+
+
+def _suews_columns(names: list[str]) -> pd.MultiIndex:
+    return pd.MultiIndex.from_product([["SUEWS"], names], names=["group", "var"])
 
 
 def _build_run_dir(tmp_path: Path, name: str, seed: int = 1) -> Path:
@@ -34,8 +40,6 @@ def _build_run_dir(tmp_path: Path, name: str, seed: int = 1) -> Path:
 
 def test_compare_run_against_itself_zero_rmse(tmp_path: Path) -> None:
     """Comparing a run against itself: rmse=0, bias=0, r=1."""
-    from supy.cmd.compare_runs import compare_runs_cmd
-
     run_dir = _build_run_dir(tmp_path, "run01")
 
     runner = CliRunner()
@@ -59,8 +63,6 @@ def test_compare_run_against_itself_zero_rmse(tmp_path: Path) -> None:
 
 def test_compare_two_distinct_runs_has_overlap(tmp_path: Path) -> None:
     """Two independent runs sharing a time index must report joint overlap."""
-    from supy.cmd.compare_runs import compare_runs_cmd
-
     run_a = _build_run_dir(tmp_path, "runA", seed=1)
     run_b = _build_run_dir(tmp_path, "runB", seed=2)
 
@@ -79,8 +81,6 @@ def test_compare_two_distinct_runs_has_overlap(tmp_path: Path) -> None:
 
 def test_compare_unknown_metric_rejected(tmp_path: Path) -> None:
     """Passing an unknown metric must yield a structured error."""
-    from supy.cmd.compare_runs import compare_runs_cmd
-
     run_dir = _build_run_dir(tmp_path, "runX")
 
     runner = CliRunner()
@@ -99,3 +99,98 @@ def test_compare_unknown_metric_rejected(tmp_path: Path) -> None:
     envelope = json.loads(result.stdout)
     assert envelope["status"] == "error"
     assert "bogus" in envelope["errors"][0]["message"].lower()
+
+
+def test_compare_text_metric_subset_does_not_require_all_metrics(
+    tmp_path: Path,
+) -> None:
+    run_a = _build_run_dir(tmp_path, "subsetA", seed=1)
+    run_b = _build_run_dir(tmp_path, "subsetB", seed=1)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        compare_runs_cmd,
+        [
+            str(run_a),
+            str(run_b),
+            "--variables",
+            "QH",
+            "--metrics",
+            "rmse",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "rmse=" in result.output
+    assert "bias=" not in result.output
+    assert "r=" not in result.output
+
+
+def test_compare_reads_real_parquet_output_name_and_columns(tmp_path: Path) -> None:
+    idx = pd.MultiIndex.from_product(
+        [[1], pd.date_range("2024-06-01", periods=4, freq="h")],
+        names=["grid", "datetime"],
+    )
+
+    for name, offset in (("realA", 0.0), ("realB", 1.0)):
+        run_dir = tmp_path / name
+        run_dir.mkdir(parents=True)
+        df = pd.DataFrame(
+            np.array([
+                [10.0 + offset, 20.0, 30.0],
+                [11.0 + offset, 21.0, 31.0],
+                [12.0 + offset, 22.0, 32.0],
+                [13.0 + offset, 23.0, 33.0],
+            ]),
+            columns=_suews_columns(["QH", "QE", "QN"]),
+            index=idx,
+        )
+        df.to_parquet(run_dir / "SUEWS_output.parquet")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        compare_runs_cmd,
+        [
+            str(tmp_path / "realA"),
+            str(tmp_path / "realB"),
+            "--variables",
+            "QH",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    assert "QH" in envelope["data"]["per_variable"]
+    assert envelope["data"]["per_variable"]["QH"]["bias"] == pytest.approx(1.0)
+
+
+def test_compare_reads_legacy_text_run_outputs(tmp_path: Path) -> None:
+    for name, offset in (("txtA", 0.0), ("txtB", 2.0)):
+        run_dir = tmp_path / name
+        run_dir.mkdir(parents=True)
+        df = pd.DataFrame({
+            "datetime": pd.date_range("2024-06-01", periods=4, freq="h"),
+            "QH": [10.0 + offset, 11.0 + offset, 12.0 + offset, 13.0 + offset],
+            "QE": [20.0, 21.0, 22.0, 23.0],
+            "QN": [30.0, 31.0, 32.0, 33.0],
+        })
+        df.to_csv(run_dir / "Kc1_2024_SUEWS_60.txt", sep="\t", index=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        compare_runs_cmd,
+        [
+            str(tmp_path / "txtA"),
+            str(tmp_path / "txtB"),
+            "--variables",
+            "QH",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    assert envelope["data"]["per_variable"]["QH"]["bias"] == pytest.approx(2.0)

--- a/test/cmd/test_compare_runs.py
+++ b/test/cmd/test_compare_runs.py
@@ -1,0 +1,101 @@
+"""Tests for ``suews compare``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.api
+
+
+def _build_run_dir(tmp_path: Path, name: str, seed: int = 1) -> Path:
+    """Create a minimal run dir with a parquet output."""
+    run_dir = tmp_path / name
+    run_dir.mkdir(parents=True)
+    rng = np.random.default_rng(seed)
+    n = 144  # 12 hours at 5-min steps
+    idx = pd.date_range("2024-06-01", periods=n, freq="5min", name="datetime")
+    df = pd.DataFrame(
+        {
+            "QH": rng.normal(loc=80.0, scale=10.0, size=n),
+            "QE": rng.normal(loc=40.0, scale=5.0, size=n),
+            "QN": rng.normal(loc=200.0, scale=20.0, size=n),
+        },
+        index=idx,
+    )
+    df.to_parquet(run_dir / "df_output.parquet")
+    return run_dir
+
+
+def test_compare_run_against_itself_zero_rmse(tmp_path: Path) -> None:
+    """Comparing a run against itself: rmse=0, bias=0, r=1."""
+    from supy.cmd.compare_runs import compare_runs_cmd
+
+    run_dir = _build_run_dir(tmp_path, "run01")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        compare_runs_cmd,
+        [str(run_dir), str(run_dir), "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    assert envelope["status"] in {"success", "warning"}
+
+    per_var = envelope["data"]["per_variable"]
+    for var in ("QH", "QE", "QN"):
+        assert var in per_var
+        assert per_var[var]["rmse"] == pytest.approx(0.0, abs=1e-9)
+        assert per_var[var]["bias"] == pytest.approx(0.0, abs=1e-9)
+        # r is undefined when both inputs are identical and trivially
+        # constant; for non-constant identical series it is 1.
+        assert per_var[var]["r"] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_compare_two_distinct_runs_has_overlap(tmp_path: Path) -> None:
+    """Two independent runs sharing a time index must report joint overlap."""
+    from supy.cmd.compare_runs import compare_runs_cmd
+
+    run_a = _build_run_dir(tmp_path, "runA", seed=1)
+    run_b = _build_run_dir(tmp_path, "runB", seed=2)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        compare_runs_cmd,
+        [str(run_a), str(run_b), "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    overlap = envelope["data"]["time_axis_overlap"]
+    assert overlap["n"] > 0
+    assert overlap["start"] is not None
+    assert overlap["end"] is not None
+
+
+def test_compare_unknown_metric_rejected(tmp_path: Path) -> None:
+    """Passing an unknown metric must yield a structured error."""
+    from supy.cmd.compare_runs import compare_runs_cmd
+
+    run_dir = _build_run_dir(tmp_path, "runX")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        compare_runs_cmd,
+        [
+            str(run_dir),
+            str(run_dir),
+            "--metrics",
+            "rmse,bogus",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code != 0
+    envelope = json.loads(result.stdout)
+    assert envelope["status"] == "error"
+    assert "bogus" in envelope["errors"][0]["message"].lower()

--- a/test/cmd/test_diagnose_run.py
+++ b/test/cmd/test_diagnose_run.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from click.testing import CliRunner
 import numpy as np
 import pandas as pd
 import pytest
-from click.testing import CliRunner
+
+from supy.cmd.diagnose_run import diagnose_run_cmd
 
 pytestmark = pytest.mark.api
 
@@ -38,14 +40,10 @@ def _build_minimal_run_dir(tmp_path: Path) -> Path:
 
 def test_diagnose_returns_non_empty_check_list(tmp_path: Path) -> None:
     """A synthetic run dir must yield a non-empty checks payload."""
-    from supy.cmd.diagnose_run import diagnose_run_cmd
-
     run_dir = _build_minimal_run_dir(tmp_path)
 
     runner = CliRunner()
-    result = runner.invoke(
-        diagnose_run_cmd, [str(run_dir), "--format", "json"]
-    )
+    result = runner.invoke(diagnose_run_cmd, [str(run_dir), "--format", "json"])
     assert result.exit_code == 0, result.output
     envelope = json.loads(result.stdout)
 
@@ -63,20 +61,18 @@ def test_diagnose_returns_non_empty_check_list(tmp_path: Path) -> None:
         assert required in list_names
 
     summary = data["summary"]
-    assert summary["n_pass"] + summary["n_warn"] + summary["n_fail"] == len(data["checks"])
+    assert summary["n_pass"] + summary["n_warn"] + summary["n_fail"] == len(
+        data["checks"]
+    )
 
 
 def test_diagnose_missing_output_returns_error(tmp_path: Path) -> None:
     """A run dir with no output files must surface a fail-severity check."""
-    from supy.cmd.diagnose_run import diagnose_run_cmd
-
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir(parents=True)
 
     runner = CliRunner()
-    result = runner.invoke(
-        diagnose_run_cmd, [str(empty_dir), "--format", "json"]
-    )
+    result = runner.invoke(diagnose_run_cmd, [str(empty_dir), "--format", "json"])
     # Hard fail (no output) maps to envelope error per the CLI contract.
     assert result.exit_code == 0  # diagnose itself does not exit non-zero
     envelope = json.loads(result.stdout)
@@ -86,8 +82,6 @@ def test_diagnose_missing_output_returns_error(tmp_path: Path) -> None:
 
 def test_diagnose_text_mode(tmp_path: Path) -> None:
     """Text mode prints a human-readable summary."""
-    from supy.cmd.diagnose_run import diagnose_run_cmd
-
     run_dir = _build_minimal_run_dir(tmp_path)
 
     runner = CliRunner()
@@ -103,8 +97,6 @@ def test_diagnose_writes_sidecar(tmp_path: Path) -> None:
     a sidecar file alongside the run output so downstream tooling can
     consume the same payload without re-invoking the command.
     """
-    from supy.cmd.diagnose_run import diagnose_run_cmd
-
     run_dir = _build_minimal_run_dir(tmp_path)
 
     runner = CliRunner()
@@ -119,4 +111,22 @@ def test_diagnose_writes_sidecar(tmp_path: Path) -> None:
     assert isinstance(payload["checks"], list)
     assert len(payload["checks"]) >= 4
     assert "summary" in payload
-    assert payload["summary"]["n_pass"] + payload["summary"]["n_warn"] + payload["summary"]["n_fail"] == len(payload["checks"])
+    assert payload["summary"]["n_pass"] + payload["summary"]["n_warn"] + payload[
+        "summary"
+    ]["n_fail"] == len(payload["checks"])
+
+
+def test_diagnose_missing_provenance_recommendation_is_supported(
+    tmp_path: Path,
+) -> None:
+    run_dir = _build_minimal_run_dir(tmp_path)
+    (run_dir / "provenance.json").unlink()
+
+    runner = CliRunner()
+    result = runner.invoke(diagnose_run_cmd, [str(run_dir), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    recommendations = envelope["data"]["recommendations"]
+    assert any("provenance.json sidecar" in rec for rec in recommendations)
+    assert not any("--format json --output" in rec for rec in recommendations)

--- a/test/cmd/test_diagnose_run.py
+++ b/test/cmd/test_diagnose_run.py
@@ -1,0 +1,122 @@
+"""Tests for ``suews diagnose``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.api
+
+
+def _build_minimal_run_dir(tmp_path: Path) -> Path:
+    """Create a small synthetic run dir that satisfies the Phase-1 checks."""
+    run_dir = tmp_path / "fake_run"
+    run_dir.mkdir(parents=True)
+
+    n = 96  # one synthetic day at 15-min steps
+    rng = np.random.default_rng(seed=2026)
+    qn = rng.normal(loc=200.0, scale=50.0, size=n)
+    # Construct fluxes that close the energy balance to within ~5%.
+    qh = 0.4 * qn + rng.normal(scale=2.0, size=n)
+    qe = 0.3 * qn + rng.normal(scale=2.0, size=n)
+    qs = 0.2 * qn + rng.normal(scale=2.0, size=n)
+    qf = 0.1 * qn + rng.normal(scale=2.0, size=n)
+    df = pd.DataFrame({"QN": qn, "QH": qh, "QE": qe, "QS": qs, "QF": qf})
+    df.to_csv(run_dir / "df_output.csv", index=False)
+
+    (run_dir / "provenance.json").write_text(
+        json.dumps({"command": "suews run --format json"}, indent=2),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def test_diagnose_returns_non_empty_check_list(tmp_path: Path) -> None:
+    """A synthetic run dir must yield a non-empty checks payload."""
+    from supy.cmd.diagnose_run import diagnose_run_cmd
+
+    run_dir = _build_minimal_run_dir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        diagnose_run_cmd, [str(run_dir), "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+
+    data = envelope["data"]
+    assert data["run_dir"] == str(run_dir)
+    assert isinstance(data["checks"], list)
+    assert len(data["checks"]) >= 4
+    list_names = {check["name"] for check in data["checks"]}
+    for required in (
+        "provenance_present",
+        "output_files_present",
+        "nan_proportion",
+        "energy_balance_closure",
+    ):
+        assert required in list_names
+
+    summary = data["summary"]
+    assert summary["n_pass"] + summary["n_warn"] + summary["n_fail"] == len(data["checks"])
+
+
+def test_diagnose_missing_output_returns_error(tmp_path: Path) -> None:
+    """A run dir with no output files must surface a fail-severity check."""
+    from supy.cmd.diagnose_run import diagnose_run_cmd
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir(parents=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        diagnose_run_cmd, [str(empty_dir), "--format", "json"]
+    )
+    # Hard fail (no output) maps to envelope error per the CLI contract.
+    assert result.exit_code == 0  # diagnose itself does not exit non-zero
+    envelope = json.loads(result.stdout)
+    assert envelope["status"] == "error"
+    assert envelope["errors"]
+
+
+def test_diagnose_text_mode(tmp_path: Path) -> None:
+    """Text mode prints a human-readable summary."""
+    from supy.cmd.diagnose_run import diagnose_run_cmd
+
+    run_dir = _build_minimal_run_dir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(diagnose_run_cmd, [str(run_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Checks:" in result.output
+
+
+def test_diagnose_writes_sidecar(tmp_path: Path) -> None:
+    """`suews diagnose` must write a parseable diagnostics.json sidecar.
+
+    Acceptance criterion #2 from gh#1361: the diagnose subcommand writes
+    a sidecar file alongside the run output so downstream tooling can
+    consume the same payload without re-invoking the command.
+    """
+    from supy.cmd.diagnose_run import diagnose_run_cmd
+
+    run_dir = _build_minimal_run_dir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(diagnose_run_cmd, [str(run_dir), "--format", "json"])
+    assert result.exit_code == 0, result.output
+
+    path_sidecar = run_dir / "diagnostics.json"
+    assert path_sidecar.exists(), "diagnostics.json sidecar missing"
+
+    payload = json.loads(path_sidecar.read_text(encoding="utf-8"))
+    assert payload["run_dir"] == str(run_dir)
+    assert isinstance(payload["checks"], list)
+    assert len(payload["checks"]) >= 4
+    assert "summary" in payload
+    assert payload["summary"]["n_pass"] + payload["summary"]["n_warn"] + payload["summary"]["n_fail"] == len(payload["checks"])

--- a/test/cmd/test_diagnostics.py
+++ b/test/cmd/test_diagnostics.py
@@ -1,0 +1,159 @@
+"""Unit tests for ``supy.diagnostics`` check helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.api
+
+
+def _make_run_dir(
+    tmp_path: Path,
+    *,
+    with_provenance: bool = True,
+    with_output: bool = True,
+    nan_fraction: float = 0.0,
+    closure_offset: float = 0.0,
+    n: int = 96,
+) -> Path:
+    """Construct a synthetic run directory with controlled noise.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Test temp directory.
+    with_provenance : bool
+        Write provenance.json sidecar.
+    with_output : bool
+        Write df_output.csv.
+    nan_fraction : float
+        Inject this fraction of NaNs into QH.
+    closure_offset : float
+        Multiply QH/QE/QS/QF sum by ``(1 + closure_offset)`` so the energy
+        balance residual is non-trivial when nonzero.
+    n : int
+        Number of synthetic timesteps.
+    """
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(seed=1)
+    qn = rng.normal(loc=200.0, scale=10.0, size=n)
+    qh = 0.4 * qn
+    qe = 0.3 * qn
+    qs = 0.2 * qn
+    qf = 0.1 * qn
+
+    if closure_offset:
+        qh *= 1.0 + closure_offset
+
+    if nan_fraction > 0.0:
+        n_nan = int(n * nan_fraction)
+        qh[:n_nan] = np.nan
+
+    if with_output:
+        df = pd.DataFrame({"QN": qn, "QH": qh, "QE": qe, "QS": qs, "QF": qf})
+        df.to_csv(run_dir / "df_output.csv", index=False)
+
+    if with_provenance:
+        (run_dir / "provenance.json").write_text(
+            json.dumps({"command": "test"}), encoding="utf-8"
+        )
+
+    return run_dir
+
+
+def test_check_provenance_present_pass(tmp_path: Path) -> None:
+    from supy.diagnostics import check_provenance_present
+
+    run_dir = _make_run_dir(tmp_path, with_provenance=True)
+    res = check_provenance_present(run_dir)
+    assert res.passed
+    assert res.severity == "pass"
+    assert res.name == "provenance_present"
+
+
+def test_check_provenance_present_warning(tmp_path: Path) -> None:
+    from supy.diagnostics import check_provenance_present
+
+    run_dir = _make_run_dir(tmp_path, with_provenance=False)
+    res = check_provenance_present(run_dir)
+    assert not res.passed
+    assert res.severity == "warning"
+
+
+def test_check_output_files_present_pass(tmp_path: Path) -> None:
+    from supy.diagnostics import check_output_files_present
+
+    run_dir = _make_run_dir(tmp_path, with_output=True)
+    res = check_output_files_present(run_dir)
+    assert res.passed
+    assert res.severity == "pass"
+    assert res.details["files"]
+
+
+def test_check_output_files_present_fail(tmp_path: Path) -> None:
+    from supy.diagnostics import check_output_files_present
+
+    empty = tmp_path / "empty"
+    empty.mkdir(parents=True)
+    res = check_output_files_present(empty)
+    assert not res.passed
+    assert res.severity == "fail"
+
+
+def test_check_nan_proportion_pass(tmp_path: Path) -> None:
+    from supy.diagnostics import check_nan_proportion
+
+    run_dir = _make_run_dir(tmp_path, nan_fraction=0.0)
+    res = check_nan_proportion(run_dir)
+    assert res.passed
+    assert res.severity == "pass"
+
+
+def test_check_nan_proportion_warning(tmp_path: Path) -> None:
+    from supy.diagnostics import check_nan_proportion
+
+    run_dir = _make_run_dir(tmp_path, nan_fraction=0.10)
+    res = check_nan_proportion(run_dir)
+    assert not res.passed
+    assert res.severity == "warning"
+
+
+def test_check_energy_balance_closure_pass(tmp_path: Path) -> None:
+    from supy.diagnostics import check_energy_balance_closure
+
+    run_dir = _make_run_dir(tmp_path, closure_offset=0.0)
+    res = check_energy_balance_closure(run_dir)
+    assert res.passed
+    assert res.severity == "pass"
+
+
+def test_check_energy_balance_closure_warning(tmp_path: Path) -> None:
+    from supy.diagnostics import check_energy_balance_closure
+
+    # 80% offset on QH inflates the residual well beyond the 10% gate.
+    run_dir = _make_run_dir(tmp_path, closure_offset=0.8)
+    res = check_energy_balance_closure(run_dir)
+    assert not res.passed
+    assert res.severity == "warning"
+
+
+def test_check_run_aggregator_returns_all_checks(tmp_path: Path) -> None:
+    from supy.diagnostics import check_run
+
+    run_dir = _make_run_dir(tmp_path)
+    list_results = check_run(run_dir)
+    assert len(list_results) == 4
+    list_names = {res.name for res in list_results}
+    assert list_names == {
+        "provenance_present",
+        "output_files_present",
+        "nan_proportion",
+        "energy_balance_closure",
+    }

--- a/test/cmd/test_diagnostics.py
+++ b/test/cmd/test_diagnostics.py
@@ -9,7 +9,19 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from supy.diagnostics import (
+    check_energy_balance_closure,
+    check_nan_proportion,
+    check_output_files_present,
+    check_provenance_present,
+    check_run,
+)
+
 pytestmark = pytest.mark.api
+
+
+def _suews_columns(names: list[str]) -> pd.MultiIndex:
+    return pd.MultiIndex.from_product([["SUEWS"], names], names=["group", "var"])
 
 
 def _make_run_dir(
@@ -69,8 +81,6 @@ def _make_run_dir(
 
 
 def test_check_provenance_present_pass(tmp_path: Path) -> None:
-    from supy.diagnostics import check_provenance_present
-
     run_dir = _make_run_dir(tmp_path, with_provenance=True)
     res = check_provenance_present(run_dir)
     assert res.passed
@@ -79,8 +89,6 @@ def test_check_provenance_present_pass(tmp_path: Path) -> None:
 
 
 def test_check_provenance_present_warning(tmp_path: Path) -> None:
-    from supy.diagnostics import check_provenance_present
-
     run_dir = _make_run_dir(tmp_path, with_provenance=False)
     res = check_provenance_present(run_dir)
     assert not res.passed
@@ -88,8 +96,6 @@ def test_check_provenance_present_warning(tmp_path: Path) -> None:
 
 
 def test_check_output_files_present_pass(tmp_path: Path) -> None:
-    from supy.diagnostics import check_output_files_present
-
     run_dir = _make_run_dir(tmp_path, with_output=True)
     res = check_output_files_present(run_dir)
     assert res.passed
@@ -98,8 +104,6 @@ def test_check_output_files_present_pass(tmp_path: Path) -> None:
 
 
 def test_check_output_files_present_fail(tmp_path: Path) -> None:
-    from supy.diagnostics import check_output_files_present
-
     empty = tmp_path / "empty"
     empty.mkdir(parents=True)
     res = check_output_files_present(empty)
@@ -108,8 +112,6 @@ def test_check_output_files_present_fail(tmp_path: Path) -> None:
 
 
 def test_check_nan_proportion_pass(tmp_path: Path) -> None:
-    from supy.diagnostics import check_nan_proportion
-
     run_dir = _make_run_dir(tmp_path, nan_fraction=0.0)
     res = check_nan_proportion(run_dir)
     assert res.passed
@@ -117,8 +119,6 @@ def test_check_nan_proportion_pass(tmp_path: Path) -> None:
 
 
 def test_check_nan_proportion_warning(tmp_path: Path) -> None:
-    from supy.diagnostics import check_nan_proportion
-
     run_dir = _make_run_dir(tmp_path, nan_fraction=0.10)
     res = check_nan_proportion(run_dir)
     assert not res.passed
@@ -126,8 +126,6 @@ def test_check_nan_proportion_warning(tmp_path: Path) -> None:
 
 
 def test_check_energy_balance_closure_pass(tmp_path: Path) -> None:
-    from supy.diagnostics import check_energy_balance_closure
-
     run_dir = _make_run_dir(tmp_path, closure_offset=0.0)
     res = check_energy_balance_closure(run_dir)
     assert res.passed
@@ -135,8 +133,6 @@ def test_check_energy_balance_closure_pass(tmp_path: Path) -> None:
 
 
 def test_check_energy_balance_closure_warning(tmp_path: Path) -> None:
-    from supy.diagnostics import check_energy_balance_closure
-
     # 80% offset on QH inflates the residual well beyond the 10% gate.
     run_dir = _make_run_dir(tmp_path, closure_offset=0.8)
     res = check_energy_balance_closure(run_dir)
@@ -145,8 +141,6 @@ def test_check_energy_balance_closure_warning(tmp_path: Path) -> None:
 
 
 def test_check_run_aggregator_returns_all_checks(tmp_path: Path) -> None:
-    from supy.diagnostics import check_run
-
     run_dir = _make_run_dir(tmp_path)
     list_results = check_run(run_dir)
     assert len(list_results) == 4
@@ -157,3 +151,23 @@ def test_check_run_aggregator_returns_all_checks(tmp_path: Path) -> None:
         "nan_proportion",
         "energy_balance_closure",
     }
+
+
+def test_check_run_reads_real_parquet_output_name_and_columns(tmp_path: Path) -> None:
+    run_dir = tmp_path / "parquet-run"
+    run_dir.mkdir(parents=True)
+
+    qn = np.full(12, 200.0)
+    df = pd.DataFrame(
+        np.column_stack([qn, 0.4 * qn, 0.3 * qn, 0.2 * qn, 0.1 * qn]),
+        columns=_suews_columns(["QN", "QH", "QE", "QS", "QF"]),
+    )
+    df.to_parquet(run_dir / "SUEWS_output.parquet")
+    (run_dir / "provenance.json").write_text("{}", encoding="utf-8")
+
+    list_results = check_run(run_dir)
+    by_name = {res.name: res for res in list_results}
+
+    assert by_name["output_files_present"].passed
+    assert by_name["nan_proportion"].passed
+    assert by_name["energy_balance_closure"].passed

--- a/test/cmd/test_metrics.py
+++ b/test/cmd/test_metrics.py
@@ -1,0 +1,93 @@
+"""Unit tests for ``supy.metrics``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.api
+
+
+def test_rmse_identity_zero() -> None:
+    """RMSE of a series against itself is zero."""
+    from supy.metrics import rmse
+
+    ser = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert rmse(ser, ser) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_bias_identity_zero() -> None:
+    """Mean bias of a series against itself is zero."""
+    from supy.metrics import bias
+
+    ser = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert bias(ser, ser) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_pearson_r_identity_one() -> None:
+    """Pearson r of a non-constant series against itself is 1."""
+    from supy.metrics import pearson_r
+
+    ser = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert pearson_r(ser, ser) == pytest.approx(1.0, abs=1e-12)
+
+
+def test_rmse_known_value() -> None:
+    """RMSE of a constant offset matches the offset magnitude."""
+    from supy.metrics import rmse
+
+    arr_a = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+    arr_b = np.array([2.0, 2.0, 2.0, 2.0, 2.0])
+    assert rmse(arr_a, arr_b) == pytest.approx(2.0, abs=1e-12)
+
+
+def test_bias_known_value() -> None:
+    """Bias is signed; ``y_pred - y_true`` mean."""
+    from supy.metrics import bias
+
+    arr_a = np.array([0.0, 0.0, 0.0, 0.0])
+    arr_b = np.array([1.0, 2.0, 3.0, 4.0])
+    assert bias(arr_a, arr_b) == pytest.approx(2.5, abs=1e-12)
+
+
+def test_nan_pairs_dropped() -> None:
+    """NaN pairs are discarded before metric computation."""
+    from supy.metrics import bias, rmse
+
+    arr_a = np.array([1.0, np.nan, 3.0, 4.0, 5.0])
+    arr_b = np.array([1.0, 2.0, 3.0, np.nan, 5.0])
+    # Valid pairs: (1,1), (3,3), (5,5) -> rmse 0, bias 0.
+    assert rmse(arr_a, arr_b) == pytest.approx(0.0, abs=1e-12)
+    assert bias(arr_a, arr_b) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_too_few_pairs_raises() -> None:
+    """Fewer than 3 valid pairs must raise ValueError."""
+    from supy.metrics import rmse
+
+    arr_a = np.array([1.0, np.nan, np.nan, np.nan])
+    arr_b = np.array([1.0, 2.0, 3.0, 4.0])
+    with pytest.raises(ValueError, match="at least 3"):
+        rmse(arr_a, arr_b)
+
+
+def test_pearson_r_zero_variance_returns_nan() -> None:
+    """Pearson r with a flat predictor is undefined; return nan."""
+    from supy.metrics import pearson_r
+
+    arr_a = np.array([1.0, 2.0, 3.0, 4.0])
+    arr_b = np.array([5.0, 5.0, 5.0, 5.0])
+    result = pearson_r(arr_a, arr_b)
+    assert np.isnan(result)
+
+
+def test_index_alignment_for_pandas_series() -> None:
+    """Pandas series are joined on the inner intersection of their indices."""
+    from supy.metrics import rmse
+
+    ser_a = pd.Series([1.0, 2.0, 3.0], index=[0, 1, 2])
+    ser_b = pd.Series([1.0, 2.0, 3.0], index=[1, 2, 3])
+    # Inner join keeps indices 1 and 2 only -> 2 pairs, below the floor.
+    with pytest.raises(ValueError, match="at least 3"):
+        rmse(ser_a, ser_b)

--- a/test/cmd/test_metrics.py
+++ b/test/cmd/test_metrics.py
@@ -6,37 +6,31 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from supy.metrics import bias, pearson_r, rmse
+
 pytestmark = pytest.mark.api
 
 
 def test_rmse_identity_zero() -> None:
     """RMSE of a series against itself is zero."""
-    from supy.metrics import rmse
-
     ser = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
     assert rmse(ser, ser) == pytest.approx(0.0, abs=1e-12)
 
 
 def test_bias_identity_zero() -> None:
     """Mean bias of a series against itself is zero."""
-    from supy.metrics import bias
-
     ser = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
     assert bias(ser, ser) == pytest.approx(0.0, abs=1e-12)
 
 
 def test_pearson_r_identity_one() -> None:
     """Pearson r of a non-constant series against itself is 1."""
-    from supy.metrics import pearson_r
-
     ser = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
     assert pearson_r(ser, ser) == pytest.approx(1.0, abs=1e-12)
 
 
 def test_rmse_known_value() -> None:
     """RMSE of a constant offset matches the offset magnitude."""
-    from supy.metrics import rmse
-
     arr_a = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
     arr_b = np.array([2.0, 2.0, 2.0, 2.0, 2.0])
     assert rmse(arr_a, arr_b) == pytest.approx(2.0, abs=1e-12)
@@ -44,8 +38,6 @@ def test_rmse_known_value() -> None:
 
 def test_bias_known_value() -> None:
     """Bias is signed; ``y_pred - y_true`` mean."""
-    from supy.metrics import bias
-
     arr_a = np.array([0.0, 0.0, 0.0, 0.0])
     arr_b = np.array([1.0, 2.0, 3.0, 4.0])
     assert bias(arr_a, arr_b) == pytest.approx(2.5, abs=1e-12)
@@ -53,8 +45,6 @@ def test_bias_known_value() -> None:
 
 def test_nan_pairs_dropped() -> None:
     """NaN pairs are discarded before metric computation."""
-    from supy.metrics import bias, rmse
-
     arr_a = np.array([1.0, np.nan, 3.0, 4.0, 5.0])
     arr_b = np.array([1.0, 2.0, 3.0, np.nan, 5.0])
     # Valid pairs: (1,1), (3,3), (5,5) -> rmse 0, bias 0.
@@ -64,8 +54,6 @@ def test_nan_pairs_dropped() -> None:
 
 def test_too_few_pairs_raises() -> None:
     """Fewer than 3 valid pairs must raise ValueError."""
-    from supy.metrics import rmse
-
     arr_a = np.array([1.0, np.nan, np.nan, np.nan])
     arr_b = np.array([1.0, 2.0, 3.0, 4.0])
     with pytest.raises(ValueError, match="at least 3"):
@@ -74,8 +62,6 @@ def test_too_few_pairs_raises() -> None:
 
 def test_pearson_r_zero_variance_returns_nan() -> None:
     """Pearson r with a flat predictor is undefined; return nan."""
-    from supy.metrics import pearson_r
-
     arr_a = np.array([1.0, 2.0, 3.0, 4.0])
     arr_b = np.array([5.0, 5.0, 5.0, 5.0])
     result = pearson_r(arr_a, arr_b)
@@ -84,8 +70,6 @@ def test_pearson_r_zero_variance_returns_nan() -> None:
 
 def test_index_alignment_for_pandas_series() -> None:
     """Pandas series are joined on the inner intersection of their indices."""
-    from supy.metrics import rmse
-
     ser_a = pd.Series([1.0, 2.0, 3.0], index=[0, 1, 2])
     ser_b = pd.Series([1.0, 2.0, 3.0], index=[1, 2, 3])
     # Inner join keeps indices 1 and 2 only -> 2 pairs, below the floor.

--- a/test/cmd/test_summarise_output.py
+++ b/test/cmd/test_summarise_output.py
@@ -1,0 +1,84 @@
+"""Tests for ``suews summarise``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.api
+
+
+def _build_run_dir(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "run01"
+    run_dir.mkdir(parents=True)
+    n = 240
+    idx = pd.date_range("2024-06-01", periods=n, freq="h", name="datetime")
+    rng = np.random.default_rng(seed=42)
+    df = pd.DataFrame(
+        {
+            "QH": rng.normal(loc=70.0, scale=15.0, size=n),
+            "QE": rng.normal(loc=40.0, scale=10.0, size=n),
+            "QN": rng.normal(loc=180.0, scale=30.0, size=n),
+        },
+        index=idx,
+    )
+    df.to_csv(run_dir / "df_output.csv")
+    return run_dir
+
+
+def test_summarise_returns_non_nan_means(tmp_path: Path) -> None:
+    """Default invocation summarises every numeric column and gets non-NaN means."""
+    from supy.cmd.summarise_output import summarise_output_cmd
+
+    run_dir = _build_run_dir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        summarise_output_cmd, [str(run_dir), "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    assert envelope["status"] in {"success", "warning"}
+
+    data = envelope["data"]
+    assert data["run_dir"] == str(run_dir)
+    assert data["n_steps"] > 0
+    assert data["variables"], "variables list must be non-empty"
+    list_names = {var["name"] for var in data["variables"]}
+    assert {"QH", "QE", "QN"} <= list_names
+    for var in data["variables"]:
+        assert var["mean"] is not None, "mean should be defined for synthetic data"
+        assert not np.isnan(var["mean"])
+
+
+def test_summarise_with_explicit_variables(tmp_path: Path) -> None:
+    """Restricting --variables narrows the summary to those columns."""
+    from supy.cmd.summarise_output import summarise_output_cmd
+
+    run_dir = _build_run_dir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        summarise_output_cmd,
+        [str(run_dir), "--variables", "QH,QE", "--format", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    list_names = {var["name"] for var in envelope["data"]["variables"]}
+    assert list_names == {"QH", "QE"}
+
+
+def test_summarise_text_format(tmp_path: Path) -> None:
+    from supy.cmd.summarise_output import summarise_output_cmd
+
+    run_dir = _build_run_dir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(summarise_output_cmd, [str(run_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Variable summary" in result.output

--- a/test/cmd/test_summarise_output.py
+++ b/test/cmd/test_summarise_output.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from click.testing import CliRunner
 import numpy as np
 import pandas as pd
 import pytest
-from click.testing import CliRunner
+
+from supy.cmd.summarise_output import summarise_output_cmd
 
 pytestmark = pytest.mark.api
+
+
+def _suews_columns(names: list[str]) -> pd.MultiIndex:
+    return pd.MultiIndex.from_product([["SUEWS"], names], names=["group", "var"])
 
 
 def _build_run_dir(tmp_path: Path) -> Path:
@@ -33,14 +39,10 @@ def _build_run_dir(tmp_path: Path) -> Path:
 
 def test_summarise_returns_non_nan_means(tmp_path: Path) -> None:
     """Default invocation summarises every numeric column and gets non-NaN means."""
-    from supy.cmd.summarise_output import summarise_output_cmd
-
     run_dir = _build_run_dir(tmp_path)
 
     runner = CliRunner()
-    result = runner.invoke(
-        summarise_output_cmd, [str(run_dir), "--format", "json"]
-    )
+    result = runner.invoke(summarise_output_cmd, [str(run_dir), "--format", "json"])
     assert result.exit_code == 0, result.output
     envelope = json.loads(result.stdout)
     assert envelope["status"] in {"success", "warning"}
@@ -58,8 +60,6 @@ def test_summarise_returns_non_nan_means(tmp_path: Path) -> None:
 
 def test_summarise_with_explicit_variables(tmp_path: Path) -> None:
     """Restricting --variables narrows the summary to those columns."""
-    from supy.cmd.summarise_output import summarise_output_cmd
-
     run_dir = _build_run_dir(tmp_path)
 
     runner = CliRunner()
@@ -74,11 +74,41 @@ def test_summarise_with_explicit_variables(tmp_path: Path) -> None:
 
 
 def test_summarise_text_format(tmp_path: Path) -> None:
-    from supy.cmd.summarise_output import summarise_output_cmd
-
     run_dir = _build_run_dir(tmp_path)
 
     runner = CliRunner()
     result = runner.invoke(summarise_output_cmd, [str(run_dir)])
     assert result.exit_code == 0, result.output
     assert "Variable summary" in result.output
+
+
+def test_summarise_reads_real_parquet_output_name_and_columns(tmp_path: Path) -> None:
+    run_dir = tmp_path / "parquet-run"
+    run_dir.mkdir(parents=True)
+    idx = pd.MultiIndex.from_product(
+        [[1], pd.date_range("2024-06-01", periods=4, freq="h")],
+        names=["grid", "datetime"],
+    )
+    df = pd.DataFrame(
+        np.array([
+            [10.0, 20.0, 30.0],
+            [11.0, 21.0, 31.0],
+            [12.0, 22.0, 32.0],
+            [13.0, 23.0, 33.0],
+        ]),
+        columns=_suews_columns(["QH", "QE", "QN"]),
+        index=idx,
+    )
+    df.to_parquet(run_dir / "SUEWS_output.parquet")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        summarise_output_cmd,
+        [str(run_dir), "--variables", "QH", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.stdout)
+    variables = envelope["data"]["variables"]
+    assert [var["name"] for var in variables] == ["QH"]
+    assert variables[0]["mean"] == pytest.approx(11.5)


### PR DESCRIPTION
## Summary

Wave-3 post-run triage commands of the canonical AI architecture (#1355). Adds three new subcommands to the unified `suews` CLI plus their backing helper modules:

- **`supy.diagnostics`** — Phase-1 checks (`provenance_present`, `output_files_present`, `nan_proportion`, `energy_balance_closure`) with a `check_run` aggregator.
- **`supy.metrics`** — NaN-aware `rmse`, `bias`, `pearson_r` with a 3-pair floor.
- **`suews summarise`** — per-variable mean / min / max / NaN-pct.
- **`suews compare`** — per-variable RMSE / bias / r with time-axis overlap.
- **`suews diagnose`** — runs the Phase-1 checks and emits both the JSON envelope and a `diagnostics.json` sidecar (degrades to a warning on read-only mounts).

All three commands re-use the JSON envelope contract from gh#1368 and never reimplement physics, schema, or run logic. Tests cover each backing module and subcommand, plus a dedicated `test_agent_flow.py` that simulates four canonical MCP-agent decision branches against the dispatcher (happy-path triage chained into summarise, warning branch on structured `recommendations`, error short-circuit consistency across commands, and a comparison-driven drill-down).

Resolves #1361. Part of #1355.

## Test plan

- [x] `python -m pytest test/cmd/test_metrics.py test/cmd/test_diagnostics.py test/cmd/test_summarise_output.py test/cmd/test_compare_runs.py test/cmd/test_diagnose_run.py test/cmd/test_agent_flow.py` — 32 passed
- [x] `make test-smoke` — 8 passed, 0 regressions
- [x] Shell agent flow on a synthetic run dir: `suews diagnose` -> `success` (4 pass / 0 warn / 0 fail), sidecar written, `summarise QH` returns finite stats, self-compare returns `rmse=0 bias=0 r=1`, text mode prints four `[PASS]` lines.