### PR TITLE
ci: bump pypa/gh-action-pypi-publish to v1.14.0 (Metadata-Version 2.4)

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -517,7 +517,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish wheels to Test PyPI
-        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # release/v1.8
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
         with:
           packages-dir: dist/
           verbose: true
@@ -558,7 +558,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish all wheels to PyPI
-        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # release/v1.8
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
         with:
           packages-dir: dist/
           verbose: true


### PR DESCRIPTION
## Summary

- Bump `pypa/gh-action-pypi-publish` from `release/v1.8` (twine 5.0) to `v1.14.0` (twine 6.x) so it accepts wheels emitting `Metadata-Version: 2.4`.
- Both `deploy_testpypi` and `deploy_pypi` jobs are pinned to commit SHA `6733eb7d741f0b11ec6a39b58540dab7590f9b7d`.

## Why

The new `suews-mcp` package (added in #1389) is built with `setuptools>=70`, whose default metadata version is `2.4`. The previously pinned action ships twine 5.0, which only recognises `Metadata-Version` up to 2.3 and silently treats the file as having no `Name`/`Version`, failing pre-flight with:

```
Checking dist/suews_mcp-2026.5.3.dev0-py3-none-any.whl: ERROR InvalidDistribution:
Metadata is missing required fields: Name, Version.
... using a supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.3.
```

Failure reproduced on https://github.com/UMEP-dev/SUEWS/actions/runs/25268315967.

## Pending Trusted Publishers

Already registered on both indexes for `suews-mcp` (matching the existing `supy` setup, no environment):

- TestPyPI: https://test.pypi.org/manage/account/publishing/
- PyPI: https://pypi.org/manage/account/publishing/

Owner `UMEP-dev`, repository `SUEWS`, workflow `build-publish_to_pypi.yml`.

## Test plan

- [ ] Merge queue passes
- [ ] Next nightly (or first dev tag after merge) successfully uploads `suews-mcp` wheel to TestPyPI
- [ ] First production tag successfully uploads `suews-mcp` to PyPI