### PR TITLE
ci: stop running PR docs build in privileged Pages workflow

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -25,8 +25,6 @@ on:
   pull_request:
     paths:
       - 'site/**'
-      - 'docs/**'
-      - 'src/supy/data_model/**'
       - '.github/workflows/pages-deploy.yml'
 
   workflow_dispatch:
@@ -70,6 +68,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pandoc
 
       - name: Build documentation
+        if: github.event_name != 'pull_request'
         env:
           CI: "true"  # Enable reduced computation in sphinx-gallery examples
         run: |
@@ -95,10 +94,12 @@ jobs:
             cp -r site/* "_site/${PR_DIR}/"
             echo "Preview created at /${PR_DIR}/"
 
-            # Copy Sphinx docs to preview
-            mkdir -p "_site/${PR_DIR}/docs"
-            cp -r docs/build/html/* "_site/${PR_DIR}/docs/"
-            echo "Docs preview created at /${PR_DIR}/docs/"
+            # Copy Sphinx docs to preview when available (push/manual builds)
+            if [ -d docs/build/html ]; then
+              mkdir -p "_site/${PR_DIR}/docs"
+              cp -r docs/build/html/* "_site/${PR_DIR}/docs/"
+              echo "Docs preview created at /${PR_DIR}/docs/"
+            fi
 
             # Rewrite absolute paths for preview context
             # /brand/ → /preview/pr-N/brand/ so links work within preview


### PR DESCRIPTION
### Motivation
- The Pages deployment workflow held privileged permissions (`pages: write`, `id-token: write`, `pull-requests: write`) while running `uv pip install` and `make docs` on checked-out PR content, creating a CI privilege-boundary that could let untrusted PRs execute arbitrary code before deployment. 
- The intent is to remove the untrusted build step from the privileged workflow while preserving trusted `push`-time documentation builds and site previews.

### Description
- Removed `docs/**` and `src/supy/data_model/**` from the `pull_request` trigger paths in `.github/workflows/pages-deploy.yml`. 
- Added `if: github.event_name != 'pull_request'` to the `Build documentation` step so PR jobs do not run `uv pip install` or `make docs`. 
- Made docs preview copying conditional using `if [ -d docs/build/html ]; then ... fi` so preview logic only copies docs when they were built. 
- Left `push`-triggered doc builds intact so trusted branch builds continue to produce docs for production deployment.

### Testing
- Inspected the workflow with `sed -n '1,240p' .github/workflows/pages-deploy.yml` to confirm original vulnerable lines were present and then changed; the command completed successfully. 
- Verified the patch with `git diff -- .github/workflows/pages-deploy.yml` and committed the change with `git commit`, both of which succeeded. 
- Confirmed the resulting file contents and the presence of the `if` guard and removed PR triggers with `nl -ba .github/workflows/pages-deploy.yml | sed -n '18,120p'`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e4e2b7e08330a6df13e15b955957)