### PR TITLE
ci: include SUEWS Makefiles in fortran path-filters

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -27,6 +27,9 @@ fortran:
   - 'src/suews/src/**'
   # External Fortran library (spartacus-surface)
   - 'src/suews/ext_lib/**'
+  # SUEWS makefiles executed during extension builds
+  - 'src/suews/Makefile'
+  - 'src/suews/Makefile.*'
   # Fortran static library build helper
   - 'src/supy/run_make.py'
 


### PR DESCRIPTION
### Motivation
- The granular CI path filters omitted build-executed SUEWS Makefiles (for example `src/suews/Makefile` and `src/suews/Makefile.*`), which allowed PRs that modify those files to skip wheel builds and bypass release build validation, creating a supply-chain risk.

### Description
- Add `src/suews/Makefile` and `src/suews/Makefile.*` to the `fortran` category in `.github/path-filters.yml` so changes to SUEWS build-executed makefiles are treated as build-relevant, and commit the minimal CI filter update.

### Testing
- Verified the update with repository checks using `git diff -- .github/path-filters.yml`, `git add`/`git commit`, and `nl -ba .github/path-filters.yml` to confirm the new patterns are present and the commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00dfd110f08330923177eed3dce604)