### PR TITLE
Harden wheel builds by enforcing binary-only pip installs

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -95,6 +95,7 @@ runs:
         # NOTE: CIBW_ENVIRONMENT_{PLATFORM} replaces this block entirely,
         # so any vars needed on Linux/Windows must be repeated there.
         CIBW_ENVIRONMENT: >
+          PIP_ONLY_BINARY=:all:
           PIP_PREFER_BINARY=1
           CARGO_HOME=${{ github.workspace }}/.cargo-cache
           CARGO_TARGET_DIR=${{ github.workspace }}/.rust-target-cache
@@ -105,6 +106,7 @@ runs:
         CIBW_ENVIRONMENT_LINUX: >
           FCFLAGS="-fno-optimize-sibling-calls -ffree-line-length-none"
           F90=gfortran
+          PIP_ONLY_BINARY=:all:
           PIP_PREFER_BINARY=1
           CARGO_HOME=/cargo-cache
           CARGO_TARGET_DIR=/rust-target-cache
@@ -137,6 +139,7 @@ runs:
           CXXFLAGS="-D__USE_MINGW_ANSI_STDIO=1 -mlong-double-64"
           FCFLAGS="-fno-optimize-sibling-calls -ffree-line-length-none"
           LDFLAGS="-lucrt -static-libgcc -static-libgfortran -LC:/msys64/ucrt64/lib -lsetjmp_compat"
+          PIP_ONLY_BINARY=:all:
           PIP_PREFER_BINARY=1
           CARGO_HOME='${{ github.workspace }}/.cargo-cache'
           CARGO_TARGET_DIR='${{ github.workspace }}/.rust-target-cache'


### PR DESCRIPTION
### Motivation
- Prevent CI from building untrusted source distributions during release wheel builds by restoring a strict pip policy that forbids falling back to sdists and executing PEP 517 build backends.
- Close a supply-chain execution path introduced when only `PIP_PREFER_BINARY=1` was set, which allows pip to build sdists when compatible wheels are unavailable.

### Description
- Added `PIP_ONLY_BINARY=:all:` to the cibuildwheel environment blocks in `.github/actions/build-suews/action.yml` to enforce binary-only installs.
- Applied the guard in all relevant environment blocks: `CIBW_ENVIRONMENT`, `CIBW_ENVIRONMENT_LINUX`, and `CIBW_ENVIRONMENT_WINDOWS` so platform-specific overrides cannot bypass the protection.
- This is a minimal, security-focused change confined to the reusable wheel build action and does not alter runtime/application code.

### Testing
- Verified the vulnerable configuration existed in `HEAD` prior to the change using file inspection and the security report parser, and validated the patch with `git diff` and file content inspection (`sed -n` / `nl`).
- Confirmed the presence of `PIP_ONLY_BINARY=:all:` alongside `PIP_PREFER_BINARY=1` in all three cibuildwheel environment blocks using `rg -n "PIP_(ONLY_BINARY|PREFER_BINARY)"`; the check succeeded.
- No unit or CI test runs were executed as part of this patch; only automated repository/file checks were performed and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f91f7eec83308e6d3797fd98669d)