### PR TITLE
ci: publish release docs from the clean tag to a dedicated `release` branch

### DIFF
--- a/.github/scripts/make_release_branch_files.py
+++ b/.github/scripts/make_release_branch_files.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Write the release-branch Read the Docs config and provenance file.
+
+Populates a ``release``-branch staging directory with a copy-only RTD config
+and a provenance record.
+
+Usage::
+
+    make_release_branch_files.py <staging_dir> <tag> <version>
+
+``<staging_dir>`` already contains ``docs/build/html`` (the pre-built docs).
+This script adds:
+
+- ``.readthedocs.yaml`` -- tells Read the Docs to serve that HTML verbatim
+  (no source build, no Fortran compiler);
+- ``docs/.docs-release.json`` -- provenance for humans inspecting the branch.
+
+Called by ``.github/workflows/docs-release.yml``. Kept as a tracked helper
+(rather than an in-workflow heredoc) so it is reviewable and unit-testable,
+and so the YAML block-scalar indentation cannot corrupt the generated files.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+import sys
+
+# Copy-only RTD config: the release branch carries pre-built HTML only.
+RTD_CONFIG = """\
+# Read the Docs configuration for the `release` branch.
+# This branch carries ONLY pre-built HTML (built from the clean CalVer tag by
+# .github/workflows/docs-release.yml). RTD copies it verbatim -- no source
+# build, no Fortran compiler. Do not edit by hand; the docs-release workflow
+# force-replaces this branch on every release.
+version: 2
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"  # Required by the RTD v2 schema; unused here.
+  commands:
+    - |
+      if [ ! -d docs/build/html ]; then
+        echo "ERROR: Pre-built HTML not found on the release branch."
+        exit 1
+      fi
+    - mkdir -p $READTHEDOCS_OUTPUT/html
+    - cp -r docs/build/html/* $READTHEDOCS_OUTPUT/html/
+formats: []
+"""
+
+
+def make_files(staging: Path, tag: str, version: str) -> None:
+    """Write ``.readthedocs.yaml`` and ``docs/.docs-release.json`` into ``staging``."""
+    (staging / ".readthedocs.yaml").write_text(RTD_CONFIG, encoding="utf-8")
+
+    provenance = {
+        "source_tag": tag,
+        "docs_version": version,
+        "docs_built": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "builder": "github-actions",
+        "note": (
+            "Release docs built at the clean CalVer tag and served by Read "
+            "the Docs as the 'release' version. Force-replaced on each "
+            "release by .github/workflows/docs-release.yml."
+        ),
+    }
+    docs_dir = staging / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / ".docs-release.json").write_text(
+        json.dumps(provenance, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def main(argv: list[str]) -> int:
+    """Parse ``argv`` (staging_dir, tag, version) and write the files."""
+    if len(argv) != 4:
+        print(__doc__)
+        print(f"ERROR: expected 3 arguments, got {len(argv) - 1}", file=sys.stderr)
+        return 2
+    staging, tag, version = Path(argv[1]), argv[2], argv[3]
+    if not staging.is_dir():
+        print(f"ERROR: staging dir does not exist: {staging}", file=sys.stderr)
+        return 2
+    make_files(staging, tag, version)
+    print(f"Wrote .readthedocs.yaml + docs/.docs-release.json for {tag} ({version})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/scripts/make_release_branch_files.py
+++ b/.github/scripts/make_release_branch_files.py
@@ -41,7 +41,7 @@ build:
     python: "3.13"  # Required by the RTD v2 schema; unused here.
   commands:
     - |
-      if [ ! -d docs/build/html ]; then
+      if [ ! -f docs/build/html/index.html ]; then
         echo "ERROR: Pre-built HTML not found on the release branch."
         exit 1
       fi

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -93,9 +93,11 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      # The release-branch helper lives on the workflow ref (not on the old
-      # tag), so fetch it separately into a sibling path.
-      - name: Checkout release-branch helper from the workflow ref
+      # The release-branch helper is not on the old tag, so fetch it separately
+      # into a sibling path. With no `ref:`, checkout uses this run's SHA — the
+      # tag commit on a tag push, or master HEAD on workflow_dispatch — both of
+      # which carry the helper once this workflow is on master.
+      - name: Checkout release-branch helper
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: .ci-tools
@@ -107,7 +109,11 @@ jobs:
       - name: Verify tag is on master
         run: |
           set -euo pipefail
-          git fetch origin master --depth=200
+          # The tag checkout already used fetch-depth: 0 (full history); this
+          # fetch only materialises the origin/master remote-tracking ref.
+          # No --depth: a shallow master could wrongly reject a tag that sits
+          # further back than the shallow window.
+          git fetch origin master
           if ! git merge-base --is-ancestor HEAD refs/remotes/origin/master; then
             echo "::error::Tag ${{ needs.resolve.outputs.tag }} is not on master — refusing to publish"
             exit 1
@@ -216,7 +222,7 @@ jobs:
           {
             echo "### Release docs published"
             echo ""
-            echo "- Tag: \`${TAG}\`"
-            echo "- Version baked into HTML: \`${VERSION}\`"
+            echo "- Tag: \`${TAG:-unknown}\`"
+            echo "- Version baked into HTML: \`${VERSION:-(build did not complete)}\`"
             echo "- Target branch: \`release\` (served by Read the Docs)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -107,6 +107,8 @@ jobs:
           persist-credentials: false
 
       - name: Verify tag is on master
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
         run: |
           set -euo pipefail
           # The tag checkout already used fetch-depth: 0 (full history); this
@@ -115,7 +117,7 @@ jobs:
           # further back than the shallow window.
           git fetch origin master
           if ! git merge-base --is-ancestor HEAD refs/remotes/origin/master; then
-            echo "::error::Tag ${{ needs.resolve.outputs.tag }} is not on master — refusing to publish"
+            echo "::error::Tag ${TAG} is not on master — refusing to publish"
             exit 1
           fi
 

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,222 @@
+name: Publish release docs to the release branch
+
+# Builds the documentation FROM THE CLEAN CalVer tag (so get_ver_git reports
+# the exact release version, e.g. 2026.4.3, with no `.devN` suffix), then
+# publishes the pre-built HTML to the long-lived `release` branch as a single
+# orphan commit.
+#
+# Read the Docs serves the `release` branch as the public "release" version
+# (project default + /stable/ redirect). This is the release-docs counterpart
+# to docs-sync.yml, which keeps the `rtd` branch (RTD `latest`) tracking master.
+#
+# Why a dedicated build at the tag (not the rtd branch): docs-sync builds on
+# the `rtd` branch, which is always many commits ahead of any release tag, so
+# `git describe` yields a dirty `2026.x.y.devN` version and RTD shows a
+# "development version" banner. Building at the clean tag fixes both the
+# version string and the banner. See gh#1167 for the pre-built-HTML strategy.
+
+on:
+  push:
+    tags:
+      - "[0-9]*"           # CalVer releases, e.g. 2026.4.3 (excludes rtd/*, agent/*)
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "CalVer release tag to build docs from (e.g. 2026.4.3)"
+        required: true
+        type: string
+
+# Serialise; never cancel a half-finished publish to the release branch.
+concurrency:
+  group: docs-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # --------------------------------------------------------------------
+  # Resolve + strictly validate the tag. Dev tags (e.g. 2026.5.31.dev)
+  # pushed by the nightly pipeline are skipped, not failed.
+  # --------------------------------------------------------------------
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.pick.outputs.tag }}
+      skip: ${{ steps.pick.outputs.skip }}
+    steps:
+      - name: Resolve and validate tag
+        id: pick
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="${REF_NAME}"
+          fi
+
+          # Strict CalVer release form YYYY.M.D — no dev/rc suffix. This both
+          # selects genuine releases and sanitises the value before it is used
+          # as a git ref in the build job (defends against ref injection).
+          if printf '%s' "${TAG}" | grep -Eq '^[0-9]{4}\.[0-9]+\.[0-9]+$'; then
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Release tag accepted: ${TAG}"
+          elif [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "::error::'${TAG}' is not a clean CalVer release tag (expected YYYY.M.D)"
+            exit 1
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Tag '${TAG}' is not a clean CalVer release (likely a dev tag) — skipping release-docs publish."
+          fi
+
+  # --------------------------------------------------------------------
+  # Build at the clean tag and publish HTML to the `release` branch.
+  # --------------------------------------------------------------------
+  publish:
+    needs: resolve
+    if: needs.resolve.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: rtd-sync
+    steps:
+      # Checkout AT THE CLEAN TAG (full history + tags so git describe
+      # resolves to a distance-0, dev-free version).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      # The release-branch helper lives on the workflow ref (not on the old
+      # tag), so fetch it separately into a sibling path.
+      - name: Checkout release-branch helper from the workflow ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: .ci-tools
+          sparse-checkout: |
+            .github/scripts/make_release_branch_files.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Verify tag is on master
+        run: |
+          set -euo pipefail
+          git fetch origin master --depth=200
+          if ! git merge-base --is-ancestor HEAD refs/remotes/origin/master; then
+            echo "::error::Tag ${{ needs.resolve.outputs.tag }} is not on master — refusing to publish"
+            exit 1
+          fi
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        with:
+          enable-cache: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          # Documentation tooling requires Python 3.11+; runtime support remains 3.9+.
+          python-version: "3.13"
+
+      - name: Install supy and build docs
+        id: build
+        run: |
+          set -euo pipefail
+          uv pip install --system ".[docs]"
+          # Tolerate older tags that may predate this hardening script.
+          if [ -f scripts/security/remove_legacy_namespace_pth.py ]; then
+            python3 scripts/security/remove_legacy_namespace_pth.py
+          fi
+
+          # Building at a clean tag => git describe distance 0 => no `.devN`.
+          # Refuse to publish a dev version as a release (the bug this fixes).
+          VERSION="$(python3 -c 'from get_ver_git import get_version_from_git; print(get_version_from_git())')"
+          echo "Resolved docs version: ${VERSION}"
+          case "${VERSION}" in
+            *.dev*)
+              echo "::error::get_ver_git resolved a dev version (${VERSION}); build is not at a clean tag. Aborting."
+              exit 1
+              ;;
+          esac
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          cd docs
+          make generate-rst
+          sphinx-build -M html source build
+
+      - name: Sanity-check the built HTML carries a clean version
+        env:
+          VERSION: ${{ steps.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          test -d docs/build/html
+          test -f docs/build/html/index.html
+          # Page title is "SUEWS <version> documentation"; a stray `.dev` there
+          # means the build did not pick up the clean tag version.
+          if grep -Eo 'SUEWS [0-9][^<]*documentation' docs/build/html/index.html | grep -q '\.dev'; then
+            echo "::error::Built HTML title still shows a dev version:"
+            grep -Eo 'SUEWS [0-9][^<]*documentation' docs/build/html/index.html | head -1
+            exit 1
+          fi
+          echo "OK: built HTML reports version ${VERSION}"
+
+      # Publish HTML to the `release` branch as one orphan commit. The
+      # copy-only .readthedocs.yaml and provenance file are written by a
+      # tracked helper script (no in-YAML heredoc), so the branch never
+      # depends on whatever RTD config the tag carried.
+      - name: Publish to the release branch
+        env:
+          RTD_PUSH_TOKEN: ${{ secrets.RTD_PUSH_TOKEN }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ steps.build.outputs.version }}
+          GH_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          HELPER="$(pwd)/.ci-tools/.github/scripts/make_release_branch_files.py"
+          SRC_HTML="$(pwd)/docs/build/html"
+          test -d "${SRC_HTML}"
+          test -f "${HELPER}"
+
+          PUB="$(mktemp -d)"
+          mkdir -p "${PUB}/docs/build"
+          cp -R "${SRC_HTML}" "${PUB}/docs/build/html"
+
+          # Write the copy-only .readthedocs.yaml + provenance into the staging dir.
+          python3 "${HELPER}" "${PUB}" "${TAG}" "${VERSION}"
+
+          cd "${PUB}"
+          git init -q
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -q --orphan release
+          git add -A
+          git commit -qm "Release docs for ${TAG} (version ${VERSION})"
+          echo "Pushing ${VERSION} docs to the 'release' branch..."
+          git push --force \
+            "https://x-access-token:${RTD_PUSH_TOKEN}@github.com/${GH_REPOSITORY}.git" \
+            HEAD:release
+
+      - name: Summary
+        if: always()
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ steps.build.outputs.version }}
+        run: |
+          {
+            echo "### Release docs published"
+            echo ""
+            echo "- Tag: \`${TAG}\`"
+            echo "- Version baked into HTML: \`${VERSION}\`"
+            echo "- Target branch: \`release\` (served by Read the Docs)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,9 +1,14 @@
 name: Sync rtd branch from master
 
-# Merges master into the `rtd` branch, builds full HTML when docs-related
-# files change, and propagates CalVer tags as rtd/* tags for RTD versioned builds.
-# RTD serves the pre-built HTML directly — no source compilation needed.
+# Merges master into the `rtd` branch and builds full HTML when docs-related
+# files change. RTD serves this branch as the `latest` (rolling) version,
+# directly from the pre-built HTML — no source compilation needed.
 # Branch is named `rtd` (not `docs`) to avoid ref conflict with existing docs/* branches.
+#
+# Release (versioned) docs are handled separately by docs-release.yml, which
+# builds at the clean CalVer tag and publishes to the `release` branch. This
+# workflow no longer creates `rtd/<tag>` tags (they produced ugly `rtd-*` RTD
+# slugs and dev-tainted version strings).
 
 on:
   push:
@@ -290,18 +295,7 @@ jobs:
           git commit -m "Sync rtd branch with master @ ${SHORT_SHA}" || echo "No changes to commit"
 
       # ------------------------------------------------------------------
-      # 7. Tag for versioned RTD builds (on CalVer tag push)
-      # ------------------------------------------------------------------
-      - name: Create rtd tag
-        if: github.ref_type == 'tag'
-        run: |
-          TAG_NAME="${GITHUB_REF_NAME}"
-          RTD_TAG="rtd/${TAG_NAME}"
-          echo "Creating tag: $RTD_TAG"
-          git tag "$RTD_TAG"
-
-      # ------------------------------------------------------------------
-      # 7a. Validate rtd only diverges from master in docs-related paths
+      # 7. Validate rtd only diverges from master in docs-related paths
       # ------------------------------------------------------------------
       - name: Validate docs-only divergence
         run: |
@@ -325,16 +319,9 @@ jobs:
           echo "✓ rtd branch diverges from master only in docs-allowed paths"
 
       # ------------------------------------------------------------------
-      # 8. Push rtd branch (and tag if created)
+      # 8. Push rtd branch
       # ------------------------------------------------------------------
       - name: Push rtd branch
         env:
           RTD_PUSH_TOKEN: ${{ secrets.RTD_PUSH_TOKEN }}
         run: git push "https://x-access-token:${RTD_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" rtd
-
-      - name: Push rtd tag
-        if: github.ref_type == 'tag'
-        env:
-          RTD_PUSH_TOKEN: ${{ secrets.RTD_PUSH_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
-        run: git push "https://x-access-token:${RTD_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "rtd/${TAG_NAME}"


### PR DESCRIPTION
## Problem

`docs.suews.io/stable` was serving a stale **2026.1.28** build (Sue spotted the Version History page missing v2026.4.3), and the release docs that *did* exist (`rtd-2026.4.3`) showed a dirty `2026.4.3.dev151` version string, a "development version" banner, and an ugly `rtd-` slug.

Two root causes, both confirmed against the RTD API:

- **Stale `stable`.** RTD's automatic `stable` version tracks the highest plain CalVer tag (`2026.4.3`). That tag lives on `master`, whose commit has **no pre-built `docs/build/html`**, so the build fails (`built=False`) and `stable` keeps serving the last *successful* build — 2026.1.28 (from 2026-02-10).
- **Dirty version string.** `docs-sync.yml` builds the HTML on the `rtd` branch, which is always far ahead of any release tag. `get_ver_git` is `git describe`-based, so it reports `2026.x.y.devN` even for a release → the dev banner.

## Fix

A dedicated `release` branch carries the release docs, built **from the clean CalVer tag** (distance 0 → clean version, no banner). Read the Docs serves that branch as the public release version.

- **`.github/workflows/docs-release.yml`** (new) — on a CalVer tag push (or manual dispatch with a tag), checks out *at the clean tag*, builds the docs, verifies the version is dev-free, and force-publishes the HTML to the `release` branch as a single orphan commit. Dev tags (e.g. `2026.5.31.dev`) are skipped, not failed. The tag is strictly validated (`^[0-9]{4}\.[0-9]+\.[0-9]+$`) before it is used as a git ref.
- **`.github/scripts/make_release_branch_files.py`** (new) — writes the `release` branch's copy-only `.readthedocs.yaml` + a provenance file. Tracked and unit-testable, so YAML block-scalar indentation can't corrupt the generated config.
- **`.github/workflows/docs-sync.yml`** — keeps the `rtd` branch as RTD `latest` (unchanged), but no longer creates the `rtd/<tag>` tags that produced the messy `rtd-*` slugs.

## Read the Docs side (done out-of-band by a maintainer, not in this PR)

- Activate the `release` branch as a version; set it as the project **default**; add a `/stable/ → /release/` redirect.
- Deactivate the broken plain CalVer tag versions, the `rtd-*` versions, and the auto `stable`.
- The current 2026.4.3 release branch is bootstrapped by dispatching `docs-release.yml` with `tag=2026.4.3` (a clean rebuild).

## Result

- `docs.suews.io/` → clean release docs (clean `2026.4.3` version, no dev banner, clean slug), still served instantly from pre-built HTML.
- `/latest/` → rolling `rtd` branch for development.
- No build churn on `master`; no Fortran compile on RTD.