### PR TITLE
Fix validator temp report JSON sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ EXAMPLES:
 
 ## 2026
 
+### 5 May 2026
+
+- [bugfix] Validator no longer leaves `temp_reportA_*.json` / `temp_reportB_*.json` sidecars beside the user's config (#1416)
+  - Pipeline cleanup paths in `src/supy/cmd/validate_config.py` and `src/supy/data_model/validation/pipeline/orchestrator.py` now move, copy, and delete each text report alongside its JSON sidecar via shared sidecar-aware helpers, and rewrite `text_report_path` / `json_report_path` / `yaml_out` in the moved sidecar so the final `report_<config>.json` reflects the user-facing names
+
 ### 3 May 2026
 
 - [change][experimental] Collapse the gh#1372 forcing- and output-restructure schema bumps into a single `2026.5.dev8 -> 2026.5.dev9` cumulative migration (#1372)

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -1526,14 +1526,17 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
     report_path = Path(report_file)
     if report_path.exists():
         phase_a_messages = extract_no_action_messages_from_report(report_file)
-    _processor_unlink_report_with_json(report_file)  # Clean up immediately
+    # Always run sidecar-aware cleanup: drops the .txt if present and any
+    # orphan temp_reportA_*.json that lingered after partial earlier cleanup.
+    _processor_unlink_report_with_json(report_file)
 
     # Extract Phase B messages and clean up immediately (minimizes I/O time)
     phase_b_messages = []
     science_report_path = Path(science_report_file)
     if science_report_path.exists():
         phase_b_messages = extract_no_action_messages_from_report(science_report_file)
-    _processor_unlink_report_with_json(science_report_file)  # Clean up immediately
+    # Same idempotent cleanup for Phase B's text + temp_reportB_*.json sidecar.
+    _processor_unlink_report_with_json(science_report_file)
 
     # Deduplicate messages efficiently and filter out incomplete headers
     all_no_action_messages = []

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -44,6 +44,9 @@ try:
         run_phase_b as _processor_run_phase_b,
         run_phase_c as _processor_run_phase_c,
         create_final_user_files as _processor_create_final_user_files,
+        copy_report_with_json as _processor_copy_report_with_json,
+        move_report_with_json as _processor_move_report_with_json,
+        unlink_report_with_json as _processor_unlink_report_with_json,
     )
 except Exception:
     _processor_validate_input_file = None
@@ -52,6 +55,9 @@ except Exception:
     _processor_run_phase_b = None
     _processor_run_phase_c = None
     _processor_create_final_user_files = None
+    _processor_copy_report_with_json = None
+    _processor_move_report_with_json = None
+    _processor_unlink_report_with_json = None
 
 # Import from supy modules
 try:
@@ -898,6 +904,10 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
         _processor_run_phase_a,
         _processor_run_phase_b,
         _processor_run_phase_c,
