### PR TITLE
fix(ci): isolate write-token permissions from PR-controlled build

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -37,19 +37,13 @@ concurrency:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-  pull-requests: write
 
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  build:
+    name: Build site and docs
     runs-on: ubuntu-latest
-
-    # Use 'preview' environment for PRs (no branch restrictions)
-    environment:
-      name: ${{ github.event_name == 'pull_request' && 'preview' || 'github-pages' }}
-      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      is_fork: ${{ steps.fork-check.outputs.is_fork }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -137,6 +131,12 @@ jobs:
           touch _site/.nojekyll
           echo "Site ready: $(find _site -type f | wc -l) files"
 
+      - name: Archive built site
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        with:
+          name: site-build
+          path: _site
+
       # Fork PRs cannot deploy - they lack OIDC tokens required by deploy-pages
       # Detect fork: compare PR head repo with base repo
       - name: Check if fork PR
@@ -158,52 +158,40 @@ jobs:
             echo "is_fork=false" >> $GITHUB_OUTPUT
           fi
 
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: needs.build.outputs.is_fork != 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      pull-requests: write
+
+    # Use 'preview' environment for PRs (no branch restrictions)
+    environment:
+      name: ${{ github.event_name == 'pull_request' && 'preview' || 'github-pages' }}
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Download built site
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: site-build
+          path: _site
+
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
-        if: steps.fork-check.outputs.is_fork != 'true'
 
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
-        if: steps.fork-check.outputs.is_fork != 'true'
         with:
           path: _site
 
       - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
-        if: steps.fork-check.outputs.is_fork != 'true'
         id: deployment
 
-      - name: Comment fork PR status
-        if: github.event_name == 'pull_request' && steps.fork-check.outputs.is_fork == 'true'
-        continue-on-error: true  # Token may lack permission for fork PRs
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            const prNumber = context.issue.number;
-            const body = `## Docs Build Validated ✓
-
-            Documentation built successfully. Preview deployment is not available for fork PRs (GitHub security restriction).
-
-            A maintainer can test the preview locally with \`make docs\`.`;
-
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
-
-            const botComment = comments.data.find(c =>
-              c.user.type === 'Bot' && c.body.includes('Docs Build Validated')
-            );
-
-            if (!botComment) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body
-              });
-            }
-
       - name: Comment preview URL
-        if: github.event_name == 'pull_request' && steps.fork-check.outputs.is_fork != 'true'
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
@@ -241,6 +229,44 @@ jobs:
                 body
               });
             } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+            }
+
+  comment-fork-pr:
+    name: Comment fork PR status
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'pull_request' && needs.build.outputs.is_fork == 'true'
+    permissions:
+      pull-requests: write
+    steps:
+      - continue-on-error: true  # Token may lack permission for fork PRs
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const body = `## Docs Build Validated ✓
+
+            Documentation built successfully. Preview deployment is not available for fork PRs (GitHub security restriction).
+
+            A maintainer can test the preview locally with \`make docs\`.`;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const botComment = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Docs Build Validated')
+            );
+
+            if (!botComment) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
### Motivation
- Prevent PR-controlled code from executing with workflow-wide write-scoped `GITHUB_TOKEN` permissions that could be abused to modify Pages, push refs, or mint OIDC tokens.
- Preserve preview and deployment behavior while reducing the attack surface by scoping write permissions to only the deployment step that does not run untrusted code.

### Description
- Removed workflow-level write permissions and left `contents: read` at the top level so jobs default to read-only access. 
- Split the single `deploy` job into a `build` job (runs untrusted PR-controlled code and builds site/docs) and a privileged `deploy` job (runs only trusted deploy steps), so the deploy job no longer checks out or executes PR-controlled source. 
- Added artifact handoff using `actions/upload-artifact` in `build` and `actions/download-artifact` in `deploy` so the deploy job consumes the pre-built site without executing PR code. 
- Added a minimal `comment-fork-pr` job with narrow `pull-requests: write` permission to notify fork PR authors while avoiding broad permissions during builds.

### Testing
- Parsed the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pages-deploy.yml')"` which succeeded. 
- Reviewed the workflow diff (`git diff .github/workflows/pages-deploy.yml`) to confirm permission scoping, job separation, and artifact handoff were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ea00bb6c8330a9db70bb781c7b58)