### PR TITLE
Move automation labels to zero track

### DIFF
--- a/.claude/rules/python/schema-versioning.md
+++ b/.claude/rules/python/schema-versioning.md
@@ -225,7 +225,7 @@ When reviewing a PR that touches `src/supy/data_model/`:
   `docs/source/contributing/schema/schema_versioning.rst` and
   `docs/source/inputs/transition_guide.rst` (see step 6 above).
   A schema bump without matching doc updates is a review blocker
-  unless a maintainer applies the `schema-audit-ok` label.
+  unless a maintainer applies the `0-ci:schema-audit-ok` label.
 
 ## CI gate and bypass label
 
@@ -246,7 +246,7 @@ changed has to move with it, or CI blocks the merge.
 
 Bypass (for genuinely cosmetic diffs — docstrings, comments,
 formatting, non-structural value tweaks): a maintainer adds the
-`schema-audit-ok` label to the pull request. The workflow reads labels
+`0-ci:schema-audit-ok` label to the pull request. The workflow reads labels
 before running and short-circuits when that label is present. The
 label is deliberately specific to this gate so it cannot be
 absent-mindedly reused for unrelated bypasses.

--- a/.claude/skills/audit-pr/SKILL.md
+++ b/.claude/skills/audit-pr/SKILL.md
@@ -22,7 +22,7 @@ gh pr diff {pr} --name-only
 - **Testing**: Coverage, FIRST principles
 - **Docs**: CHANGELOG, PR description
 - **Governance**: Check feature status tags (see below)
-- **Schema version audit**: If the PR touches `src/supy/data_model/`, apply the triggers in `.claude/rules/python/schema-versioning.md`. Field rename, removal, type change, or required-field addition should be accompanied by a bump to `CURRENT_SCHEMA_VERSION`, a new `SCHEMA_VERSIONS` entry, a matching handler in `src/supy/util/converter/yaml_upgrade.py`, and a `sample_config.yml` resync. Flag any of these that are missing. CI gate `.github/workflows/schema-version-audit.yml` runs the automated check; if the PR carries the `schema-audit-ok` bypass label, verify from the diff yourself that the reason is genuinely cosmetic before approving.
+- **Schema version audit**: If the PR touches `src/supy/data_model/`, apply the triggers in `.claude/rules/python/schema-versioning.md`. Field rename, removal, type change, or required-field addition should be accompanied by a bump to `CURRENT_SCHEMA_VERSION`, a new `SCHEMA_VERSIONS` entry, a matching handler in `src/supy/util/converter/yaml_upgrade.py`, and a `sample_config.yml` resync. Flag any of these that are missing. CI gate `.github/workflows/schema-version-audit.yml` runs the automated check; if the PR carries the `0-ci:schema-audit-ok` bypass label, verify from the diff yourself that the reason is genuinely cosmetic before approving.
 - **Build**: CI status, meson.build
 - **Draft**: Comments for approval
 - **Approval**: Wait for human confirmation

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug or unexpected behaviour
 title: ''
-labels: bug
+labels: 1-bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/docs-issue-report.md
+++ b/.github/ISSUE_TEMPLATE/docs-issue-report.md
@@ -2,7 +2,7 @@
 name: Docs issue report
 about: Create a report to help us improve the documentation
 title: ''
-labels: docs
+labels: '1-maintenance,2-doc:user'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 1-feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -2,7 +2,7 @@
 name: Release Checklist
 about: SUEWS release checklist. ONLY FOR DEVELOPERS!
 title: 'Release YYYY.M.D: [Feature Name]'
-labels: release
+labels: '1-maintenance,2-meta:release'
 assignees: ''
 
 ---

--- a/.github/workflows/discourse-to-issue.yml
+++ b/.github/workflows/discourse-to-issue.yml
@@ -116,7 +116,8 @@ jobs:
             --repo "${TARGET_REPO}" \
             --title "${ISSUE_TITLE}" \
             --body-file /tmp/issue-body.md \