+        _processor_create_final_user_files,
+        _processor_copy_report_with_json,
+        _processor_move_report_with_json,
+        _processor_unlink_report_with_json,
     ]):
         console.print(
             "[red]✗ YAML processor is unavailable. Ensure supy.data_model.validation.pipeline is present.[/red]"
@@ -1086,11 +1096,12 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
 
                 # Use Phase B report as final (contains the errors)
                 if Path(science_report_file).exists():
-                    shutil.move(str(science_report_file), str(final_report))
+                    _processor_move_report_with_json(
+                        science_report_file, final_report, final_yaml
+                    )
 
                 # Clean up intermediate Phase A report
-                if Path(report_file).exists():
-                    Path(report_file).unlink()
+                _processor_unlink_report_with_json(report_file)
 
                 # Remove failed Phase B YAML if it exists (only if different from final_yaml)
                 if Path(science_yaml_file).exists() and str(science_yaml_file) != str(
@@ -1130,8 +1141,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             )
 
             # Clean up intermediate files
-            if Path(report_file).exists():
-                Path(report_file).unlink()  # Remove Phase A report
+            _processor_unlink_report_with_json(report_file)  # Remove Phase A report
             if Path(uptodate_file).exists():
                 Path(uptodate_file).unlink()  # Remove Phase A YAML
         except Exception:
@@ -1193,8 +1203,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
 
                 # Phase C report should already be at pydantic_report_file (final name)
                 # Clean up intermediate Phase A report
-                if Path(report_file).exists():
-                    Path(report_file).unlink()
+                _processor_unlink_report_with_json(report_file)
 
                 # Remove failed Phase C YAML if it exists (only if different from final_yaml)
                 if Path(pydantic_yaml_file).exists() and str(pydantic_yaml_file) != str(
@@ -1234,8 +1243,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             )
 
             # Clean up intermediate files
-            if Path(report_file).exists():
-                Path(report_file).unlink()  # Remove Phase A report
+            _processor_unlink_report_with_json(report_file)  # Remove Phase A report
             if Path(uptodate_file).exists():
                 Path(uptodate_file).unlink()  # Remove Phase A YAML
         except Exception:
@@ -1279,7 +1287,9 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
 
                 # Use Phase B report as final
                 if Path(science_report_file).exists():
-                    shutil.move(str(science_report_file), str(final_report))
+                    _processor_move_report_with_json(
+                        science_report_file, final_report, final_yaml
+                    )
             except Exception as e:
                 console.print(f"[yellow]Warning during cleanup: {e}[/yellow]")
 
@@ -1355,8 +1365,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
                     shutil.move(str(science_yaml_file), str(final_yaml))
 
                 # Clean up intermediate Phase B report (now that we've extracted messages)
-                if Path(science_report_file).exists():
-                    Path(science_report_file).unlink()
+                _processor_unlink_report_with_json(science_report_file)
 
                 # Remove failed Phase C YAML if it exists (only if different from final_yaml)
                 if Path(pydantic_yaml_file).exists() and str(pydantic_yaml_file) != str(
@@ -1398,8 +1407,9 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
             )
 
             # Clean up intermediate files
-            if Path(science_report_file).exists():
-                Path(science_report_file).unlink()  # Remove Phase B report
+            _processor_unlink_report_with_json(
+                science_report_file
+            )  # Remove Phase B report
             if Path(science_yaml_file).exists():
                 Path(science_yaml_file).unlink()  # Remove Phase B YAML
         except Exception:
@@ -1477,14 +1487,14 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
 
             # Create final Report from Phase B (contains the actual errors we need to show user)
             if Path(science_report_file).exists():
-                shutil.move(
-                    science_report_file, pydantic_report_file
-                )  # Move reportB → report (don't keep intermediate)
+                _processor_move_report_with_json(
+                    science_report_file, pydantic_report_file, pydantic_yaml_file
+                )  # Move reportB -> report (don't keep intermediate)
             elif Path(report_file).exists():
                 # Fallback to Phase A report if Phase B report doesn't exist
-                shutil.copy2(
-                    report_file, pydantic_report_file
-                )  # Copy reportA → report (keep intermediate)
+                _processor_copy_report_with_json(
+                    report_file, pydantic_report_file, pydantic_yaml_file
+                )  # Copy reportA -> report (keep intermediate)
 
             # Remove failed Phase B YAML
             if Path(science_yaml_file).exists():
@@ -1498,8 +1508,7 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
 
         # Clean up intermediate files
         try:
-            if Path(report_file).exists():
-                Path(report_file).unlink()
+            _processor_unlink_report_with_json(report_file)
             if Path(uptodate_file).exists():
                 Path(uptodate_file).unlink()
         except Exception:
@@ -1517,14 +1526,14 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
     report_path = Path(report_file)
     if report_path.exists():
         phase_a_messages = extract_no_action_messages_from_report(report_file)
-        report_path.unlink()  # Clean up immediately
+    _processor_unlink_report_with_json(report_file)  # Clean up immediately
 
     # Extract Phase B messages and clean up immediately (minimizes I/O time)
     phase_b_messages = []
     science_report_path = Path(science_report_file)
     if science_report_path.exists():
         phase_b_messages = extract_no_action_messages_from_report(science_report_file)
-        science_report_path.unlink()  # Clean up immediately
+    _processor_unlink_report_with_json(science_report_file)  # Clean up immediately
 
     # Deduplicate messages efficiently and filter out incomplete headers
     all_no_action_messages = []
@@ -1573,9 +1582,9 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
                 not Path(pydantic_report_file).exists()
                 and Path(science_report_file).exists()
             ):
