### PR TITLE
Fix broken test API surface import

### DIFF
--- a/test/cmd/test_init_case.py
+++ b/test/cmd/test_init_case.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 import pytest
 import yaml
 
-from supy import suews_sim
+import supy.suews_sim as suews_sim
 from supy.cmd.init_case import init_case_cmd
 from supy.cmd.suews_cli import cli as dispatcher
 from supy.suews_sim import SUEWSSimulation


### PR DESCRIPTION
## Summary

Fixes #1442 by importing the internal `supy.suews_sim` module directly in the init-case tests instead of treating `suews_sim` as a top-level `supy` API attribute.

This keeps the public `supy` API unchanged while satisfying the import-surface smoke test.

## Validation

- `PYTHONPATH=src uv run --no-sync python -m pytest test/test_api_surface.py::test_all_test_imports_resolve -q`
- `PYTHONPATH=src uv run --no-sync python -m pytest test/cmd/test_init_case.py -q`
- `git diff --check`

Full local `make test-smoke` is blocked in this workspace: without `PYTHONPATH`, `supy` is not installed; with `PYTHONPATH=src`, the Rust backend is unavailable, and an editable rebuild currently stops in Fortran with the existing `anthroemis_prm` `startdls`/`start_dls` mismatch.
