### PR TITLE
fix(check_forcing): accept per-landcover named forcing (gh#1413)

### DIFF
--- a/src/supy/_check.py
+++ b/src/supy/_check.py
@@ -9,7 +9,12 @@ import numpy as np
 import pandas as pd
 
 from ._env import logger_supy, trv_supy_module, trv_supy_module
-from ._load import dict_var_type_forcing, set_var_use
+from ._load import (
+    CANONICAL_FORCING_COLUMNS,
+    _is_per_landcover_column,
+    dict_var_type_forcing,
+    set_var_use,
+)
 
 
 # the check list file with ranges and logics
@@ -336,18 +341,33 @@ def check_forcing(
     # check the following:
     # 1. correct columns
     col_df = df_forcing.columns
-    # 1.1 if all columns are present
-    set_diff = set(list_col_forcing).difference(col_df)
+    # 1.1 all canonical user-facing columns must be present (gh#1413).
+    # The reference list is CANONICAL_FORCING_COLUMNS (24 names), not
+    # ``list_col_forcing``: the latter is keyed off the internal
+    # ``dict_var_type_forcing`` resampling table and inadvertently
+    # included ``isec``, which the named-column reader does not produce.
+    set_diff = set(CANONICAL_FORCING_COLUMNS).difference(col_df)
     if len(set_diff) > 0:
-        str_issue = f"Missing columns found: {set_diff}"
+        str_issue = f"Missing columns found: {sorted(set_diff)}"
         list_issues.append(str_issue)
         flag_valid = False
-    # 1.2 if all columns are in right position
-    for col_v, col in zip(list_col_forcing, col_df):
-        if col_v != col:
-            str_issue = f"Column {col} is not in the valid position for {col_v}"
-            list_issues.append(str_issue)
-            flag_valid = False
+    # 1.2 forcing is matched by column name, not by position (gh#1372,
+    # gh#1378). Per-landcover extras (``lai_<surface>``,
+    # ``wuh_<surface>``) are appended after the canonical 24 columns,
+    # so the legacy positional ``zip`` produced false negatives. Flag
+    # any column that is neither canonical nor a whitelisted per-LC
+    # extra.
+    unknown_cols = [
+        col
+        for col in col_df
+        if col not in CANONICAL_FORCING_COLUMNS
+        and col != "isec"
+        and not _is_per_landcover_column(col)
+    ]
+    if unknown_cols:
+        str_issue = f"Unknown forcing columns: {unknown_cols}"
+        list_issues.append(str_issue)
+        flag_valid = False
 
     # 2. valid timestamps:
     ind_df = df_forcing.index

--- a/test/io_tests/test_named_column_forcing.py
+++ b/test/io_tests/test_named_column_forcing.py
@@ -248,3 +248,48 @@ def test_shuffled_header_yields_same_dataframe_as_canonical():
 
     assert list(df_canonical.columns) == list(df_shuffled.columns)
     pd.testing.assert_frame_equal(df_canonical, df_shuffled)
+
+
+def test_check_forcing_accepts_per_landcover_extras():
+    """gh#1413 (PR#1378 follow-up): check_forcing must not flag per-landcover
+    extras as missing/positional errors. Pre-fix, the validator zipped
+    columns positionally against a 25-key reference list including the
+    internal `isec` key, so any DataFrame with `lai_<surface>` or
+    `wuh_<surface>` columns appended after the canonical 24 hit
+    "Missing columns: {'isec'}" and "Column lai_evetr is not in the
+    valid position for isec".
+    """
+    from supy._check import check_forcing
+    from supy._load import CANONICAL_FORCING_COLUMNS
+
+    idx = pd.date_range("2024-01-01", periods=24, freq="h")
+    data = {
+        "iy": idx.year,
+        "id": idx.dayofyear,
+        "it": idx.hour,
+        "imin": idx.minute,
+        "U": np.full(24, 3.0),
+        "RH": np.full(24, 60.0),
+        "Tair": np.full(24, 15.0),
+        "pres": np.full(24, 1013.0),
+        "rain": np.zeros(24),
+        "kdown": np.full(24, 100.0),
+    }
+    # fill remaining canonical optionals with the sentinel the named-column
+    # reader uses (-999.0)
+    for col in CANONICAL_FORCING_COLUMNS:
+        if col not in data:
+            data[col] = np.full(24, -999.0)
+    # per-landcover extras appended at the end
+    data["lai_evetr"] = np.full(24, 1.5)
+    data["lai_dectr"] = np.full(24, 1.2)
+    data["wuh_paved"] = np.zeros(24)
+    df_forcing = pd.DataFrame(data, index=idx)
+
+    issues = check_forcing(df_forcing, fix=False)
+
+    # validator should return None (passes) — no missing-column or
+    # positional issues attributable to per-LC extras or to `isec`.
+    assert issues is None, (
+        f"check_forcing flagged per-landcover-aware DataFrame: {issues}"
+    )

--- a/test/io_tests/test_named_column_forcing.py
+++ b/test/io_tests/test_named_column_forcing.py
@@ -293,3 +293,27 @@ def test_check_forcing_accepts_per_landcover_extras():
     assert issues is None, (
         f"check_forcing flagged per-landcover-aware DataFrame: {issues}"
     )
+
+
+def test_check_forcing_flags_truly_unknown_columns():
+    """gh#1413: the name-based unknown-column check (replacing the legacy
+    positional zip) must still reject columns that are neither canonical,
+    `isec`, nor a whitelisted per-landcover extra.
+    """
+    from supy._check import check_forcing
+    from supy._load import CANONICAL_FORCING_COLUMNS
+
+    idx = pd.date_range("2024-01-01", periods=24, freq="h")
+    data = {col: np.full(24, -999.0) for col in CANONICAL_FORCING_COLUMNS}
+    # plausible but unsupported: soil moisture per land cover (see
+    # @suegrimmond's #1378 comment — only LAI and water-use are
+    # land-cover-resolved at the forcing layer).
+    data["xsmd_evetr"] = np.full(24, 0.2)
+    df_forcing = pd.DataFrame(data, index=idx)
+
+    issues = check_forcing(df_forcing, fix=False)
+
+    assert issues is not None
+    assert any("Unknown forcing columns" in s and "xsmd_evetr" in s for s in issues), (
+        f"expected 'Unknown forcing columns' issue mentioning xsmd_evetr; got: {issues}"
+    )


### PR DESCRIPTION
Closes #1413. Follow-up to PR #1378 (gh#1372 named-column forcing).

## Summary

Reported by @MatthewPaskin in [#1378 (comment)](https://github.com/UMEP-dev/SUEWS/pull/1378#issuecomment-4378160198):

> Seems there is still some code that is designed around fixed positions that is leading to errors in loading forcing data with per land cover values. The first point in the PR is to process the forcing by column name rather than position, however this code checks against position and names of the strict format.

`check_forcing` had two defects, both downstream of the same inconsistency between two reference lists:

| List | Where | Length | Notes |
|---|---|---|---|
| `dict_var_type_forcing.keys()` | `_load.py:106-132` | 25 | Internal resampling-type table; includes `isec` |
| `CANONICAL_FORCING_COLUMNS` | `_load.py:141-147` | 24 | User-facing canonical names produced by the named-column reader; no `isec` |

`list_col_forcing` at `_check.py:145` was built from the 25-key dict, but DataFrames produced by `_apply_named_column_matching` follow the 24-name canonical list (with per-landcover extras appended). Net effect: any `lai_<surface>` / `wuh_<surface>` DataFrame hit `Missing columns: {'isec'}` and `Column lai_evetr is not in the valid position for isec` — defeating the by-name promise of #1372/#1378.

## Changes

- `src/supy/_check.py`
  - Set-diff (1.1) now references `CANONICAL_FORCING_COLUMNS` instead of `list_col_forcing`.
  - The legacy positional `zip` (1.2) is removed. Replaced with a name-based unknown-column check that whitelists per-landcover extras via `_is_per_landcover_column` (the same helper already used at line 393 for the range loop) and tolerates legacy `isec` for back-compat with hand-built DataFrames.
- `test/io_tests/test_named_column_forcing.py`
  - `test_check_forcing_accepts_per_landcover_extras` — 24 canonical + `lai_evetr`/`lai_dectr`/`wuh_paved` must pass `check_forcing`.
  - `test_check_forcing_flags_truly_unknown_columns` — covers the inverse per the *Validation Edge Cases* rule: a plausible-but-unsupported column (`xsmd_<surface>` — only LAI and water-use are land-cover-resolved per @suegrimmond's #1378 comment) must still be rejected.

No schema bump (column shape unchanged), no Fortran/Rust impact.

## Test plan

- [x] `pytest test/io_tests/test_named_column_forcing.py` — 14/14 pass (including both new regressions).
- [x] `pytest test/core/test_wind_speed_validation.py test/core/test_laimethod.py` — 39/39 pass (existing `check_forcing` callers unaffected).
- [x] `make test-smoke` — 8/8 pass.
- [ ] CI: standard PR matrix.

## References

- Issue: #1413
- Original PR: #1378
- Feature issue: #1372

https://claude.ai/code/session_01BoHyGn5DJ7bzjPgnsv1eXR