### PR TITLE
Make standalone Phase B/C validation rename-aware

### DIFF
--- a/.claude/rules/naming-convention.md
+++ b/.claude/rules/naming-convention.md
@@ -164,7 +164,6 @@ written and **not** reordered under Rule 2:
 - `ground_depth`
 - `ventilation_rate`
 - `lighting_power_density`
-- `month_mean_air_temperature_diffmax`
 
 The test for membership: the phrase is one a domain reader would say
 aloud as a unit ("ventilation rate", "lighting power density"), and
@@ -172,6 +171,11 @@ splitting the quantity off the front would read awkwardly
 (`rate_ventilation`, `power_density_lighting`). This list is closed;
 adding to it requires a convention amendment. When in doubt, apply
 Rule 2 (reorder) — this exception is deliberately narrow.
+
+`month_mean_air_temperature_diffmax` is **not** in this list: it was
+reordered under Rule 2 to the canonical `temperature_air_month_mean_diffmax`
+(dev12, gh#1452). The physical quantity (`temperature_air`) leads, so the
+grep-ability argument applied and the compound-noun exception did not.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ EXAMPLES:
 
 ## 2026
 
+### 29 May 2026
+
+- [bugfix] Make standalone Phase B/C validation rename-aware (#1457)
+  - `suews validate` in standalone (BC/C/AC) mode inspected the raw user YAML by current field name without the old->new normalisation that `SUEWSConfig.from_yaml` applies, so a still-compatible config written with a legacy spelling of a field renamed in #1452 (e.g. `outer_cap_fraction` for `capacitance`, `month_mean_air_temperature_diffmax`, the scalar `*_setpoint` names) was mishandled by three raw-dict checks
+  - Most seriously, a legacy `outer_cap_fraction: {value: null}` slipped the orchestrator's critical-null check and could later crash df_state conversion via `int(None)`; the CRU diffmax update and the setpoint-cleanup science adjustment in Phase B were also silently skipped
+  - Fixed by normalising the loaded YAML once at each phase's load chokepoint (`load_user_yaml_normalised` / `normalise_yaml_renames`) so every standalone rule sees current names; a config carrying both a legacy and its current spelling is left untouched so the downstream validator still reports the conflict
+  - The normal `SUEWSConfig.from_yaml` load path was never affected (its sub-models normalise via `@model_validator(mode="before")`)
+
 ### 28 May 2026
 
 - [bugfix] `SUEWSOutput.save()` no longer forces parquet output regardless of the configured format (#1451)

--- a/src/supy/data_model/core/field_renames.py
+++ b/src/supy/data_model/core/field_renames.py
@@ -1486,6 +1486,30 @@ def rename_keys_recursive(
     return data
 
 
+def normalise_yaml_renames(data: Any) -> Any:
+    """Rewrite legacy field spellings in a loaded YAML mapping to current names.
+
+    ``SUEWSConfig.from_yaml`` normalises old->new before validation, so the
+    normal load path already sees current names. The standalone Phase B/C
+    validation path (``suews validate`` in BC / C / AC modes) inspects the raw
+    user YAML without going through ``from_yaml``, so a still-compatible config
+    written with a legacy spelling would otherwise be looked up by the current
+    name and silently missed (gh#1457). Normalising once at each phase's load
+    chokepoint lets every rule match either spelling.
+
+    If both a legacy and its current spelling are present (ambiguous), the data
+    is returned unchanged so the downstream validation path reports the
+    conflict, rather than this normalisation step raising. This guarantees the
+    helper can only resolve rename-blindness, never introduce a new failure.
+    """
+    if not isinstance(data, dict):
+        return data
+    try:
+        return rename_keys_recursive(data, RAW_YAML_FIELD_RENAMES)
+    except ValueError:
+        return data
+
+
 def reverse_field_renames(data: dict) -> dict:
     """Recursively replace new field names with old ones for serialisation.
 

--- a/src/supy/data_model/validation/core/yaml_helpers.py
+++ b/src/supy/data_model/validation/core/yaml_helpers.py
@@ -32,6 +32,7 @@ import pytz
 from ...core.field_renames import (
     RAW_YAML_FIELD_RENAMES,
     has_renamed_key,
+    normalise_yaml_renames,
     read_physics_key,
     read_renamed_key,
     rename_keys_recursive,
@@ -107,6 +108,27 @@ except ImportError:
             return False
 
     trv_supy_module = MockTraversable()
+
+
+def load_user_yaml_normalised(path: str) -> Any:
+    """Load a user YAML file and normalise legacy field spellings to current names.
+
+    The single load chokepoint for the standalone validation pipeline (gh#1457).
+    Routing every raw user-YAML read through this helper means a new load site
+    cannot silently forget to normalise: ``SUEWSConfig.from_yaml`` normalises
+    before validation, but the standalone Phase B/C path does not, so rules that
+    look up the current name would otherwise miss a legacy spelling.
+
+    Args:
+        path: Path to the user YAML file.
+
+    Returns:
+        The parsed YAML with legacy field spellings rewritten to current names
+        (or untouched if both a legacy and current spelling are present; see
+        ``normalise_yaml_renames``).
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        return normalise_yaml_renames(yaml.safe_load(f))
 
 
 def get_value_safe(param_dict, param_key, default=None):

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -974,9 +974,19 @@ def _run_phase_c_legacy(
             try:
                 # Load original YAML data for comparison
                 import yaml
+                from supy.data_model.core.field_renames import (
+                    normalise_yaml_renames,
+                )
 
                 with open(input_yaml_file, "r") as f:
-                    original_data = yaml.safe_load(f)
+                    # Normalise legacy field spellings so the critical-null
+                    # comparison below (detect_pydantic_defaults) matches the
+                    # current-name keys in processed_data. Without this, a
+                    # legacy spelling of a renamed critical parameter (e.g.
+                    # outer_cap_fraction -> capacitance) set to null slips the
+                    # critical-null check and can crash later in df_state
+                    # conversion via int(None). gh#1457.
+                    original_data = normalise_yaml_renames(yaml.safe_load(f))
 
                 config = SUEWSConfig.from_yaml(input_yaml_file)
 

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -974,19 +974,16 @@ def _run_phase_c_legacy(
             try:
                 # Load original YAML data for comparison
                 import yaml
-                from supy.data_model.core.field_renames import (
-                    normalise_yaml_renames,
-                )
+                from ..core.yaml_helpers import load_user_yaml_normalised
 
-                with open(input_yaml_file, "r") as f:
-                    # Normalise legacy field spellings so the critical-null
-                    # comparison below (detect_pydantic_defaults) matches the
-                    # current-name keys in processed_data. Without this, a
-                    # legacy spelling of a renamed critical parameter (e.g.
-                    # outer_cap_fraction -> capacitance) set to null slips the
-                    # critical-null check and can crash later in df_state
-                    # conversion via int(None). gh#1457.
-                    original_data = normalise_yaml_renames(yaml.safe_load(f))
+                # Normalise legacy field spellings so the critical-null
+                # comparison below (detect_pydantic_defaults) matches the
+                # current-name keys in processed_data. Without this, a legacy
+                # spelling of a renamed critical parameter (e.g.
+                # outer_cap_fraction -> capacitance) set to null slips the
+                # critical-null check and can crash later in df_state conversion
+                # via int(None). gh#1457.
+                original_data = load_user_yaml_normalised(input_yaml_file)
 
                 config = SUEWSConfig.from_yaml(input_yaml_file)
 

--- a/src/supy/data_model/validation/pipeline/phase_b.py
+++ b/src/supy/data_model/validation/pipeline/phase_b.py
@@ -41,6 +41,7 @@ from ..core.yaml_helpers import (
     get_value_safe,
     HAS_TIMEZONE_FINDER,
 )
+from ...core.field_renames import normalise_yaml_renames
 
 from .phase_b_rules import (
     RulesRegistry,
@@ -302,12 +303,15 @@ def validate_phase_b_inputs(
     try:
         with open(uptodate_yaml_file, "r") as f:
             uptodate_content = f.read()
-            uptodate_data = yaml.safe_load(uptodate_content)
+            # Normalise legacy field spellings to current names so the science
+            # checks below match configs that bypass Phase A's normalisation
+            # (standalone BC mode reads the raw user YAML here). gh#1457.
+            uptodate_data = normalise_yaml_renames(yaml.safe_load(uptodate_content))
 
         is_phase_a_output = "UP TO DATE YAML" in uptodate_content
 
         with open(user_yaml_file, "r") as f:
-            user_data = yaml.safe_load(f)
+            user_data = normalise_yaml_renames(yaml.safe_load(f))
 
         with open(standard_yaml_file, "r") as f:
             standard_data = yaml.safe_load(f)

--- a/src/supy/data_model/validation/pipeline/phase_b.py
+++ b/src/supy/data_model/validation/pipeline/phase_b.py
@@ -40,6 +40,7 @@ from ..core.yaml_helpers import (
     DLSCheck,
     get_value_safe,
     HAS_TIMEZONE_FINDER,
+    load_user_yaml_normalised,
 )
 from ...core.field_renames import normalise_yaml_renames
 
@@ -305,13 +306,15 @@ def validate_phase_b_inputs(
             uptodate_content = f.read()
             # Normalise legacy field spellings to current names so the science
             # checks below match configs that bypass Phase A's normalisation
-            # (standalone BC mode reads the raw user YAML here). gh#1457.
+            # (standalone BC mode reads the raw user YAML here). gh#1457. This
+            # reads the raw text first for the header sniff below, so it cannot
+            # use load_user_yaml_normalised (the path-based canonical loader);
+            # the normalise_yaml_renames call keeps it equivalent.
             uptodate_data = normalise_yaml_renames(yaml.safe_load(uptodate_content))
 
         is_phase_a_output = "UP TO DATE YAML" in uptodate_content
 
-        with open(user_yaml_file, "r") as f:
-            user_data = normalise_yaml_renames(yaml.safe_load(f))
+        user_data = load_user_yaml_normalised(user_yaml_file)
 
         with open(standard_yaml_file, "r") as f:
             standard_data = yaml.safe_load(f)

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -4701,3 +4701,107 @@ class TestPhaseBRenameAwareLookups:
         flagged = self._empty_param_errors(physics)
         assert "model.physics.net_radiation" not in flagged
         assert "model.physics.capacitance" not in flagged
+
+
+class TestStandaloneValidationRenameNormalisation:
+    """gh#1457: the standalone Phase B/C validation path (``suews validate`` in
+    BC / C / AC modes) inspects the raw user YAML without going through
+    ``SUEWSConfig.from_yaml``'s normalisation. A normalise-once step at each
+    phase's load chokepoint lets every rule match a legacy spelling of a renamed
+    field. These guard the chokepoints rather than the individual rules (the
+    per-rule routing is covered by ``TestPhaseBRenameAwareLookups``).
+    """
+
+    def test_normalise_helper_rewrites_nested_legacy(self):
+        from supy.data_model.core.field_renames import normalise_yaml_renames
+
+        out = normalise_yaml_renames(
+            {"sites": [{"stebbs": {"outer_cap_fraction": {"value": 1}}}]}
+        )
+        assert out["sites"][0]["stebbs"] == {"capacitance": {"value": 1}}
+
+    def test_normalise_helper_idempotent_on_current_names(self):
+        from supy.data_model.core.field_renames import normalise_yaml_renames
+
+        current = {"sites": [{"stebbs": {"capacitance": {"value": 1}}}]}
+        assert normalise_yaml_renames(current) == current
+
+    def test_normalise_helper_keeps_ambiguous_config_unchanged(self):
+        # Both a legacy and its current spelling present is ambiguous; the helper
+        # must return the data untouched (not raise) so the downstream validator
+        # reports the conflict. This guarantees normalisation can only resolve
+        # rename-blindness, never introduce a new failure.
+        from supy.data_model.core.field_renames import normalise_yaml_renames
+
+        both = {
+            "physics": {
+                "outer_cap_fraction": {"value": 1},
+                "capacitance": {"value": 2},
+            }
+        }
+        assert normalise_yaml_renames(both) == both
+
+    def test_normalise_helper_passes_through_non_mappings(self):
+        from supy.data_model.core.field_renames import normalise_yaml_renames
+
+        assert normalise_yaml_renames([1, 2]) == [1, 2]
+        assert normalise_yaml_renames("scalar") == "scalar"
+        assert normalise_yaml_renames(None) is None
+
+    def test_phase_b_load_normalises_legacy_user_yaml(self, tmp_path):
+        # The Phase B load chokepoint must hand current names to the science
+        # checks (CRU diffmax ~phase_b:1206, setpoint cleanup ~phase_b:2051),
+        # which look up the current spelling only.
+        import json
+        from supy.data_model.validation.pipeline.phase_b import (
+            validate_phase_b_inputs,
+        )
+
+        legacy = tmp_path / "legacy.yml"
+        legacy.write_text(
+            "sites:\n"
+            "- properties:\n"
+            "    stebbs:\n"
+            "      outer_cap_fraction: {value: 1.0}\n"
+            "      month_mean_air_temperature_diffmax: {value: 5.0}\n"
+            "      heating_setpoint_temperature: {value: 19.0}\n",
+            encoding="utf-8",
+        )
+        # Same file for all three args; only the user / uptodate dicts are
+        # asserted (standard_data is the packaged sample in real runs).
+        uptodate_data, user_data, _ = validate_phase_b_inputs(
+            str(legacy), str(legacy), str(legacy)
+        )
+        for data in (uptodate_data, user_data):
+            dumped = json.dumps(data)
+            assert "outer_cap_fraction" not in dumped
+            assert "capacitance" in dumped
+            assert "month_mean_air_temperature_diffmax" not in dumped
+            assert "temperature_air_month_mean_diffmax" in dumped
+            assert "heating_setpoint_temperature" not in dumped
+            assert "setpoint_temperature_heating_air" in dumped
+
+    def test_legacy_null_capacitance_caught_as_critical_after_normalisation(self):
+        # The crash-path regression. A user-supplied null under the legacy
+        # spelling must be recognised as a critical null (failing validation with
+        # an actionable message) instead of slipping through to a later
+        # int(None) crash in df_state conversion.
+        from supy.data_model.validation.pipeline.orchestrator import (
+            detect_pydantic_defaults,
+        )
+        from supy.data_model.core.field_renames import normalise_yaml_renames
+
+        # Pydantic-processed data carries the current name with a null value.
+        processed = {"model": {"physics": {"capacitance": {"value": None}}}}
+        legacy_raw = {"model": {"physics": {"outer_cap_fraction": {"value": None}}}}
+
+        # Without normalisation the orchestrator looks up `capacitance`, absent
+        # from the legacy raw data, so the null is NOT flagged critical.
+        crit_raw, _ = detect_pydantic_defaults(legacy_raw, processed, "", {})
+        assert not any(c["field_name"] == "capacitance" for c in crit_raw)
+
+        # With the gh#1457 normalise-once step the legacy null is recognised.
+        crit_norm, _ = detect_pydantic_defaults(
+            normalise_yaml_renames(legacy_raw), processed, "", {}
+        )
+        assert any(c["field_name"] == "capacitance" for c in crit_norm)

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -4805,3 +4805,29 @@ class TestStandaloneValidationRenameNormalisation:
             normalise_yaml_renames(legacy_raw), processed, "", {}
         )
         assert any(c["field_name"] == "capacitance" for c in crit_norm)
+
+    def test_load_user_yaml_normalised_rewrites_legacy_file(self, tmp_path):
+        # The single load chokepoint: reading a legacy-spelling file from disk
+        # yields current names, so every standalone rule matches regardless of
+        # the spelling the user wrote.
+        import json
+        from supy.data_model.validation.core.yaml_helpers import (
+            load_user_yaml_normalised,
+        )
+
+        legacy = tmp_path / "legacy.yml"
+        legacy.write_text(
+            "model:\n"
+            "  physics:\n"
+            "    rcmethod: {value: 1}\n"
+            "sites:\n"
+            "- properties:\n"
+            "    stebbs:\n"
+            "      heating_setpoint_temperature: {value: 19.0}\n",
+            encoding="utf-8",
+        )
+        dumped = json.dumps(load_user_yaml_normalised(str(legacy)))
+        assert "rcmethod" not in dumped
+        assert "capacitance" in dumped
+        assert "heating_setpoint_temperature" not in dumped
+        assert "setpoint_temperature_heating_air" in dumped


### PR DESCRIPTION
## Summary

Makes the **standalone** Phase B/C validation path (`suews validate` in BC/C/AC mode) rename-aware. Follow-up to #1452.

The normal `SUEWSConfig.from_yaml` flow normalises legacy→current field spellings via `@model_validator(mode="before")` on its sub-models, so it was never affected. But three sites that inspect the **raw user YAML dict by current field name** (without going through Pydantic) mishandled a still-compatible config written with a legacy spelling of a field renamed in #1452:

1. **`orchestrator.py` `_run_phase_c_legacy` → `detect_pydantic_defaults`** (crash path): a legacy `outer_cap_fraction: {value: null}` slipped the critical-null check, then crashed later in df_state conversion via `int(None)`.
2. **`phase_b.py` (~1206)**: the CRU `temperature_air_month_mean_diffmax` adjustment silently skipped a legacy `month_mean_air_temperature_diffmax` config.
3. **`phase_b.py` (~2051)** `adjust_model_option_setpointmethod`: the setpoint-cleanup skipped legacy `*_setpoint` names, leaving stale scalar setpoints non-null under `setpoint: 2`.

## Approach

Normalise the loaded YAML **once at each phase's load chokepoint** so every downstream rule sees current names — no per-rule rename handling needed, and future renames are covered automatically:

- `normalise_yaml_renames()` (`core/field_renames.py`) wraps `rename_keys_recursive(data, RAW_YAML_FIELD_RENAMES)`.
- `load_user_yaml_normalised()` (`validation/core/yaml_helpers.py`) is the single load chokepoint.
- Wired into the orchestrator `original_data` load and the Phase B `user_data`/`uptodate_data` loads.

A config carrying **both** a legacy and its current spelling is returned untouched, so the downstream validator still reports the conflict — the helper can only resolve rename-blindness, never introduce a new failure.

`phase_c.py::collect_phase_c_issues` is intentionally untouched: it builds `SUEWSConfig(**config_data)` directly, so the model's before-validators already normalise renames.

## Scope

Standalone validation only. No YAML-surface change (no field rename/removal/type change), so `CURRENT_SCHEMA_VERSION` is deliberately not bumped — needs the `0-ci:schema-audit-ok` maintainer bypass on the schema-version-audit gate.

## Tests

- 7 new tests (`TestStandaloneValidationRenameNormalisation`) covering the helper, the chokepoint loader, the Phase B load normalisation, and the `capacitance` crash-path regression.
- Existing `TestPhaseBRenameAwareLookups` suite still green; `make test-smoke` passes.

Closes #1457
