### PR TITLE
feat(validator): structured per-phase machine-readable output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ EXAMPLES:
 
 ### 1 May 2026
 
+- [feature][experimental] Validator pipeline now emits a structured machine-readable `PhaseReport` for every phase
+  - Added a canonical `Issue` / `PhaseReport` / `ValidationReport` schema in `src/supy/data_model/validation/pipeline/report_schema.py` so Phase A (structure), Phase B (physics), and Phase C (Pydantic consistency) all return the same shape — `phase`, `severity`, `code`, `message`, `yaml_path`, `site_gridid`, `category`, `suggested_value`, `applied_fix`
+  - Each phase now writes a JSON sidecar (`<report>.json`) alongside the existing `<report>.txt`; downstream tooling (MCP, agents, CI) can consume the structured form without parsing the human-readable report
+  - Replaced brittle string-grep status checks (`"## ACTION NEEDED"`, `"CRITICAL ISSUES DETECTED"`, `"URGENT"`) in the orchestrator with `PhaseReport.has_errors`
+  - Phase B's existing internal `ValidationResult` dataclass is preserved and bridged via a new `to_issue()` adapter; `ScienceSuggestion` and `ScientificAdjustment` are surfaced as `B.SCIENCE.*` and `B.APPLIED_FIX.*` issues respectively
+  - Phase C sidesteps `SUEWSConfig.from_yaml`'s `ValueError` wrapping (which discards Pydantic's structured `errors()`) so `C.PYDANTIC.<TYPE>` issues survive into the JSON sidecar with GRIDID-friendly `yaml_path` strings
+  - Text reports are byte-for-byte unchanged — no breaking change for any downstream parser of the legacy human form
 - [change][experimental] Surface procedural-API deprecation warnings on first attribute access (#1370)
   - `supy.__getattr__` now routes every name in `_FUNCTIONAL_DEPRECATIONS` through `_warn_functional_deprecation` on first resolution, so users who hold a reference (`from supy import run_supy`) see the `FutureWarning` immediately rather than only at call time; subsequent accesses hit `_lazy_cache` and stay silent
   - The in-body `_warn_functional_deprecation` calls inside each procedural function remain as a safety net for code that bypasses `__getattr__` (e.g. `from supy._supy_module import run_supy`)

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -943,7 +943,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
 
     # Execute selected phases (logic mirrors orchestrator.main for consistency)
     if pipeline == "A":
-        ok = _processor_run_phase_a(
+        phase_a_report = _processor_run_phase_a(
             user_yaml_file,
             standard_yaml_file,
             uptodate_file,
@@ -953,6 +953,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             silent=True,
             forcing=forcing,
         )
+        ok = not phase_a_report.has_errors
         console.print(
             "[green]✓ Validation completed[/green]"
             if ok
@@ -970,7 +971,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         return 0 if ok else 1
 
     if pipeline == "B":
-        ok = _processor_run_phase_b(
+        phase_b_report = _processor_run_phase_b(
             user_yaml_file,
             user_yaml_file,
             standard_yaml_file,
@@ -983,6 +984,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             silent=True,
             science_fixes=science_fixes,
         )
+        ok = not phase_b_report.has_errors
         console.print(
             "[green]✓ Validation completed[/green]"
             if ok
@@ -1000,7 +1002,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         return 0 if ok else 1
 
     if pipeline == "C":
-        ok = _processor_run_phase_c(
+        phase_c_report = _processor_run_phase_c(
             user_yaml_file,
             pydantic_yaml_file,
             pydantic_report_file,
@@ -1008,6 +1010,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             phases_run=["C"],
             silent=True,
         )
+        ok = not phase_c_report.has_errors
         console.print(
             "[green]✓ Validation completed[/green]"
             if ok
@@ -1025,7 +1028,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         return 0 if ok else 1
 
     if pipeline == "AB":
-        a_ok = _processor_run_phase_a(
+        a_ok_report = _processor_run_phase_a(
             user_yaml_file,
             standard_yaml_file,
             uptodate_file,
@@ -1035,6 +1038,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             silent=True,
             forcing=forcing,
         )
+        a_ok = not a_ok_report.has_errors
         if not a_ok:
             # Phase A failed in AB workflow - create final user files from Phase A outputs
             final_yaml, final_report = _processor_create_final_user_files(
@@ -1045,7 +1049,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             console.print(f"Updated YAML: {final_yaml}")
             return 1
 
-        b_ok = _processor_run_phase_b(
+        b_ok_report = _processor_run_phase_b(
             user_yaml_file,
             uptodate_file,
             standard_yaml_file,
@@ -1058,6 +1062,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             silent=True,
             science_fixes=science_fixes,
         )
+        b_ok = not b_ok_report.has_errors
 
         if not b_ok:
             # Phase B failed in AB workflow - create final user files from Phase B error report and Phase A YAML
@@ -1138,7 +1143,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         return 0
 
     if pipeline == "AC":
-        a_ok = _processor_run_phase_a(
+        a_ok_report = _processor_run_phase_a(
             user_yaml_file,
             standard_yaml_file,
             uptodate_file,
@@ -1148,6 +1153,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             silent=True,
             forcing=forcing,
         )
+        a_ok = not a_ok_report.has_errors
         if not a_ok:
             # Phase A failed in AC workflow - create final user files from Phase A outputs
             final_yaml, final_report = _processor_create_final_user_files(
@@ -1158,7 +1164,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             console.print(f"Updated YAML: {final_yaml}")
             return 1
 
-        c_ok = _processor_run_phase_c(
+        c_ok_report = _processor_run_phase_c(
             uptodate_file,
             pydantic_yaml_file,
             pydantic_report_file,
@@ -1167,6 +1173,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             phases_run=["A", "C"],
             silent=True,
         )
+        c_ok = not c_ok_report.has_errors
 
         if not c_ok:
             # Phase C failed in AC workflow - create final user files from Phase C error report and Phase A YAML
@@ -1240,7 +1247,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         return 0
 
     if pipeline == "BC":
-        b_ok = _processor_run_phase_b(
+        b_ok_report = _processor_run_phase_b(
             user_yaml_file,
             user_yaml_file,
             standard_yaml_file,
@@ -1253,6 +1260,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             silent=True,
             science_fixes=science_fixes,
         )
+        b_ok = not b_ok_report.has_errors
         if not b_ok:
             # Phase B failed in BC workflow - create final user files from Phase B outputs
             import shutil
@@ -1281,7 +1289,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
                 console.print(f"Updated YAML: {final_yaml}")
             return 1
 
-        c_ok = _processor_run_phase_c(
+        c_ok_report = _processor_run_phase_c(
             science_yaml_file,
             pydantic_yaml_file,
             pydantic_report_file,
@@ -1289,6 +1297,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             phases_run=["B", "C"],
             silent=True,
         )
+        c_ok = not c_ok_report.has_errors
 
         if not c_ok:
             # Phase C failed in BC workflow - consolidate Phase B messages into Phase C error report
@@ -1402,7 +1411,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         return 0
 
     # Default: ABC
-    a_ok = _processor_run_phase_a(
+    a_ok_report = _processor_run_phase_a(
         user_yaml_file,
         standard_yaml_file,
         uptodate_file,
@@ -1412,6 +1421,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         silent=True,
         forcing=forcing,
     )
+    a_ok = not a_ok_report.has_errors
     if not a_ok:
         # Phase A failed in ABC - create final files from Phase A outputs
         if debug:
@@ -1438,7 +1448,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         console.print(f"Updated YAML: {pydantic_yaml_file}")
         return 1
 
-    b_ok = _processor_run_phase_b(
+    b_ok_report = _processor_run_phase_b(
         user_yaml_file,
         uptodate_file,
         standard_yaml_file,
@@ -1451,6 +1461,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         silent=True,
         science_fixes=science_fixes,
     )
+    b_ok = not b_ok_report.has_errors
 
     if not b_ok:
         # Phase B failed in ABC - create final files with mixed content
@@ -1531,7 +1542,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             all_no_action_messages.append(msg)
             seen_messages.add(msg)
 
-    c_ok = _processor_run_phase_c(
+    c_ok_report = _processor_run_phase_c(
         science_yaml_file,
         pydantic_yaml_file,
         pydantic_report_file,
@@ -1542,6 +1553,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         no_action_messages=all_no_action_messages,
         silent=True,
     )
+    c_ok = not c_ok_report.has_errors
 
     if not c_ok:
         # Phase C failed in ABC - create final files with mixed content

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -646,11 +646,22 @@ def run_phase_b(
     phase: str = "B",
     silent: bool = False,
     science_fixes: str = "suggest",
-) -> bool:
-    """Execute Phase B: physics validation and optional scientific fixes."""
+) -> "PhaseReport":
+    """Execute Phase B: physics validation and optional scientific fixes.
+
+    Returns the structured ``PhaseReport`` from this phase. Use
+    ``phase_report.has_errors`` to gate downstream work.
+    """
+    from .report_schema import (
+        Issue,
+        JSON_REPORT_WRITER,
+        PhaseReport,
+        SEVERITY_ERROR,
+    )
+
     try:
         with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
-            science_checked_data = run_science_check(
+            _, phase_report = run_science_check(
                 uptodate_yaml_file=uptodate_file,
                 user_yaml_file=user_yaml_file,
                 standard_yaml_file=standard_yaml_file,
@@ -662,52 +673,52 @@ def run_phase_b(
                 phase=phase,
                 science_fixes=science_fixes,
             )
+    except Exception as exc:
+        phase_report = PhaseReport(
+            phase="B",
+            issues=[Issue(
+                phase="B",
+                severity=SEVERITY_ERROR,
+                code="B.PIPELINE.EXCEPTION",
+                message=str(exc),
+            )],
+            yaml_in=uptodate_file,
+            yaml_out=science_yaml_file,
+            text_report_path=science_report_file,
+        )
 
-        # Check if Phase B produced output files
-        if not os.path.exists(science_yaml_file):
-            if not silent:
-                print()
-                print("[X] Validation failed - check report for details")
-            return False
+    # File existence checks remain — they catch IO failures the phase
+    # itself did not surface.
+    if not os.path.exists(science_report_file):
+        phase_report.issues.append(Issue(
+            phase="B",
+            severity=SEVERITY_ERROR,
+            code="B.PIPELINE.MISSING_REPORT",
+            message="Phase B did not produce the expected text report",
+        ))
+    if science_yaml_file and not os.path.exists(science_yaml_file) and not phase_report.has_errors:
+        phase_report.issues.append(Issue(
+            phase="B",
+            severity=SEVERITY_ERROR,
+            code="B.PIPELINE.MISSING_YAML",
+            message="Phase B did not produce the expected YAML output",
+        ))
 
-        if not os.path.exists(science_report_file):
-            if not silent:
-                print()
-                print("[X] Validation failed - unable to generate report")
-            return False
+    if science_report_file:
+        json_path = Path(science_report_file).with_suffix(".json")
+        JSON_REPORT_WRITER.write(json_path, phase_report)
+        phase_report.json_report_path = str(json_path)
 
-        # Check if Phase B report indicates critical issues
-        report_content = REPORT_WRITER.read(science_report_file)
-
-        if "CRITICAL ISSUES DETECTED" in report_content or "URGENT" in report_content:
-            if not silent:
-                print("[X] Validation failed!")
-                print(f"Report: {science_report_file}")
+    if not silent:
+        if phase_report.has_errors:
+            print("[X] Validation failed!")
+            print(f"Report: {science_report_file}")
+            if science_yaml_file:
                 print(f"Updated YAML: {science_yaml_file}")
-            return False
-
-        if not silent:
-            print("[OK] Phase B completed")
-        return True
-
-    except ValueError as e:
-        if "Critical scientific errors detected" in str(e):
-            # if not silent:
-            print("[X] Validation failed!")
-            print(f"Report: {science_report_file}")
-            print(f"Updated YAML: {science_yaml_file}")
-            return False
         else:
-            # if not silent:
-            print("[X] Validation failed!")
-            print(f"Report: {science_report_file}")
-            print(f"Updated YAML: {science_yaml_file}")
-            return False
-    except Exception as e:
-        # if not silent:
-        print()
-        print(f"[X] Validation failed with unexpected error: {e}")
-        return False
+            print("[OK] Phase B completed")
+
+    return phase_report
 
 
 def run_phase_c(
@@ -1398,7 +1409,7 @@ Modes:
             phase_a_report = None
 
             print("Physics validation check...")
-            phase_b_success = run_phase_b(
+            phase_b_report = run_phase_b(
                 user_yaml_file,
                 input_yaml_file,
                 standard_yaml_file,
@@ -1411,6 +1422,7 @@ Modes:
                 silent=True,  # Suppress phase function output, main function handles terminal output
                 science_fixes=science_fixes,
             )
+            phase_b_success = not phase_b_report.has_errors
 
             # Always create final user files with simple names
             final_yaml, final_report = create_final_user_files(
@@ -1500,7 +1512,7 @@ Modes:
 
             print("[OK] Validation completed")
             print("Physics validation check...")
-            phase_b_success = run_phase_b(
+            phase_b_report = run_phase_b(
                 user_yaml_file,
                 uptodate_file,
                 standard_yaml_file,
@@ -1513,6 +1525,7 @@ Modes:
                 silent=True,
                 science_fixes=science_fixes,
             )
+            phase_b_success = not phase_b_report.has_errors
 
             if not phase_b_success:
                 # Phase B failed in AB workflow - create final user files from Phase B error report and Phase A YAML
@@ -1696,7 +1709,7 @@ Modes:
         elif phase == "BC":
             # Complete B→C workflow
             print("Physics validation check...")
-            phase_b_success = run_phase_b(
+            phase_b_report = run_phase_b(
                 user_yaml_file,
                 user_yaml_file,  # Phase B runs directly on user YAML
                 standard_yaml_file,
@@ -1709,6 +1722,7 @@ Modes:
                 silent=True,
                 science_fixes=science_fixes,
             )
+            phase_b_success = not phase_b_report.has_errors
 
             if not phase_b_success:
                 # Phase B failed in BC workflow - preserve Phase B outputs as BC outputs (when Phase B passes, we have updated from B)
@@ -1893,7 +1907,7 @@ Modes:
 
             # Step 2: Run Phase B (A passed, try B)
             print("Physics validation check...")
-            phase_b_success = run_phase_b(
+            phase_b_report = run_phase_b(
                 user_yaml_file,
                 uptodate_file,
                 standard_yaml_file,
@@ -1906,6 +1920,7 @@ Modes:
                 silent=True,
                 science_fixes=science_fixes,
             )
+            phase_b_success = not phase_b_report.has_errors
 
             if not phase_b_success:
                 # Phase B failed in ABC workflow - create final files from Phase A (last successful phase)

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -649,8 +649,8 @@ def run_phase_a(
 
     if report_file:
         json_path = Path(report_file).with_suffix(".json")
-        JSON_REPORT_WRITER.write(json_path, phase_report)
         phase_report.json_report_path = str(json_path)
+        JSON_REPORT_WRITER.write(json_path, phase_report)
 
     if not silent:
         if phase_report.has_errors:
@@ -735,8 +735,8 @@ def run_phase_b(
 
     if science_report_file:
         json_path = Path(science_report_file).with_suffix(".json")
-        JSON_REPORT_WRITER.write(json_path, phase_report)
         phase_report.json_report_path = str(json_path)
+        JSON_REPORT_WRITER.write(json_path, phase_report)
 
     if not silent:
         if phase_report.has_errors:
@@ -812,8 +812,8 @@ def run_phase_c(
 
     if pydantic_report_file:
         json_path = Path(pydantic_report_file).with_suffix(".json")
-        JSON_REPORT_WRITER.write(json_path, phase_report)
         phase_report.json_report_path = str(json_path)
+        JSON_REPORT_WRITER.write(json_path, phase_report)
 
     return phase_report
 

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -573,17 +573,27 @@ def run_phase_a(
     phase: str = "A",
     silent: bool = False,
     forcing: str = "on",
-) -> bool:
-    """Execute Phase A: Configuration structure checks and parameter updates."""
+) -> "PhaseReport":
+    """Execute Phase A: Configuration structure checks and parameter updates.
+
+    Returns the structured ``PhaseReport`` from this phase. Use
+    ``phase_report.has_errors`` to gate downstream work.
+    """
+    from .report_schema import (
+        Issue,
+        JSON_REPORT_WRITER,
+        PhaseReport,
+        SEVERITY_ERROR,
+    )
+
     if not silent:
         print("Configuration structure check...")
 
-    # Detect nlayer from user YAML for dimension validation
     nlayer_value = detect_nlayer_from_user_yaml(user_yaml_file)
 
     try:
         with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
-            annotate_missing_parameters(
+            phase_report = annotate_missing_parameters(
                 user_file=user_yaml_file,
                 standard_file=standard_yaml_file,
                 uptodate_file=uptodate_file,
@@ -593,45 +603,64 @@ def run_phase_a(
                 nlayer=nlayer_value,
                 forcing=forcing,
             )
+    except Exception as exc:
+        phase_report = PhaseReport(
+            phase="A",
+            issues=[Issue(
+                phase="A",
+                severity=SEVERITY_ERROR,
+                code="A.PIPELINE.EXCEPTION",
+                message=str(exc),
+                category="PIPELINE",
+            )],
+            yaml_in=user_yaml_file,
+            yaml_out=uptodate_file,
+            text_report_path=report_file,
+        )
 
-        if not os.path.exists(uptodate_file):
-            if not silent:
-                print()
-                print("[X] Validation failed - check report for details")
-            return False
+    # File existence checks remain — they catch IO failures the phase
+    # itself did not surface.
+    if not os.path.exists(uptodate_file):
+        phase_report.issues.append(Issue(
+            phase="A",
+            severity=SEVERITY_ERROR,
+            code="A.PIPELINE.MISSING_YAML",
+            message="Phase A did not produce an updated YAML",
+            category="PIPELINE",
+        ))
+    elif not phase_report.has_errors:
+        with open(uptodate_file, "r", encoding="utf-8", errors="replace") as fh:
+            if "Updated YAML" not in fh.read():
+                phase_report.issues.append(Issue(
+                    phase="A",
+                    severity=SEVERITY_ERROR,
+                    code="A.PIPELINE.MALFORMED_YAML_HEADER",
+                    message="Updated YAML output missing expected header",
+                    category="PIPELINE",
+                ))
+    if not os.path.exists(report_file):
+        phase_report.issues.append(Issue(
+            phase="A",
+            severity=SEVERITY_ERROR,
+            code="A.PIPELINE.MISSING_REPORT",
+            message="Phase A did not produce a text report",
+            category="PIPELINE",
+        ))
 
-        if not os.path.exists(report_file):
-            if not silent:
-                print()
-                print("[X] Validation failed - unable to generate report")
-            return False
+    if report_file:
+        json_path = Path(report_file).with_suffix(".json")
+        JSON_REPORT_WRITER.write(json_path, phase_report)
+        phase_report.json_report_path = str(json_path)
 
-        with open(uptodate_file, "r", encoding="utf-8", errors="replace") as f:
-            content = f.read()
-            if "Updated YAML" not in content:
-                if not silent:
-                    print()
-                    print("[X] Validation failed - check report for details")
-                return False
-
-        report_content = REPORT_WRITER.read(report_file)
-
-        if "## ACTION NEEDED" in report_content:
-            if not silent:
-                print("[X] Validation failed!")
-                print(f"Report: {report_file}")
-                print(f"Updated YAML: {uptodate_file}")
-            return False
-
-        if not silent:
+    if not silent:
+        if phase_report.has_errors:
+            print("[X] Validation failed!")
+            print(f"Report: {report_file}")
+            print(f"Updated YAML: {uptodate_file}")
+        else:
             print("[OK] Validation completed")
-        return True
 
-    except Exception as e:
-        if not silent:
-            print()
-            print(f"[X] Validation failed with error: {e}")
-        return False
+    return phase_report
 
 
 def run_phase_b(
@@ -1378,7 +1407,7 @@ Modes:
         print(f"DEBUG: Executing phase '{phase}'")
         if phase == "A":
             # Phase A only
-            phase_a_success = run_phase_a(
+            phase_a_report = run_phase_a(
                 user_yaml_file,
                 standard_yaml_file,
                 uptodate_file,
@@ -1387,6 +1416,7 @@ Modes:
                 phase="A",
                 silent=True,  # Suppress phase function output, main function handles terminal output
             )
+            phase_a_success = not phase_a_report.has_errors
 
             # Always create final user files with simple names
             final_yaml, final_report = create_final_user_files(
@@ -1488,7 +1518,7 @@ Modes:
         elif phase == "AB":
             # Complete A→B workflow
             print("Configuration structure check...")
-            phase_a_success = run_phase_a(
+            phase_a_report = run_phase_a(
                 user_yaml_file,
                 standard_yaml_file,
                 uptodate_file,
@@ -1498,6 +1528,7 @@ Modes:
                 silent=True,
                 science_fixes=science_fixes,
             )
+            phase_a_success = not phase_a_report.has_errors
 
             if not phase_a_success:
                 # Phase A failed in AB workflow - create final user files from Phase A outputs
@@ -1599,7 +1630,7 @@ Modes:
         elif phase == "AC":
             # Complete A→C workflow
             print("Configuration structure check...")
-            phase_a_success = run_phase_a(
+            phase_a_report = run_phase_a(
                 user_yaml_file,
                 standard_yaml_file,
                 uptodate_file,
@@ -1608,6 +1639,7 @@ Modes:
                 phase="AC",
                 silent=True,
             )
+            phase_a_success = not phase_a_report.has_errors
 
             if not phase_a_success:
                 # Phase A failed in AC workflow - preserve Phase A outputs as AC outputs (when Phase A passes, we have updated from A)
@@ -1861,7 +1893,7 @@ Modes:
             # Step 1: Run Phase A
             print("DEBUG: Starting ABC workflow")
             print("Configuration structure check...")
-            phase_a_success = run_phase_a(
+            phase_a_report = run_phase_a(
                 user_yaml_file,
                 standard_yaml_file,
                 uptodate_file,
@@ -1871,6 +1903,7 @@ Modes:
                 silent=True,
                 science_fixes=science_fixes,
             )
+            phase_a_success = not phase_a_report.has_errors
 
             if not phase_a_success:
                 # Phase A failed in ABC workflow - preserve Phase A outputs as ABC outputs (when Phase A passes, we have updated from A)

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -760,8 +760,78 @@ def run_phase_c(
     phases_run: list = None,
     no_action_messages: list = None,
     silent: bool = False,
+) -> "PhaseReport":
+    """Execute Phase C and return the structured ``PhaseReport``.
+
+    The legacy bool-returning body (``_run_phase_c_legacy``) is preserved
+    intact so the human-readable text report it writes is byte-for-byte
+    unchanged. This wrapper additionally collects structured Pydantic
+    issues via ``collect_phase_c_issues`` and writes a JSON sidecar.
+    """
+    from .phase_c import collect_phase_c_issues
+    from .report_schema import (
+        Issue,
+        JSON_REPORT_WRITER,
+        PhaseReport,
+        SEVERITY_ERROR,
+    )
+
+    issues = collect_phase_c_issues(input_yaml_file)
+
+    legacy_ok = _run_phase_c_legacy(
+        input_yaml_file=input_yaml_file,
+        pydantic_yaml_file=pydantic_yaml_file,
+        pydantic_report_file=pydantic_report_file,
+        mode=mode,
+        phase_a_report_file=phase_a_report_file,
+        science_report_file=science_report_file,
+        phases_run=phases_run,
+        no_action_messages=no_action_messages,
+        silent=silent,
+    )
+
+    if not legacy_ok and not any(i.severity == SEVERITY_ERROR for i in issues):
+        # Legacy reported failure but no structured issue was captured —
+        # surface a generic pipeline failure so the JSON sidecar is
+        # still actionable.
+        issues.append(Issue(
+            phase="C",
+            severity=SEVERITY_ERROR,
+            code="C.PIPELINE.UNKNOWN",
+            message="Phase C reported failure with no structured details",
+            category="PIPELINE",
+        ))
+
+    phase_report = PhaseReport(
+        phase="C",
+        issues=issues,
+        yaml_in=input_yaml_file,
+        yaml_out=pydantic_yaml_file,
+        text_report_path=pydantic_report_file,
+    )
+
+    if pydantic_report_file:
+        json_path = Path(pydantic_report_file).with_suffix(".json")
+        JSON_REPORT_WRITER.write(json_path, phase_report)
+        phase_report.json_report_path = str(json_path)
+
+    return phase_report
+
+
+def _run_phase_c_legacy(
+    input_yaml_file: str,
+    pydantic_yaml_file: str,
+    pydantic_report_file: str,
+    mode: str = "public",
+    phase_a_report_file: str = None,
+    science_report_file: str = None,
+    phases_run: list = None,
+    no_action_messages: list = None,
+    silent: bool = False,
 ) -> bool:
-    """Execute Phase C: Configuration consistency validation based on physics options."""
+    """Legacy bool-returning Phase C body. Preserved for the text-report
+    generation. Callers should use ``run_phase_c`` (PhaseReport-returning).
+    """
     debug = os.environ.get("SUEWS_DEBUG", "").lower() in ("1", "true", "yes")
     if debug:
         print(f"[DEBUG] run_phase_c called", file=sys.stderr)
@@ -1482,7 +1552,7 @@ Modes:
             # Phase C only - run Pydantic validation on original user YAML
             print("Configuration consistency check...")
 
-            phase_c_success = run_phase_c(
+            phase_c_report = run_phase_c(
                 user_yaml_file,
                 pydantic_yaml_file,
                 pydantic_report_file,
@@ -1490,6 +1560,7 @@ Modes:
                 phases_run=["C"],
                 silent=True,  # Suppress phase function output, main function handles terminal output
             )
+            phase_c_success = not phase_c_report.has_errors
 
             # Always create final user files with simple names
             final_yaml, final_report = create_final_user_files(
@@ -1662,7 +1733,7 @@ Modes:
 
             print("[OK] Validation completed")
             print("Configuration consistency check...")
-            phase_c_success = run_phase_c(
+            phase_c_report = run_phase_c(
                 uptodate_file,  # Use Phase A output as input to Phase C
                 pydantic_yaml_file,
                 pydantic_report_file,
@@ -1671,6 +1742,7 @@ Modes:
                 phases_run=["A", "C"],
                 silent=True,
             )
+            phase_c_success = not phase_c_report.has_errors
 
             if not phase_c_success:
                 # Phase C failed in AC workflow - create final user files from Phase C error report and Phase A YAML
@@ -1777,7 +1849,7 @@ Modes:
 
             print("[OK] Phase B completed")
             print("Configuration consistency check...")
-            phase_c_success = run_phase_c(
+            phase_c_report = run_phase_c(
                 science_yaml_file,  # Use Phase B output as input to Phase C
                 pydantic_yaml_file,
                 pydantic_report_file,
@@ -1786,6 +1858,7 @@ Modes:
                 phases_run=["B", "C"],
                 silent=True,
             )
+            phase_c_success = not phase_c_report.has_errors
 
             if not phase_c_success:
                 # Phase C failed in BC workflow - consolidate Phase B messages into Phase C error report
@@ -1996,7 +2069,7 @@ Modes:
                 f"temp_reportC_{os.path.splitext(os.path.basename(user_yaml_file))[0]}.txt",
             )
 
-            phase_c_success = run_phase_c(
+            phase_c_report = run_phase_c(
                 science_yaml_file,  # Use Phase B output as input to Phase C
                 pydantic_yaml_file,
                 temp_report_c,  # Temporary Phase C report
@@ -2005,6 +2078,7 @@ Modes:
                 phases_run=["C"],  # Only Phase C content
                 silent=True,
             )
+            phase_c_success = not phase_c_report.has_errors
 
             if not phase_c_success:
                 # Phase C failed in ABC workflow - create final files from Phase B (last successful phase)

--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -1755,10 +1755,22 @@ def annotate_missing_parameters(
             standard_data = yaml.safe_load(f)
     except FileNotFoundError as e:
         print(f"Error: File not found - {e}")
-        return
+        return _phase_a_failure_report(
+            user_file=user_file,
+            uptodate_file=uptodate_file,
+            report_file=report_file,
+            code="A.PIPELINE.FILE_NOT_FOUND",
+            message=f"File not found: {e}",
+        )
     except yaml.YAMLError as e:
         print(f"Error: Invalid YAML - {e}")
-        return
+        return _phase_a_failure_report(
+            user_file=user_file,
+            uptodate_file=uptodate_file,
+            report_file=report_file,
+            code="A.PIPELINE.YAML_PARSE_ERROR",
+            message=f"Invalid YAML: {e}",
+        )
 
     # Validate nlayer dimensions if nlayer is provided
     dimension_errors = []
@@ -1906,6 +1918,153 @@ def annotate_missing_parameters(
             actual_size = os.path.getsize(report_file) if os.path.exists(report_file) else -1
             print(f"[DEBUG] Phase A: After write, file size: {actual_size} bytes", file=sys.stderr)
         # print(f" Analysis report written to: {report_file}")
+
+    from .report_schema import PhaseReport
+
+    issues = _issues_from_phase_a_state(
+        missing_params=missing_params,
+        renamed_replacements=renamed_replacements,
+        extra_params=extra_params,
+        dimension_errors=dimension_errors,
+        forcing_errors=forcing_errors,
+        nlayer_limit_errors=nlayer_limit_errors,
+    )
+    return PhaseReport(
+        phase="A",
+        issues=issues,
+        yaml_in=user_file,
+        yaml_out=uptodate_file,
+        text_report_path=report_file,
+    )
+
+
+def _phase_a_failure_report(
+    *,
+    user_file,
+    uptodate_file,
+    report_file,
+    code: str,
+    message: str,
+):
+    """Build a single-error ``PhaseReport`` for Phase A I/O failures."""
+    from .report_schema import Issue, PhaseReport, SEVERITY_ERROR
+
+    return PhaseReport(
+        phase="A",
+        issues=[Issue(
+            phase="A",
+            severity=SEVERITY_ERROR,
+            code=code,
+            message=message,
+            category="PIPELINE",
+        )],
+        yaml_in=user_file,
+        yaml_out=uptodate_file,
+        text_report_path=report_file,
+    )
+
+
+def _issues_from_phase_a_state(
+    *,
+    missing_params,
+    renamed_replacements,
+    extra_params,
+    dimension_errors,
+    forcing_errors,
+    nlayer_limit_errors,
+):
+    """Translate Phase A's accumulated lists into ``Issue`` objects.
+
+    Producer shapes (do not deviate — these are the contracts of the
+    upstream finder/validator helpers):
+
+    - ``missing_params``: list of ``(full_path, standard_value, is_physics)``.
+      ``is_physics`` flags the entry as a CRITICAL parameter.
+    - ``renamed_replacements``: list of ``(old_key, new_key)``.
+    - ``extra_params``: list of ``full_path`` strings.
+    - ``dimension_errors``: list of ``(path, expected_len, actual_len, nulls_added)``.
+    - ``nlayer_limit_errors``: list of ``(path, nlayer_value, error_message)``.
+    - ``forcing_errors``: list of plain message strings.
+    """
+    from .report_schema import (
+        Issue,
+        SEVERITY_APPLIED_FIX,
+        SEVERITY_ERROR,
+        SEVERITY_WARNING,
+    )
+
+    issues = []
+
+    for entry in missing_params or []:
+        full_path, _standard_value, is_physics = entry
+        severity = SEVERITY_ERROR if is_physics else SEVERITY_WARNING
+        issues.append(Issue(
+            phase="A",
+            severity=severity,
+            code="A.MISSING_PARAM.CRITICAL" if is_physics else "A.MISSING_PARAM",
+            message=f"Missing parameter: {full_path}",
+            yaml_path=str(full_path),
+            category="STRUCTURE",
+        ))
+
+    for old_key, new_key in renamed_replacements or []:
+        issues.append(Issue(
+            phase="A",
+            severity=SEVERITY_APPLIED_FIX,
+            code="A.RENAMED_PARAM",
+            message=f"Renamed {old_key} -> {new_key}",
+            yaml_path=str(new_key),
+            category="STRUCTURE",
+            applied_fix=True,
+        ))
+
+    for full_path in extra_params or []:
+        issues.append(Issue(
+            phase="A",
+            severity=SEVERITY_WARNING,
+            code="A.EXTRA_PARAM",
+            message=f"Parameter not in standard schema: {full_path}",
+            yaml_path=str(full_path),
+            category="STRUCTURE",
+        ))
+
+    for entry in dimension_errors or []:
+        path, expected, actual, nulls_added = entry
+        message = (
+            f"{path}: has {actual} elements, expected {expected}"
+        )
+        if nulls_added:
+            message += f" (added {nulls_added} null(s))"
+        issues.append(Issue(
+            phase="A",
+            severity=SEVERITY_ERROR,
+            code="A.DIMENSION_MISMATCH",
+            message=message,
+            yaml_path=str(path),
+            category="STRUCTURE",
+        ))
+
+    for entry in nlayer_limit_errors or []:
+        path, _value, err_message = entry
+        issues.append(Issue(
+            phase="A",
+            severity=SEVERITY_WARNING,
+            code="A.NLAYER_LIMIT",
+            message=err_message,
+            yaml_path=str(path),
+            category="STRUCTURE",
+        ))
+
+    for err_message in forcing_errors or []:
+        issues.append(Issue(
+            phase="A",
+            severity=SEVERITY_ERROR,
+            code="A.FORCING",
+            message=str(err_message),
+            category="FORCING",
+        ))
+
+    return issues
 
 
 def get_current_git_branch() -> str:

--- a/src/supy/data_model/validation/pipeline/phase_b.py
+++ b/src/supy/data_model/validation/pipeline/phase_b.py
@@ -118,6 +118,43 @@ class ScienceSuggestion:
             "source": self.source,
         }
 
+    def to_issue(self):
+        """Adapt to the canonical ``Issue`` schema."""
+        from .report_schema import Issue
+
+        return Issue(
+            phase="B",
+            severity=self.severity,
+            code=self.code or f"B.SCIENCE.{self.parameter}".upper(),
+            message=self.message,
+            yaml_path=self.path or self.parameter,
+            site_gridid=self.site_gridid,
+            site_index=self.site_index,
+            category="SCIENCE_SUGGESTION",
+            suggested_value=self.suggested_value,
+            applied_fix=False,
+        )
+
+
+def _adjustment_to_issue(adj: "ScientificAdjustment"):
+    """Adapt a ``ScientificAdjustment`` to the canonical ``Issue`` schema."""
+    from .report_schema import Issue, SEVERITY_APPLIED_FIX
+
+    parameter = adj.parameter
+    parameter_slug = parameter.replace(".", "_").replace(" ", "_").upper()
+    return Issue(
+        phase="B",
+        severity=SEVERITY_APPLIED_FIX,
+        code=f"B.APPLIED_FIX.{parameter_slug}",
+        message=adj.reason or f"Adjusted {parameter}: {adj.old_value} -> {adj.new_value}",
+        yaml_path=parameter,
+        site_gridid=adj.site_gridid,
+        site_index=adj.site_index,
+        category="APPLIED_FIX",
+        suggested_value=adj.new_value,
+        applied_fix=True,
+    )
+
 
 VALID_SCIENCE_FIX_MODES = {"suggest", "apply", "off"}
 
@@ -2692,7 +2729,7 @@ def run_science_check(
     mode: str = "public",
     phase: str = "B",
     science_fixes: str = "suggest",
-) -> dict:
+) -> Tuple[dict, "PhaseReport"]:
     """
     Main Phase B workflow: perform scientific validation and scientific adjustments.
 
@@ -2719,21 +2756,25 @@ def run_science_check(
 
     Returns
     -------
-    dict
-        Final science-checked YAML configuration dictionary.
+    tuple of (dict, PhaseReport)
+        Final science-checked YAML configuration dictionary and the
+        structured ``PhaseReport`` with all issues found. The
+        ``PhaseReport`` carries a ``status`` of ``FAILED`` when
+        critical errors are present (no exception is raised).
 
     Raises
     ------
-    FileNotFoundError
-        If any required input files are missing.
-    ValueError
-        If Phase A did not complete successfully or YAML is invalid.
+    FileNotFoundError, ValueError, KeyError
+        On unrecoverable initialisation failures (e.g. missing or
+        invalid input files). The orchestrator wraps these and
+        synthesises a fallback ``PhaseReport``.
 
     Notes
     -----
     - Runs all scientific validation and adjustment steps for Phase B.
-    - Writes a detailed report and optionally the updated YAML file.
-    - Halts with a clear message if critical scientific errors are detected.
+    - Writes a detailed text report and optionally the updated YAML file.
+    - Critical scientific errors are signalled via ``phase_report.has_errors``;
+      the function no longer raises ``ValueError`` for that case.
     """
     science_fixes = _normalise_science_fixes(science_fixes)
     try:
@@ -2803,8 +2844,17 @@ def run_science_check(
         if science_report_file:
             REPORT_WRITER.write(science_report_file, report_content)
 
-        # Re-raise the exception so orchestrator knows it failed
-        raise e
+        from .report_schema import PhaseReport
+
+        issues = [r.to_issue() for r in validation_results]
+        phase_report = PhaseReport(
+            phase="B",
+            issues=issues,
+            yaml_in=uptodate_yaml_file,
+            yaml_out=science_yaml_file,
+            text_report_path=science_report_file,
+        )
+        return {}, phase_report
 
     critical_errors = [r for r in validation_results if r.status == "ERROR"]
     suggestions = []
@@ -2844,9 +2894,24 @@ def run_science_check(
     if science_report_file:
         REPORT_WRITER.write(science_report_file, report_content)
 
+    from .report_schema import PhaseReport
+
+    issues = [r.to_issue() for r in validation_results]
+    issues.extend(_adjustment_to_issue(a) for a in adjustments)
+    if science_fixes == "suggest":
+        issues.extend(s.to_issue() for s in suggestions)
+
+    phase_report = PhaseReport(
+        phase="B",
+        issues=issues,
+        yaml_in=uptodate_yaml_file,
+        yaml_out=science_yaml_file,
+        text_report_path=science_report_file,
+    )
+
     if critical_errors:
         print_critical_halt_message(critical_errors)
-        raise ValueError("Critical scientific errors detected - Phase B halted")
+        return science_checked_data, phase_report
 
     print_science_check_results(
         validation_results, adjustments, suggestions, science_fixes
@@ -2860,7 +2925,7 @@ def run_science_check(
                 science_checked_data, f, default_flow_style=False, sort_keys=False
             )
 
-    return science_checked_data
+    return science_checked_data, phase_report
 
 
 def main():

--- a/src/supy/data_model/validation/pipeline/phase_b_rules/rules_core.py
+++ b/src/supy/data_model/validation/pipeline/phase_b_rules/rules_core.py
@@ -80,6 +80,29 @@ class ValidationResult:
         """Return a stable serialisable representation for reports and JSON."""
         return asdict(self)
 
+    def to_issue(self):
+        """Adapt this Phase B result to the canonical ``Issue`` schema.
+
+        Imported lazily to keep ``rules_core`` independent of the
+        ``report_schema`` module's import order.
+        """
+        from ..report_schema import Issue, SEVERITY_INFO
+
+        severity = (self.severity or self.status or SEVERITY_INFO).upper()
+        code = self.code or f"B.{self.category}.{self.parameter}".upper()
+        return Issue(
+            phase="B",
+            severity=severity,
+            code=code,
+            message=self.message,
+            yaml_path=self.path or self.parameter,
+            site_gridid=self.site_gridid,
+            site_index=self.site_index,
+            category=self.category,
+            suggested_value=self.suggested_value,
+            applied_fix=bool(self.applied_fix),
+        )
+
 
 @dataclass(frozen=True)
 class ValidationContext:

--- a/src/supy/data_model/validation/pipeline/phase_c.py
+++ b/src/supy/data_model/validation/pipeline/phase_c.py
@@ -10,6 +10,97 @@ from .report_writer import REPORT_WRITER
 REPORT_TITLE = "SUEWS Validation Report"
 
 
+def collect_phase_c_issues(input_yaml_file: str):
+    """Run a structured Pydantic validation pass and return canonical ``Issue``\\ s.
+
+    The orchestrator's ``run_phase_c`` calls ``SUEWSConfig.from_yaml``
+    which formats Pydantic ``ValidationError`` into a string-only
+    ``ValueError`` (see ``SUEWSConfig._transform_validation_error``).
+    This helper sidesteps that wrapper by calling ``SUEWSConfig`` directly
+    so the raw ``ValidationError.errors()`` survive into the JSON sidecar.
+    The cost is one extra Pydantic pass per failing config, which is
+    acceptable for the validation surface.
+    """
+    from .report_schema import Issue, SEVERITY_ERROR
+
+    issues = []
+
+    try:
+        from supy.data_model import SUEWSConfig
+    except ImportError as exc:
+        issues.append(Issue(
+            phase="C",
+            severity=SEVERITY_ERROR,
+            code="C.PIPELINE.IMPORT_ERROR",
+            message=f"Cannot import SUEWSConfig: {exc}",
+            category="PIPELINE",
+        ))
+        return issues
+
+    try:
+        with open(input_yaml_file, "r", encoding="utf-8") as fh:
+            config_data = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError) as exc:
+        issues.append(Issue(
+            phase="C",
+            severity=SEVERITY_ERROR,
+            code="C.PIPELINE.YAML_PARSE_ERROR",
+            message=str(exc),
+            category="PIPELINE",
+        ))
+        return issues
+
+    if not isinstance(config_data, dict):
+        issues.append(Issue(
+            phase="C",
+            severity=SEVERITY_ERROR,
+            code="C.PIPELINE.YAML_NOT_MAPPING",
+            message="YAML root is not a mapping",
+            category="PIPELINE",
+        ))
+        return issues
+
+    # Replicate the minimal fields ``from_yaml`` injects so the model
+    # construction reaches Pydantic with the same shape, but without
+    # the ValidationError-to-ValueError wrapping.
+    config_data.setdefault("_yaml_path", input_yaml_file)
+
+    try:
+        from pydantic import ValidationError
+    except ImportError:
+        ValidationError = None
+
+    try:
+        SUEWSConfig(**config_data)
+        return issues  # No errors
+    except Exception as exc:
+        if ValidationError is not None and isinstance(exc, ValidationError):
+            for err in exc.errors():
+                loc_tuple = err.get("loc", ())
+                gridid_path = convert_pydantic_location_to_gridid_path(
+                    loc_tuple, input_yaml_file
+                )
+                err_type = err.get("type", "value_error")
+                code_slug = str(err_type).upper().replace(".", "_")
+                issues.append(Issue(
+                    phase="C",
+                    severity=SEVERITY_ERROR,
+                    code=f"C.PYDANTIC.{code_slug}",
+                    message=err.get("msg", str(err)),
+                    yaml_path=gridid_path,
+                    category="CONFIG_CONSISTENCY",
+                ))
+        else:
+            issues.append(Issue(
+                phase="C",
+                severity=SEVERITY_ERROR,
+                code="C.PIPELINE.EXCEPTION",
+                message=str(exc),
+                category="PIPELINE",
+            ))
+        return issues
+
+
 def convert_pydantic_location_to_gridid_path(loc_tuple, input_yaml_file):
     """Convert Pydantic error location tuple to user-friendly GRIDID path.
 

--- a/src/supy/data_model/validation/pipeline/report_schema.py
+++ b/src/supy/data_model/validation/pipeline/report_schema.py
@@ -1,0 +1,159 @@
+"""Canonical machine-readable schema for validator phase output.
+
+Every phase of the validation pipeline (A: structure, B: physics,
+C: Pydantic consistency) emits issues that conform to ``Issue``.
+The orchestrator aggregates per-phase ``PhaseReport`` objects into a
+single ``ValidationReport`` which is also what the CLI envelope's
+``data.phases`` field carries.
+
+Severity vocabulary matches the legacy ``ValidationResult`` used by
+Phase B (see ``phase_b_rules/rules_core.py``); both share the same
+``Issue.severity`` strings so consumers do not need to special-case
+which phase produced the issue.
+
+The text reports written by each phase are unchanged; this module
+adds a JSON sidecar (``<report>.json``) next to every ``<report>.txt``
+so downstream tooling (MCP, agents, CI) can consume the validator
+output without parsing the human-readable form.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+PathLike = Union[str, Path]
+
+SEVERITY_ERROR = "ERROR"
+SEVERITY_WARNING = "WARNING"
+SEVERITY_INFO = "INFO"
+SEVERITY_SUGGESTION = "SUGGESTION"
+SEVERITY_APPLIED_FIX = "APPLIED_FIX"
+SEVERITY_PASS = "PASS"
+
+VALID_SEVERITIES = frozenset({
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+    SEVERITY_INFO,
+    SEVERITY_SUGGESTION,
+    SEVERITY_APPLIED_FIX,
+    SEVERITY_PASS,
+})
+
+VALID_PHASES = frozenset({"A", "B", "C"})
+
+
+@dataclass
+class Issue:
+    """One discrete validator finding.
+
+    ``code`` is a stable dotted slug ``<phase>.<category>.<parameter>``
+    that downstream tooling can match on without reading ``message``.
+    """
+
+    phase: str
+    severity: str
+    code: str
+    message: str
+    yaml_path: Optional[str] = None
+    site_gridid: Optional[int] = None
+    site_index: Optional[int] = None
+    category: Optional[str] = None
+    suggested_value: Any = None
+    applied_fix: bool = False
+
+    def __post_init__(self) -> None:
+        if self.phase not in VALID_PHASES:
+            raise ValueError(
+                f"Invalid phase {self.phase!r}; expected one of {sorted(VALID_PHASES)}"
+            )
+        self.severity = (self.severity or SEVERITY_INFO).upper()
+        if self.severity not in VALID_SEVERITIES:
+            raise ValueError(
+                f"Invalid severity {self.severity!r}; expected one of {sorted(VALID_SEVERITIES)}"
+            )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class PhaseReport:
+    """Aggregate of issues produced by one phase of the validator."""
+
+    phase: str
+    issues: List[Issue] = field(default_factory=list)
+    yaml_in: Optional[str] = None
+    yaml_out: Optional[str] = None
+    text_report_path: Optional[str] = None
+    json_report_path: Optional[str] = None
+    extra: dict = field(default_factory=dict)
+
+    @property
+    def has_errors(self) -> bool:
+        return any(i.severity == SEVERITY_ERROR for i in self.issues)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(i.severity == SEVERITY_WARNING for i in self.issues)
+
+    @property
+    def status(self) -> str:
+        if self.has_errors:
+            return "FAILED"
+        if self.has_warnings:
+            return "WARNING"
+        return "PASSED"
+
+    def to_dict(self) -> dict:
+        return {
+            "phase": self.phase,
+            "status": self.status,
+            "issues": [i.to_dict() for i in self.issues],
+            "yaml_in": self.yaml_in,
+            "yaml_out": self.yaml_out,
+            "text_report_path": self.text_report_path,
+            "json_report_path": self.json_report_path,
+            "extra": self.extra,
+        }
+
+
+@dataclass
+class ValidationReport:
+    """Aggregate of every phase run for a single config."""
+
+    phases: List[PhaseReport] = field(default_factory=list)
+
+    @property
+    def overall_status(self) -> str:
+        if any(p.has_errors for p in self.phases):
+            return "FAILED"
+        if any(p.has_warnings for p in self.phases):
+            return "WARNING"
+        return "PASSED"
+
+    def to_dict(self) -> dict:
+        return {
+            "overall_status": self.overall_status,
+            "phases": [p.to_dict() for p in self.phases],
+        }
+
+
+@dataclass(frozen=True)
+class JSONReportWriter:
+    """Writes a ``PhaseReport`` to a JSON sidecar file."""
+
+    encoding: str = "utf-8"
+    indent: int = 2
+
+    def write(self, filepath: PathLike, report: PhaseReport) -> None:
+        path = Path(filepath)
+        text = json.dumps(report.to_dict(), indent=self.indent, ensure_ascii=False)
+        with path.open("w", encoding=self.encoding, newline="\n") as handle:
+            handle.write(text)
+            handle.write("\n")
+
+
+JSON_REPORT_WRITER = JSONReportWriter()

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -152,6 +152,7 @@ py.install_sources(
             'data_model/validation/pipeline/phase_a.py',
             'data_model/validation/pipeline/phase_b.py',
             'data_model/validation/pipeline/phase_c.py',
+            'data_model/validation/pipeline/report_schema.py',
             'data_model/validation/pipeline/report_writer.py',
             'data_model/validation/pipeline/yaml_annotator.py',
             'data_model/validation/pipeline/phase_b_rules/__init__.py',

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -17,6 +17,7 @@ import supy as sp
 from supy.data_model.validation.pipeline.orchestrator import (
     run_phase_a,
     run_phase_b,
+    run_phase_c,
 )
 from supy.data_model.validation.pipeline.report_schema import PhaseReport
 
@@ -92,6 +93,61 @@ def test_phase_b_emits_json_sidecar(tmp_path, sample_config_path):
         assert "severity" in issue
         assert "code" in issue
         assert "message" in issue
+
+
+def test_phase_c_emits_json_for_passing_config(tmp_path, sample_config_path):
+    """Phase C writes a JSON sidecar even on the success path."""
+    pydantic_yaml = tmp_path / "pydantic.yml"
+    pydantic_report = tmp_path / "pydantic_report.txt"
+
+    report = run_phase_c(
+        input_yaml_file=str(sample_config_path),
+        pydantic_yaml_file=str(pydantic_yaml),
+        pydantic_report_file=str(pydantic_report),
+        phases_run=["C"],
+        silent=True,
+    )
+
+    assert isinstance(report, PhaseReport)
+    assert report.phase == "C"
+    json_path = pydantic_report.with_suffix(".json")
+    assert json_path.exists()
+    payload = json.loads(json_path.read_text())
+    assert payload["phase"] == "C"
+    # Sample config should pass; status is PASSED unless there are
+    # legitimate warnings in the sample.
+    assert payload["status"] in {"PASSED", "WARNING"}
+
+
+def test_phase_c_emits_structured_pydantic_errors_for_bad_config(tmp_path):
+    """A YAML that fails Pydantic produces ``C.PYDANTIC.*`` issues."""
+    bad_yaml = tmp_path / "bad.yml"
+    # ``tstep`` must be an integer; supplying a string forces a Pydantic error.
+    bad_yaml.write_text(
+        "model:\n"
+        "  control:\n"
+        "    tstep: not_an_int\n"
+        "    forcing_file: forcing.txt\n"
+        "sites: []\n"
+    )
+    pydantic_yaml = tmp_path / "pydantic.yml"
+    pydantic_report = tmp_path / "pydantic_report.txt"
+
+    report = run_phase_c(
+        input_yaml_file=str(bad_yaml),
+        pydantic_yaml_file=str(pydantic_yaml),
+        pydantic_report_file=str(pydantic_report),
+        phases_run=["C"],
+        silent=True,
+    )
+
+    assert report.has_errors, "A malformed config must produce errors"
+    payload = json.loads(pydantic_report.with_suffix(".json").read_text())
+    assert payload["phase"] == "C"
+    assert payload["status"] == "FAILED"
+    # At least one issue should be a structured Pydantic error.
+    pydantic_codes = [i["code"] for i in payload["issues"] if i["code"].startswith("C.PYDANTIC.")]
+    assert pydantic_codes, "Expected at least one C.PYDANTIC.* issue"
 
 
 def test_phase_b_text_report_unchanged(tmp_path, sample_config_path):

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -1,0 +1,85 @@
+"""End-to-end tests for the validator pipeline's structured JSON output.
+
+Each phase (A, B, C) writes a ``<report>.json`` sidecar next to the
+existing ``<report>.txt``. The sidecar conforms to ``PhaseReport.to_dict()``
+from ``report_schema.py`` and is the canonical machine-readable
+representation of the phase's findings.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import supy as sp
+from supy.data_model.validation.pipeline.orchestrator import (
+    run_phase_b,
+)
+from supy.data_model.validation.pipeline.report_schema import PhaseReport
+
+pytestmark = pytest.mark.api
+
+
+@pytest.fixture
+def sample_config_path() -> Path:
+    return Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+
+
+def test_phase_b_emits_json_sidecar(tmp_path, sample_config_path):
+    """Phase B writes a JSON sidecar alongside its text report."""
+    science_yaml = tmp_path / "science.yml"
+    science_report = tmp_path / "science_report.txt"
+
+    report = run_phase_b(
+        user_yaml_file=str(sample_config_path),
+        uptodate_file=str(sample_config_path),  # Skip Phase A
+        standard_yaml_file=str(sample_config_path),
+        science_yaml_file=str(science_yaml),
+        science_report_file=str(science_report),
+        phase_a_report_file=str(tmp_path / "phase_a_report.txt"),
+        phase_a_performed=False,
+        silent=True,
+    )
+
+    assert isinstance(report, PhaseReport)
+    assert report.phase == "B"
+
+    json_path = science_report.with_suffix(".json")
+    assert json_path.exists(), "Phase B should write a JSON sidecar"
+
+    payload = json.loads(json_path.read_text())
+    assert payload["phase"] == "B"
+    assert payload["status"] in {"PASSED", "WARNING", "FAILED"}
+    assert isinstance(payload["issues"], list)
+    # Every issue must carry the canonical fields
+    for issue in payload["issues"]:
+        assert issue["phase"] == "B"
+        assert "severity" in issue
+        assert "code" in issue
+        assert "message" in issue
+
+
+def test_phase_b_text_report_unchanged(tmp_path, sample_config_path):
+    """Confirm the text report still exists and is non-empty (no regression)."""
+    science_yaml = tmp_path / "science.yml"
+    science_report = tmp_path / "science_report.txt"
+
+    run_phase_b(
+        user_yaml_file=str(sample_config_path),
+        uptodate_file=str(sample_config_path),
+        standard_yaml_file=str(sample_config_path),
+        science_yaml_file=str(science_yaml),
+        science_report_file=str(science_report),
+        phase_a_report_file=str(tmp_path / "phase_a_report.txt"),
+        phase_a_performed=False,
+        silent=True,
+    )
+
+    assert science_report.exists()
+    text = science_report.read_text()
+    assert len(text) > 0
+    # The text report still uses the historical section markers.
+    # Downstream tooling that greps these strings must continue to work.
+    assert "SUEWS" in text or "Phase B" in text or "Science" in text

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -172,3 +172,63 @@ def test_phase_b_text_report_unchanged(tmp_path, sample_config_path):
     # The text report still uses the historical section markers.
     # Downstream tooling that greps these strings must continue to work.
     assert "SUEWS" in text or "Phase B" in text or "Science" in text
+
+
+def test_pipeline_writes_json_sidecars_alongside_text_reports(tmp_path, sample_config_path):
+    """Running A then B then C produces a JSON sidecar for every text report.
+
+    This is the end-to-end machine-format contract: any tool that wants the
+    structured per-phase result reads ``<text_report_path>.json`` rather than
+    parsing the human-readable form.
+    """
+    uptodate_file = tmp_path / "uptodate.yml"
+    report_file = tmp_path / "report.txt"
+    science_yaml = tmp_path / "science.yml"
+    science_report = tmp_path / "science_report.txt"
+    pydantic_yaml = tmp_path / "pydantic.yml"
+    pydantic_report = tmp_path / "pydantic_report.txt"
+
+    a_report = run_phase_a(
+        user_yaml_file=str(sample_config_path),
+        standard_yaml_file=str(sample_config_path),
+        uptodate_file=str(uptodate_file),
+        report_file=str(report_file),
+        silent=True,
+        forcing="off",
+    )
+    b_report = run_phase_b(
+        user_yaml_file=str(sample_config_path),
+        uptodate_file=str(uptodate_file),
+        standard_yaml_file=str(sample_config_path),
+        science_yaml_file=str(science_yaml),
+        science_report_file=str(science_report),
+        phase_a_report_file=str(report_file),
+        phase_a_performed=True,
+        silent=True,
+    )
+    c_report = run_phase_c(
+        input_yaml_file=str(sample_config_path),
+        pydantic_yaml_file=str(pydantic_yaml),
+        pydantic_report_file=str(pydantic_report),
+        phases_run=["A", "B", "C"],
+        silent=True,
+    )
+
+    # Every phase should have advertised its JSON sidecar via PhaseReport.
+    for r, expected in [
+        (a_report, report_file),
+        (b_report, science_report),
+        (c_report, pydantic_report),
+    ]:
+        assert r.json_report_path is not None, f"{r.phase}: missing json_report_path"
+        assert Path(r.json_report_path) == expected.with_suffix(".json")
+        assert Path(r.json_report_path).exists()
+
+    # Each sidecar carries the same canonical schema.
+    for r in (a_report, b_report, c_report):
+        payload = json.loads(Path(r.json_report_path).read_text())
+        assert set(payload.keys()) == {
+            "phase", "status", "issues", "yaml_in", "yaml_out",
+            "text_report_path", "json_report_path", "extra",
+        }
+        assert payload["phase"] == r.phase

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -15,6 +15,7 @@ import pytest
 
 import supy as sp
 from supy.data_model.validation.pipeline.orchestrator import (
+    run_phase_a,
     run_phase_b,
 )
 from supy.data_model.validation.pipeline.report_schema import PhaseReport
@@ -25,6 +26,38 @@ pytestmark = pytest.mark.api
 @pytest.fixture
 def sample_config_path() -> Path:
     return Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+
+
+def test_phase_a_emits_json_sidecar(tmp_path, sample_config_path):
+    """Phase A writes a JSON sidecar alongside its text report."""
+    uptodate_file = tmp_path / "uptodate.yml"
+    report_file = tmp_path / "report.txt"
+
+    report = run_phase_a(
+        user_yaml_file=str(sample_config_path),
+        standard_yaml_file=str(sample_config_path),
+        uptodate_file=str(uptodate_file),
+        report_file=str(report_file),
+        silent=True,
+        forcing="off",
+    )
+
+    assert isinstance(report, PhaseReport)
+    assert report.phase == "A"
+
+    json_path = report_file.with_suffix(".json")
+    assert json_path.exists(), "Phase A should write a JSON sidecar"
+
+    payload = json.loads(json_path.read_text())
+    assert payload["phase"] == "A"
+    assert payload["status"] in {"PASSED", "WARNING", "FAILED"}
+    assert isinstance(payload["issues"], list)
+    for issue in payload["issues"]:
+        assert issue["phase"] == "A"
+        assert "severity" in issue
+        assert "code" in issue
+        # Phase A codes always start with "A."
+        assert issue["code"].startswith("A.")
 
 
 def test_phase_b_emits_json_sidecar(tmp_path, sample_config_path):

--- a/test/data_model/test_report_schema.py
+++ b/test/data_model/test_report_schema.py
@@ -1,0 +1,112 @@
+"""Tests for the canonical validator report schema."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from supy.data_model.validation.pipeline.report_schema import (
+    Issue,
+    JSONReportWriter,
+    PhaseReport,
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+    ValidationReport,
+)
+
+
+def test_issue_round_trips_through_dict():
+    issue = Issue(
+        phase="B",
+        severity=SEVERITY_ERROR,
+        code="B.PHYSICS.LAIMAX",
+        message="laimax must exceed laimin",
+        yaml_path="sites.0.properties.land_cover.evetr.lai.laimax",
+        site_gridid=1,
+        category="PHYSICS",
+        suggested_value=5.0,
+    )
+    payload = issue.to_dict()
+    assert payload["severity"] == "ERROR"
+    assert payload["code"] == "B.PHYSICS.LAIMAX"
+    assert payload["yaml_path"].endswith("laimax")
+    # Round-trip through JSON to confirm it is fully serialisable.
+    assert json.loads(json.dumps(payload)) == payload
+
+
+def test_issue_rejects_invalid_phase_or_severity():
+    with pytest.raises(ValueError):
+        Issue(phase="Z", severity=SEVERITY_ERROR, code="X", message="m")
+    with pytest.raises(ValueError):
+        Issue(phase="A", severity="OOPS", code="X", message="m")
+
+
+def test_phase_report_status_derives_from_issues():
+    err = Issue(phase="A", severity=SEVERITY_ERROR, code="A.X", message="bad")
+    warn = Issue(phase="A", severity=SEVERITY_WARNING, code="A.Y", message="hmm")
+
+    failed = PhaseReport(phase="A", issues=[err, warn])
+    assert failed.has_errors is True
+    assert failed.status == "FAILED"
+
+    warned = PhaseReport(phase="A", issues=[warn])
+    assert warned.has_errors is False
+    assert warned.status == "WARNING"
+
+    clean = PhaseReport(phase="A", issues=[])
+    assert clean.status == "PASSED"
+
+
+def test_phase_report_to_dict_is_json_safe():
+    report = PhaseReport(
+        phase="B",
+        issues=[Issue(phase="B", severity=SEVERITY_WARNING, code="B.X", message="x")],
+        yaml_in="/tmp/in.yml",
+        yaml_out="/tmp/out.yml",
+        text_report_path="/tmp/report.txt",
+        json_report_path="/tmp/report.json",
+    )
+    payload = report.to_dict()
+    assert payload["phase"] == "B"
+    assert payload["status"] == "WARNING"
+    assert len(payload["issues"]) == 1
+    assert json.loads(json.dumps(payload)) == payload
+
+
+def test_validation_report_aggregates_overall_status():
+    a = PhaseReport(phase="A", issues=[])
+    b = PhaseReport(
+        phase="B",
+        issues=[Issue(phase="B", severity=SEVERITY_WARNING, code="B.W", message="w")],
+    )
+    report = ValidationReport(phases=[a, b])
+    assert report.overall_status == "WARNING"
+
+    c = PhaseReport(
+        phase="C",
+        issues=[Issue(phase="C", severity=SEVERITY_ERROR, code="C.E", message="e")],
+    )
+    report.phases.append(c)
+    assert report.overall_status == "FAILED"
+
+    clean = ValidationReport(phases=[
+        PhaseReport(phase="A", issues=[]),
+        PhaseReport(phase="B", issues=[]),
+    ])
+    assert clean.overall_status == "PASSED"
+
+
+def test_json_report_writer_emits_utf8_with_trailing_newline(tmp_path):
+    writer = JSONReportWriter()
+    report = PhaseReport(
+        phase="A",
+        issues=[Issue(phase="A", severity=SEVERITY_ERROR, code="A.X", message="é")],
+    )
+    out = tmp_path / "report.json"
+    writer.write(out, report)
+
+    text = out.read_text(encoding="utf-8")
+    assert text.endswith("\n")
+    payload = json.loads(text)
+    assert payload["issues"][0]["message"] == "é"

--- a/test/data_model/test_report_schema.py
+++ b/test/data_model/test_report_schema.py
@@ -15,6 +15,8 @@ from supy.data_model.validation.pipeline.report_schema import (
     ValidationReport,
 )
 
+pytestmark = pytest.mark.api
+
 
 def test_issue_round_trips_through_dict():
     issue = Issue(

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -515,26 +515,36 @@ sites:
         )
 
     def test_error_handling(self):
-        """Test error handling for invalid inputs."""
+        """Test error handling for invalid inputs.
+
+        ``annotate_missing_parameters`` returns a structured ``PhaseReport``
+        on every path (success and pipeline failure) so callers and the
+        JSON sidecar share the same shape. I/O failures surface as a
+        single ``A.PIPELINE.*`` issue rather than collapsing to ``None``.
+        """
+        from supy.data_model.validation.pipeline.report_schema import PhaseReport
+
         with tempfile.TemporaryDirectory() as temp_dir:
-            # Test with non-existent file
+            # Test with non-existent file -> A.PIPELINE.FILE_NOT_FOUND
             non_existent = os.path.join(temp_dir, "does_not_exist.yml")
             result = annotate_missing_parameters(
                 user_file=non_existent, standard_file=self.standard_file
             )
-            # Should handle gracefully (returns None)
-            self.assertIsNone(result)
+            self.assertIsInstance(result, PhaseReport)
+            self.assertTrue(result.has_errors)
+            self.assertEqual(result.issues[0].code, "A.PIPELINE.FILE_NOT_FOUND")
 
-            # Test with invalid YAML
+            # Test with invalid YAML -> A.PIPELINE.YAML_PARSE_ERROR
             invalid_yaml = os.path.join(temp_dir, "invalid.yml")
-            with open(invalid_yaml, "w") as f:
+            with open(invalid_yaml, "w", encoding="utf-8") as f:
                 f.write("invalid: yaml: content: [unclosed")
 
             result = annotate_missing_parameters(
                 user_file=invalid_yaml, standard_file=self.standard_file
             )
-            # Should handle gracefully
-            self.assertIsNone(result)
+            self.assertIsInstance(result, PhaseReport)
+            self.assertTrue(result.has_errors)
+            self.assertEqual(result.issues[0].code, "A.PIPELINE.YAML_PARSE_ERROR")
 
     def test_renamed_params_consistency(self):
         """Test that RENAMED_PARAMS dictionary is consistent."""


### PR DESCRIPTION
## Summary

The validator pipeline (Phase A structure / Phase B physics / Phase C Pydantic consistency) previously emitted free-form text reports only — pass/fail had to be inferred by grepping report files for substrings like `## ACTION NEEDED`, `CRITICAL ISSUES DETECTED`, or `URGENT`. Downstream tooling (MCP, agents, CI) couldn't consume the output without parsing the human-readable form.

This PR adds a canonical machine-readable schema that every phase emits **alongside** the existing text reports. The text reports are byte-for-byte unchanged.

## What changed

- New `Issue` / `PhaseReport` / `ValidationReport` schema in `src/supy/data_model/validation/pipeline/report_schema.py`. Every phase produces issues with a stable shape: `phase`, `severity`, `code`, `message`, `yaml_path`, `site_gridid`, `category`, `suggested_value`, `applied_fix`.
- Each phase writes a JSON sidecar at `<report>.json` next to its existing `<report>.txt`. The sidecar self-references its own path.
- Replaced the brittle string-grep status checks in the orchestrator with `PhaseReport.has_errors`. All caller sites of `run_phase_a/b/c` are rewired to derive a bool from the structured report; downstream branch logic is unchanged.
- Phase B's existing internal `ValidationResult` dataclass is preserved and bridged via a new `to_issue()` adapter. `ScienceSuggestion` and `ScientificAdjustment` are surfaced as `B.SCIENCE.*` and `B.APPLIED_FIX.*` issues.
- Phase C sidesteps `SUEWSConfig.from_yaml`'s `ValueError` wrapping (which discards Pydantic's structured `errors()`) by calling `SUEWSConfig(**config_data)` directly so `C.PYDANTIC.<TYPE>` issues survive into the JSON sidecar with GRIDID-friendly `yaml_path` strings.

## What's preserved

- The `<report>.txt` files are byte-for-byte identical. Any tooling that already parses them keeps working.
- `run_phase_*` keep their CLI-visible behaviour (`[OK] Validation completed` / `[X] Validation failed!` etc.).
- Phase B's internal API (`ValidationResult`, `RulesRegistry`, `ValidationContext`) is untouched.

## Example sidecar

```json
{
  "phase": "C",
  "status": "FAILED",
  "issues": [
    {
      "phase": "C",
      "severity": "ERROR",
      "code": "C.PYDANTIC.MISSING",
      "message": "Field required",
      "yaml_path": "sites.1.properties.lat",
      "site_gridid": null,
      "category": "CONFIG_CONSISTENCY",
      "suggested_value": null,
      "applied_fix": false
    }
  ],
  "yaml_in": "/path/to/config.yml",
  "yaml_out": "/path/to/updated_config.yml",
  "text_report_path": "/path/to/report.txt",
  "json_report_path": "/path/to/report.json",
  "extra": {}
}
```

## Why now

This unblocks the MCP-side work that needs to consume validator results programmatically — the next presentation depends on agents being able to read structured pass/fail across all three phases without text parsing.

## Test plan

- [x] `make test-smoke` (8/8 passed)
- [x] `pytest test/data_model/test_report_schema.py test/data_model/test_pipeline_structured_output.py test/cmd/test_validate_config.py test/data_model/test_validation.py` (182/182 passed)
- [x] Hand-tested with `suews validate -p ABC --forcing off config.yml` — three JSON sidecars produced, schema verified, text reports unchanged
- [x] New end-to-end regression locks the JSON sidecar contract (`test_pipeline_writes_json_sidecars_alongside_text_reports`)

## Out of scope

- Removing the legacy `ValidationResult` dataclass (preserved as the bridge into the new schema).
- Restructuring `create_analysis_report` to be driven by `Issue` rather than the raw lists — text reports must stay byte-identical for now.
- Wiring `data.phases` into the top-level CLI envelope. The structured contract lives in the per-phase JSON sidecars; an envelope-level surfacing can come in a follow-up if needed.
