### PR TITLE
ci: run workflow control scripts from trusted base ref

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -288,6 +288,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -331,6 +332,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -465,6 +467,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false


### PR DESCRIPTION
### Motivation
- Prevent executing PR-controlled CI control scripts by ensuring jobs that run branch-protection or privileged actions (`pr-gate`, `post-ci-summary`, `determine_matrix`) load `.github/scripts` from the trusted base commit rather than the PR workspace.

### Description
- Add `ref: ${{ github.event.pull_request.base.sha || github.sha }}` to the three `actions/checkout` sparse checkouts that load `./.github/scripts` in `.github/workflows/build-publish_to_pypi.yml` so gate/comment scripts are sourced from the trusted base ref.

### Testing
- Ran repository verification commands: located checkout sites with `rg`, applied the scripted patch with a `python` replacement that asserted exactly 3 occurrences, inspected the change with `git diff` and `nl | sed`, and committed the updated workflow file, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00dee5688483308212b5f7b955986f)