### PR TITLE
fix: SUEWSOutput.save() honours configured output format (#1451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ EXAMPLES:
 
 ## 2026
 
+### 28 May 2026
+
+- [bugfix] `SUEWSOutput.save()` no longer forces parquet output regardless of the configured format (#1451)
+  - The `format` parameter defaulted to `"parquet"`, which always satisfied the `output_format is None` short-circuit in `_save_supy()` and overrode `model.control.output.format` from the run configuration
+  - `format` now defaults to `None`, so an unspecified format follows the configured value (falling back to `txt` when no configuration is present); an explicit `format` argument still wins, matching the existing `SUEWSSimulation.save()` behaviour
+
 ### 19 May 2026
 
 - [maintenance] Move automation-only repository labels onto the `0-*` special track

--- a/src/supy/suews_output.py
+++ b/src/supy/suews_output.py
@@ -431,7 +431,7 @@ class SUEWSOutput:
     def save(
         self,
         path: Union[str, Path] = ".",
-        format: str = "parquet",
+        format: Optional[str] = None,
         freq_s: Optional[int] = None,
         groups: Optional[List[str]] = None,
     ) -> List[Path]:
@@ -442,8 +442,12 @@ class SUEWSOutput:
         ----------
         path : str or Path
             Output directory
-        format : str
-            'txt' or 'parquet'
+        format : str, optional
+            'txt' or 'parquet'. When ``None`` (the default), the format
+            stored in the run configuration
+            (``model.control.output.format``) is used, falling back to
+            'txt' if no configuration is available. An explicit value
+            always overrides the configuration.
         freq_s : int, optional
             Output frequency in seconds (default: from config or 3600)
         groups : list, optional

--- a/test/io_tests/test_save_supy.py
+++ b/test/io_tests/test_save_supy.py
@@ -8,7 +8,9 @@ import tempfile
 import shutil
 import supy as sp
 from supy._supy_module import _save_supy
+from supy.data_model.core import SUEWSConfig
 from supy.data_model.core.model import OutputControl, OutputFormat
+from supy.suews_output import SUEWSOutput
 
 pytestmark = pytest.mark.api
 
@@ -16,9 +18,14 @@ pytestmark = pytest.mark.api
 class TestSaveSuPy:
     """Test saving functionality of SuPy outputs."""
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def sample_output(self):
-        """Create sample output data for testing."""
+        """Create sample output data for testing.
+
+        Class-scoped: the short simulation runs once and the read-only
+        ``(df_output, df_state_final)`` tuple is shared across every test
+        in the class (each test writes to its own ``TemporaryDirectory``).
+        """
         # Load sample data and run a short simulation
         df_state_init, df_forcing = sp.load_sample_data()
         # Use just 3 days for faster tests
@@ -150,3 +157,62 @@ class TestSaveSuPy:
                 "explicit output_format kwarg is supplied"
             )
             assert not txt_files, "Parquet save should not fall back to text output"
+
+    @staticmethod
+    def _make_output(sample_output, output_format):
+        """Build a SUEWSOutput whose config requests ``output_format``."""
+        df_output, df_state_final = sample_output
+        config = SUEWSConfig()
+        config.model.control.output.format = output_format
+        return SUEWSOutput(
+            df_output=df_output,
+            df_state_final=df_state_final,
+            config=config,
+        )
+
+    def test_output_save_honours_config_txt_format(self, sample_output):
+        """SUEWSOutput.save() must respect config format=txt (gh#1451)."""
+        output = self._make_output(sample_output, OutputFormat.TXT)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # No explicit format: must follow the config, not the old
+            # hard-coded parquet default.
+            list_files = output.save(path=tmpdir)
+
+            txt_files = [Path(f) for f in list_files if str(f).endswith(".txt")]
+            parquet_files = [Path(f) for f in list_files if str(f).endswith(".parquet")]
+
+            assert txt_files, (
+                "SUEWSOutput.save() should honour config format=txt when no "
+                "explicit format is supplied"
+            )
+            assert not parquet_files, (
+                "SUEWSOutput.save() must not override config format with parquet"
+            )
+
+    def test_output_save_honours_config_parquet_format(self, sample_output):
+        """SUEWSOutput.save() must respect config format=parquet (gh#1451)."""
+        output = self._make_output(sample_output, OutputFormat.PARQUET)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            list_files = output.save(path=tmpdir)
+
+            parquet_files = [Path(f) for f in list_files if str(f).endswith(".parquet")]
+            txt_files = [Path(f) for f in list_files if str(f).endswith(".txt")]
+
+            assert parquet_files, (
+                "SUEWSOutput.save() should honour config format=parquet"
+            )
+            assert not txt_files, "Parquet save should not fall back to text output"
+
+    def test_output_save_explicit_format_overrides_config(self, sample_output):
+        """An explicit format kwarg still wins over the stored config."""
+        output = self._make_output(sample_output, OutputFormat.TXT)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            list_files = output.save(path=tmpdir, format="parquet")
+
+            parquet_files = [Path(f) for f in list_files if str(f).endswith(".parquet")]
+            assert parquet_files, (
+                "An explicit format='parquet' must override config format=txt"
+            )


### PR DESCRIPTION
Fixes #1451.

## Problem

`SUEWSOutput.save()` declared `format: str = "parquet"` and passed it straight through to `_save_supy()`. Because `_save_supy()` only uses the configured `model.control.output.format` when its `output_format` argument is `None`, the hard-coded `"parquet"` default always won — so output was always written as parquet regardless of the format selected in the config.

## Fix

`SUEWSOutput.save()` now defaults `format` to `None`. An unspecified format follows the configured value (`model.control.output.format`), falling back to `txt` when no configuration is present; an explicit `format` argument still wins. This mirrors the existing, already-correct `SUEWSSimulation.save()` behaviour, bringing the two public save paths into agreement.

## Tests

Adds three regression tests for the public `SUEWSOutput.save()` path in `test/io_tests/test_save_supy.py` (config=txt -> txt, config=parquet -> parquet, explicit override wins). Confirmed the txt test fails against the old `"parquet"` default and passes after the fix.

## Validation

- `test/io_tests/test_save_supy.py`, `test_resample_output.py`, `test_public_api_wrappers.py`: pass.
- `make test-smoke`: 9 passed.
- No `src/supy/data_model/` change, so no schema-version bump required.
