### PR TITLE
Fix Phase A output control migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ EXAMPLES:
 
 ## 2026
 
+### 5 May 2026
+
+- [bugfix] Phase A no longer flags `model.control.forcing_file`/`output_file` as missing/extra and no longer surfaces a misleading `model.control.output.format` enum error when the legacy block already carries a valid `format` (#1417)
+  - Phase A previously compared a legacy YAML directly against the current `sample_config.yml`, inserting an all-null current `output` block while leaving the valid legacy `output_file` in place; Phase C then gave precedence to the all-null current block, raising `Input should be 'txt' or 'parquet'` even though the user had `output_file.format: txt`
+  - `phase_a.py` now mirrors the runtime `ModelControl._coerce_legacy_forcing_file` / `_coerce_legacy_output_file` validators: legacy `forcing_file` lifts under `forcing.file`, legacy `output_file` lifts under `output` (with `path -> dir`), current shape wins on duplicates, and a non-dict current `output` is preserved so Phase C still surfaces the genuine validation error
+  - `report_config.txt` records the migration as a renamed parameter (`forcing_file changed to forcing.file`, `output_file changed to output`) so the user sees the same migration breadcrumb that the Pydantic layer emits as a `DeprecationWarning` at runtime
+
 ### 3 May 2026
 
 - [change][experimental] Collapse the gh#1372 forcing- and output-restructure schema bumps into a single `2026.5.dev8 -> 2026.5.dev9` cumulative migration (#1372)

--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -48,7 +48,7 @@ ALLOWED_REF_KEYS = {"desc", "DOI", "ID"}
 _MISSING = object()
 
 
-def _is_nullish_tree(value):
+def _is_nullish_tree(value: object) -> bool:
     """Return True when a generated placeholder carries no user value."""
     if value is None:
         return True
@@ -69,13 +69,24 @@ def _is_default_backed_control_path(param_path: str) -> bool:
     )
 
 
-def _normalise_model_control_subobjects(config_data):
+def _normalise_model_control_subobjects(
+    config_data: object,
+) -> tuple[object, list[tuple[str, str]]]:
     """Normalise legacy model.control sub-objects before Phase A comparison.
 
     The Pydantic layer already accepts ``forcing_file`` and ``output_file``.
     Phase A must mirror that compatibility before comparing a user YAML
     against the current sample config; otherwise it inserts all-null current
     sub-objects that later take precedence over the valid legacy blocks.
+
+    The returned ``replacements`` list records every legacy key that has
+    been consumed so the report writer can surface the migration in
+    ``renamed_replacements``. The note is recorded both when legacy values
+    are migrated into the modern block and when a current modern block
+    already exists and the legacy duplicate is dropped — mirroring the
+    ``DeprecationWarning`` that ``ModelControl._coerce_legacy_*`` emits at
+    runtime, so the user sees the same migration breadcrumb in
+    ``report_config.txt``.
     """
     if not isinstance(config_data, dict):
         return config_data, []
@@ -88,17 +99,18 @@ def _normalise_model_control_subobjects(config_data):
     if not isinstance(control, dict):
         return normalised, []
 
-    replacements = []
+    replacements: list[tuple[str, str]] = []
 
     legacy_forcing = control.pop("forcing_file", _MISSING)
     if legacy_forcing is not _MISSING:
         forcing = control.get("forcing")
         if not isinstance(forcing, dict) or _is_nullish_tree(forcing):
             control["forcing"] = {"file": legacy_forcing}
-            replacements.append(("forcing_file", "forcing.file"))
         elif "file" not in forcing or _is_nullish_tree(forcing.get("file")):
             forcing["file"] = legacy_forcing
-            replacements.append(("forcing_file", "forcing.file"))
+        # else: current forcing.file is real; legacy value is dropped, but
+        # we still record the key migration so the user sees it.
+        replacements.append(("forcing_file", "forcing.file"))
 
     legacy_output = control.pop("output_file", _MISSING)
     if legacy_output is not _MISSING:
@@ -116,9 +128,13 @@ def _normalise_model_control_subobjects(config_data):
                 if "path" in legacy_output and "dir" not in migrated:
                     migrated["dir"] = legacy_output["path"]
                 control["output"] = migrated
-                replacements.append(("output_file", "output"))
             else:
                 control.pop("output", None)