-            --label "user-report" \
+            --label "0-source:discourse" \
+            --label "1-question" \
             2>&1)
 
           echo "issue_url=${ISSUE_URL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/knowledge-pack-audit.yml
+++ b/.github/workflows/knowledge-pack-audit.yml
@@ -7,7 +7,7 @@ name: Knowledge pack freshness audit
 # names. Motivated by gh#1406 (manual smoke 2026-05-04 found pack
 # `git_sha` lagging HEAD by 5 PRs).
 #
-# Maintainers can label a PR with `knowledge-pack-audit-ok` to bypass
+# Maintainers can label a PR with `0-ci:knowledge-pack-audit-ok` to bypass
 # the check when the diff is genuinely cosmetic (docstring or comment
 # only).
 
@@ -36,9 +36,9 @@ jobs:
         run: |
           set -eu
           echo "Labels on this PR: $LABELS"
-          if printf '%s' "$LABELS" | grep -q '"knowledge-pack-audit-ok"'; then
+          if printf '%s' "$LABELS" | grep -q '"0-ci:knowledge-pack-audit-ok"'; then
             echo "bypass=true" >> "$GITHUB_OUTPUT"
-            echo "PR carries label 'knowledge-pack-audit-ok'; skipping."
+            echo "PR carries label '0-ci:knowledge-pack-audit-ok'; skipping."
           else
             echo "bypass=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/schema-version-audit.yml
+++ b/.github/workflows/schema-version-audit.yml
@@ -3,7 +3,7 @@ name: Schema version audit
 # Enforce that any PR touching the Pydantic data model or the shipped
 # sample_config also bumps `CURRENT_SCHEMA_VERSION` in
 # `src/supy/data_model/schema/version.py`. Maintainers can label a PR
-# with `schema-audit-ok` to bypass the check when the diff is genuinely
+# with `0-ci:schema-audit-ok` to bypass the check when the diff is genuinely
 # cosmetic. Motivated by gh#1304.
 
 on:
@@ -32,9 +32,9 @@ jobs:
         run: |
           set -eu
           echo "Labels on this PR: $LABELS"
-          if printf '%s' "$LABELS" | grep -q '"schema-audit-ok"'; then
+          if printf '%s' "$LABELS" | grep -q '"0-ci:schema-audit-ok"'; then
             echo "bypass=true" >> "$GITHUB_OUTPUT"
-            echo "PR carries label 'schema-audit-ok'; skipping schema bump check."
+            echo "PR carries label '0-ci:schema-audit-ok'; skipping schema bump check."
           else
             echo "bypass=false" >> "$GITHUB_OUTPUT"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 74 | 83 | 29 | 80 | 40 | 307 |
+| 2026 | 74 | 83 | 29 | 81 | 40 | 308 |
 | 2025 | 60 | 68 | 22 | 71 | 36 | 256 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
@@ -53,6 +53,12 @@ EXAMPLES:
 | 2017 | 9 | 0 | 3 | 2 | 0 | 14 |
 
 ## 2026
+
+### 19 May 2026
+
+- [maintenance] Move automation-only repository labels onto the `0-*` special track
+  - Schema and knowledge-pack audit bypass labels now live under `0-ci:*`, preserving the repository-wide numeric label hierarchy while keeping the maintainer bypasses available
+  - Discourse-created issues now carry `0-source:discourse` plus the existing `1-question` type label, and issue templates no longer reference removed legacy labels such as `bug`, `docs`, or `release`
 
 ### 11 May 2026
 
