### PR TITLE
fix(ci): prevent PR workflows from deploying Pages artifacts

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -159,15 +159,15 @@ jobs:
           fi
 
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
-        if: steps.fork-check.outputs.is_fork != 'true'
+        if: github.event_name != 'pull_request' && steps.fork-check.outputs.is_fork != 'true'
 
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
-        if: steps.fork-check.outputs.is_fork != 'true'
+        if: github.event_name != 'pull_request' && steps.fork-check.outputs.is_fork != 'true'
         with:
           path: _site
 
       - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
-        if: steps.fork-check.outputs.is_fork != 'true'
+        if: github.event_name != 'pull_request' && steps.fork-check.outputs.is_fork != 'true'
         id: deployment
 
       - name: Comment fork PR status
@@ -203,7 +203,7 @@ jobs:
             }
 
       - name: Comment preview URL
-        if: github.event_name == 'pull_request' && steps.fork-check.outputs.is_fork != 'true'
+        if: github.event_name == 'pull_request' && steps.fork-check.outputs.is_fork != 'true' && steps.deployment.outputs.page_url != ''
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |


### PR DESCRIPTION
### Motivation
- A change to the Pages workflow allowed pull-request checkouts to place `site/*` into the artifact root `_site/`, enabling unmerged PR content to be published to the production Pages root and risking site defacement or trusted-domain attacks.
- The intent of this change is to preserve PR build/preview validation while ensuring unmerged PR content cannot be uploaded/published to the public GitHub Pages site.

### Description
- Added a guard to the Pages publication steps so that `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` only run when `github.event_name != 'pull_request'` and the PR is not a fork, thereby preventing PR-triggered deployments from publishing the artifact.
- Tightened the preview comment condition so the preview announcement only runs when `steps.deployment.outputs.page_url` is present, avoiding false “preview deployed” messages when deployment is skipped.
- Kept the existing build and preview-generation steps for PRs intact so docs/site are still built and validated without publishing to production.

### Testing
- Inspected the modified workflow file ` .github/workflows/pages-deploy.yml` with `sed` and `nl` to verify the new `if: github.event_name != 'pull_request' && steps.fork-check.outputs.is_fork != 'true'` conditions were applied to the Pages publish steps, and the checks succeeded.
- Used `rg` to locate `configure-pages`, `upload-pages-artifact`, `deploy-pages`, and the preview comment gating line to confirm the appropriate `if:` expressions are present, and the search returned the expected matches.
- Verified the workflow logic around the preview comment now includes `steps.deployment.outputs.page_url != ''` so preview notifications are only posted when a deployment URL exists, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e57f98f483309bb06967c7e71ea8)