### PR TITLE
feat(supy): warn on first attribute access for procedural API (gh#1370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ EXAMPLES:
 
 ## 2026
 
+### 1 May 2026
+
+- [change][experimental] Surface procedural-API deprecation warnings on first attribute access (#1370)
+  - `supy.__getattr__` now routes every name in `_FUNCTIONAL_DEPRECATIONS` through `_warn_functional_deprecation` on first resolution, so users who hold a reference (`from supy import run_supy`) see the `FutureWarning` immediately rather than only at call time; subsequent accesses hit `_lazy_cache` and stay silent
+  - The in-body `_warn_functional_deprecation` calls inside each procedural function remain as a safety net for code that bypasses `__getattr__` (e.g. `from supy._supy_module import run_supy`)
+  - Added `test/core/test_deprecation_visibility.py` with subprocess-isolated parametrised checks for every key in `_FUNCTIONAL_DEPRECATIONS` plus a router-vs-registry equality guard
+  - Continues phase 2 of #1370 (visibility); does not yet address the user-facing notebook/README audit (slice B) or the phase 3 removal-release timeline
+
 ### 30 Apr 2026
 
 - [feature][experimental] Packaged SUEWS as a first-class plugin in the Claude Code and Codex AI-agent ecosystems via the open Agent Skills standard (#1363)

--- a/src/supy/__init__.py
+++ b/src/supy/__init__.py
@@ -66,6 +66,25 @@ __all__ = [
 # Cache for lazy-loaded modules and attributes
 _lazy_cache = {}
 
+# Procedural-API names that must emit a one-shot FutureWarning on first
+# attribute access (gh#1370 phase 2 — visibility). Kept in sync with
+# `supy._supy_module._FUNCTIONAL_DEPRECATIONS`; a regression test asserts
+# the two are equal so a future addition cannot drift silently. Hard-coded
+# here so the lazy-import router does not need to load `_supy_module` on
+# every attribute miss — that would defeat fast CLI startup.
+_DEPRECATED_FUNCTIONAL_NAMES = frozenset({
+    "init_supy",
+    "load_forcing_grid",
+    "load_sample_data",
+    "load_SampleData",
+    "load_config_from_df",
+    "run_supy",
+    "run_supy_sample",
+    "save_supy",
+    "init_config",
+    "resample_output",
+})
+
 
 def __getattr__(name):
     """Lazy attribute loader - defers heavy imports until actually needed.
@@ -75,31 +94,24 @@ def __getattr__(name):
     if name in _lazy_cache:
         return _lazy_cache[name]
 
-    # Core functions from _supy_module
-    if name in {
-        "init_supy",
-        "load_SampleData",
-        "load_sample_data",
-        "load_forcing_grid",
-        "load_config_from_df",
-        "run_supy",
-        "save_supy",
-        "check_forcing",
-        "check_state",
-        "init_config",
-        "run_supy_sample",
-    }:
+    # Procedural API: emit a one-shot FutureWarning on first attribute access
+    # so users importing the symbol see the migration nudge immediately rather
+    # than only when the function is called (gh#1370 phase 2). Subsequent
+    # accesses hit `_lazy_cache` and stay silent. The in-body
+    # `_warn_functional_deprecation` calls inside each function definition
+    # remain as a safety net for code that bypasses `__getattr__`.
+    if name in _DEPRECATED_FUNCTIONAL_NAMES:
         from . import _supy_module
 
+        _supy_module._warn_functional_deprecation(name)
         _lazy_cache[name] = getattr(_supy_module, name)
         return _lazy_cache[name]
 
-    # resample_output - deprecated, use SUEWSOutput.resample() instead
-    if name == "resample_output":
-        from ._supy_module import _warn_functional_deprecation, resample_output
+    # Non-deprecated `_supy_module` exports (utilities — keep silent)
+    if name in {"check_forcing", "check_state"}:
+        from . import _supy_module
 
-        _warn_functional_deprecation("resample_output")
-        _lazy_cache[name] = resample_output
+        _lazy_cache[name] = getattr(_supy_module, name)
         return _lazy_cache[name]
 
     # Submodules

--- a/test/core/test_deprecation_visibility.py
+++ b/test/core/test_deprecation_visibility.py
@@ -1,0 +1,171 @@
+"""Import-time visibility tests for the procedural-API deprecation (gh#1370).
+
+The procedural top-level API (``run_supy``, ``init_supy``, ...) is being
+phased out in favour of ``SUEWSSimulation``. Phase 1 added an in-body
+``_warn_functional_deprecation`` call to each function so that *calling*
+the function emits a ``FutureWarning``. This test guards Phase 2 of the
+plan: the lazy ``__getattr__`` in ``supy/__init__.py`` must also emit the
+warning on the first attribute access, so users who hold a reference but
+defer the call still see the migration nudge.
+
+The tests run in subprocesses on purpose. ``test/conftest.py`` monkey-patches
+the public functions to private implementations during ``pytest_configure``,
+which both populates ``supy.__dict__`` (bypassing ``__getattr__`` entirely)
+and would consume the import-time warning before any in-process test could
+observe it. A clean subprocess gives us the user-visible behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = pytest.mark.api
+
+
+def _run_visibility_probe(name: str) -> dict:
+    """Spawn a fresh interpreter and return the warning trace for `name`.
+
+    The probe:
+
+    1. imports ``supy`` (does not trigger ``__getattr__`` for `name`),
+    2. resolves the attribute twice through ``getattr``,
+    3. dumps the captured warnings to stdout as JSON.
+
+    Subprocess isolation guarantees a clean module cache and a clean
+    warning filter, neither of which can be enforced from inside the
+    pytest run because of ``conftest.py`` monkey-patching.
+    """
+    probe = textwrap.dedent(
+        f"""
+        import json, sys, warnings
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as caught_first:
+            warnings.simplefilter("always")
+            import supy
+            getattr(supy, {name!r})
+        with warnings.catch_warnings(record=True) as caught_second:
+            warnings.simplefilter("always")
+            getattr(supy, {name!r})
+
+        def _serialise(records):
+            return [
+                {{"category": w.category.__name__, "message": str(w.message)}}
+                for w in records
+            ]
+
+        json.dump(
+            {{"first": _serialise(caught_first), "second": _serialise(caught_second)}},
+            sys.stdout,
+        )
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _registry_keys() -> list[str]:
+    """Read `_FUNCTIONAL_DEPRECATIONS` from a fresh subprocess.
+
+    Reading it in-process would import `_supy_module` and surface the
+    monkey-patched module under conftest, which we want to avoid.
+    """
+    probe = textwrap.dedent(
+        """
+        import json, sys
+        from supy._supy_module import _FUNCTIONAL_DEPRECATIONS
+        json.dump(sorted(_FUNCTIONAL_DEPRECATIONS.keys()), sys.stdout)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+# Resolved at collection time so failures show one parametrised case per
+# deprecated name rather than collapsing into a single opaque assertion.
+_DEPRECATED_NAMES = _registry_keys()
+
+
+@pytest.mark.core
+def test_router_set_matches_registry():
+    """`_DEPRECATED_FUNCTIONAL_NAMES` in `__init__.py` must equal the registry.
+
+    The router hard-codes the deprecated-name set so the lazy path stays
+    fast (no `_supy_module` import on every attribute miss). This test
+    guards against the two drifting silently when a future PR adds a new
+    deprecated symbol but forgets to wire the router.
+    """
+    probe = textwrap.dedent(
+        """
+        import json, sys
+        from supy import _DEPRECATED_FUNCTIONAL_NAMES
+        from supy._supy_module import _FUNCTIONAL_DEPRECATIONS
+        json.dump(
+            {
+                "router": sorted(_DEPRECATED_FUNCTIONAL_NAMES),
+                "registry": sorted(_FUNCTIONAL_DEPRECATIONS.keys()),
+            },
+            sys.stdout,
+        )
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["router"] == payload["registry"], (
+        "supy.__init__._DEPRECATED_FUNCTIONAL_NAMES has drifted from "
+        "_supy_module._FUNCTIONAL_DEPRECATIONS — "
+        f"router={payload['router']} registry={payload['registry']}"
+    )
+
+
+@pytest.mark.core
+@pytest.mark.parametrize("name", _DEPRECATED_NAMES)
+def test_first_access_emits_future_warning(name):
+    """First `getattr(supy, name)` must emit one FutureWarning naming the symbol."""
+    trace = _run_visibility_probe(name)
+    future_warnings_first = [
+        record
+        for record in trace["first"]
+        if record["category"] == "FutureWarning"
+        and "deprecated" in record["message"].lower()
+        and name in record["message"]
+    ]
+    assert len(future_warnings_first) == 1, (
+        f"Expected exactly one FutureWarning for first access of supy.{name}; "
+        f"got {trace['first']}"
+    )
+
+
+@pytest.mark.core
+@pytest.mark.parametrize("name", _DEPRECATED_NAMES)
+def test_second_access_is_silent(name):
+    """Second `getattr` must hit `_lazy_cache` and emit no new warning."""
+    trace = _run_visibility_probe(name)
+    future_warnings_second = [
+        record
+        for record in trace["second"]
+        if record["category"] == "FutureWarning"
+    ]
+    assert future_warnings_second == [], (
+        f"Second access of supy.{name} re-emitted FutureWarning(s); "
+        f"cache should suppress: {trace['second']}"
+    )


### PR DESCRIPTION
## Summary

Slice A of #1370 (visibility plumbing). The lazy `__getattr__` in
`src/supy/__init__.py` now routes every name in `_FUNCTIONAL_DEPRECATIONS`
through `_warn_functional_deprecation` on first attribute access, so a user
who imports a procedural-API symbol but defers the call (`from supy import
run_supy`) sees the migration nudge immediately instead of only at call
time. Subsequent accesses hit `_lazy_cache` and stay silent; the in-body
warnings inside each function definition remain as a safety net for code
that bypasses `__getattr__` (e.g. `from supy._supy_module import run_supy`).

Before this PR, only `resample_output` warned at attribute access — the
other nine procedural names (`init_supy`, `load_sample_data`,
`load_SampleData`, `load_forcing_grid`, `load_config_from_df`, `run_supy`,
`run_supy_sample`, `save_supy`, `init_config`) were silent until called.

`_DEPRECATED_FUNCTIONAL_NAMES` is hard-coded in `__init__.py` so the lazy
router does not need to import `_supy_module` on every attribute miss
(that would defeat fast CLI startup); a parametrised regression test
asserts the local set stays equal to `_FUNCTIONAL_DEPRECATIONS.keys()`
in `_supy_module`.

## Out of scope (deliberately deferred)

- **Slice B** — user-facing surface audit (notebooks, README, sub-tutorials, `core-functions.rst` examples) and the procedural ↔ OOP migration cookbook page. Will be a follow-up PR.
- **Slice C** — Phase 3 removal: concrete target release in `_FUNCTIONAL_DEPRECATIONS`, `serial_mode=` coordination with #1365, and migrating the ~163 procedural test references. Decision-heavy; will be a separate tracking-issue update plus its own PR.

## Test plan

- [x] `pytest test/core/test_deprecation_visibility.py -v` — 21/21 pass (router-vs-registry guard + per-name first-access-warns / second-access-silent for every key in the registry, all in subprocess-isolated probes that bypass conftest monkey-patching)
- [x] `make test-smoke` — 8/8 pass, no regression
- [x] `pytest test/core/test_public_api_wrappers.py -v` — 15/15 pass, existing call-time wrapper tests unaffected
- [x] `ruff check test/core/test_deprecation_visibility.py` — clean
- [x] `ruff check src/supy/__init__.py` — adds 1 finding (`RUF067` for the new `_DEPRECATED_FUNCTIONAL_NAMES` constant); same systemic exception as the pre-existing `_lazy_cache` constant. `PLC0415` count unchanged.
- [x] Manual: `python -c "import supy; supy.run_supy"` writes the migration nudge to stderr from a fresh interpreter.