@@ -88,7 +94,7 @@ EXAMPLES:
 - [maintenance] Knowledge-pack staleness guard at MCP startup + CI freshness audit (#1406)
   - The pack's meson `custom_target` only depends on `knowledge/pack.py`, so changes under `src/supy/data_model/` or `src/supy/cmd/` did not trigger an automatic rebuild — the installed pack drifted from HEAD and `query_knowledge` started surfacing stale field names. Manual smoke 2026-05-04 found pack `git_sha` lagging HEAD by 5 PRs (incl. the 44-rename ArchetypeProperties refactor)
   - `suews-mcp` now compares the pack manifest's `suews_version` against the running `supy.__version__` at server startup; on mismatch it logs a stderr warning naming the stale version and pointing at `suews knowledge build`. MCP hosts route stderr to their plugin log so the user sees this without polluting the JSON-RPC stdio channel
-  - New CI workflow `.github/workflows/knowledge-pack-audit.yml` + script `scripts/lint/check_knowledge_pack_freshness.py` flags PRs that touch `src/supy/data_model/**` or `src/supy/cmd/**` without rebuilding the pack. Bypass label: `knowledge-pack-audit-ok`
+  - New CI workflow `.github/workflows/knowledge-pack-audit.yml` + script `scripts/lint/check_knowledge_pack_freshness.py` flags PRs that touch `src/supy/data_model/**` or `src/supy/cmd/**` without rebuilding the pack. Bypass label: `0-ci:knowledge-pack-audit-ok`
   - `prep-release` skill checklist updated with the rebuild step
 - [bugfix] `query_knowledge` matches now carry an `audience` tag and a `legacy_name_for` hint when the chunk text references retired field names (#1402)
   - Previously the tool returned chunks drawn from the full source-evidence pack (Fortran sources, Pydantic data models, validation pipeline docs) without telling the consumer which audience each chunk belonged to. An assistant that called `query_knowledge` first instead of `search_schema` would happily quote internal Fortran names like `stebbsmethod` or `netradiationmethod` back to the user as YAML fields, producing configuration advice that fails validation
@@ -281,7 +287,7 @@ EXAMPLES:
   - Updated `.claude/rules/python/schema-versioning.md`, `scripts/lint/check_schema_version_bump.py`, and the `prep-release` skill to stop asking contributors to edit `COMPATIBLE_VERSIONS`; the audit now terminates at `_HANDLERS`
 - [maintenance] Guardrails against schema-version drift (#1304)
   - New pytest regression `test/data_model/test_schema_version_sync.py` asserts `src/supy/sample_data/sample_config.yml::schema_version` equals `CURRENT_SCHEMA_VERSION` on every test run; the `verify-build` shell recipe is no longer the only line of defence
-  - New CI gate `.github/workflows/schema-version-audit.yml` runs on every PR that touches `src/supy/data_model/**` or `src/supy/sample_data/sample_config.yml` and fails unless `src/supy/data_model/schema/version.py` is also modified. Backed by `scripts/lint/check_schema_version_bump.py`. Maintainers can add the `schema-audit-ok` label to bypass the gate for genuinely cosmetic diffs
+  - New CI gate `.github/workflows/schema-version-audit.yml` runs on every PR that touches `src/supy/data_model/**` or `src/supy/sample_data/sample_config.yml` and fails unless `src/supy/data_model/schema/version.py` is also modified. Backed by `scripts/lint/check_schema_version_bump.py`. Maintainers can add the `0-ci:schema-audit-ok` label to bypass the gate for genuinely cosmetic diffs
   - New rule `.claude/rules/python/schema-versioning.md` documents when to bump, how to bump, pre-release audit, PR review gate, and the bypass-label workflow; `prep-release` skill gained a schema-audit step, `audit-pr` skill acknowledges the CI gate
 - [change][experimental] Retrospective schema version bump closes the gap from #1240 / #1242 / #1261 (#1304)
   - `CURRENT_SCHEMA_VERSION` stayed at `2025.12` through the STEBBS clean-up (#879 Nov 2025), the `DeepSoilTemperature` rename (#1240), the DHW volume-bound removal (#1242), and the setpoint split (#1261); the YAML upgrade dispatcher had no real schema versions to key on and had to fall back on synthetic labels that sorted numerically below `CURRENT_SCHEMA_VERSION`

--- a/docs/source/contributing/schema/schema-developer.rst
+++ b/docs/source/contributing/schema/schema-developer.rst
@@ -98,10 +98,10 @@ with everything it needs:
    ``docs/source/contributing/schema/schema_versioning.rst`` nor
    ``docs/source/inputs/transition_guide.rst`` was touched.
 
-**Bypass label: schema-audit-ok**
+**Bypass label: 0-ci:schema-audit-ok**
    For genuinely cosmetic diffs (docstring edits, comment
    reformatting, non-structural ``sample_config.yml`` tweaks) a
-   maintainer can attach the ``schema-audit-ok`` label to the PR.
+   maintainer can attach the ``0-ci:schema-audit-ok`` label to the PR.
    The workflow reads labels before running and short-circuits when
    the label is present. Contributors should **not** add the label
    themselves — the failure message is the prompt to open a review

--- a/scripts/lint/check_knowledge_pack_freshness.py
+++ b/scripts/lint/check_knowledge_pack_freshness.py
@@ -22,7 +22,7 @@ move with the guarded source changes.
 Bypassing
 ---------
 If the diff is genuinely cosmetic (docstring-only edits, comment
-reformats), a maintainer can add the ``knowledge-pack-audit-ok`` label
+reformats), a maintainer can add the ``0-ci:knowledge-pack-audit-ok`` label
 to the PR. The companion workflow short-circuits when that label is
 present.
 
@@ -198,7 +198,7 @@ def main(argv: list[str] | None = None) -> int:
             f"Run `suews knowledge build --output "
             f"src/supy/knowledge/pack/current --repo-root .` and commit "
             f"the resulting manifest.json + chunks.jsonl.gz, or apply "
-            f"the `knowledge-pack-audit-ok` label if the diff is "
+            f"the `0-ci:knowledge-pack-audit-ok` label if the diff is "
             f"genuinely cosmetic (docstring / comment only).",
             file=sys.stderr,
         )

--- a/scripts/lint/check_schema_version_bump.py
+++ b/scripts/lint/check_schema_version_bump.py
@@ -38,7 +38,7 @@ Bypassing
 ---------
 If the diff is genuinely cosmetic (docstring edits, comment reformats,
 a non-structural sample_config value change), a maintainer can add the
-label `schema-audit-ok` to the pull request. The CI workflow at
+label `0-ci:schema-audit-ok` to the pull request. The CI workflow at
 `.github/workflows/schema-version-audit.yml` skips this script when
 that label is present, so this script itself has no label
 awareness — its only job is to detect the file-level change pattern.
@@ -205,7 +205,7 @@ def _report_failure(watched: list[str], reason: str) -> None:
         "See .claude/rules/python/schema-versioning.md for the checklist.\n"
         "\n"
         "If the diff is genuinely cosmetic (docstring, comment, formatting, "
-        "non-structural edit), a maintainer can add the 'schema-audit-ok' "
+        "non-structural edit), a maintainer can add the '0-ci:schema-audit-ok' "
         "label to this PR to skip this check.",
         file=sys.stderr,
     )
@@ -232,7 +232,7 @@ def _report_docs_failure(
         "\n"
         "If the bump is genuinely internal and has no user-visible "
         "footprint (very rare), a maintainer can add the "
-        "'schema-audit-ok' label to this PR to skip this check.",
+        "'0-ci:schema-audit-ok' label to this PR to skip this check.",
         file=sys.stderr,
     )
 


### PR DESCRIPTION
## Summary
- Move CI bypass labels onto the 0-ci special track and update workflow checks/docs.
- Add a 0-source Discourse label and update Discourse issue creation to combine it with 1-question.
- Update issue templates to use the numeric label hierarchy instead of removed legacy labels.

## Validation
- python3 -m py_compile scripts/lint/check_schema_version_bump.py scripts/lint/check_knowledge_pack_freshness.py
- ruby -ryaml workflow and issue-template parsing checks
- git diff --check
- make test-smoke