### PR TITLE
fix(mcp): prevent project_root from expanding sandbox boundary

### DIFF
--- a/mcp/src/suews_mcp/backend/sandbox.py
+++ b/mcp/src/suews_mcp/backend/sandbox.py
@@ -23,9 +23,29 @@ class ProjectRoot:
     """Validates and resolves user-supplied paths against a fixed root."""
 
     def __init__(self, root: Optional[Union[str, Path]] = None) -> None:
+        configured_root = os.environ.get(ENV_PROJECT_ROOT)
+        session_root = (
+            Path(configured_root).resolve(strict=False)
+            if configured_root
+            else None
+        )
+
         if root is None:
-            root = os.environ.get(ENV_PROJECT_ROOT, os.getcwd())
-        self._root = Path(root).resolve(strict=False)
+            self._root = session_root or Path(os.getcwd()).resolve(strict=False)
+            return
+
+        requested_root = Path(root).resolve(strict=False)
+        if session_root is None:
+            self._root = requested_root
+            return
+
+        try:
+            requested_root.relative_to(session_root)
+        except ValueError:
+            self._root = session_root
+            return
+
+        self._root = requested_root
 
     @property
     def root(self) -> Path:

--- a/test/mcp/test_backend_sandbox.py
+++ b/test/mcp/test_backend_sandbox.py
@@ -64,3 +64,15 @@ def test_default_root_from_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     monkeypatch.setenv("SUEWS_MCP_PROJECT_ROOT", str(tmp_path))
     root = ProjectRoot()
     assert root.root == tmp_path.resolve()
+
+def test_requested_root_cannot_escape_session_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from suews_mcp.backend.sandbox import ProjectRoot
+
+    session_root = tmp_path / "session"
+    session_root.mkdir()
+    monkeypatch.setenv("SUEWS_MCP_PROJECT_ROOT", str(session_root))
+
+    root = ProjectRoot("/")
+    assert root.root == session_root.resolve()


### PR DESCRIPTION
### Motivation
- The MCP tools accepted a caller-supplied `project_root` and treated it as authoritative, letting untrusted callers widen the filesystem sandbox beyond the operator-configured `SUEWS_MCP_PROJECT_ROOT`.
- The change clamps or validates any requested root so callers can only narrow the session sandbox, closing the bypass.

### Description
- Update `ProjectRoot.__init__` in `mcp/src/suews_mcp/backend/sandbox.py` to read the session root from `ENV_PROJECT_ROOT` and to accept a requested `root` only when it is inside that session root, otherwise clamping to the session root; preserve existing behavior when no session root is configured.
- Add a regression test `test_requested_root_cannot_escape_session_root` to `test/mcp/test_backend_sandbox.py` that asserts a requested override such as `"/"` cannot escape the configured `SUEWS_MCP_PROJECT_ROOT`.

### Testing
- Ran `python -m pytest test/mcp -q` and all tests in that suite passed (`54 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d4415f0083308b6399ccfb069868)