### PR TITLE
Fix validator report collapsing to schema_version INFO when the field is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ EXAMPLES:
 
 ## 2026
 
+### 30 May 2026
+
+- [bugfix] Validator report no longer collapses to a lone `schema_version` INFO line when that field is absent (#1466, #1458)
+  - When a user YAML omitted `schema_version`, Phase C detected it as a normal default and built an INFO entry, which made the multi-phase consolidation short-circuit to an INFO-only report — silently dropping the Phase A renamed-parameter list and the Phase B `REVIEW ADVISED` / `SUGGESTED UPDATES` sections carried in `no_action_messages`
+  - The INFO-only path now fires only for single-phase Phase C runs; multi-phase runs always route through `create_consolidated_report`, folding any Phase C defaults into the `INFO` section alongside (not instead of) the upstream phase sections
+
 ### 29 May 2026
 
 - [bugfix] Make standalone Phase B/C validation rename-aware (#1457)

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -1149,8 +1149,16 @@ def _run_phase_c_legacy(
                         ):
                             consolidated_no_action.append(line.strip())
 
-                # Only add INFO section if there are items to show
-                if consolidated_no_action:
+                # A single-phase Phase C run that detected defaults reports
+                # them as the whole story (INFO-only). For multi-phase runs
+                # the upstream sections (Phase A renames, Phase B REVIEW
+                # ADVISED / SUGGESTED UPDATES carried in no_action_messages)
+                # are consolidated below and must NOT be replaced by an
+                # INFO-only report — see gh#1458, gh#1466. Defer to
+                # create_consolidated_report in that case.
+                if consolidated_no_action and not (
+                    phases_run and len(phases_run) > 1
+                ):
                     success_report = f"""# {title}
 # ============================================
 # Mode: {"Public" if mode.lower() == "public" else mode.title()}
@@ -1198,8 +1206,10 @@ def _run_phase_c_legacy(
                             print(f"[DEBUG]   Taking multi-phase consolidation path", file=sys.stderr)
                         # Multi-phase consolidation: use passed messages or extract from files
                         if no_action_messages is not None:
-                            # Use passed messages (variable-based approach)
-                            all_messages = no_action_messages
+                            # Use passed messages (variable-based approach).
+                            # Copy so the INFO prepend below cannot mutate the
+                            # caller's list.
+                            all_messages = list(no_action_messages)
                         else:
                             # Fallback: extract from files (file-based approach)
                             all_messages = []
@@ -1219,6 +1229,17 @@ def _run_phase_c_legacy(
                                         science_report_file
                                     )
                                 )
+
+                        # Fold any defaults Phase C detected itself (e.g. a
+                        # missing schema_version) into the INFO section so they
+                        # appear alongside the upstream phase sections rather
+                        # than replacing them (gh#1458, gh#1466).
+                        if consolidated_no_action:
+                            all_messages = [
+                                "## INFO",
+                                *consolidated_no_action,
+                                *all_messages,
+                            ]
 
                         # Create consolidated final report
                         create_consolidated_report(

--- a/test/cmd/test_validate_config.py
+++ b/test/cmd/test_validate_config.py
@@ -142,6 +142,70 @@ def test_validate_pipeline_c_json_accepts_multiple_files() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Report consolidation regressions — gh#1466 / gh#1458
+# ---------------------------------------------------------------------------
+
+
+def _copy_sample_data(dst: Path) -> Path:
+    """Copy the bundled sample config and its forcing file into ``dst``.
+
+    The forcing file must sit beside the config so Phase B forcing
+    validation resolves it and the science checks run end-to-end. Returns
+    the path to the copied ``sample_config.yml``.
+    """
+    sample_dir = files("supy").joinpath("sample_data")
+    if not sample_dir.joinpath("sample_config.yml").is_file():
+        pytest.skip("Sample data not available")
+    for resource in sample_dir.iterdir():
+        if resource.is_file():
+            (dst / resource.name).write_bytes(resource.read_bytes())
+    return dst / "sample_config.yml"
+
+
+def test_missing_schema_version_keeps_review_and_suggestion_sections(
+    tmp_path: Path,
+) -> None:
+    """A YAML missing ``schema_version`` must still surface the Phase B
+    ``REVIEW ADVISED`` / ``SUGGESTED UPDATES`` sections — gh#1466 / gh#1458.
+
+    Root cause: Phase C's INFO consolidation short-circuited to an
+    INFO-only report whenever it detected *any* default value. A missing
+    ``schema_version`` is the common trigger, so the upstream phase
+    content carried in ``no_action_messages`` (Phase A renames, Phase B
+    review/suggestion sections) was silently dropped — the report
+    collapsed to a single ``## INFO`` line about the missing field.
+    """
+    from supy.cmd.validate_config import cli as validate_cli
+
+    config_path = _copy_sample_data(tmp_path)
+
+    # Strip the ``schema_version`` line textually so the rest of the
+    # bundled config is byte-for-byte unchanged (no YAML round-trip).
+    original = config_path.read_text(encoding="utf-8")
+    stripped = "".join(
+        line
+        for line in original.splitlines(keepends=True)
+        if not line.startswith("schema_version")
+    )
+    assert stripped != original, "fixture must contain a schema_version line"
+    config_path.write_text(stripped, encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(validate_cli, ["--mode", "dev", str(config_path)])
+    assert result.exit_code in {0, 1}, result.output
+
+    report_path = tmp_path / "report_sample_config.txt"
+    assert report_path.exists(), result.output
+    report = report_path.read_text(encoding="utf-8")
+
+    # The missing-schema_version INFO is expected to be reported ...
+    assert "schema_version" in report, report
+    # ... but it must NOT have replaced the upstream phase sections.
+    assert "## REVIEW ADVISED" in report, report
+    assert "## SUGGESTED UPDATES" in report, report
+
+
+# ---------------------------------------------------------------------------
 # Validation edge cases — CLI path
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Running `suews validate --mode dev <config>` on a YAML that omits the top-level `schema_version` field produced a report that contained **only** a single INFO line about the missing field, e.g.:

```
## INFO
- schema_version found missing in user YAML at level schema_version.
The validation system will interpret that as default value: 2026.5.dev12 - check doc ...
```

The Phase A renamed-parameter list and the Phase B `REVIEW ADVISED` / `SUGGESTED UPDATES` sections that normally appear were silently dropped. Adding `schema_version` back to the YAML restored the full report. (#1458 reported the same collapse, noticing the missing rename list; #1466 is the broader characterisation — the review/suggested sections go too.)

## Root cause

In `_run_phase_c_legacy` (`src/supy/data_model/validation/pipeline/orchestrator.py`), once Phases A+B+C all pass, an `if consolidated_no_action:` branch wrote an INFO-only report built from Phase C's *own* detected defaults and discarded `no_action_messages` (the combined Phase A renames + Phase B review/suggestion sections).

A missing `schema_version` is detected by `detect_pydantic_defaults` as a "normal default", so that branch fired and the report collapsed. With `schema_version` present, nothing was detected, the proper `create_consolidated_report` path ran, and the full report appeared.

## Fix

- The INFO-only branch now fires only for single-phase Phase C runs.
- Multi-phase runs (ABC, AC, BC) always route through `create_consolidated_report`, folding any Phase C defaults into the `INFO` section alongside (not instead of) the upstream phase sections.

## Testing

- New regression test `test_missing_schema_version_keeps_review_and_suggestion_sections` (mirrors the reported command): fails on the previous behaviour, passes with the fix.
- Verified the schema-present baseline report is unchanged.
- Verified a config with both a legacy field name and a missing `schema_version` now reports the rename line **and** the review/suggested sections together (covers the #1458 symptom).
- 353 validation/pipeline tests pass; no new lint findings.

## Note for reviewers

This touches `src/supy/data_model/**` but makes no schema-surface change (no field rename/removal/type change), so `CURRENT_SCHEMA_VERSION` is intentionally not bumped. The `0-ci:schema-audit-ok` label is applied to bypass the schema-version-audit gate per `.claude/rules/python/schema-versioning.md`.

Closes #1466

(#1458 is the same bug reported earlier; it is closed as a duplicate of #1466.)
