### PR TITLE
build: fix docs extra resolution for Python 3.9/3.10

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -203,6 +203,7 @@ jobs:
         if: steps.detect.outputs.docs_changed == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
+          # Documentation tooling requires Python 3.11+; runtime support remains 3.9+.
           python-version: "3.13"
 
       - name: Install supy and build docs

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
+          # Documentation tooling requires Python 3.11+; runtime support remains 3.9+.
           python-version: '3.13'
 
       - name: Install uv

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,11 @@ docs-setup:
 		echo ""; \
 		exit 1; \
 	fi
+	@$(PYTHON) -c "import sys; sys.exit(sys.version_info < (3, 11))" || { \
+		echo "ERROR: Documentation tooling requires Python 3.11 or newer."; \
+		echo "Runtime support remains Python 3.9+."; \
+		exit 1; \
+	}
 	@TMP_REQ=$$(mktemp "$${TMPDIR:-/tmp}/suews-docs.XXXXXX" 2>/dev/null || mktemp -t suews-docs); \
 	trap 'rm -f "$$TMP_REQ"' EXIT; \
 	$(PYTHON) scripts/security/export_pyproject_requirements.py --extra docs > "$$TMP_REQ"; \

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,6 +140,9 @@ The build system automatically:
 
 ### Dependencies
 Python dependencies specified in `pyproject.toml`.
+Runtime installs support Python 3.9 and newer. Documentation tooling requires
+Python 3.11 or newer because current Sphinx extension versions, including
+`sphinx-design>=0.7.0`, do not support Python 3.9/3.10.
 Recommended local setup:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,9 @@ dev = [
     "ipykernel",
 ]
 
-# Documentation tooling (isolated from the default dev environment)
+# Documentation tooling (isolated from the default dev environment).
+# Runtime support remains Python 3.9+; documentation builds require Python 3.11+
+# because current Sphinx extension versions, notably sphinx-design 0.7+, do.
 docs = [
     # Documentation - Essential only (based on conf.py usage)
     "sphinx>=7,<9",
@@ -116,7 +118,8 @@ docs = [
     "sphinx-book-theme",        # Active theme in conf.py
     "pybtex",                   # Bibliography processing
     "sphinxcontrib-bibtex>=2.6,<3", # Bibliography support (heavily customised)
-    "sphinx-design>=0.7.0",     # Collapsible sections for YAML config docs (>=0.7 supports Sphinx 8)
+    # Collapsible sections for YAML config docs (>=0.7 supports Sphinx 8)
+    "sphinx-design>=0.7.0; python_version >= '3.11'",
     "sphinx-last-updated-by-git", # Git info in docs
     "sphinx-click",             # CLI documentation
     "sphinx-gallery>=0.16.0",   # Gallery examples from Python scripts (GH-1029)


### PR DESCRIPTION
Gates `sphinx-design>=0.7.0` on `python_version >= '3.11'` so the `docs` extra resolves cleanly on 3.9/3.10 runtime installs, while documentation builds still require 3.11+. Documents the runtime-vs-docs Python split in `pyproject.toml` and `docs/README.md`, pins the docs-sync and pages-deploy workflows' Python comment to clarify the constraint, and adds a `make docs-setup` guard that fails fast when invoked on an older interpreter.

Fixes #1385