### PR TITLE
Harden tutorial validation hook to avoid executing edited code

### DIFF
--- a/.claude/hooks/validate-tutorial.sh
+++ b/.claude/hooks/validate-tutorial.sh
@@ -11,13 +11,28 @@ CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
 
-# Exit if no file path or not a tutorial file
-if [[ -z "$FILE_PATH" ]] || [[ ! "$FILE_PATH" =~ docs/source/tutorials/.*\.py$ ]]; then
+# Exit if no path provided
+if [[ -z "$FILE_PATH" ]]; then
+    exit 0
+fi
+
+# Resolve to canonical path under project root
+if [[ "$FILE_PATH" = /* ]]; then
+    CANDIDATE_PATH="$FILE_PATH"
+else
+    CANDIDATE_PATH="$CLAUDE_PROJECT_DIR/$FILE_PATH"
+fi
+
+CANONICAL_PATH=$(python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CANDIDATE_PATH" 2>/dev/null || true)
+PROJECT_ROOT=$(python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CLAUDE_PROJECT_DIR")
+
+# Only validate tutorial Python files inside this repository
+if [[ -z "$CANONICAL_PATH" ]] || [[ ! "$CANONICAL_PATH" =~ ^$PROJECT_ROOT/docs/source/tutorials/[^/]+\.py$ ]]; then
     exit 0
 fi
 
 # Check if file exists
-if [[ ! -f "$FILE_PATH" ]]; then
+if [[ ! -f "$CANONICAL_PATH" ]]; then
     exit 0
 fi
 
@@ -26,19 +41,7 @@ if [[ -f "$CLAUDE_PROJECT_DIR/.venv/bin/activate" ]]; then
     source "$CLAUDE_PROJECT_DIR/.venv/bin/activate"
 fi
 
-# Run the tutorial with matplotlib non-interactive backend
-# Capture output but limit to key indicators
-cd "$CLAUDE_PROJECT_DIR"
-TUTORIAL_TIMEOUT=${TUTORIAL_TIMEOUT:-300}
-OUTPUT=$(MPLBACKEND=Agg timeout "$TUTORIAL_TIMEOUT" python "$FILE_PATH" 2>&1) || EXIT_CODE=$?
+# Validate syntax only without executing untrusted tutorial code
+python -m py_compile "$CANONICAL_PATH"
 
-if [[ ${EXIT_CODE:-0} -ne 0 ]]; then
-    # Extract the last error for context
-    ERROR_MSG=$(echo "$OUTPUT" | grep -E "(Error|Exception|Traceback)" | tail -5)
-    echo "TUTORIAL VALIDATION FAILED: $FILE_PATH"
-    echo "---"
-    echo "$ERROR_MSG"
-    exit 1
-fi
-
-echo "Tutorial validated: $(basename "$FILE_PATH")"
+echo "Tutorial syntax validated: $(basename "$CANONICAL_PATH")"


### PR DESCRIPTION
### Motivation
- A PostToolUse hook executed edited tutorial Python files with `python <file>`, creating an automatic local code-execution path for untrusted edits.
- The original path check used a loose substring match and did not canonicalize paths, allowing files outside the repo to be executed.
- Provide a minimal remediation that prevents arbitrary execution while keeping a lightweight validation step for edited tutorials.

### Description
- Replace runtime execution of tutorials with a syntax-only check using `python -m py_compile` to avoid importing or running untrusted tutorial code.
- Resolve the input path to a canonical real path and compute a repository-root `PROJECT_ROOT` to enforce a strict whitelist pattern `^$PROJECT_ROOT/docs/source/tutorials/[^/]+\.py$` so only in-repo tutorial files are considered.
- Preserve existing guardrails by no-op'ing when no path is provided or when the file does not exist, and retain optional `.venv` activation for compatibility.

### Testing
- Ran shell syntax check with `bash -n .claude/hooks/validate-tutorial.sh`, which succeeded.
- Simulated a PostToolUse payload with `printf '{"tool_input":{"file_path":"docs/source/tutorials/tutorial_01_quick_start.py"}}' | .claude/hooks/validate-tutorial.sh` and observed successful syntax validation output, indicating the hook accepts in-repo tutorials and no longer executes them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00df5d15fc8330a884e3d53a4d5a8c)