+        # Always record the migration: either we lifted legacy values into
+        # the modern block, or a real current `output` block already exists
+        # and the legacy duplicate has been dropped (current wins, matching
+        # ModelControl._coerce_legacy_output_file).
+        replacements.append(("output_file", "output"))
 
     return normalised, replacements
 

--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -59,6 +59,21 @@ def _is_nullish_tree(value: object) -> bool:
     return False
 
 
+def _is_generated_null_placeholder(value: object) -> bool:
+    """Return True for non-empty containers that only contain null placeholders."""
+    if value is None:
+        return True
+    if isinstance(value, dict):
+        return bool(value) and all(
+            _is_generated_null_placeholder(item) for item in value.values()
+        )
+    if isinstance(value, list):
+        return bool(value) and all(
+            _is_generated_null_placeholder(item) for item in value
+        )
+    return False
+
+
 def _is_default_backed_control_path(param_path: str) -> bool:
     """Phase A should not materialise nulls for Pydantic-defaulted controls."""
     return (
@@ -116,7 +131,7 @@ def _normalise_model_control_subobjects(
     if legacy_output is not _MISSING:
         output = control.get("output")
         output_is_placeholder = output is None or (
-            isinstance(output, dict) and _is_nullish_tree(output)
+            isinstance(output, dict) and _is_generated_null_placeholder(output)
         )
         if output_is_placeholder:
             if isinstance(legacy_output, dict):

--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -1,6 +1,7 @@
 import yaml
 import os
 import subprocess
+from copy import deepcopy
 from typing import Optional
 import pandas as pd
 from pathlib import Path
@@ -43,6 +44,84 @@ PHYSICS_OPTIONS = {
 }
 
 ALLOWED_REF_KEYS = {"desc", "DOI", "ID"}
+
+_MISSING = object()
+
+
+def _is_nullish_tree(value):
+    """Return True when a generated placeholder carries no user value."""
+    if value is None:
+        return True
+    if isinstance(value, dict):
+        return all(_is_nullish_tree(item) for item in value.values())
+    if isinstance(value, list):
+        return all(_is_nullish_tree(item) for item in value)
+    return False
+
+
+def _is_default_backed_control_path(param_path: str) -> bool:
+    """Phase A should not materialise nulls for Pydantic-defaulted controls."""
+    return (
+        param_path == "model.control.forcing"
+        or param_path == "model.control.forcing.file"
+        or param_path == "model.control.output"
+        or param_path.startswith("model.control.output.")
+    )
+
+
+def _normalise_model_control_subobjects(config_data):
+    """Normalise legacy model.control sub-objects before Phase A comparison.
+
+    The Pydantic layer already accepts ``forcing_file`` and ``output_file``.
+    Phase A must mirror that compatibility before comparing a user YAML
+    against the current sample config; otherwise it inserts all-null current
+    sub-objects that later take precedence over the valid legacy blocks.
+    """
+    if not isinstance(config_data, dict):
+        return config_data, []
+
+    normalised = deepcopy(config_data)
+    model = normalised.get("model")
+    if not isinstance(model, dict):
+        return normalised, []
+    control = model.get("control")
+    if not isinstance(control, dict):
+        return normalised, []
+
+    replacements = []
+
+    legacy_forcing = control.pop("forcing_file", _MISSING)
+    if legacy_forcing is not _MISSING:
+        forcing = control.get("forcing")
+        if not isinstance(forcing, dict) or _is_nullish_tree(forcing):
+            control["forcing"] = {"file": legacy_forcing}
+            replacements.append(("forcing_file", "forcing.file"))
+        elif "file" not in forcing or _is_nullish_tree(forcing.get("file")):
+            forcing["file"] = legacy_forcing
+            replacements.append(("forcing_file", "forcing.file"))
+
+    legacy_output = control.pop("output_file", _MISSING)
+    if legacy_output is not _MISSING:
+        output = control.get("output")
+        output_is_placeholder = output is None or (
+            isinstance(output, dict) and _is_nullish_tree(output)
+        )
+        if output_is_placeholder:
+            if isinstance(legacy_output, dict):
+                migrated = {
+                    key: value
+                    for key, value in legacy_output.items()
+                    if key != "path"
+                }
+                if "path" in legacy_output and "dir" not in migrated:
+                    migrated["dir"] = legacy_output["path"]
+                control["output"] = migrated
+                replacements.append(("output_file", "output"))
+            else:
+                control.pop("output", None)
+
+    return normalised, replacements
+
 
 def _strip_ref_blocks(obj):
     """
@@ -300,6 +379,10 @@ def categorise_extra_parameters(extra_params: list) -> dict:
 def find_extra_parameters(user_data, standard_data, current_path=""):
     """Find parameters that exist in user data but not in standard data."""
     extra_params = []
+    if current_path == "":
+        user_data, _ = _normalise_model_control_subobjects(user_data)
+        standard_data, _ = _normalise_model_control_subobjects(standard_data)
+
     if isinstance(user_data, dict) and isinstance(standard_data, dict):
         for key, user_value in user_data.items():
             full_path = f"{current_path}.{key}" if current_path else key
@@ -344,10 +427,16 @@ def find_extra_parameters_in_lists(user_list, standard_list, current_path=""):
 
 def find_missing_parameters(user_data, standard_data, current_path=""):
     missing_params = []
+    if current_path == "":
+        user_data, _ = _normalise_model_control_subobjects(user_data)
+        standard_data, _ = _normalise_model_control_subobjects(standard_data)
+
     if isinstance(standard_data, dict):
         user_dict = user_data if isinstance(user_data, dict) else {}
         for key, standard_value in standard_data.items():
             full_path = f"{current_path}.{key}" if current_path else key
+            if _is_default_backed_control_path(full_path):
+                continue
             if key not in user_dict:
                 is_physics = is_physics_option(full_path)
                 missing_params.append((full_path, standard_value, is_physics))
@@ -1744,7 +1833,13 @@ def annotate_missing_parameters(
         )
         user_data = yaml.safe_load(original_yaml_content)
         parsed_renames = handle_renamed_parameters_in_parsed_yaml(user_data)
-        if parsed_renames:
+        normalised_user_data, control_replacements = _normalise_model_control_subobjects(
+            user_data
+        )
+        control_normalised = normalised_user_data != user_data
+        user_data = normalised_user_data
+        parsed_renames.extend(control_replacements)
+        if parsed_renames or control_normalised:
             seen_replacements = set(renamed_replacements)
             for replacement in parsed_renames:
                 if replacement not in seen_replacements:

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -356,6 +356,165 @@ sites:
         self.assertNotIn("model.physics.rsl_method", extra_paths)
         self.assertNotIn("model.physics.gs_model", extra_paths)
 
+    def test_gh1417_legacy_control_blocks_do_not_gain_null_current_blocks(self):
+        """Legacy control keys should migrate before Phase A structure checks."""
+        legacy_data = deepcopy(self.standard_data)
+        control = legacy_data["model"]["control"]
+
+        legacy_forcing = control.pop("forcing")["file"]
+        legacy_output = deepcopy(control.pop("output"))
+        legacy_output_file = deepcopy(legacy_output)
+        legacy_output_file["path"] = legacy_output_file.pop("dir", None)
+        control["forcing_file"] = legacy_forcing
+        control["output_file"] = legacy_output_file
+
+        missing_paths = {
+            path for path, _, _ in find_missing_parameters(legacy_data, self.standard_data)
+        }
+        extra_paths = set(find_extra_parameters(legacy_data, self.standard_data))
+
+        self.assertNotIn("model.control.forcing", missing_paths)
+        self.assertNotIn("model.control.forcing.file", missing_paths)
+        self.assertNotIn("model.control.output", missing_paths)
+        self.assertNotIn("model.control.output.format", missing_paths)
+        self.assertNotIn("model.control.forcing_file", extra_paths)
+        self.assertNotIn("model.control.output_file", extra_paths)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            user_file = tmp_path / "legacy.yml"
+            standard_file = tmp_path / "standard.yml"
+            updated_file = tmp_path / "updated.yml"
+            report_file = tmp_path / "report.txt"
+
+            user_file.write_text(
+                yaml.safe_dump(legacy_data, sort_keys=False),
+                encoding="utf-8",
+            )
+            standard_file.write_text(
+                yaml.safe_dump(self.standard_data, sort_keys=False),
+                encoding="utf-8",
+            )
+
+            annotate_missing_parameters(
+                user_file=str(user_file),
+                standard_file=str(standard_file),
+                uptodate_file=str(updated_file),
+                report_file=str(report_file),
+                mode="dev",
+                phase="A",
+                forcing="off",
+            )
+
+            updated_data = yaml.safe_load(updated_file.read_text(encoding="utf-8"))
+            updated_control = updated_data["model"]["control"]
+            self.assertNotIn("forcing_file", updated_control)
+            self.assertNotIn("output_file", updated_control)
+            self.assertEqual(updated_control["forcing"]["file"], legacy_forcing)
+            self.assertEqual(updated_control["output"]["format"], "txt")
+            self.assertEqual(updated_control["output"]["dir"], legacy_output["dir"])
+            self.assertNotIn("path", updated_control["output"])
+
+            report_content = report_file.read_text(encoding="utf-8")
+            self.assertNotIn("model.control.forcing added", report_content)
+            self.assertNotIn("model.control.output added", report_content)
+            self.assertNotIn("forcing_file at level", report_content)
+            self.assertNotIn("output_file at level", report_content)
+
+    def test_gh1417_current_control_blocks_win_over_legacy_duplicates(self):
+        """Current control blocks should win and legacy duplicates should be dropped."""
+        data = deepcopy(self.standard_data)
+        control = data["model"]["control"]
+        control["forcing_file"] = {"value": "legacy_forcing.txt"}
+        control["output_file"] = {
+            "format": "parquet",
+            "freq": 1800,
+            "path": "./legacy_output",
+        }
+
+        extra_paths = set(find_extra_parameters(data, self.standard_data))
+        self.assertNotIn("model.control.forcing_file", extra_paths)
+        self.assertNotIn("model.control.output_file", extra_paths)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            user_file = tmp_path / "duplicate.yml"
+            standard_file = tmp_path / "standard.yml"
+            updated_file = tmp_path / "updated.yml"
+            report_file = tmp_path / "report.txt"
+
+            user_file.write_text(
+                yaml.safe_dump(data, sort_keys=False),
+                encoding="utf-8",
+            )
+            standard_file.write_text(
+                yaml.safe_dump(self.standard_data, sort_keys=False),
+                encoding="utf-8",
+            )
+
+            annotate_missing_parameters(
+                user_file=str(user_file),
+                standard_file=str(standard_file),
+                uptodate_file=str(updated_file),
+                report_file=str(report_file),
+                mode="dev",
+                phase="A",
+                forcing="off",
+            )
+
+            updated_data = yaml.safe_load(updated_file.read_text(encoding="utf-8"))
+            updated_control = updated_data["model"]["control"]
+            self.assertNotIn("forcing_file", updated_control)
+            self.assertNotIn("output_file", updated_control)
+            self.assertEqual(
+                updated_control["forcing"], self.standard_data["model"]["control"]["forcing"]
+            )
+            self.assertEqual(
+                updated_control["output"], self.standard_data["model"]["control"]["output"]
+            )
+
+    def test_gh1417_invalid_current_output_is_not_replaced_by_legacy(self):
+        """Invalid current output values should survive for Phase C validation."""
+        data = deepcopy(self.standard_data)
+        control = data["model"]["control"]
+        control["output"] = "bad"
+        control["output_file"] = {
+            "format": "txt",
+            "freq": 3600,
+            "path": "./legacy_output",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            user_file = tmp_path / "invalid_current.yml"
+            standard_file = tmp_path / "standard.yml"
+            updated_file = tmp_path / "updated.yml"
+            report_file = tmp_path / "report.txt"
+
+            user_file.write_text(
+                yaml.safe_dump(data, sort_keys=False),
+                encoding="utf-8",
+            )
+            standard_file.write_text(
+                yaml.safe_dump(self.standard_data, sort_keys=False),
+                encoding="utf-8",
+            )
+
+            annotate_missing_parameters(
+                user_file=str(user_file),
+                standard_file=str(standard_file),
+                uptodate_file=str(updated_file),
+                report_file=str(report_file),
+                mode="dev",
+                phase="A",
+                forcing="off",
+            )
+
+            updated_data = yaml.safe_load(updated_file.read_text(encoding="utf-8"))
+            updated_control = updated_data["model"]["control"]
+            self.assertEqual(updated_control["output"], "bad")
+            self.assertNotIn("output_file", updated_control)
+
     def test_extra_parameter_detection(self):
         """Test detection of NOT IN STANDARD parameters."""
         extra_params = find_extra_parameters(self.extra_params_yaml, self.standard_data)

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -482,6 +482,48 @@ sites:
             self.assertIn("forcing_file changed to forcing.file", report_content)
             self.assertIn("output_file changed to output", report_content)
 
+    def test_gh1417_empty_current_output_wins_over_legacy_duplicate(self):
+        """An empty current output block is valid and should not be overwritten."""
+        data = deepcopy(self.standard_data)
+        control = data["model"]["control"]
+        control["output"] = {}
+        control["output_file"] = {
+            "format": "parquet",
+            "freq": 1800,
+            "path": "./legacy_output",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            user_file = tmp_path / "empty_current.yml"
+            standard_file = tmp_path / "standard.yml"
+            updated_file = tmp_path / "updated.yml"
+            report_file = tmp_path / "report.txt"
+
+            user_file.write_text(
+                yaml.safe_dump(data, sort_keys=False),
+                encoding="utf-8",
+            )
+            standard_file.write_text(
+                yaml.safe_dump(self.standard_data, sort_keys=False),
+                encoding="utf-8",
+            )
+
+            annotate_missing_parameters(
+                user_file=str(user_file),
+                standard_file=str(standard_file),
+                uptodate_file=str(updated_file),
+                report_file=str(report_file),
+                mode="dev",
+                phase="A",
+                forcing="off",
+            )
+
+            updated_data = yaml.safe_load(updated_file.read_text(encoding="utf-8"))
+            updated_control = updated_data["model"]["control"]
+            self.assertEqual(updated_control["output"], {})
+            self.assertNotIn("output_file", updated_control)
+
     def test_gh1417_invalid_current_output_is_not_replaced_by_legacy(self):
         """Invalid current output values should survive for Phase C validation."""
         data = deepcopy(self.standard_data)

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -473,6 +473,15 @@ sites:
                 updated_control["output"], self.standard_data["model"]["control"]["output"]
             )
 
+            # Even though current `forcing`/`output` win on duplicates,
+            # Phase A must still surface the legacy-key migration in the
+            # report so the user knows their `forcing_file`/`output_file`
+            # blocks were dropped (matching the DeprecationWarning that
+            # ModelControl._coerce_legacy_* emits at runtime).
+            report_content = report_file.read_text(encoding="utf-8")
+            self.assertIn("forcing_file changed to forcing.file", report_content)
+            self.assertIn("output_file changed to output", report_content)
+
     def test_gh1417_invalid_current_output_is_not_replaced_by_legacy(self):
         """Invalid current output values should survive for Phase C validation."""
         data = deepcopy(self.standard_data)


### PR DESCRIPTION
## Summary

Fixes gh#1417 by normalising legacy `model.control.forcing_file` and `model.control.output_file` during Phase A before the validator compares a user YAML against the current sample configuration.

## Root cause

Phase A compared older YAML directly against the current `sample_config.yml`, so it added a new `model.control.output` block filled with `null` values while leaving the valid legacy `output_file` block in place. Phase C then gave precedence to the current `output` key, causing the misleading `model.control.output.format` enum error even though the legacy `output_file.format` was `txt`.

## Changes

- Normalise legacy control sub-objects before Phase A missing/extra checks and emitted YAML generation.
- Populate `output` from `output_file` only when current `output` is absent or an all-null generated placeholder.
- Always drop legacy `output_file`/`forcing_file` from Phase A's updated YAML so the output uses the current schema surface only.
- Avoid adding null placeholders for default-backed `forcing` and `output` control blocks.
- Add GH1417 regression tests for legacy-only blocks, duplicate current+legacy blocks, and invalid current `output` values that must remain visible to Phase C.

## Validation

- `PYTHONPATH=src python3 -m pytest test/data_model/test_yaml_processing.py -k "forcing_file or output_file or gh1417"`
- `PYTHONPATH=src python3 -m pytest test/io_tests/test_output_config.py`
- Re-ran `PYTHONPATH=src python3 -m supy.cmd.suews_cli validate --mode dev -f off /tmp/old_veg-gh1417.yml`; the misleading `model.control.output.format` enum error is gone, and the report now surfaces the genuine remaining configuration errors.

Closes #1417

Closes #1183