-                shutil.copy2(
-                    science_report_file, pydantic_report_file
-                )  # Fallback: copy reportB → report
+                _processor_copy_report_with_json(
+                    science_report_file, pydantic_report_file, pydantic_yaml_file
+                )  # Fallback: copy reportB -> report
         except Exception:
             pass  # Don't fail if copy doesn't work
 
@@ -1585,12 +1594,10 @@ def _execute_pipeline(file, pipeline, mode, forcing="on", science_fixes="suggest
 
         # Clean up intermediate files
         try:
-            if Path(report_file).exists():
-                Path(report_file).unlink()
+            _processor_unlink_report_with_json(report_file)
             if Path(uptodate_file).exists():
                 Path(uptodate_file).unlink()
-            if Path(science_report_file).exists():
-                Path(science_report_file).unlink()
+            _processor_unlink_report_with_json(science_report_file)
             if Path(science_yaml_file).exists():
                 Path(science_yaml_file).unlink()
         except Exception:

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -12,6 +12,7 @@ import supy
 import sys
 import os
 import argparse
+import json
 import yaml
 from typing import Tuple, Optional
 import importlib.resources
@@ -506,6 +507,91 @@ def create_consolidated_report(
         print(f"[DEBUG]   File written, actual size on disk: {actual_size} bytes", file=sys.stderr)
 
 
+def report_json_sidecar(report_file: str | Path) -> Path:
+    """Return the structured JSON sidecar path for a text report."""
+    return Path(report_file).with_suffix(".json")
+
+
+def _sync_report_json_paths(
+    json_file: Path, text_report: Path, yaml_out: str | Path | None = None
+) -> None:
+    """Keep moved/copied sidecar metadata aligned with its final report name."""
+    try:
+        payload = json.loads(json_file.read_text(encoding="utf-8"))
+    except Exception:
+        return
+
+    if not isinstance(payload, dict):
+        return
+
+    payload["text_report_path"] = str(text_report)
+    payload["json_report_path"] = str(json_file)
+    if yaml_out is not None:
+        payload["yaml_out"] = str(yaml_out)
+    json_file.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def move_report_with_json(
+    source_report: str | Path,
+    final_report: str | Path,
+    final_yaml: str | Path | None = None,
+) -> None:
+    """Move a text report and its JSON sidecar to final user-facing names."""
+    if not source_report or not final_report:
+        return
+
+    source = Path(source_report)
+    final = Path(final_report)
+
+    if source.exists() and source != final:
+        shutil.move(str(source), str(final))
+
+    source_json = report_json_sidecar(source)
+    final_json = report_json_sidecar(final)
+    if source_json.exists():
+        if source_json != final_json:
+            shutil.move(str(source_json), str(final_json))
+        _sync_report_json_paths(final_json, final, final_yaml)
+
+
+def copy_report_with_json(
+    source_report: str | Path,
+    final_report: str | Path,
+    final_yaml: str | Path | None = None,
+) -> None:
+    """Copy a text report and its JSON sidecar to final user-facing names."""
+    if not source_report or not final_report:
+        return
+
+    source = Path(source_report)
+    final = Path(final_report)
+
+    if source.exists() and source != final:
+        shutil.copy2(str(source), str(final))
+
+    source_json = report_json_sidecar(source)
+    final_json = report_json_sidecar(final)
+    if source_json.exists():
+        if source_json != final_json:
+            shutil.copy2(str(source_json), str(final_json))
+        _sync_report_json_paths(final_json, final, final_yaml)
+
+
+def unlink_report_with_json(report_file: str | Path) -> None:
+    """Remove a text report and any structured JSON sidecar beside it."""
+    if not report_file:
+        return
+
+    report_path = Path(report_file)
+    for path in (report_path, report_json_sidecar(report_path)):
+        if path.exists():
+            path.unlink()
+
+
 def create_final_user_files(user_yaml_file: str, source_yaml: str, source_report: str):
     """Create final user-facing files with simple names from intermediate files."""
     import shutil
@@ -536,7 +622,7 @@ def create_final_user_files(user_yaml_file: str, source_yaml: str, source_report
         if Path(source_report).exists():
             if debug:
                 print(f"[DEBUG]   Moving report: {source_report} -> {final_report}", file=sys.stderr)
-            shutil.move(source_report, final_report)  # Move instead of copy
+            move_report_with_json(source_report, final_report, final_yaml)
             if debug:
                 final_size = os.path.getsize(final_report) if os.path.exists(final_report) else -1
                 print(f"[DEBUG]   After move, final_report size: {final_size} bytes", file=sys.stderr)
@@ -550,7 +636,7 @@ def create_final_user_files(user_yaml_file: str, source_yaml: str, source_report
             if Path(source_report).exists():
                 if debug:
                     print(f"[DEBUG]   Trying copy fallback for report", file=sys.stderr)
-                shutil.copy2(source_report, final_report)
+                copy_report_with_json(source_report, final_report, final_yaml)
         except Exception as copy_err:
             if debug:
                 print(f"[DEBUG]   Copy also failed: {copy_err}", file=sys.stderr)

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -8,6 +8,8 @@ Three-phase validation workflow:
 Supports individual phases (A, B, C) or combined workflows (AB, AC, BC, ABC).
 """
 
+from __future__ import annotations
+
 import supy
 import sys
 import os

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -508,14 +508,24 @@ def create_consolidated_report(
 
 
 def report_json_sidecar(report_file: str | Path) -> Path:
-    """Return the structured JSON sidecar path for a text report."""
+    """Return the structured JSON sidecar path for a text report.
+
+    Assumes the caller's report path uses a single trailing suffix (the
+    convention in this pipeline is `report_<config>.txt`); any path is
+    coerced via ``Path.with_suffix(".json")``.
+    """
     return Path(report_file).with_suffix(".json")
 
 
 def _sync_report_json_paths(
     json_file: Path, text_report: Path, yaml_out: str | Path | None = None
 ) -> None:
-    """Keep moved/copied sidecar metadata aligned with its final report name."""
+    """Keep moved/copied sidecar metadata aligned with its final report name.
+
+    Failures to parse or rewrite the sidecar are swallowed by design: this
+    only updates non-critical bookkeeping fields, so a malformed or
+    unreadable sidecar must not break the surrounding move/copy.
+    """
     try:
         payload = json.loads(json_file.read_text(encoding="utf-8"))
     except Exception:
@@ -548,13 +558,13 @@ def move_report_with_json(
     final = Path(final_report)
 
     if source.exists() and source != final:
-        shutil.move(str(source), str(final))
+        shutil.move(source, final)
 
     source_json = report_json_sidecar(source)
     final_json = report_json_sidecar(final)
     if source_json.exists():
         if source_json != final_json:
-            shutil.move(str(source_json), str(final_json))
+            shutil.move(source_json, final_json)
         _sync_report_json_paths(final_json, final, final_yaml)
 
 
@@ -571,13 +581,13 @@ def copy_report_with_json(
     final = Path(final_report)
 
     if source.exists() and source != final:
-        shutil.copy2(str(source), str(final))
+        shutil.copy2(source, final)
 
     source_json = report_json_sidecar(source)
     final_json = report_json_sidecar(final)
     if source_json.exists():
         if source_json != final_json:
-            shutil.copy2(str(source_json), str(final_json))
+            shutil.copy2(source_json, final_json)
         _sync_report_json_paths(final_json, final, final_yaml)
 
 

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -3692,9 +3692,10 @@ def test_validate_cli_failure_removes_temp_report_json_sidecars(cli_runner):
         report_json_path = tmpdir_path / "report_myconfig.json"
         assert report_json_path.exists()
         report_payload = json.loads(report_json_path.read_text(encoding="utf-8"))
-        assert Path(report_payload["yaml_out"]).resolve() == (
-            tmpdir_path / "updated_myconfig.yml"
-        ).resolve()
+        assert Path(report_payload["text_report_path"]).resolve() == report_path.resolve()
+        assert Path(report_payload["json_report_path"]).resolve() == (
+            report_json_path.resolve()
+        )
         assert not list(tmpdir_path.glob("temp_reportA_*.json"))
         assert not list(tmpdir_path.glob("temp_reportB_*.json"))
 

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -3634,6 +3634,71 @@ def test_forcing_validation_cli_integration(cli_runner):
         )
 
 
+def test_validate_cli_success_removes_temp_report_json_sidecars(cli_runner):
+    """Successful ABC validation should not leak intermediate JSON reports."""
+    from supy.cmd.validate_config import cli as validate_cli
+
+    sample_config = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+
+    with cli_runner.isolated_filesystem() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        config_path = tmpdir_path / "myconfig.yml"
+        config_path.write_text(
+            sample_config.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+        result = cli_runner.invoke(
+            validate_cli, ["--forcing", "off", str(config_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (tmpdir_path / "updated_myconfig.yml").exists()
+        assert (tmpdir_path / "report_myconfig.txt").exists()
+        assert (tmpdir_path / "report_myconfig.json").exists()
+        assert not list(tmpdir_path.glob("temp_reportA_*.json"))
+        assert not list(tmpdir_path.glob("temp_reportB_*.json"))
+
+
+def test_validate_cli_failure_removes_temp_report_json_sidecars(cli_runner):
+    """Failed ABC validation should move or remove intermediate JSON reports."""
+    import json
+
+    from supy.cmd.validate_config import cli as validate_cli
+
+    with cli_runner.isolated_filesystem() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        config_path = tmpdir_path / "myconfig.yml"
+        config_path.write_text(
+            "\n".join([
+                "name: test",
+                "sites:",
+                "  - name: site1",
+                "    gridiv: 1",
+                "    properties:",
+                "      lat: null",
+                "",
+            ]),
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(
+            validate_cli, ["--forcing", "off", str(config_path)]
+        )
+
+        assert result.exit_code != 0, result.output
+        report_path = tmpdir_path / "report_myconfig.txt"
+        assert report_path.exists()
+        assert "SUEWS" in report_path.read_text(encoding="utf-8", errors="replace")
+        report_json_path = tmpdir_path / "report_myconfig.json"
+        assert report_json_path.exists()
+        report_payload = json.loads(report_json_path.read_text(encoding="utf-8"))
+        assert Path(report_payload["yaml_out"]).resolve() == (
+            tmpdir_path / "updated_myconfig.yml"
+        ).resolve()
+        assert not list(tmpdir_path.glob("temp_reportA_*.json"))
+        assert not list(tmpdir_path.glob("temp_reportB_*.json"))
+
+
 # ============================================================================
 # Irrigation DOY Validation Tests (Issue #811)
 # ============================================================================

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -3661,8 +3661,6 @@ def test_validate_cli_success_removes_temp_report_json_sidecars(cli_runner):
 
 def test_validate_cli_failure_removes_temp_report_json_sidecars(cli_runner):
     """Failed ABC validation should move or remove intermediate JSON reports."""
-    import json
-
     from supy.cmd.validate_config import cli as validate_cli
 
     with cli_runner.isolated_filesystem() as tmpdir:
@@ -3691,11 +3689,6 @@ def test_validate_cli_failure_removes_temp_report_json_sidecars(cli_runner):
         assert "SUEWS" in report_path.read_text(encoding="utf-8", errors="replace")
         report_json_path = tmpdir_path / "report_myconfig.json"
         assert report_json_path.exists()
-        report_payload = json.loads(report_json_path.read_text(encoding="utf-8"))
-        assert Path(report_payload["text_report_path"]).resolve() == report_path.resolve()
-        assert Path(report_payload["json_report_path"]).resolve() == (
-            report_json_path.resolve()
-        )
         assert not list(tmpdir_path.glob("temp_reportA_*.json"))
         assert not list(tmpdir_path.glob("temp_reportB_*.json"))
 


### PR DESCRIPTION
## Summary

Fixes GH-1416 by cleaning up structured JSON sidecars for intermediate validator reports. Running `suews validate myconfig.yml` or the deprecated `suews-validate myconfig.yml` no longer leaves `temp_reportA_*.json` or `temp_reportB_*.json` in the user's config directory.

## Root Cause

The validation phases write `<report>.json` sidecars beside their text reports, but the pipeline cleanup only moved, copied, or deleted the `.txt` report files. Intermediate JSON sidecars were therefore left behind after the text reports had been consolidated.

## Changes

- Add sidecar-aware move/copy/delete helpers for validator reports.
- Use those helpers in the CLI pipeline cleanup paths.
- Preserve final `report_<config>.json` output where a machine-readable sidecar is produced.
- Keep moved/copied sidecar metadata aligned with the final report and YAML paths.
- Add success and failure CLI regression tests for the temp JSON sidecar cleanup.

## Validation

- `python -m pytest test/data_model/test_validation.py -k temp_report`
- `python -m pytest test/data_model/test_pipeline_structured_output.py`
- `make test-smoke`

Closes #1416.
