### PR TITLE
ci: re-pin pypa/gh-action-pypi-publish to release/v1.14 head (ghcr image)

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -517,7 +517,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish wheels to Test PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1.14 (v1.14.0 tag commit lacks a published ghcr image)
         with:
           packages-dir: dist/
           verbose: true
@@ -558,7 +558,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish all wheels to PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1.14 (v1.14.0 tag commit lacks a published ghcr image)
         with:
           packages-dir: dist/
           verbose: true


### PR DESCRIPTION
## Summary

Re-pin to commit `cef22109` (current `release/v1.14` head) instead of the v1.14.0 tag commit `6733eb7d`. Both are 40-char SHAs and pass `check_action_pins.py`, but only `cef22109` has a published Docker image on `ghcr.io/pypa/gh-action-pypi-publish`.

## Why

#1396 bumped from `release/v1.8` to v1.14.0 to fix the Metadata-Version 2.4 wheel rejection. That part worked (build passed, no twine pre-flight error). But the publish step failed at runtime:

```
Unable to find image 'ghcr.io/pypa/gh-action-pypi-publish:6733eb7d741f0b11ec6a39b58540dab7590f9b7d' locally
docker: Error response from daemon: manifest unknown
```

`pypa/gh-action-pypi-publish` v1.12+ runs as a pre-built Docker container. The image is published to ghcr keyed by **release-branch HEAD SHAs**, not by tagged release commits. Verified the published tag list — `6733eb7d` (v1.14.0) is absent, `cef22109` (release/v1.14 head) is present.

`cef22109` is currently both `release/v1.14` and `release/v1` head, so it carries v1.14.0 plus any release-branch fixes; twine 6.x is included.

## Verification reference

Failed publish run (with the v1.14.0-tag pin from #1396):
- https://github.com/UMEP-dev/SUEWS/actions/runs/25273026677 — Build/test all green; only `Publish to TestPyPI` failed on the missing ghcr image.

## Test plan

- [ ] Merge queue passes
- [ ] Workflow_dispatch on master with `deploy_target=testpypi` succeeds end-to-end (build + cross-Python tests + actual TestPyPI upload of `suews-mcp` and `supy` wheels)