### PR TITLE
Accept human-readable names for physics method options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 74 | 83 | 30 | 81 | 40 | 309 |
+| 2026 | 75 | 83 | 30 | 81 | 40 | 310 |
 | 2025 | 60 | 68 | 22 | 71 | 36 | 256 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
@@ -61,7 +61,10 @@ EXAMPLES:
 - [change][experimental] Relocate STEBBS physics switches under `model.physics.stebbs` (#1456)
   - The legacy flat STEBBS physics switches now serialise under the nested `model.physics.stebbs` object, splitting the `stebbs` master toggle into `enabled` plus `parameters`
   - Existing flat YAML input remains accepted and is folded during validation and migration; bridge and Fortran-facing columns such as `stebbsmethod`, `rcmethod`, `setpointmethod`, and the `same_*` switches remain unchanged
-  - This is a structural YAML/data-model move only; the capacitance-method semantics tracked by #1472 remain open
+  - This is a structural YAML/data-model move; the capacitance selector keeps the Reading-requested `capacitance` name while the wall/roof heat-capacity fraction fields remain physical values
+- [feature][experimental] Accept human-readable names for physics method options (#1471)
+  - YAML input now accepts registered readable method tokens such as `storage_heat: ohm`, `stability: cn98`, `snow_use: enabled`, and nested STEBBS leaves such as `stebbs.capacitance: provided`
+  - The accepted names are input-only compatibility forms; validation still normalises to the existing flat enum-code representation and exports canonical numeric `{value: N}` YAML
 
 ### 30 May 2026
 

--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -2453,9 +2453,9 @@ model:
     }
 
     #[test]
-    fn nested_stebbs_string_parameters_rejected() {
-        // Python/Pydantic rejects enum-name strings here; the bridge must not
-        // silently run them as PROVIDED.
+    fn nested_stebbs_refvalue_string_parameters_compose_method_two() {
+        // Readable enum-name strings are accepted on input and collapse to the
+        // numeric code before the bridge writes the legacy fused key.
         let yaml = "\
 model:
   physics:
@@ -2464,9 +2464,24 @@ model:
       parameters: {value: provided}
 ";
         let mut root: Value = from_str(yaml).unwrap();
-        let err = normalize_field_names(&mut root).expect_err("string parameters must fail");
+        normalize_field_names(&mut root).unwrap();
+        assert_eq!(physics_i64(&root, "stebbsmethod"), Some(2));
+    }
+
+    #[test]
+    fn nested_stebbs_unknown_string_parameters_rejected() {
+        let yaml = "\
+model:
+  physics:
+    stebbs:
+      enabled: {value: true}
+      parameters: {value: custom}
+";
+        let mut root: Value = from_str(yaml).unwrap();
+        let err =
+            normalize_field_names(&mut root).expect_err("unknown string parameters must fail");
         assert!(
-            err.contains("stebbs.parameters"),
+            err.contains("unknown scheme name"),
             "unexpected error message: {err}"
         );
     }

--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -106,17 +106,11 @@ pub const FIELD_RENAMES: &[(&str, &str)] = &[
     // here; the gh#1329 PascalCase intermediate (WallExternalThickness
     // etc.) lives in FIELD_COMPAT_ALIASES below.
     ("thickness_wall_outer", "WallextThickness"),
-    (
-        "conductivity_wall_outer",
-        "WallextEffectiveConductivity",
-    ),
+    ("conductivity_wall_outer", "WallextEffectiveConductivity"),
     ("density_wall_outer", "WallextDensity"),
     ("specific_heat_capacity_wall_outer", "WallextCp"),
     ("thickness_roof_outer", "RoofextThickness"),
-    (
-        "conductivity_roof_outer",
-        "RoofextEffectiveConductivity",
-    ),
+    ("conductivity_roof_outer", "RoofextEffectiveConductivity"),
     ("density_roof_outer", "RoofextDensity"),
     ("specific_heat_capacity_roof_outer", "RoofextCp"),
     ("archetype_name", "BuildingName"),
@@ -156,10 +150,7 @@ pub const FIELD_RENAMES: &[(&str, &str)] = &[
     ("density_ground_floor", "GroundFloorDensity"),
     ("specific_heat_capacity_ground_floor", "GroundFloorCp"),
     ("thickness_window", "WindowThickness"),
-    (
-        "conductivity_window",
-        "WindowEffectiveConductivity",
-    ),
+    ("conductivity_window", "WindowEffectiveConductivity"),
     ("density_window", "WindowDensity"),
     ("specific_heat_capacity_window", "WindowCp"),
     ("emissivity_window_external", "WindowExternalEmissivity"),
@@ -172,12 +163,15 @@ pub const FIELD_RENAMES: &[(&str, &str)] = &[
     ("emissivity_internal_mass", "InternalMassEmissivity"),
     ("power_air_heating_max", "MaxHeatingPower"),
     ("volume_hot_water_tank", "WaterTankWaterVolume"),
+    ("power_water_heating_max", "MaximumHotWaterHeatingPower"),
     (
-        "power_water_heating_max",
-        "MaximumHotWaterHeatingPower",
+        "temperature_air_heating_setpoint",
+        "HeatingSetpointTemperature",
     ),
-    ("temperature_air_heating_setpoint", "HeatingSetpointTemperature"),
-    ("temperature_air_cooling_setpoint", "CoolingSetpointTemperature"),
+    (
+        "temperature_air_cooling_setpoint",
+        "CoolingSetpointTemperature",
+    ),
     (
         "profile_temperature_air_heating_setpoint",
         "HeatingSetpointTemperatureProfile",
@@ -454,14 +448,8 @@ pub const FIELD_COMPAT_ALIASES: &[(&str, &str)] = &[
         "maximumhotwaterheatingpower",
     ),
     ("hot_water_tank_volume", "watertankwatervolume"),
-    (
-        "heating_setpoint_temperature",
-        "heatingsetpointtemperature",
-    ),
-    (
-        "cooling_setpoint_temperature",
-        "coolingsetpointtemperature",
-    ),
+    ("heating_setpoint_temperature", "heatingsetpointtemperature"),
+    ("cooling_setpoint_temperature", "coolingsetpointtemperature"),
     (
         "heating_setpoint_temperature_profile",
         "heatingsetpointtemperatureprofile",
@@ -485,33 +473,75 @@ pub const FIELD_COMPAT_ALIASES: &[(&str, &str)] = &[
     // Schema 2026.5.dev9 StebbsProperties Rule-2 final names. Python
     // reaches these through the Pydantic rename chain; the Rust CLI bypasses
     // that shim, so current YAML needs a direct alias to the bridge keys.
-    ("convection_coefficient_wall_internal", "wallinternalconvectioncoefficient"),
-    ("convection_coefficient_roof_internal", "roofinternalconvectioncoefficient"),
-    ("convection_coefficient_internal_mass", "internalmassconvectioncoefficient"),
-    ("convection_coefficient_ground_floor_internal", "floorinternalconvectioncoefficient"),
-    ("convection_coefficient_window_internal", "windowinternalconvectioncoefficient"),
-    ("convection_coefficient_wall_external", "wallexternalconvectioncoefficient"),
-    ("convection_coefficient_roof_external", "roofexternalconvectioncoefficient"),
-    ("convection_coefficient_window_external", "windowexternalconvectioncoefficient"),
+    (
+        "convection_coefficient_wall_internal",
+        "wallinternalconvectioncoefficient",
+    ),
+    (
+        "convection_coefficient_roof_internal",
+        "roofinternalconvectioncoefficient",
+    ),
+    (
+        "convection_coefficient_internal_mass",
+        "internalmassconvectioncoefficient",
+    ),
+    (
+        "convection_coefficient_ground_floor_internal",
+        "floorinternalconvectioncoefficient",
+    ),
+    (
+        "convection_coefficient_window_internal",
+        "windowinternalconvectioncoefficient",
+    ),
+    (
+        "convection_coefficient_wall_external",
+        "wallexternalconvectioncoefficient",
+    ),
+    (
+        "convection_coefficient_roof_external",
+        "roofexternalconvectioncoefficient",
+    ),
+    (
+        "convection_coefficient_window_external",
+        "windowexternalconvectioncoefficient",
+    ),
     ("thermal_conductivity_ground", "externalgroundconductivity"),
     ("threshold_metabolism", "metabolismthreshold"),
     ("ratio_latent_sensible", "latentsensibleratio"),
     ("control_daylight", "daylightcontrol"),
-    ("threshold_lighting_illuminance", "lightingilluminancethreshold"),
+    (
+        "threshold_lighting_illuminance",
+        "lightingilluminancethreshold",
+    ),
     ("efficiency_heating_system_air", "heatingsystemefficiency"),
     ("power_air_cooling_max", "maxcoolingpower"),
     ("efficiency_cooling_system_air", "coolingsystemcop"),
-    ("temperature_air_outdoor_initial", "initialoutdoortemperature"),
+    (
+        "temperature_air_outdoor_initial",
+        "initialoutdoortemperature",
+    ),
     ("temperature_air_indoor_initial", "initialindoortemperature"),
     ("temperature_air_annual_mean", "annualmeanairtemperature"),
     ("thickness_hot_water_tank_wall", "watertankwallthickness"),
     ("temperature_water_mains", "mainswatertemperature"),
     ("area_hot_water_tank_surface", "watertanksurfacearea"),
-    ("temperature_water_heating_setpoint", "hotwaterheatingsetpointtemperature"),
-    ("emissivity_hot_water_tank_wall", "hotwatertankwallemissivity"),
-    ("conductivity_hot_water_tank_wall", "hotwatertankwallconductivity"),
+    (
+        "temperature_water_heating_setpoint",
+        "hotwaterheatingsetpointtemperature",
+    ),
+    (
+        "emissivity_hot_water_tank_wall",
+        "hotwatertankwallemissivity",
+    ),
+    (
+        "conductivity_hot_water_tank_wall",
+        "hotwatertankwallconductivity",
+    ),
     ("density_hot_water_tank_wall", "hotwatertankwalldensity"),
-    ("specific_heat_capacity_hot_water_tank_wall", "hotwatertankspecificheatcapacity"),
+    (
+        "specific_heat_capacity_hot_water_tank_wall",
+        "hotwatertankspecificheatcapacity",
+    ),
     (
         "convection_coefficient_hot_water_tank_wall_internal",
         "hotwatertankinternalwallconvectioncoefficient",
@@ -521,9 +551,15 @@ pub const FIELD_COMPAT_ALIASES: &[(&str, &str)] = &[
         "hotwatertankexternalwallconvectioncoefficient",
     ),
     ("thickness_hot_water_vessel_wall", "dhwvesselwallthickness"),
-    ("conductivity_hot_water_vessel_wall", "dhwvesselwallconductivity"),
+    (
+        "conductivity_hot_water_vessel_wall",
+        "dhwvesselwallconductivity",
+    ),
     ("density_hot_water_vessel_wall", "dhwvesseldensity"),
-    ("specific_heat_capacity_hot_water_vessel_wall", "dhwvesselspecificheatcapacity"),
+    (
+        "specific_heat_capacity_hot_water_vessel_wall",
+        "dhwvesselspecificheatcapacity",
+    ),
     (
         "convection_coefficient_hot_water_vessel_wall_internal",
         "dhwvesselinternalwallconvectioncoefficient",
@@ -532,13 +568,22 @@ pub const FIELD_COMPAT_ALIASES: &[(&str, &str)] = &[
         "convection_coefficient_hot_water_vessel_wall_external",
         "dhwvesselexternalwallconvectioncoefficient",
     ),
-    ("emissivity_hot_water_vessel_wall", "dhwvesselwallemissivity"),
+    (
+        "emissivity_hot_water_vessel_wall",
+        "dhwvesselwallemissivity",
+    ),
     ("volume_hot_water", "dhwwatervolume"),
     ("area_hot_water_surface", "dhwsurfacearea"),
     ("rate_hot_water_flow", "hotwaterflowrate"),
     ("density_hot_water", "dhwdensity"),
-    ("specific_heat_capacity_hot_water", "dhwspecificheatcapacity"),
-    ("efficiency_heating_system_water", "hotwaterheatingefficiency"),
+    (
+        "specific_heat_capacity_hot_water",
+        "dhwspecificheatcapacity",
+    ),
+    (
+        "efficiency_heating_system_water",
+        "hotwaterheatingefficiency",
+    ),
     ("profile_hot_water_flow", "hotwaterflowprofile"),
     ("profile_appliance", "applianceprofile"),
     // Schema 2026.5.dev12 STEBBS straggler reorder (gh#1392 follow-up). The
@@ -551,7 +596,10 @@ pub const FIELD_COMPAT_ALIASES: &[(&str, &str)] = &[
     ("depth_ground", "GroundDepth"),
     ("rate_ventilation", "VentilationRate"),
     ("power_density_lighting", "LightingPowerDensity"),
-    ("temperature_air_month_mean_diffmax", "MonthMeanAirTemperature_diffmax"),
+    (
+        "temperature_air_month_mean_diffmax",
+        "MonthMeanAirTemperature_diffmax",
+    ),
     // Schema 2026.5.dev12 Column D alignment (gh#1392 follow-up): sixteen more
     // STEBBS / Archetype fields adopt the Reading STEBBS team's "Column D"
     // names (D. Hertwig / S. Rognone, 2026-05). The current YAML carries the
@@ -564,9 +612,18 @@ pub const FIELD_COMPAT_ALIASES: &[(&str, &str)] = &[
     // so the PascalCase ancestry is required for the profile fields.
     // ArchetypeProperties (6)
     ("max_power_heating_system_air", "MaxHeatingPower"),
-    ("max_power_heating_system_water", "MaximumHotWaterHeatingPower"),
-    ("setpoint_temperature_heating_air", "HeatingSetpointTemperature"),
-    ("setpoint_temperature_cooling_air", "CoolingSetpointTemperature"),
+    (
+        "max_power_heating_system_water",
+        "MaximumHotWaterHeatingPower",
+    ),
+    (
+        "setpoint_temperature_heating_air",
+        "HeatingSetpointTemperature",
+    ),
+    (
+        "setpoint_temperature_cooling_air",
+        "CoolingSetpointTemperature",
+    ),
     (
         "profile_setpoint_temperature_heating_air",
         "HeatingSetpointTemperatureProfile",
@@ -577,7 +634,10 @@ pub const FIELD_COMPAT_ALIASES: &[(&str, &str)] = &[
     ),
     // StebbsProperties (10)
     ("max_power_cooling_system_air", "MaxCoolingPower"),
-    ("setpoint_temperature_heating_water", "HotWaterHeatingSetpointTemperature"),
+    (
+        "setpoint_temperature_heating_water",
+        "HotWaterHeatingSetpointTemperature",
+    ),
     ("temperature_mains_water", "MainsWaterTemperature"),
     ("surface_area_hot_water_tank", "WaterTankSurfaceArea"),
     ("surface_area_hot_water", "DHWSurfaceArea"),
@@ -642,6 +702,168 @@ pub const PHYSICS_FAMILIES_RS: &[(&str, &[(&str, FamilyCodes)])] = &[
             ("biogenic_conductance", &[41, 42, 43, 44, 45, 46]),
         ],
     ),
+];
+
+/// Human-readable scalar name -> code registry for every accepted
+/// model.physics enum surface (gh#1471). Mirrors `_PHYSICS_NAME_SPECS` in
+/// `src/supy/data_model/core/physics_families.py`.
+pub const PHYSICS_NAME_ALIASES_RS: &[(&str, &[(&str, i64)])] = &[
+    (
+        "net_radiation",
+        &[
+            ("observed", 0),
+            ("forcing", 0),
+            ("ldown_observed", 1),
+            ("ldown_cloud", 2),
+            ("ldown_air", 3),
+            ("ldown_surface", 11),
+            ("ldown_cloud_surface", 12),
+            ("ldown_air_surface", 13),
+            ("ldown_zenith", 100),
+            ("ldown_cloud_zenith", 200),
+            ("ldown_air_zenith", 300),
+            ("ldown_ss_observed", 1001),
+            ("ldown_ss_cloud", 1002),
+            ("ldown_ss_air", 1003),
+        ],
+    ),
+    (
+        "emissions",
+        &[
+            ("observed", 0),
+            ("l11", 1),
+            ("j11", 2),
+            ("l11_updated", 3),
+            ("j19", 4),
+            ("j19_updated", 5),
+            ("l11_updated_detailed", 6),
+            ("biogen_rect_l11", 11),
+            ("biogen_rect_j11", 12),
+            ("biogen_rect_l11_updated", 13),
+            ("biogen_rect_l11_detailed", 14),
+            ("biogen_rect_j11_detailed", 15),
+            ("biogen_rect_l11_updated_detailed", 16),
+            ("biogen_bellucco_local_l11", 21),
+            ("biogen_bellucco_local_j11", 22),
+            ("biogen_bellucco_local_l11_updated", 23),
+            ("biogen_bellucco_local_l11_detailed", 24),
+            ("biogen_bellucco_local_j11_detailed", 25),
+            ("biogen_bellucco_local_l11_updated_detailed", 26),
+            ("biogen_bellucco_general_l11", 31),
+            ("biogen_bellucco_general_j11", 32),
+            ("biogen_bellucco_general_l11_updated", 33),
+            ("biogen_bellucco_general_l11_detailed", 34),
+            ("biogen_bellucco_general_j11_detailed", 35),
+            ("biogen_bellucco_general_l11_updated_detailed", 36),
+            ("biogen_conductance_l11", 41),
+            ("biogen_conductance_j11", 42),
+            ("biogen_conductance_l11_updated", 43),
+            ("biogen_conductance_l11_detailed", 44),
+            ("biogen_conductance_j11_detailed", 45),
+            ("biogen_conductance_l11_updated_detailed", 46),
+        ],
+    ),
+    (
+        "storage_heat",
+        &[
+            ("observed", 0),
+            ("ohm", 1),
+            ("ohm_without_qf", 1),
+            ("anohm", 3),
+            ("s17", 3),
+            ("estm", 4),
+            ("o05", 4),
+            ("ehc", 5),
+            ("dyohm", 6),
+            ("l25", 6),
+            ("stebbs", 7),
+        ],
+    ),
+    ("ohm_inc_qf", &[("exclude", 0), ("include", 1)]),
+    (
+        "roughness_length_momentum",
+        &[
+            ("fixed", 1),
+            ("variable", 2),
+            ("macdonald", 3),
+            ("m98", 3),
+            ("lambdap_dependent", 4),
+            ("go99", 4),
+            ("alternative", 5),
+        ],
+    ),
+    (
+        "roughness_length_heat",
+        &[
+            ("brutsaert", 1),
+            ("b82", 1),
+            ("kawai", 2),
+            ("k09", 2),
+            ("voogt_grimmond", 3),
+            ("vg00", 3),
+            ("kanda", 4),
+            ("k07", 4),
+            ("adaptive", 5),
+        ],
+    ),
+    (
+        "stability",
+        &[
+            ("not_used", 0),
+            ("not_used2", 1),
+            ("hoegstrom", 2),
+            ("campbell_norman", 3),
+            ("cn98", 3),
+            ("businger_hoegstrom", 4),
+            ("bh71", 4),
+        ],
+    ),
+    (
+        "soil_moisture_deficit",
+        &[
+            ("modelled", 0),
+            ("observed_volumetric", 1),
+            ("observed_gravimetric", 2),
+        ],
+    ),
+    ("water_use", &[("modelled", 0), ("observed", 1)]),
+    ("laimethod", &[("observed", 0), ("calculated", 1)]),
+    (
+        "roughness_sublayer",
+        &[("most", 0), ("rst", 1), ("t19", 1), ("variable", 2)],
+    ),
+    (
+        "frontal_area_index",
+        &[("use_provided", 0), ("simple_scheme", 1)],
+    ),
+    (
+        "roughness_sublayer_level",
+        &[("none", 0), ("basic", 1), ("detailed", 2)],
+    ),
+    (
+        "surface_conductance",
+        &[("jarvi", 1), ("j11", 1), ("ward", 2), ("w16", 2)],
+    ),
+    ("snow_use", &[("disabled", 0), ("enabled", 1)]),
+    ("stebbs", &[("none", 0), ("default", 1), ("provided", 2)]),
+    ("parameters", &[("default", 1), ("provided", 2)]),
+    (
+        "capacitance",
+        &[
+            ("default", 0),
+            ("provided", 1),
+            ("parameterise", 2),
+            ("parameterize", 2),
+        ],
+    ),
+    (
+        "setpoint",
+        &[("constant", 0), ("dependent", 1), ("scheduled", 2)],
+    ),
+    ("same_albedo_wall", &[("disabled", 0), ("enabled", 1)]),
+    ("same_albedo_roof", &[("disabled", 0), ("enabled", 1)]),
+    ("same_emissivity_wall", &[("disabled", 0), ("enabled", 1)]),
+    ("same_emissivity_roof", &[("disabled", 0), ("enabled", 1)]),
 ];
 
 const NET_RADIATION_OUTER_KEYS: &[&str] = &[
@@ -1019,6 +1241,100 @@ fn collapse_nested_physics(root: &mut Value) -> Result<(), String> {
     Ok(())
 }
 
+fn physics_name_to_code(field: &str, name: &str) -> Option<i64> {
+    let key = name.trim().to_ascii_lowercase();
+    PHYSICS_NAME_ALIASES_RS
+        .iter()
+        .find(|(f, _)| *f == field)
+        .and_then(|(_, aliases)| {
+            aliases
+                .iter()
+                .find(|(n, _)| *n == key)
+                .map(|(_, code)| *code)
+        })
+}
+
+fn collapse_physics_scalar_entry(field: &str, entry: &mut Value) -> Result<bool, String> {
+    if let Some(name) = entry.as_str().map(|s| s.to_string()) {
+        let code = physics_name_to_code(field, &name)
+            .ok_or_else(|| format!("'{field}' got unknown scheme name '{name}'."))?;
+        let mut flat = serde_yaml::Mapping::new();
+        flat.insert(Value::String("value".into()), Value::Number(code.into()));
+        *entry = Value::Mapping(flat);
+        return Ok(true);
+    }
+
+    if let Value::Mapping(map) = entry {
+        let value_key = Value::String("value".into());
+        if let Some(name) = map
+            .get(&value_key)
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+        {
+            let code = physics_name_to_code(field, &name)
+                .ok_or_else(|| format!("'{field}' got unknown scheme name '{name}'."))?;
+            map.insert(value_key, Value::Number(code.into()));
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn collapse_physics_names(root: &mut Value) -> Result<(), String> {
+    let physics = match root
+        .get_mut("model")
+        .and_then(|m| m.as_mapping_mut())
+        .and_then(|m| m.get_mut(Value::String("physics".into())))
+        .and_then(|p| p.as_mapping_mut())
+    {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+
+    for (field, _) in PHYSICS_NAME_ALIASES_RS {
+        for spelling in physics_field_key_spellings(field) {
+            let key = Value::String(spelling);
+            let entry = match physics.get_mut(&key) {
+                Some(entry) => entry,
+                None => continue,
+            };
+            collapse_physics_scalar_entry(field, entry)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn physics_field_key_spellings(field: &str) -> Vec<String> {
+    let mut keys = vec![field.to_string()];
+    let push = |keys: &mut Vec<String>, key: &str| {
+        if !keys.iter().any(|existing| existing == key) {
+            keys.push(key.to_string());
+        }
+    };
+
+    let mut targets: Vec<String> = physics_outer_keys(field)
+        .iter()
+        .map(|key| key.to_string())
+        .collect();
+    for (new, old) in FIELD_RENAMES.iter().chain(FIELD_COMPAT_ALIASES.iter()) {
+        if *new == field && !targets.iter().any(|target| target == old) {
+            targets.push((*old).to_string());
+        }
+    }
+
+    for target in &targets {
+        push(&mut keys, target);
+    }
+    for (new, old) in FIELD_RENAMES.iter().chain(FIELD_COMPAT_ALIASES.iter()) {
+        if targets.iter().any(|target| target == old) {
+            push(&mut keys, new);
+        }
+    }
+    keys
+}
+
 /// Nested `model.physics.stebbs` leaf keys recognised by the flatten
 /// pre-pass. Mirrors `_STEBBS_NESTED_KEYS` in
 /// `src/supy/data_model/core/field_renames.py` (gh#1456). A `stebbs` mapping
@@ -1081,9 +1397,8 @@ fn is_stebbs_refvalue_scalar(map: &serde_yaml::Mapping) -> bool {
     if !has_value {
         return false;
     }
-    map.keys().all(|k| {
-        matches!(k, Value::String(s) if s == "value" || s == "ref")
-    })
+    map.keys()
+        .all(|k| matches!(k, Value::String(s) if s == "value" || s == "ref"))
 }
 
 fn has_stebbs_nested_key(map: &serde_yaml::Mapping) -> bool {
@@ -1213,6 +1528,9 @@ fn read_parameters_code(entry: &Value) -> Result<i64, String> {
         Value::Bool(false) => {
             Err("model.physics.stebbs.parameters expects 1 or 2, got false".to_string())
         }
+        Value::String(s) => physics_name_to_code("parameters", s).ok_or_else(|| {
+            format!("model.physics.stebbs.parameters got unknown scheme name {s:?}")
+        }),
         other => Err(format!(
             "model.physics.stebbs.parameters expects numeric 1 or 2, got {other:?}"
         )),
@@ -1390,6 +1708,7 @@ pub fn normalize_field_names(root: &mut Value) -> Result<(), String> {
     // otherwise rewrite (`stebbs` -> `stebbsmethod`). See
     // `PHYSICS_FAMILIES_RS` for the full rationale (gh#972).
     collapse_nested_physics(root)?;
+    collapse_physics_names(root)?;
     normalize_field_names_at(root, "<root>")?;
     Ok(())
 }
@@ -1930,6 +2249,85 @@ model:
         );
     }
 
+    #[test]
+    fn readable_physics_names_collapse_to_flat() {
+        let yaml = "\
+model:
+  physics:
+    storage_heat: ohm
+    stability: cn98
+    snow_use: enabled
+";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+        let physics = &root["model"]["physics"];
+        assert_eq!(
+            physics["storageheatmethod"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(1)
+        );
+        assert_eq!(
+            physics["stabilitymethod"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(3)
+        );
+        assert_eq!(
+            physics["snowuse"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn readable_names_under_legacy_and_refvalue_keys_collapse() {
+        let yaml = "\
+model:
+  physics:
+    storage_heat_method: ehc
+    emissionsmethod:
+      value: biogen_conductance_j11_detailed
+";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+        let physics = &root["model"]["physics"];
+        assert_eq!(
+            physics["storageheatmethod"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(5)
+        );
+        assert_eq!(
+            physics["emissionsmethod"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(45)
+        );
+    }
+
+    #[test]
+    fn nested_stebbs_readable_names_flatten_to_fused_keys() {
+        let yaml = "\
+model:
+  physics:
+    stebbs:
+      enabled: true
+      parameters: provided
+      capacitance: parameterise
+      setpoint:
+        value: scheduled
+      same_albedo_wall: enabled
+";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+        assert_eq!(physics_i64(&root, "stebbsmethod"), Some(2));
+        assert_eq!(physics_i64(&root, "rcmethod"), Some(2));
+        assert_eq!(physics_i64(&root, "setpointmethod"), Some(2));
+        assert_eq!(physics_i64(&root, "same_albedo_wall"), Some(1));
+    }
+
     // -- gh#1456: nested `model.physics.stebbs` flatten pre-pass --------------
 
     fn physics_i64(root: &Value, key: &str) -> Option<i64> {
@@ -2030,8 +2428,8 @@ model:
 "
             );
             let mut root: Value = from_str(&yaml).unwrap();
-            let err = normalize_field_names(&mut root)
-                .expect_err("duplicate nested aliases must fail");
+            let err =
+                normalize_field_names(&mut root).expect_err("duplicate nested aliases must fail");
             assert!(
                 err.contains("Multiple nested STEBBS"),
                 "unexpected error message: {err}"

--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -1256,6 +1256,9 @@ fn physics_name_to_code(field: &str, name: &str) -> Option<i64> {
 
 fn collapse_physics_scalar_entry(field: &str, entry: &mut Value) -> Result<bool, String> {
     if let Some(name) = entry.as_str().map(|s| s.to_string()) {
+        if name.trim().is_empty() {
+            return Ok(false);
+        }
         let code = physics_name_to_code(field, &name)
             .ok_or_else(|| format!("'{field}' got unknown scheme name '{name}'."))?;
         let mut flat = serde_yaml::Mapping::new();
@@ -1271,6 +1274,9 @@ fn collapse_physics_scalar_entry(field: &str, entry: &mut Value) -> Result<bool,
             .and_then(|v| v.as_str())
             .map(str::to_string)
         {
+            if name.trim().is_empty() {
+                return Ok(false);
+            }
             let code = physics_name_to_code(field, &name)
                 .ok_or_else(|| format!("'{field}' got unknown scheme name '{name}'."))?;
             map.insert(value_key, Value::Number(code.into()));
@@ -2484,6 +2490,21 @@ model:
             err.contains("unknown scheme name"),
             "unexpected error message: {err}"
         );
+    }
+
+    #[test]
+    fn blank_physics_method_strings_preserve_placeholders() {
+        let yaml = "\
+model:
+  physics:
+    roughness_sublayer: ''
+    emissions: {value: ''}
+";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+        let physics = &root["model"]["physics"];
+        assert_eq!(physics["rslmethod"].as_str(), Some(""));
+        assert_eq!(physics["emissionsmethod"]["value"].as_str(), Some(""));
     }
 
     #[test]

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -70,6 +70,7 @@ try:
         fold_stebbs_physics as _fold_stebbs_physics,
         STEBBS_PHYSICS_LEAF_RENAMES as _STEBBS_PHYSICS_LEAF_RENAMES,
     )
+    from ..data_model.core.physics_families import flatten_physics_in_config
     from ..data_model.schema.version import CURRENT_SCHEMA_VERSION
     from ..data_model.schema.publisher import generate_json_schema
     from ..data_model.schema.migration import SchemaMigrator, check_migration_needed
@@ -84,6 +85,7 @@ except ImportError:
         fold_stebbs_physics as _fold_stebbs_physics,
         STEBBS_PHYSICS_LEAF_RENAMES as _STEBBS_PHYSICS_LEAF_RENAMES,
     )
+    from supy.data_model.core.physics_families import flatten_physics_in_config
     from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
     from supy.data_model.schema.publisher import generate_json_schema
     from supy.data_model.schema.migration import SchemaMigrator, check_migration_needed
@@ -114,6 +116,7 @@ def validate_single_file(
         # Load configuration
         with open(file_path, "r") as f:
             config = yaml.safe_load(f)
+        flatten_physics_in_config(config)
 
         target_is_current = (
             schema_version is None or schema_version == CURRENT_SCHEMA_VERSION

--- a/src/supy/data_model/core/field_renames.py
+++ b/src/supy/data_model/core/field_renames.py
@@ -11,7 +11,7 @@ import warnings
 from collections.abc import Mapping
 from typing import Any, Dict
 
-from .physics_families import coerce_nested_to_flat
+from .physics_families import coerce_nested_to_flat, flatten_physics_in_config
 from .physics_orthogonal import coerce_orthogonal_to_flat
 
 
@@ -1419,6 +1419,7 @@ def _decompose_stebbs_master(entry: Any) -> tuple[Any, Any]:
             "'stebbs.enabled' / 'stebbs.parameters' for the nested form."
         )
 
+    entry = coerce_nested_to_flat("stebbs", entry)
     raw = _unwrap_scalar(entry)
     if isinstance(raw, bool):
         code = int(raw)
@@ -1786,13 +1787,8 @@ def normalise_yaml_renames(data: Any) -> Any:
                 "ModelPhysics",
                 warn=False,
             )
-            for field_name in ("net_radiation", "storage_heat", "emissions"):
-                if field_name in physics:
-                    physics[field_name] = coerce_nested_to_flat(
-                        field_name,
-                        coerce_orthogonal_to_flat(field_name, physics[field_name]),
-                    )
             model["physics"] = physics
+            flatten_physics_in_config(normalised)
 
     return normalised
 

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -13,7 +13,11 @@ from .field_renames import (
     apply_field_renames,
     fold_stebbs_physics,
 )
-from .physics_families import PHYSICS_FAMILIES, coerce_nested_to_flat
+from .physics_families import (
+    MODEL_PHYSICS_ENUM_FIELDS,
+    STEBBS_PHYSICS_ENUM_FIELDS,
+    coerce_nested_to_flat,
+)
 from .physics_orthogonal import coerce_orthogonal_to_flat
 
 
@@ -586,6 +590,7 @@ class RCMethod(Enum):
     def __repr__(self):
         return str(self.value)
 
+
 class SetpointMethod(Enum):
     """
     Method to determine the approach of space heating/cooling setpoints in STEBBS.
@@ -605,6 +610,7 @@ class SetpointMethod(Enum):
     def __repr__(self):
         return str(self.value)
 
+
 class SnowUse(Enum):
     """
     Controls snow process calculations (Järvi et al. 2014).
@@ -621,7 +627,8 @@ class SnowUse(Enum):
 
     def __repr__(self):
         return str(self.value)
-    
+
+
 class SameAlbedoWall(Enum):
     """
     Controls assumption of same albedoes for walls.
@@ -638,7 +645,7 @@ class SameAlbedoWall(Enum):
 
     def __repr__(self):
         return str(self.value)
-    
+
 
 class SameAlbedoRoof(Enum):
     """
@@ -656,7 +663,8 @@ class SameAlbedoRoof(Enum):
 
     def __repr__(self):
         return str(self.value)
-    
+
+
 class SameEmissivityWall(Enum):
     """
     Controls assumption of same emissivities for walls.
@@ -673,7 +681,7 @@ class SameEmissivityWall(Enum):
 
     def __repr__(self):
         return str(self.value)
-    
+
 
 class SameEmissivityRoof(Enum):
     """
@@ -690,8 +698,7 @@ class SameEmissivityRoof(Enum):
         return self.value
 
     def __repr__(self):
-        return str(self.value)    
-
+        return str(self.value)
 
 
 def yaml_equivalent_of_default(dumper, data):
@@ -807,6 +814,13 @@ class StebbsPhysics(BaseModel):
             raise ValueError("STEBBS enabled/parameters switches cannot be null")
         return value
 
+    @field_validator(*STEBBS_PHYSICS_ENUM_FIELDS, mode="before")
+    @classmethod
+    def _coerce_readable_stebbs_physics(cls, value, info):
+        # Accept readable method tokens under the nested STEBBS surface while
+        # keeping the canonical stored shape as the existing enum code.
+        return coerce_nested_to_flat(info.field_name, value)
+
 
 class ModelPhysics(BaseModel):
     """
@@ -823,7 +837,9 @@ class ModelPhysics(BaseModel):
             # (suffix drop + abbreviation expansion). Chaining lets a single
             # YAML carrying either legacy shape land on the final name.
             values = apply_field_renames(values, MODELPHYSICS_RENAMES, cls.__name__)
-            values = apply_field_renames(values, MODELPHYSICS_SUFFIX_RENAMES, cls.__name__)
+            values = apply_field_renames(
+                values, MODELPHYSICS_SUFFIX_RENAMES, cls.__name__
+            )
             # gh#1456: fold the legacy flat STEBBS switches into the nested
             # `stebbs` object. Runs after the key renames so a YAML carrying
             # either fused or snake_case legacy spellings lands here. The fold
@@ -832,12 +848,12 @@ class ModelPhysics(BaseModel):
             values = fold_stebbs_physics(values, cls.__name__)
         return values
 
-    @field_validator(*PHYSICS_FAMILIES.keys(), mode="before")
+    @field_validator(*MODEL_PHYSICS_ENUM_FIELDS, mode="before")
     @classmethod
     def _coerce_nested_physics(cls, value, info):
         # Widens accepted input before FlexibleRefValue resolves:
-        # orthogonal physics tokens and family tags both collapse to
-        # the flat `{value: N}` canonical shape.
+        # orthogonal physics tokens, family tags, and human-readable names
+        # collapse to the flat `{value: N}` canonical shape.
         value = coerce_orthogonal_to_flat(info.field_name, value)
         return coerce_nested_to_flat(info.field_name, value)
 
@@ -1000,7 +1016,9 @@ class ModelPhysics(BaseModel):
         enabled = stebbs.enabled
         enabled = enabled.value if isinstance(enabled, RefValue) else enabled
         parameters = stebbs.parameters
-        parameters = parameters.value if isinstance(parameters, RefValue) else parameters
+        parameters = (
+            parameters.value if isinstance(parameters, RefValue) else parameters
+        )
         cols[("stebbsmethod", "0")] = 0 if not bool(enabled) else int(parameters)
 
         for member_name, col_name in self._STEBBS_FIELD_COL_PAIRS:

--- a/src/supy/data_model/core/physics_families.py
+++ b/src/supy/data_model/core/physics_families.py
@@ -256,8 +256,12 @@ def resolve_scalar_name(field_name: str, name: str) -> int:
 def _coerce_scalar_name(field_name: str, value: Any) -> Any:
     """Collapse bare or RefValue-wrapped readable names to ``{value: code}``."""
     if isinstance(value, str):
+        if not value.strip():
+            return value
         return {"value": resolve_scalar_name(field_name, value)}
     if isinstance(value, Mapping) and isinstance(value.get("value"), str):
+        if not value["value"].strip():
+            return value
         flat = dict(value)
         flat["value"] = resolve_scalar_name(field_name, value["value"])
         return flat

--- a/src/supy/data_model/core/physics_families.py
+++ b/src/supy/data_model/core/physics_families.py
@@ -1,4 +1,4 @@
-"""Family-tagged nested physics option registry (gh#972).
+"""Readable and family-tagged physics option registry (gh#972 follow-up).
 
 Users may supply ``model.physics`` fields with a family tag::
 
@@ -10,6 +10,13 @@ The family tag is validated against the numeric codes it covers, then
 discarded so the canonical internal representation stays flat
 (``{value: N}``). YAML round-trip emits the flat form.
 
+Users may also supply registered human-readable method names::
+
+    storage_heat: ohm
+    stability: cn98
+    stebbs:
+      capacitance: provided
+
 Accept-only widening: no schema bump. Every previously-valid YAML
 continues to validate and round-trips byte-identically.
 """
@@ -20,6 +27,8 @@ from collections.abc import Mapping
 from enum import Enum
 from numbers import Integral, Real
 from typing import Any
+
+from .physics_orthogonal import coerce_orthogonal_to_flat
 
 
 PHYSICS_FAMILIES: dict[str, dict[str, frozenset[int]]] = {
@@ -47,36 +56,215 @@ PHYSICS_FAMILIES: dict[str, dict[str, frozenset[int]]] = {
     },
 }
 
+_PHYSICS_NAME_SPECS: dict[str, list[tuple[int, str, tuple[str, ...]]]] = {
+    "net_radiation": [
+        (0, "observed", ("forcing",)),
+        (1, "ldown_observed", ()),
+        (2, "ldown_cloud", ()),
+        (3, "ldown_air", ()),
+        (11, "ldown_surface", ()),
+        (12, "ldown_cloud_surface", ()),
+        (13, "ldown_air_surface", ()),
+        (100, "ldown_zenith", ()),
+        (200, "ldown_cloud_zenith", ()),
+        (300, "ldown_air_zenith", ()),
+        (1001, "ldown_ss_observed", ()),
+        (1002, "ldown_ss_cloud", ()),
+        (1003, "ldown_ss_air", ()),
+    ],
+    "emissions": [
+        (0, "observed", ()),
+        (1, "l11", ()),
+        (2, "j11", ()),
+        (3, "l11_updated", ()),
+        (4, "j19", ()),
+        (5, "j19_updated", ()),
+        (6, "l11_updated_detailed", ()),
+        (11, "biogen_rect_l11", ()),
+        (12, "biogen_rect_j11", ()),
+        (13, "biogen_rect_l11_updated", ()),
+        (14, "biogen_rect_l11_detailed", ()),
+        (15, "biogen_rect_j11_detailed", ()),
+        (16, "biogen_rect_l11_updated_detailed", ()),
+        (21, "biogen_bellucco_local_l11", ()),
+        (22, "biogen_bellucco_local_j11", ()),
+        (23, "biogen_bellucco_local_l11_updated", ()),
+        (24, "biogen_bellucco_local_l11_detailed", ()),
+        (25, "biogen_bellucco_local_j11_detailed", ()),
+        (26, "biogen_bellucco_local_l11_updated_detailed", ()),
+        (31, "biogen_bellucco_general_l11", ()),
+        (32, "biogen_bellucco_general_j11", ()),
+        (33, "biogen_bellucco_general_l11_updated", ()),
+        (34, "biogen_bellucco_general_l11_detailed", ()),
+        (35, "biogen_bellucco_general_j11_detailed", ()),
+        (36, "biogen_bellucco_general_l11_updated_detailed", ()),
+        (41, "biogen_conductance_l11", ()),
+        (42, "biogen_conductance_j11", ()),
+        (43, "biogen_conductance_l11_updated", ()),
+        (44, "biogen_conductance_l11_detailed", ()),
+        (45, "biogen_conductance_j11_detailed", ()),
+        (46, "biogen_conductance_l11_updated_detailed", ()),
+    ],
+    "storage_heat": [
+        (0, "observed", ()),
+        (1, "ohm", ("ohm_without_qf",)),
+        (3, "anohm", ("s17",)),
+        (4, "estm", ("o05",)),
+        (5, "ehc", ()),
+        (6, "dyohm", ("l25",)),
+        (7, "stebbs", ()),
+    ],
+    "ohm_inc_qf": [(0, "exclude", ()), (1, "include", ())],
+    "roughness_length_momentum": [
+        (1, "fixed", ()),
+        (2, "variable", ()),
+        (3, "macdonald", ("m98",)),
+        (4, "lambdap_dependent", ("go99",)),
+        (5, "alternative", ()),
+    ],
+    "roughness_length_heat": [
+        (1, "brutsaert", ("b82",)),
+        (2, "kawai", ("k09",)),
+        (3, "voogt_grimmond", ("vg00",)),
+        (4, "kanda", ("k07",)),
+        (5, "adaptive", ()),
+    ],
+    "stability": [
+        (0, "not_used", ()),
+        (1, "not_used2", ()),
+        (2, "hoegstrom", ()),
+        (3, "campbell_norman", ("cn98",)),
+        (4, "businger_hoegstrom", ("bh71",)),
+    ],
+    "soil_moisture_deficit": [
+        (0, "modelled", ()),
+        (1, "observed_volumetric", ()),
+        (2, "observed_gravimetric", ()),
+    ],
+    "water_use": [(0, "modelled", ()), (1, "observed", ())],
+    "laimethod": [(0, "observed", ()), (1, "calculated", ())],
+    "roughness_sublayer": [
+        (0, "most", ()),
+        (1, "rst", ("t19",)),
+        (2, "variable", ()),
+    ],
+    "frontal_area_index": [(0, "use_provided", ()), (1, "simple_scheme", ())],
+    "roughness_sublayer_level": [
+        (0, "none", ()),
+        (1, "basic", ()),
+        (2, "detailed", ()),
+    ],
+    "surface_conductance": [
+        (1, "jarvi", ("j11",)),
+        (2, "ward", ("w16",)),
+    ],
+    "snow_use": [(0, "disabled", ()), (1, "enabled", ())],
+    # Legacy flat STEBBS master toggle; the current public surface is the
+    # nested `stebbs.enabled` + `stebbs.parameters` object.
+    "stebbs": [(0, "none", ()), (1, "default", ()), (2, "provided", ())],
+    "parameters": [(1, "default", ()), (2, "provided", ())],
+    # Reading/STEBBS Column-D public selector name: `capacitance`, not
+    # `capacitance_method` (Silvia Rognone mapping_names_28May.xlsx, row 115).
+    "capacitance": [
+        (0, "default", ()),
+        (1, "provided", ()),
+        (2, "parameterise", ("parameterize",)),
+    ],
+    "setpoint": [
+        (0, "constant", ()),
+        (1, "dependent", ()),
+        (2, "scheduled", ()),
+    ],
+    "same_albedo_wall": [(0, "disabled", ()), (1, "enabled", ())],
+    "same_albedo_roof": [(0, "disabled", ()), (1, "enabled", ())],
+    "same_emissivity_wall": [(0, "disabled", ()), (1, "enabled", ())],
+    "same_emissivity_roof": [(0, "disabled", ()), (1, "enabled", ())],
+}
 
-def coerce_nested_to_flat(field_name: str, value: Any) -> Any:
-    """Collapse a family-tagged nested mapping to the flat ``{value: N}`` form.
+MODEL_PHYSICS_ENUM_FIELDS: tuple[str, ...] = (
+    "net_radiation",
+    "emissions",
+    "storage_heat",
+    "ohm_inc_qf",
+    "roughness_length_momentum",
+    "roughness_length_heat",
+    "stability",
+    "soil_moisture_deficit",
+    "water_use",
+    "laimethod",
+    "roughness_sublayer",
+    "frontal_area_index",
+    "roughness_sublayer_level",
+    "surface_conductance",
+    "snow_use",
+)
 
-    Parameters
-    ----------
-    field_name : str
-        ModelPhysics field name (e.g. ``"net_radiation"``).
-    value : Any
-        Raw input from YAML / dict. Unknown shapes pass through untouched
-        so Pydantic can report a consistent error.
+STEBBS_PHYSICS_ENUM_FIELDS: tuple[str, ...] = (
+    "parameters",
+    "capacitance",
+    "setpoint",
+    "same_albedo_wall",
+    "same_albedo_roof",
+    "same_emissivity_wall",
+    "same_emissivity_roof",
+)
 
-    Returns
-    -------
-    Any
-        ``{"value": N}`` (plus any ``ref`` the nested dict carried) when a
-        family tag was detected; otherwise ``value`` unchanged.
+PHYSICS_ENUM_FIELDS: tuple[str, ...] = tuple(_PHYSICS_NAME_SPECS)
 
-    Raises
-    ------
-    ValueError
-        When the input carries multiple family tags, combines a family
-        tag with other sibling keys, the inner mapping lacks ``value``,
-        or the numeric code does not belong to the declared family.
-    """
-    if field_name not in PHYSICS_FAMILIES:
-        return value
-    if not isinstance(value, Mapping):
-        return value
 
+def _build_lookup_tables() -> tuple[
+    dict[str, dict[int, str]], dict[str, dict[str, int]]
+]:
+    code_to_canonical: dict[str, dict[int, str]] = {}
+    alias_to_code: dict[str, dict[str, int]] = {}
+    for field_name, specs in _PHYSICS_NAME_SPECS.items():
+        canon: dict[int, str] = {}
+        aliases: dict[str, int] = {}
+        for code, canonical, extras in specs:
+            canon[code] = canonical
+            for name in (canonical, *extras):
+                key = name.lower()
+                if key in aliases and aliases[key] != code:
+                    raise ValueError(
+                        f"physics_families: alias {key!r} for '{field_name}' "
+                        f"maps to both {aliases[key]} and {code}."
+                    )
+                aliases[key] = code
+        code_to_canonical[field_name] = canon
+        alias_to_code[field_name] = aliases
+    return code_to_canonical, alias_to_code
+
+
+_CODE_TO_CANONICAL, _ALIAS_TO_CODE = _build_lookup_tables()
+
+
+def resolve_scalar_name(field_name: str, name: str) -> int:
+    """Resolve a registered human-readable physics method name to its code."""
+    table = _ALIAS_TO_CODE.get(field_name, {})
+    key = name.strip().lower()
+    if key in table:
+        return table[key]
+    valid = sorted(table)
+    hint = ""
+    if field_name in {"net_radiation", "emissions"}:
+        hint = " Orthogonal decomposed mappings are also accepted for this field."
+    raise ValueError(
+        f"'{field_name}' got unknown scheme name {name!r}; valid names: {valid}.{hint}"
+    )
+
+
+def _coerce_scalar_name(field_name: str, value: Any) -> Any:
+    """Collapse bare or RefValue-wrapped readable names to ``{value: code}``."""
+    if isinstance(value, str):
+        return {"value": resolve_scalar_name(field_name, value)}
+    if isinstance(value, Mapping) and isinstance(value.get("value"), str):
+        flat = dict(value)
+        flat["value"] = resolve_scalar_name(field_name, value["value"])
+        return flat
+    return value
+
+
+def _coerce_family_tag(field_name: str, value: Mapping[str, Any]) -> Any:
     families = PHYSICS_FAMILIES[field_name]
     matched = [key for key in families if key in value]
     if not matched:
@@ -122,14 +310,12 @@ def coerce_nested_to_flat(field_name: str, value: Any) -> Any:
         code_real = float(code)
         if not code_real.is_integer():
             raise ValueError(
-                f"'{field_name}.{family}.value' must be an integer code "
-                f"(got {code!r})."
+                f"'{field_name}.{family}.value' must be an integer code (got {code!r})."
             )
         code_int = int(code_real)
     else:
         raise ValueError(
-            f"'{field_name}.{family}.value' must be an integer code "
-            f"(got {code!r})."
+            f"'{field_name}.{family}.value' must be an integer code (got {code!r})."
         )
 
     if code_int not in families[family]:
@@ -149,3 +335,81 @@ def coerce_nested_to_flat(field_name: str, value: Any) -> Any:
     if carried is not None:
         flat["ref"] = carried
     return flat
+
+
+def flatten_physics_in_config(data: Any) -> Any:
+    """Rewrite supported readable physics inputs to flat ``{value: N}`` mappings.
+
+    The raw-dict validation pipeline predates these readable names and expects
+    enum fields to look like RefValue mappings. This mutates and returns
+    ``data``; malformed values are left for the normal validators to report.
+    """
+    if not isinstance(data, Mapping):
+        return data
+    model = data.get("model")
+    if not isinstance(model, Mapping):
+        return data
+    physics = model.get("physics")
+    if not isinstance(physics, dict):
+        return data
+
+    for field_name in MODEL_PHYSICS_ENUM_FIELDS:
+        if field_name not in physics:
+            continue
+        try:
+            value = coerce_orthogonal_to_flat(field_name, physics[field_name])
+            physics[field_name] = coerce_nested_to_flat(field_name, value)
+        except (TypeError, ValueError):
+            pass
+
+    stebbs = physics.get("stebbs")
+    if isinstance(stebbs, dict) and "value" not in stebbs:
+        for field_name in STEBBS_PHYSICS_ENUM_FIELDS:
+            if field_name not in stebbs:
+                continue
+            try:
+                stebbs[field_name] = coerce_nested_to_flat(
+                    field_name,
+                    stebbs[field_name],
+                )
+            except (TypeError, ValueError):
+                pass
+
+    return data
+
+
+def coerce_nested_to_flat(field_name: str, value: Any) -> Any:
+    """Collapse accepted readable/family physics inputs to ``{value: N}``.
+
+    Parameters
+    ----------
+    field_name : str
+        ModelPhysics field name (e.g. ``"net_radiation"``).
+    value : Any
+        Raw input from YAML / dict. Unknown shapes pass through untouched
+        so Pydantic can report a consistent error.
+
+    Returns
+    -------
+    Any
+        ``{"value": N}`` (plus any ``ref`` the nested dict carried) when a
+        family tag was detected; otherwise ``value`` unchanged.
+
+    Raises
+    ------
+    ValueError
+        When the input carries an unknown scalar name, multiple family tags,
+        combines a family tag with other sibling keys, the inner mapping lacks
+        ``value``, or the numeric code does not belong to the declared family.
+    """
+    if field_name not in PHYSICS_ENUM_FIELDS:
+        return value
+
+    value = _coerce_scalar_name(field_name, value)
+    if not isinstance(value, Mapping):
+        return value
+
+    if field_name in PHYSICS_FAMILIES:
+        return _coerce_family_tag(field_name, value)
+
+    return value

--- a/src/supy/data_model/validation/core/yaml_helpers.py
+++ b/src/supy/data_model/validation/core/yaml_helpers.py
@@ -38,7 +38,7 @@ from ...core.field_renames import (
     read_renamed_key,
     rename_keys_recursive,
 )
-from ...core.physics_families import coerce_nested_to_flat
+from ...core.physics_families import coerce_nested_to_flat, flatten_physics_in_config
 from ...core.physics_orthogonal import coerce_orthogonal_to_flat
 
 # Use tzfpy instead of timezonefinder for Windows compatibility
@@ -254,6 +254,7 @@ def _is_stebbs_nested_block(entry):
 
 def _legacy_stebbs_master_value(entry):
     """Compose the legacy tri-state ``stebbsmethod`` from a raw scalar."""
+    entry = coerce_nested_to_flat("stebbs", entry)
     if isinstance(entry, Mapping) and "value" not in entry:
         raise ValueError(
             "Legacy 'stebbs' mappings must use a 'value' key; use "
@@ -1962,6 +1963,7 @@ def run_precheck(path: str) -> dict:
 
     original_data = deepcopy(data)
     data = rename_keys_recursive(data, RAW_YAML_FIELD_RENAMES)
+    flatten_physics_in_config(data)
 
     # ---- Step 1: Print start message ----
     data = precheck_printing(data)

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -24,6 +24,7 @@ from contextlib import redirect_stdout, redirect_stderr
 from pathlib import Path
 
 from .report_writer import REPORT_WRITER
+from ...core.physics_families import flatten_physics_in_config
 
 # Import Phase A and B functions
 try:
@@ -989,6 +990,7 @@ def _run_phase_c_legacy(
                 # critical-null check and can crash later in df_state conversion
                 # via int(None). gh#1457.
                 original_data = load_user_yaml_normalised(input_yaml_file)
+                flatten_physics_in_config(original_data)
 
                 config = SUEWSConfig.from_yaml(input_yaml_file)
 
@@ -1018,6 +1020,7 @@ def _run_phase_c_legacy(
                     ) as standard_yaml_path:
                         with open(standard_yaml_path, "r") as f:
                             standard_data = yaml.safe_load(f)
+                        flatten_physics_in_config(standard_data)
                 except FileNotFoundError:
                     print(
                         "Warning: Standard config file not found, reporting all defaults"
@@ -1551,6 +1554,7 @@ Modes:
 
                 with open(user_yaml_file, "r") as f:
                     user_yaml_data = yaml.safe_load(f)
+                flatten_physics_in_config(user_yaml_data)
 
                 # Check public mode restrictions.
                 # Read physics keys via helpers that accept both the new

--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .report_writer import REPORT_WRITER
 from ...core.field_renames import RAW_YAML_FIELD_RENAMES
+from ...core.physics_families import flatten_physics_in_config
 
 RENAMED_PARAMS = {
     "cp": "rho_cp",
@@ -435,6 +436,8 @@ def find_extra_parameters(user_data, standard_data, current_path=""):
     if current_path == "":
         user_data, _ = _normalise_model_control_subobjects(user_data)
         standard_data, _ = _normalise_model_control_subobjects(standard_data)
+        flatten_physics_in_config(user_data)
+        flatten_physics_in_config(standard_data)
 
     if isinstance(user_data, dict) and isinstance(standard_data, dict):
         for key, user_value in user_data.items():
@@ -483,6 +486,8 @@ def find_missing_parameters(user_data, standard_data, current_path=""):
     if current_path == "":
         user_data, _ = _normalise_model_control_subobjects(user_data)
         standard_data, _ = _normalise_model_control_subobjects(standard_data)
+        flatten_physics_in_config(user_data)
+        flatten_physics_in_config(standard_data)
 
     if isinstance(standard_data, dict):
         user_dict = user_data if isinstance(user_data, dict) else {}
@@ -1854,6 +1859,9 @@ def annotate_missing_parameters(
             original_yaml_content = stream.getvalue()
         with open(standard_file, "r") as f:
             standard_data = yaml.safe_load(f)
+        # Collapse readable physics names in both trees before structure diffs.
+        flatten_physics_in_config(user_data)
+        flatten_physics_in_config(standard_data)
     except FileNotFoundError as e:
         print(f"Error: File not found - {e}")
         return _phase_a_failure_report(

--- a/src/supy/data_model/validation/pipeline/phase_b.py
+++ b/src/supy/data_model/validation/pipeline/phase_b.py
@@ -304,6 +304,8 @@ def validate_phase_b_inputs(
             raise FileNotFoundError(f"Required file not found: {file_path}")
 
     try:
+        from ...core.physics_families import flatten_physics_in_config
+
         with open(uptodate_yaml_file, "r") as f:
             uptodate_content = f.read()
             # Normalise legacy field spellings to current names so the science
@@ -320,6 +322,11 @@ def validate_phase_b_inputs(
 
         with open(standard_yaml_file, "r") as f:
             standard_data = yaml.safe_load(f)
+
+        # Collapse readable physics names for raw-dict science checks.
+        flatten_physics_in_config(uptodate_data)
+        flatten_physics_in_config(user_data)
+        flatten_physics_in_config(standard_data)
 
     except yaml.YAMLError as e:
         raise ValueError(f"Invalid YAML format: {e}")

--- a/src/supy/sample_data/sample_config.yml
+++ b/src/supy/sample_data/sample_config.yml
@@ -16,19 +16,18 @@ model:
       groups:
         - "SUEWS"
   physics:
-    # Three fields (net_radiation, storage_heat, emissions) accept a
-    # family-tagged nested form too (gh#972), e.g.:
-    #   net_radiation:
-    #     narp:
-    #       value: 3
-    # The family tag is validated against its numeric codes; round-trip
-    # always emits the flat form below.
+    # These method selectors use the accepted nested/readable input forms so
+    # the chosen physics family or axis is explicit in the sample. Round-trip
+    # serializers still emit the canonical flat {value: N} representation.
     net_radiation:
-      value: 3
+      scheme: narp
+      ldown: air
     emissions:
-      value: 2
-    storage_heat:
-      value: 1
+      heat: j11
+      co2:
+        anthropogenic: none
+        biogenic: none
+    storage_heat: ohm
     ohm_inc_qf:
       value: 0
     roughness_length_momentum:

--- a/test/data_model/test_physics_families.py
+++ b/test/data_model/test_physics_families.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import pytest
 
 from supy.data_model.core.physics_families import (
+    MODEL_PHYSICS_ENUM_FIELDS,
+    PHYSICS_ENUM_FIELDS,
     PHYSICS_FAMILIES,
+    STEBBS_PHYSICS_ENUM_FIELDS,
     coerce_nested_to_flat,
 )
 
@@ -25,7 +28,15 @@ class TestRegistryShape:
 
     def test_storage_heat_families(self):
         fams = PHYSICS_FAMILIES["storage_heat"]
-        assert set(fams) == {"observed", "ohm", "anohm", "estm", "ehc", "dyohm", "stebbs"}
+        assert set(fams) == {
+            "observed",
+            "ohm",
+            "anohm",
+            "estm",
+            "ehc",
+            "dyohm",
+            "stebbs",
+        }
         assert fams["ohm"] == frozenset({1})
         assert fams["ehc"] == frozenset({5})
 
@@ -65,9 +76,9 @@ class TestCoerceFlatPassthrough:
         assert coerce_nested_to_flat("net_radiation", None) is None
 
     def test_unknown_field_passes_through(self):
-        assert coerce_nested_to_flat(
-            "snow_use", {"narp": {"value": 1}}
-        ) == {"narp": {"value": 1}}
+        assert coerce_nested_to_flat("snow_use", {"narp": {"value": 1}}) == {
+            "narp": {"value": 1}
+        }
 
     def test_flat_with_ref_preserved(self):
         payload = {"value": 3, "ref": {"DOI": "10.x/abc"}}
@@ -76,21 +87,15 @@ class TestCoerceFlatPassthrough:
 
 class TestCoerceNestedHappyPath:
     def test_narp_family_collapses(self):
-        result = coerce_nested_to_flat(
-            "net_radiation", {"narp": {"value": 3}}
-        )
+        result = coerce_nested_to_flat("net_radiation", {"narp": {"value": 3}})
         assert result == {"value": 3}
 
     def test_spartacus_family_collapses(self):
-        result = coerce_nested_to_flat(
-            "net_radiation", {"spartacus": {"value": 1001}}
-        )
+        result = coerce_nested_to_flat("net_radiation", {"spartacus": {"value": 1001}})
         assert result == {"value": 1001}
 
     def test_forcing_family_collapses(self):
-        result = coerce_nested_to_flat(
-            "net_radiation", {"forcing": {"value": 0}}
-        )
+        result = coerce_nested_to_flat("net_radiation", {"forcing": {"value": 0}})
         assert result == {"value": 0}
 
     def test_inner_ref_preserved(self):
@@ -101,14 +106,14 @@ class TestCoerceNestedHappyPath:
         assert result == {"value": 1001, "ref": {"DOI": "10.x/abc"}}
 
     def test_storage_heat_ehc(self):
-        assert coerce_nested_to_flat(
-            "storage_heat", {"ehc": {"value": 5}}
-        ) == {"value": 5}
+        assert coerce_nested_to_flat("storage_heat", {"ehc": {"value": 5}}) == {
+            "value": 5
+        }
 
     def test_emissions_simple_hidden_l11_updated_detailed(self):
-        assert coerce_nested_to_flat(
-            "emissions", {"simple": {"value": 6}}
-        ) == {"value": 6}
+        assert coerce_nested_to_flat("emissions", {"simple": {"value": 6}}) == {
+            "value": 6
+        }
 
     def test_emissions_biogenic_rectangular(self):
         assert coerce_nested_to_flat(
@@ -116,9 +121,9 @@ class TestCoerceNestedHappyPath:
         ) == {"value": 16}
 
     def test_integral_float_matches_flat_acceptance(self):
-        assert coerce_nested_to_flat(
-            "net_radiation", {"narp": {"value": 3.0}}
-        ) == {"value": 3}
+        assert coerce_nested_to_flat("net_radiation", {"narp": {"value": 3.0}}) == {
+            "value": 3
+        }
 
 
 class TestCoerceErrorPaths:
@@ -146,36 +151,158 @@ class TestCoerceErrorPaths:
 
     def test_inner_value_is_dict_rejected(self):
         with pytest.raises(ValueError, match="must be a scalar numeric code"):
-            coerce_nested_to_flat(
-                "net_radiation", {"narp": {"value": {"nested": 3}}}
-            )
+            coerce_nested_to_flat("net_radiation", {"narp": {"value": {"nested": 3}}})
 
     def test_inner_value_not_integerlike_rejected(self):
         with pytest.raises(ValueError, match="must be an integer code"):
-            coerce_nested_to_flat(
-                "net_radiation", {"narp": {"value": "abc"}}
-            )
+            coerce_nested_to_flat("net_radiation", {"narp": {"value": "abc"}})
 
     def test_stringified_integer_rejected(self):
         with pytest.raises(ValueError, match="must be an integer code"):
-            coerce_nested_to_flat(
-                "net_radiation", {"narp": {"value": "3"}}
-            )
+            coerce_nested_to_flat("net_radiation", {"narp": {"value": "3"}})
 
     def test_non_integral_float_rejected(self):
         with pytest.raises(ValueError, match="must be an integer code"):
-            coerce_nested_to_flat(
-                "net_radiation", {"narp": {"value": 3.7}}
-            )
+            coerce_nested_to_flat("net_radiation", {"narp": {"value": 3.7}})
 
     def test_code_wrong_family_rejected(self):
         with pytest.raises(ValueError, match="expects one of"):
-            coerce_nested_to_flat(
-                "net_radiation", {"narp": {"value": 1001}}
-            )
+            coerce_nested_to_flat("net_radiation", {"narp": {"value": 1001}})
 
     def test_unknown_family_tag_falls_through(self):
-        result = coerce_nested_to_flat(
-            "net_radiation", {"bogus": {"value": 3}}
-        )
+        result = coerce_nested_to_flat("net_radiation", {"bogus": {"value": 3}})
         assert result == {"bogus": {"value": 3}}
+
+
+class TestCoerceScalarNames:
+    """Human-readable scalar names and bibliographic codes."""
+
+    def test_family_tag_name_resolves(self):
+        assert coerce_nested_to_flat("storage_heat", "ohm") == {"value": 1}
+        assert coerce_nested_to_flat("storage_heat", "ehc") == {"value": 5}
+
+    def test_enum_member_name_resolves(self):
+        assert coerce_nested_to_flat("storage_heat", "ohm_without_qf") == {"value": 1}
+        assert coerce_nested_to_flat("stability", "campbell_norman") == {"value": 3}
+
+    def test_bibliographic_code_resolves(self):
+        assert coerce_nested_to_flat("stability", "cn98") == {"value": 3}
+        assert coerce_nested_to_flat("roughness_length_heat", "k09") == {"value": 2}
+        assert coerce_nested_to_flat("roughness_length_momentum", "m98") == {"value": 3}
+
+    def test_name_is_case_insensitive(self):
+        assert coerce_nested_to_flat("storage_heat", "OHM") == {"value": 1}
+        assert coerce_nested_to_flat("stability", "CN98") == {"value": 3}
+
+    def test_refvalue_string_resolves_and_preserves_ref(self):
+        payload = {"value": "provided", "ref": {"DOI": "10.x/ref"}}
+        assert coerce_nested_to_flat("capacitance", payload) == {
+            "value": 1,
+            "ref": {"DOI": "10.x/ref"},
+        }
+
+    def test_nested_stebbs_names_resolve(self):
+        assert coerce_nested_to_flat("parameters", "provided") == {"value": 2}
+        assert coerce_nested_to_flat("capacitance", "parameterise") == {"value": 2}
+        assert coerce_nested_to_flat("same_albedo_wall", "enabled") == {"value": 1}
+
+    def test_emissions_current_hidden_and_biogenic_names_resolve(self):
+        assert coerce_nested_to_flat("emissions", "l11_updated_detailed") == {
+            "value": 6
+        }
+        assert coerce_nested_to_flat(
+            "emissions", "biogen_bellucco_general_l11_updated_detailed"
+        ) == {"value": 36}
+
+    def test_net_radiation_enum_name_scalar_resolves(self):
+        assert coerce_nested_to_flat("net_radiation", "ldown_air") == {"value": 3}
+        assert coerce_nested_to_flat("net_radiation", "forcing") == {"value": 0}
+
+    def test_unknown_scalar_name_rejected(self):
+        with pytest.raises(ValueError, match="unknown scheme name"):
+            coerce_nested_to_flat("storage_heat", "not_a_scheme")
+
+    def test_unknown_scalar_name_lists_valid_names(self):
+        with pytest.raises(ValueError, match="campbell_norman"):
+            coerce_nested_to_flat("stability", "bogus")
+
+
+class TestReadableNamesInModels:
+    def test_model_physics_accepts_top_level_readable_names(self):
+        from supy.data_model.core.model import ModelPhysics
+
+        physics = ModelPhysics(
+            storage_heat="ohm",
+            stability="cn98",
+            snow_use="enabled",
+            emissions="biogen_conductance_j11_detailed",
+        )
+
+        assert physics.storage_heat.value.value == 1
+        assert physics.stability.value.value == 3
+        assert physics.snow_use.value.value == 1
+        assert physics.emissions.value.value == 45
+
+    def test_model_physics_accepts_nested_stebbs_readable_names(self):
+        from supy.data_model.core.model import ModelPhysics
+
+        physics = ModelPhysics(
+            stebbs={
+                "enabled": True,
+                "parameters": "provided",
+                "capacitance": "parameterise",
+                "setpoint": {"value": "scheduled"},
+                "same_albedo_wall": "enabled",
+            }
+        )
+
+        assert physics.stebbs.parameters.value.value == 2
+        assert physics.stebbs.capacitance.value.value == 2
+        assert physics.stebbs.setpoint.value.value == 2
+        assert physics.stebbs.same_albedo_wall.value.value == 1
+
+
+class TestRegistryEnumParity:
+    """The hardcoded readable-name codes must match the live Enum definitions."""
+
+    def test_codes_match_enum_values(self):
+        from supy.data_model.core import model as m
+        from supy.data_model.core import physics_families as pf
+
+        field_to_enum = {
+            "net_radiation": m.NetRadiationMethod,
+            "emissions": m.EmissionsMethod,
+            "storage_heat": m.StorageHeatMethod,
+            "ohm_inc_qf": m.OhmIncQf,
+            "roughness_length_momentum": m.MomentumRoughnessMethod,
+            "roughness_length_heat": m.HeatRoughnessMethod,
+            "stability": m.StabilityMethod,
+            "soil_moisture_deficit": m.SMDMethod,
+            "water_use": m.WaterUseMethod,
+            "laimethod": m.LAIMethod,
+            "roughness_sublayer": m.RSLMethod,
+            "frontal_area_index": m.FAIMethod,
+            "roughness_sublayer_level": m.RSLLevel,
+            "surface_conductance": m.GSModel,
+            "snow_use": m.SnowUse,
+            "stebbs": m.StebbsMethod,
+            "parameters": m.StebbsParameterSource,
+            "capacitance": m.RCMethod,
+            "setpoint": m.SetpointMethod,
+            "same_albedo_wall": m.SameAlbedoWall,
+            "same_albedo_roof": m.SameAlbedoRoof,
+            "same_emissivity_wall": m.SameEmissivityWall,
+            "same_emissivity_roof": m.SameEmissivityRoof,
+        }
+
+        assert set(field_to_enum) == set(PHYSICS_ENUM_FIELDS)
+        assert set(MODEL_PHYSICS_ENUM_FIELDS).issubset(PHYSICS_ENUM_FIELDS)
+        assert set(STEBBS_PHYSICS_ENUM_FIELDS).issubset(PHYSICS_ENUM_FIELDS)
+
+        for field, enum_cls in field_to_enum.items():
+            valid = {member.value for member in enum_cls}
+            for code in pf._ALIAS_TO_CODE[field].values():
+                assert code in valid, f"{field}: code {code} not in {enum_cls}"
+            assert set(pf._CODE_TO_CANONICAL[field]) == valid, (
+                f"{field}: canonical names do not cover every enum value"
+            )

--- a/test/data_model/test_physics_orthogonal.py
+++ b/test/data_model/test_physics_orthogonal.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 import pytest
 import yaml
 
+from supy._env import trv_supy_module
 from supy.data_model.core.field_renames import read_physics_key
 from supy.data_model.core.model import ModelPhysics
 from supy.data_model.core.physics_orthogonal import coerce_orthogonal_to_flat
@@ -61,6 +62,23 @@ def test_non_orthogonal_shapes_pass_through_for_existing_normalisers():
 def test_model_physics_accepts_orthogonal_narp_default_variant():
     phys = ModelPhysics(net_radiation={"scheme": "narp", "ldown": "air"})
     assert int(_unwrap(phys.net_radiation)) == 3
+
+
+def test_sample_config_prefers_nested_readable_physics_defaults():
+    path = trv_supy_module / "sample_data" / "sample_config.yml"
+    physics = yaml.safe_load(path.read_text(encoding="utf-8"))["model"]["physics"]
+
+    assert physics["net_radiation"] == {"scheme": "narp", "ldown": "air"}
+    assert physics["emissions"] == {
+        "heat": "j11",
+        "co2": {"anthropogenic": "none", "biogenic": "none"},
+    }
+    assert physics["storage_heat"] == "ohm"
+
+    parsed = ModelPhysics.model_validate(physics)
+    assert int(_unwrap(parsed.net_radiation)) == 3
+    assert int(_unwrap(parsed.emissions)) == 2
+    assert int(_unwrap(parsed.storage_heat)) == 1
 
 
 def test_model_physics_accepts_orthogonal_spartacus():

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -5024,12 +5024,23 @@ class TestPhaseBRenameAwareLookups:
     def test_stebbsmethod_helper_rejects_invalid_nested_switch_values(self):
         from supy.data_model.validation.core.yaml_helpers import get_stebbsmethod_value
 
-        with pytest.raises(ValueError, match="stebbs.parameters"):
+        assert (
             get_stebbsmethod_value(
                 {
                     "stebbs": {
                         "enabled": {"value": True},
                         "parameters": {"value": "provided"},
+                    }
+                }
+            )
+            == 2
+        )
+        with pytest.raises(ValueError, match="unknown scheme name"):
+            get_stebbsmethod_value(
+                {
+                    "stebbs": {
+                        "enabled": {"value": True},
+                        "parameters": {"value": "custom"},
                     }
                 }
             )


### PR DESCRIPTION
## Summary

Accept human-readable names for `model.physics` method options as an alternative to integer codes, resolving #1465.

Each physics method field now accepts three input forms in addition to the existing integer / flat `{value: N}` / family-tagged (#972) shapes:

- **Canonical / family name** — `storage_heat: ohm`, `roughness_sublayer: rst`
- **Enum-member name** — `stability: campbell_norman`, `storage_heat: ohm_without_qf`
- **Bibliographic short code** — `stability: cn98`, `roughness_length_heat: k09`, `roughness_length_momentum: m98` (derived from the citation in each enum docstring)

`net_radiation` additionally accepts the orthogonal-axis mapping `{scheme: narp, ldown: air[, variant: ...]}`.

The bundled `sample_config.yml` now uses nested/readable defaults for the main physics selectors so the hand-authored sample exposes the chosen family or axis (`net_radiation.scheme/ldown`, `emissions.heat/co2`, and readable scalar `storage_heat: ohm`). This folds the sample-config side of #1481 into this PR while leaving the broader generated config-reference layout as a docs follow-up.

## Accept-only (no schema bump)

The canonical internal representation and `to_yaml` / `suews schema migrate` output stay the flat integer `{value: N}`, so there is **no `CURRENT_SCHEMA_VERSION` bump** and every previously-valid YAML round-trips byte-identically. Names are accepted on input only. This matches the stance of the sibling orthogonal-axis work (#1464 / #1460) — see the design decision recorded on #1465 (option A).

## Implementation

- Name<->code registry built from the `Enum` definitions in `src/supy/data_model/core/physics_families.py`; a parity test asserts the registry stays in lock-step with the enums.
- Input coercion widened in `ModelPhysics` so all accepted shapes collapse to `{value: N}` before the `FlexibleRefValue` union resolves; the compute-engine path (`to_df_state`, Fortran bridge) stays integer.
- The dict-based validation pipeline normalises names back to `{value: N}` at each raw-YAML entry point so hand-authored names validate.
- The Rust CLI (`suews run`) accepts the same input shapes via `src/suews_bridge/src/field_renames.rs`.
- `sample_config.yml` now defaults to accepted nested/readable forms and has a regression to keep those forms loadable and code-equivalent.

## Latest local validation

- `uv run python -m pytest test/data_model/test_physics_orthogonal.py test/data_model/test_physics_families.py test/data_model/test_to_yaml_roundtrip.py test/cmd/test_validate_config.py test/data_model/test_data_model.py::test_flexible_refvalue_with_cleaning -q` — 140 passed
- `uv run make test-smoke` — 9 passed, 1573 deselected
- `uv run python scripts/lint/check_rust_yaml_aliases.py` — OK
- `git diff --check` — clean

## CI note

This PR touches `src/supy/data_model/**` without bumping `version.py` (correct for an accept-only widening per `.claude/rules/python/schema-versioning.md`). The `schema-version-audit` gate therefore needs the existing `0-ci:schema-audit-ok` label, which is already present.

Closes #1465.
Refs #1481.
