### PR TITLE
Use readable physics defaults in sample config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ EXAMPLES:
   - `model.physics.net_radiation.narp.ldown` is accepted as the scheme-scoped spelling for NARP longwave forcing options, while the existing `scheme: narp` form remains accepted
   - The sample also uses readable net-radiation and emissions groupings plus citation-style aliases such as `J11`, `K09`, `CN98`, and `W16` so new YAML users see semantic axes rather than opaque integer method codes
   - `model.physics.leaf_area_index` and `model.physics.snow` are accepted as public-facing aliases for the existing LAI and snow switches, folding back to `laimethod` and `snow_use` internally
-  - Source-choice physics options now use the consistent public names `observed` and `model`; older readable aliases such as `modelled`, `provided`, `use_provided`, and `simple_scheme` remain accepted where already introduced, while `laimethod: calculated` is no longer a readable public option
+  - Source-choice physics options now use the consistent public names `observed` and `modelled`; older readable aliases such as `provided`, `use_provided`, and `simple_scheme` remain accepted where already introduced, while `laimethod: calculated` and `laimethod: model` are no longer readable public options
+  - `model.physics.soil_moisture_deficit` now exposes only `modelled` and `observed` as readable public names; the old volumetric/gravimetric split remains an internal numeric compatibility path pending the water/soil-moisture unit unification work
   - `model.physics.stebbs.parameter_source` is accepted as the public nested spelling for the STEBBS parameter-source choice, folding back to `stebbs.parameters` internally
 
 ### 31 May 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 75 | 83 | 30 | 81 | 40 | 310 |
+| 2026 | 76 | 83 | 30 | 81 | 40 | 311 |
 | 2025 | 60 | 68 | 22 | 71 | 36 | 256 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
@@ -53,6 +53,16 @@ EXAMPLES:
 | 2017 | 9 | 0 | 3 | 2 | 0 | 14 |
 
 ## 2026
+
+### 1 Jun 2026
+
+- [feature][experimental] Advertise readable sample-config physics defaults with nested orthogonal groupings (#1483)
+  - `model.physics.storage_heat.ohm.include_qf` now represents the OHM QF inclusion choice under the storage heat selector in the sample config, while legacy flat `ohm_inc_qf` input remains accepted and normalised to the existing Fortran-facing state
+  - `model.physics.net_radiation.narp.ldown` is accepted as the scheme-scoped spelling for NARP longwave forcing options, while the existing `scheme: narp` form remains accepted
+  - The sample also uses readable net-radiation and emissions groupings plus citation-style aliases such as `J11`, `K09`, `CN98`, and `W16` so new YAML users see semantic axes rather than opaque integer method codes
+  - `model.physics.leaf_area_index` and `model.physics.snow` are accepted as public-facing aliases for the existing LAI and snow switches, folding back to `laimethod` and `snow_use` internally
+  - Source-choice physics options now use the consistent public names `observed` and `model`; older readable aliases such as `modelled`, `provided`, `use_provided`, and `simple_scheme` remain accepted where already introduced, while `laimethod: calculated` is no longer a readable public option
+  - `model.physics.stebbs.parameter_source` is accepted as the public nested spelling for the STEBBS parameter-source choice, folding back to `stebbs.parameters` internally
 
 ### 31 May 2026
 

--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -822,20 +822,9 @@ pub const PHYSICS_NAME_ALIASES_RS: &[(&str, &[(&str, i64)])] = &[
             ("bh71", 4),
         ],
     ),
-    (
-        "soil_moisture_deficit",
-        &[
-            ("model", 0),
-            ("modelled", 0),
-            ("observed_volumetric", 1),
-            ("observed_gravimetric", 2),
-        ],
-    ),
-    (
-        "water_use",
-        &[("model", 0), ("modelled", 0), ("observed", 1)],
-    ),
-    ("laimethod", &[("observed", 0), ("model", 1)]),
+    ("soil_moisture_deficit", &[("modelled", 0), ("observed", 1)]),
+    ("water_use", &[("modelled", 0), ("observed", 1)]),
+    ("laimethod", &[("observed", 0), ("modelled", 1)]),
     (
         "roughness_sublayer",
         &[("most", 0), ("rst", 1), ("t19", 1), ("variable", 2)],
@@ -846,7 +835,7 @@ pub const PHYSICS_NAME_ALIASES_RS: &[(&str, &[(&str, i64)])] = &[
             ("observed", 0),
             ("provided", 0),
             ("use_provided", 0),
-            ("model", 1),
+            ("modelled", 1),
             ("simple_scheme", 1),
         ],
     ),
@@ -2450,7 +2439,7 @@ model:
 
     #[test]
     fn public_physics_aliases_do_not_rename_site_snow_section() {
-        let yaml = "model:\n  physics:\n    leaf_area_index: model\n    snow: disabled\nsites:\n- properties:\n    snow:\n      initially: {value: 0}\n";
+        let yaml = "model:\n  physics:\n    leaf_area_index: modelled\n    snow: disabled\nsites:\n- properties:\n    snow:\n      initially: {value: 0}\n";
         let mut root: Value = from_str(yaml).unwrap();
         normalize_field_names(&mut root).unwrap();
         let physics = &root["model"]["physics"];

--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -1611,23 +1611,30 @@ fn physics_field_key_spellings(field: &str) -> Vec<String> {
         }
     };
 
-    let mut targets: Vec<String> = physics_outer_keys(field)
-        .iter()
-        .map(|key| key.to_string())
-        .collect();
+    let mut targets: Vec<String> = vec![field.to_string()];
+    for key in physics_outer_keys(field) {
+        push(&mut targets, key);
+    }
     for (new, old) in FIELD_RENAMES.iter().chain(FIELD_COMPAT_ALIASES.iter()) {
-        if *new == field && !targets.iter().any(|target| target == old) {
-            targets.push((*old).to_string());
+        if *new == field {
+            push(&mut targets, old);
         }
+    }
+    let alias_keys: Vec<String> = targets
+        .iter()
+        .flat_map(|target| {
+            FIELD_RENAMES
+                .iter()
+                .chain(FIELD_COMPAT_ALIASES.iter())
+                .filter_map(move |(new, old)| (*old == target).then_some((*new).to_string()))
+        })
+        .collect();
+    for key in alias_keys {
+        push(&mut targets, &key);
     }
 
     for target in &targets {
         push(&mut keys, target);
-    }
-    for (new, old) in FIELD_RENAMES.iter().chain(FIELD_COMPAT_ALIASES.iter()) {
-        if targets.iter().any(|target| target == old) {
-            push(&mut keys, new);
-        }
     }
     keys
 }
@@ -2459,6 +2466,22 @@ model:
         let properties = root["sites"][0]["properties"].as_mapping().unwrap();
         assert!(properties.contains_key(Value::String("snow".into())));
         assert!(!properties.contains_key(Value::String("snowuse".into())));
+    }
+
+    #[test]
+    fn public_leaf_area_index_alias_collapses_before_rename() {
+        for (name, expected) in [("observed", 0), ("modelled", 1)] {
+            let yaml = format!("model:\n  physics:\n    leaf_area_index: {name}\n");
+            let mut root: Value = from_str(&yaml).unwrap();
+            normalize_field_names(&mut root).unwrap();
+            let physics = &root["model"]["physics"];
+            assert_eq!(
+                physics["laimethod"]
+                    .get(Value::String("value".into()))
+                    .and_then(|v| v.as_i64()),
+                Some(expected)
+            );
+        }
     }
 
     #[test]

--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -352,6 +352,10 @@ pub const FIELD_COMPAT_ALIASES: &[(&str, &str)] = &[
     // spelling needs a direct alias to the bridge column `rcmethod`.
     ("outer_cap_fraction", "rcmethod"),
     ("gs_model", "gsmodel"),
+    // Public sample/config aliases accepted without changing the internal
+    // Fortran-facing switches (gh#1483 naming audit).
+    ("leaf_area_index", "laimethod"),
+    ("snow", "snowuse"),
     // Schema 2026.5.dev1 STEBBS ArchetypeProperties Cat 5 intermediate
     // (gh#1327). After gh#1334 the final names are snake_case; the
     // PascalCase intermediate stays accepted for back-compat.
@@ -821,20 +825,30 @@ pub const PHYSICS_NAME_ALIASES_RS: &[(&str, &[(&str, i64)])] = &[
     (
         "soil_moisture_deficit",
         &[
+            ("model", 0),
             ("modelled", 0),
             ("observed_volumetric", 1),
             ("observed_gravimetric", 2),
         ],
     ),
-    ("water_use", &[("modelled", 0), ("observed", 1)]),
-    ("laimethod", &[("observed", 0), ("calculated", 1)]),
+    (
+        "water_use",
+        &[("model", 0), ("modelled", 0), ("observed", 1)],
+    ),
+    ("laimethod", &[("observed", 0), ("model", 1)]),
     (
         "roughness_sublayer",
         &[("most", 0), ("rst", 1), ("t19", 1), ("variable", 2)],
     ),
     (
         "frontal_area_index",
-        &[("use_provided", 0), ("simple_scheme", 1)],
+        &[
+            ("observed", 0),
+            ("provided", 0),
+            ("use_provided", 0),
+            ("model", 1),
+            ("simple_scheme", 1),
+        ],
     ),
     (
         "roughness_sublayer_level",
@@ -974,6 +988,62 @@ fn emissions_biogenic_offset(biogenic: &str) -> Option<i64> {
 
 fn collapse_orthogonal_net_radiation(map: &mut serde_yaml::Mapping) -> Result<bool, String> {
     if !map.contains_key(Value::String("scheme".into())) {
+        let scheme_keys: Vec<&str> = ["forcing", "narp", "spartacus"]
+            .iter()
+            .copied()
+            .filter(|key| map.contains_key(Value::String((*key).to_string())))
+            .collect();
+        if scheme_keys.is_empty() {
+            return Ok(false);
+        }
+        if scheme_keys.len() > 1 {
+            return Err(format!(
+                "'net_radiation' received multiple scheme keys ({scheme_keys:?}); supply exactly one."
+            ));
+        }
+
+        let scheme = scheme_keys[0];
+        let scheme_key = Value::String(scheme.to_string());
+        let scoped = match map.get(&scheme_key) {
+            Some(Value::Mapping(inner)) if !inner.contains_key(Value::String("value".into())) => {
+                inner.clone()
+            }
+            _ => return Ok(false),
+        };
+
+        let foreign: Vec<String> = map
+            .keys()
+            .filter_map(|key| match key.as_str() {
+                Some("ref") => None,
+                Some(s) if s == scheme => None,
+                Some(s) => Some(s.to_string()),
+                None => Some(format!("{key:?}")),
+            })
+            .collect();
+        if !foreign.is_empty() {
+            return Err(format!(
+                "'net_radiation.{scheme}' cannot be combined with sibling keys {foreign:?}."
+            ));
+        }
+
+        let carried_ref = map.get(Value::String("ref".into())).cloned();
+        map.clear();
+        map.insert(
+            Value::String("scheme".into()),
+            Value::String(scheme.to_string()),
+        );
+        for (key, value) in scoped {
+            map.insert(key, value);
+        }
+        if let Some(r) = carried_ref {
+            let ref_key = Value::String("ref".into());
+            if !map.contains_key(&ref_key) {
+                map.insert(ref_key, r);
+            }
+        }
+    }
+
+    if !map.contains_key(Value::String("scheme".into())) {
         return Ok(false);
     }
 
@@ -1109,6 +1179,238 @@ fn collapse_orthogonal_emissions(map: &mut serde_yaml::Mapping) -> Result<bool, 
         map.insert(Value::String("ref".into()), r);
     }
     Ok(true)
+}
+
+const STORAGE_HEAT_FAMILIES_RS: &[&str] =
+    &["observed", "ohm", "anohm", "estm", "ehc", "dyohm", "stebbs"];
+
+fn fold_storage_heat_ohm_inc_qf(root: &mut Value) -> Result<(), String> {
+    let physics = match root
+        .get_mut("model")
+        .and_then(|m| m.as_mapping_mut())
+        .and_then(|m| m.get_mut(Value::String("physics".into())))
+        .and_then(|p| p.as_mapping_mut())
+    {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+
+    for outer_key_name in STORAGE_HEAT_OUTER_KEYS {
+        let outer_key = Value::String((*outer_key_name).to_string());
+        let mut block = match physics.get(&outer_key) {
+            Some(Value::Mapping(map)) => map.clone(),
+            _ => continue,
+        };
+
+        if let Some(Value::Mapping(ohm)) = block.get(Value::String("ohm".into())) {
+            let mut ohm_block = ohm.clone();
+            let qf_spellings: Vec<&str> = ["include_qf", "ohm_inc_qf", "ohmincqf"]
+                .iter()
+                .copied()
+                .filter(|key| ohm_block.contains_key(Value::String((*key).to_string())))
+                .collect();
+            if !qf_spellings.is_empty() {
+                if qf_spellings.len() > 1 {
+                    return Err(format!(
+                        "model.physics.{outer_key_name}.ohm contains multiple OHMIncQF spellings ({qf_spellings:?}). Use only 'storage_heat.ohm.include_qf'."
+                    ));
+                }
+
+                if physics.contains_key(Value::String("ohm_inc_qf".into()))
+                    || physics.contains_key(Value::String("ohmincqf".into()))
+                {
+                    return Err(
+                        "Both flat 'ohm_inc_qf' and nested 'storage_heat.ohm.include_qf' are present. Use only the nested form."
+                            .to_string(),
+                    );
+                }
+
+                let foreign: Vec<String> = block
+                    .keys()
+                    .filter_map(|key| match key.as_str() {
+                        Some("ohm") | Some("ref") => None,
+                        Some(s) => Some(s.to_string()),
+                        None => Some(format!("{key:?}")),
+                    })
+                    .collect();
+                if !foreign.is_empty() {
+                    return Err(format!(
+                        "'storage_heat.ohm' cannot be combined with sibling keys {foreign:?}."
+                    ));
+                }
+
+                let qf_key = qf_spellings[0];
+                let qf_value = ohm_block
+                    .remove(Value::String(qf_key.to_string()))
+                    .expect("qf key just matched");
+                let qf_value = if qf_key == "include_qf" {
+                    normalise_include_qf_value(qf_value)?
+                } else {
+                    qf_value
+                };
+                let qf_value = wrap_refvalue(qf_value);
+
+                let inner_foreign: Vec<String> = ohm_block
+                    .keys()
+                    .filter_map(|key| match key.as_str() {
+                        Some("ref") => None,
+                        Some(s) => Some(s.to_string()),
+                        None => Some(format!("{key:?}")),
+                    })
+                    .collect();
+                if !inner_foreign.is_empty() {
+                    return Err(format!(
+                        "'storage_heat.ohm' cannot be combined with sibling keys {inner_foreign:?}."
+                    ));
+                }
+
+                let mut folded = serde_yaml::Mapping::new();
+                folded.insert(Value::String("value".into()), Value::String("ohm".into()));
+                if let Some(r) = ohm_block
+                    .remove(Value::String("ref".into()))
+                    .or_else(|| block.remove(Value::String("ref".into())))
+                {
+                    folded.insert(Value::String("ref".into()), r);
+                }
+                physics.insert(outer_key, Value::Mapping(folded));
+                physics.insert(Value::String("ohm_inc_qf".into()), qf_value);
+                return Ok(());
+            }
+        }
+
+        let qf_spellings: Vec<&str> = ["ohm_inc_qf", "ohmincqf"]
+            .iter()
+            .copied()
+            .filter(|key| block.contains_key(Value::String((*key).to_string())))
+            .collect();
+        if qf_spellings.is_empty() {
+            continue;
+        }
+        if qf_spellings.len() > 1 {
+            return Err(format!(
+                "model.physics.{outer_key_name} contains multiple OHMIncQF spellings ({qf_spellings:?}). Use only 'storage_heat.ohm.include_qf'."
+            ));
+        }
+
+        if physics.contains_key(Value::String("ohm_inc_qf".into()))
+            || physics.contains_key(Value::String("ohmincqf".into()))
+        {
+            return Err(
+                "Both flat 'ohm_inc_qf' and nested 'storage_heat.ohm.include_qf' are present. Use only the nested form."
+                    .to_string(),
+            );
+        }
+
+        let qf_key = qf_spellings[0];
+        let qf_value = block
+            .remove(Value::String(qf_key.to_string()))
+            .expect("qf key just matched");
+        let qf_value = wrap_refvalue(qf_value);
+
+        if block.contains_key(Value::String("scheme".into())) {
+            reject_foreign_keys(&block, &["scheme", "ref"], "storage_heat")?;
+            let scheme = block
+                .remove(Value::String("scheme".into()))
+                .expect("scheme key was present");
+            let carried_ref = block.remove(Value::String("ref".into()));
+            let mut folded = serde_yaml::Mapping::new();
+            folded.insert(Value::String("value".into()), scheme);
+            if let Some(r) = carried_ref {
+                folded.insert(Value::String("ref".into()), r);
+            }
+            physics.insert(outer_key, Value::Mapping(folded));
+            physics.insert(Value::String("ohm_inc_qf".into()), qf_value);
+            return Ok(());
+        }
+
+        let keys: Vec<String> = block
+            .keys()
+            .filter_map(|key| key.as_str().map(str::to_string))
+            .collect();
+        if block.is_empty() {
+            return Err(
+                "Nested 'storage_heat.ohm_inc_qf' requires either 'storage_heat.scheme', \
+                 a storage heat family tag, or 'storage_heat.value'."
+                    .to_string(),
+            );
+        }
+        let all_string_keys = keys.len() == block.len();
+        let is_refvalue_scalar =
+            all_string_keys && keys.iter().all(|key| key == "value" || key == "ref");
+        if is_refvalue_scalar {
+            physics.insert(outer_key, Value::Mapping(block));
+            physics.insert(Value::String("ohm_inc_qf".into()), qf_value);
+            return Ok(());
+        }
+
+        let has_family = STORAGE_HEAT_FAMILIES_RS
+            .iter()
+            .any(|family| block.contains_key(Value::String((*family).to_string())));
+        if has_family {
+            let foreign: Vec<String> = block
+                .keys()
+                .filter_map(|key| match key.as_str() {
+                    Some("ref") => None,
+                    Some(s) if STORAGE_HEAT_FAMILIES_RS.contains(&s) => None,
+                    Some(s) => Some(s.to_string()),
+                    None => Some(format!("{key:?}")),
+                })
+                .collect();
+            if !foreign.is_empty() {
+                return Err(format!(
+                    "'storage_heat' family form cannot be combined with sibling keys {foreign:?}."
+                ));
+            }
+            physics.insert(outer_key, Value::Mapping(block));
+            physics.insert(Value::String("ohm_inc_qf".into()), qf_value);
+            return Ok(());
+        }
+
+        return Err(
+            "Nested 'storage_heat.ohm_inc_qf' requires either 'storage_heat.scheme', \
+             a storage heat family tag, or 'storage_heat.value'."
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
+fn normalise_include_qf_value(value: Value) -> Result<Value, String> {
+    let code = match value {
+        Value::Bool(true) => 1,
+        Value::Bool(false) => 0,
+        Value::Number(n) if n.as_i64() == Some(1) => 1,
+        Value::Number(n) if n.as_i64() == Some(0) => 0,
+        Value::String(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+            "include" | "included" | "true" | "yes" | "y" | "on" | "1" => 1,
+            "exclude" | "excluded" | "false" | "no" | "n" | "off" | "0" => 0,
+            _ => return Err(
+                "Nested 'storage_heat.ohm.include_qf' expects a boolean or 'include'/'exclude'."
+                    .to_string(),
+            ),
+        },
+        _ => {
+            return Err(
+                "Nested 'storage_heat.ohm.include_qf' expects a boolean or 'include'/'exclude'."
+                    .to_string(),
+            )
+        }
+    };
+    Ok(Value::Number(code.into()))
+}
+
+fn wrap_refvalue(value: Value) -> Value {
+    match value {
+        Value::Mapping(map) if map.contains_key(Value::String("value".into())) => {
+            Value::Mapping(map)
+        }
+        other => {
+            let mut map = serde_yaml::Mapping::new();
+            map.insert(Value::String("value".into()), other);
+            Value::Mapping(map)
+        }
+    }
 }
 
 /// Collapse family-tagged nested physics input to the flat `{value: N}`
@@ -1359,6 +1661,7 @@ fn physics_field_key_spellings(field: &str) -> Vec<String> {
 const STEBBS_NESTED_KEYS: &[&str] = &[
     "enabled",
     "parameters",
+    "parameter_source",
     "capacitance",
     "setpoint",
     "same_albedo_wall",
@@ -1371,6 +1674,7 @@ const STEBBS_NESTED_KEYS: &[&str] = &[
 /// object. The Python raw validator accepts these via `RAW_YAML_FIELD_RENAMES`,
 /// so the bridge flatten pre-pass must normalise them too.
 const STEBBS_NESTED_ALIAS_TO_LEAF: &[(&str, &str)] = &[
+    ("parameter_source", "parameters"),
     ("outer_cap_fraction", "capacitance"),
     ("rcmethod", "capacitance"),
     ("rc_method", "capacitance"),
@@ -1676,7 +1980,10 @@ fn should_rename_key_at_path(new_name: &str, path: &str) -> bool {
     // Only the physics option should be folded to `stebbsmethod`; the
     // `sites[].properties.stebbs` section must keep its name so the STEBBS
     // parser can read the parameter and initial-state overrides.
-    new_name != "stebbs" || path == "model.physics"
+    match new_name {
+        "stebbs" | "leaf_area_index" | "snow" => path == "model.physics",
+        _ => true,
+    }
 }
 
 /// Recursively rewrite new snake_case keys to their legacy fused spellings
@@ -1708,6 +2015,7 @@ pub fn normalize_field_names(root: &mut Value) -> Result<(), String> {
     // (master-toggle scalar + flat `outer_cap_fraction`/`setpoint`/`same_*`)
     // still flows through the walker unchanged.
     flatten_stebbs_physics(root)?;
+    fold_storage_heat_ohm_inc_qf(root)?;
     // Nested family form must be collapsed BEFORE the recursive rename
     // walker runs — some family tags (e.g. `stebbs` under `storage_heat`)
     // collide with ModelPhysics field names that the walker would
@@ -2047,6 +2355,17 @@ model:
     }
 
     #[test]
+    fn orthogonal_net_radiation_scheme_scoped_options_collapse() {
+        let yaml = "model:\n  physics:\n    net_radiation:\n      narp:\n        ldown: air\n";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+        let v = root["model"]["physics"]["netradiationmethod"]
+            .get(Value::String("value".into()))
+            .unwrap();
+        assert_eq!(v.as_i64(), Some(3));
+    }
+
+    #[test]
     fn orthogonal_net_radiation_spartacus_collapses() {
         let yaml =
             "model:\n  physics:\n    net_radiation:\n      scheme: spartacus\n      ldown: air\n";
@@ -2107,6 +2426,115 @@ model:
             .get(Value::String("value".into()))
             .unwrap();
         assert_eq!(v.as_i64(), Some(5));
+    }
+
+    #[test]
+    fn storage_heat_owns_ohm_inc_qf_axis() {
+        let yaml = "model:\n  physics:\n    storage_heat:\n      ohm:\n        include_qf: true\n";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+        let physics = &root["model"]["physics"];
+        assert_eq!(
+            physics["storageheatmethod"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(1)
+        );
+        assert_eq!(
+            physics["ohmincqf"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn public_physics_aliases_do_not_rename_site_snow_section() {
+        let yaml = "model:\n  physics:\n    leaf_area_index: model\n    snow: disabled\nsites:\n- properties:\n    snow:\n      initially: {value: 0}\n";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+        let physics = &root["model"]["physics"];
+        assert_eq!(
+            physics["laimethod"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(1)
+        );
+        assert_eq!(
+            physics["snowuse"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(0)
+        );
+
+        let properties = root["sites"][0]["properties"].as_mapping().unwrap();
+        assert!(properties.contains_key(Value::String("snow".into())));
+        assert!(!properties.contains_key(Value::String("snowuse".into())));
+    }
+
+    #[test]
+    fn storage_heat_legacy_nested_ohm_inc_qf_stays_accepted() {
+        let yaml =
+            "model:\n  physics:\n    storage_heat:\n      scheme: ohm\n      ohm_inc_qf: include\n";
+        let mut root: Value = from_str(yaml).unwrap();
+        normalize_field_names(&mut root).unwrap();
+        let physics = &root["model"]["physics"];
+        assert_eq!(
+            physics["storageheatmethod"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(1)
+        );
+        assert_eq!(
+            physics["ohmincqf"]
+                .get(Value::String("value".into()))
+                .and_then(|v| v.as_i64()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn storage_heat_nested_ohm_inc_qf_rejects_flat_duplicate() {
+        let yaml = "\
+model:
+  physics:
+    storage_heat:
+      ohm:
+        include_qf: false
+    ohm_inc_qf: include
+";
+        let mut root: Value = from_str(yaml).unwrap();
+        let err = normalize_field_names(&mut root).expect_err("duplicate qf must fail");
+        assert!(
+            err.contains("nested 'storage_heat.ohm.include_qf'"),
+            "error was: {err}"
+        );
+    }
+
+    #[test]
+    fn storage_heat_scheme_scoped_qf_rejects_sibling_scheme() {
+        let yaml = "\
+model:
+  physics:
+    storage_heat:
+      ohm:
+        include_qf: false
+      anohm: {}
+";
+        let mut root: Value = from_str(yaml).unwrap();
+        let err = normalize_field_names(&mut root).expect_err("sibling scheme must fail");
+        assert!(err.contains("cannot be combined"), "error was: {err}");
+    }
+
+    #[test]
+    fn storage_heat_nested_ohm_inc_qf_requires_storage_heat_selector() {
+        let yaml = "model:\n  physics:\n    storage_heat:\n      ohm_inc_qf: exclude\n";
+        let mut root: Value = from_str(yaml).unwrap();
+        let err = normalize_field_names(&mut root).expect_err("missing selector must fail");
+        assert!(
+            err.contains("requires either 'storage_heat.scheme'"),
+            "error was: {err}"
+        );
     }
 
     #[test]

--- a/src/supy/data_model/core/field_renames.py
+++ b/src/supy/data_model/core/field_renames.py
@@ -1621,6 +1621,11 @@ def read_physics_key(physics: dict, new_name: str, default: Any = None):
     """
     if new_name in {"storage_heat", "ohm_inc_qf"} and isinstance(physics, dict):
         physics = dict(physics)
+        if "storage_heat" not in physics:
+            for alias in ("storage_heat_method", "storageheatmethod"):
+                if alias in physics:
+                    physics["storage_heat"] = physics[alias]
+                    break
         fold_storage_heat_ohm_inc_qf(physics, "ModelPhysics")
 
     entry = read_renamed_key(

--- a/src/supy/data_model/core/field_renames.py
+++ b/src/supy/data_model/core/field_renames.py
@@ -7,13 +7,17 @@ the Phase A validation pipeline, and raw-dict compatibility helpers.
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Mapping
 from typing import Any, Dict
+import warnings
 
-from .physics_families import coerce_nested_to_flat, flatten_physics_in_config
+from .physics_families import (
+    PHYSICS_PUBLIC_KEY_ALIASES,
+    STEBBS_PUBLIC_KEY_ALIASES,
+    coerce_nested_to_flat,
+    flatten_physics_in_config,
+)
 from .physics_orthogonal import coerce_orthogonal_to_flat
-
 
 # -- ModelPhysics (model.py) -------------------------------------------------
 #
@@ -1271,6 +1275,7 @@ _MODELPHYSICS_ALL_RENAMES: Dict[str, str] = {
     # find a legacy ``outer_cap_fraction`` key. Spread before RENAMES so the
     # reverse map prefers the fused legacy ``rcmethod`` for ``capacitance``.
     **MODELPHYSICS_SUFFIX_RENAMES,
+    **PHYSICS_PUBLIC_KEY_ALIASES,
     **MODELPHYSICS_DEV12_RENAMES,
     **MODELPHYSICS_RENAMES,
 }
@@ -1361,6 +1366,7 @@ _STEBBS_NESTED_KEYS = frozenset(
     {
         "enabled",
         "parameters",
+        *STEBBS_PUBLIC_KEY_ALIASES,
         *STEBBS_PHYSICS_LEAF_RENAMES.keys(),
         *STEBBS_PHYSICS_LEAF_RENAMES.values(),
     }
@@ -1442,6 +1448,17 @@ def _decompose_stebbs_master(entry: Any) -> tuple[Any, Any]:
 
 def _normalise_stebbs_block_aliases(stebbs_block: dict) -> tuple[dict, list[str]]:
     """Rename legacy keys inside a nested ``stebbs`` block to final leaves."""
+    for old_key, nested_leaf in STEBBS_PUBLIC_KEY_ALIASES.items():
+        if old_key not in stebbs_block:
+            continue
+        if nested_leaf in stebbs_block:
+            raise ValueError(
+                "Multiple nested STEBBS physics switches map to the same nested leaf "
+                f"({old_key}, {nested_leaf} -> stebbs.{nested_leaf}). Use only one "
+                "spelling."
+            )
+        stebbs_block[nested_leaf] = stebbs_block.pop(old_key)
+
     leaf_conflicts = _stebbs_leaf_alias_conflicts(stebbs_block)
     if leaf_conflicts:
         raise ValueError(

--- a/src/supy/data_model/core/field_renames.py
+++ b/src/supy/data_model/core/field_renames.py
@@ -17,7 +17,7 @@ from .physics_families import (
     coerce_nested_to_flat,
     flatten_physics_in_config,
 )
-from .physics_orthogonal import coerce_orthogonal_to_flat
+from .physics_orthogonal import coerce_orthogonal_to_flat, fold_storage_heat_ohm_inc_qf
 
 # -- ModelPhysics (model.py) -------------------------------------------------
 #
@@ -1619,6 +1619,10 @@ def read_physics_key(physics: dict, new_name: str, default: Any = None):
     orthogonal physics forms. Returns ``default`` when neither spelling is
     present.
     """
+    if new_name in {"storage_heat", "ohm_inc_qf"} and isinstance(physics, dict):
+        physics = dict(physics)
+        fold_storage_heat_ohm_inc_qf(physics, "ModelPhysics")
+
     entry = read_renamed_key(
         physics,
         new_name,

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -1,12 +1,12 @@
-import yaml
-from typing import Optional, Union, List
-import numpy as np
-from pydantic import ConfigDict, BaseModel, Field, field_validator, model_validator
-import pandas as pd
 from enum import Enum
 import inspect
+from typing import List, Optional, Union
 
-from .type import RefValue, Reference, FlexibleRefValue, df_from_cols
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+import yaml
+
 from .field_renames import (
     MODELPHYSICS_RENAMES,
     MODELPHYSICS_SUFFIX_RENAMES,
@@ -17,8 +17,11 @@ from .physics_families import (
     MODEL_PHYSICS_ENUM_FIELDS,
     STEBBS_PHYSICS_ENUM_FIELDS,
     coerce_nested_to_flat,
+    fold_public_physics_key_aliases,
+    fold_stebbs_public_key_aliases,
 )
-from .physics_orthogonal import coerce_orthogonal_to_flat
+from .physics_orthogonal import coerce_orthogonal_to_flat, fold_storage_heat_ohm_inc_qf
+from .type import FlexibleRefValue, Reference, RefValue, df_from_cols
 
 
 def _enum_description(enum_class: type[Enum]) -> str:
@@ -806,6 +809,13 @@ class StebbsPhysics(BaseModel):
 
     ref: Optional[Reference] = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_public_key_aliases(cls, values):
+        if isinstance(values, dict):
+            return fold_stebbs_public_key_aliases(values, cls.__name__)
+        return values
+
     @field_validator("enabled", "parameters", mode="after")
     @classmethod
     def _require_master_switch_values(cls, value):
@@ -833,6 +843,7 @@ class ModelPhysics(BaseModel):
     @classmethod
     def _rename_physics_fields(cls, values):
         if isinstance(values, dict):
+            values = fold_public_physics_key_aliases(values, cls.__name__)
             # Cat 1 first (fused -> snake_case with suffix), then Cat 2 + 3
             # (suffix drop + abbreviation expansion). Chaining lets a single
             # YAML carrying either legacy shape land on the final name.
@@ -840,6 +851,9 @@ class ModelPhysics(BaseModel):
             values = apply_field_renames(
                 values, MODELPHYSICS_SUFFIX_RENAMES, cls.__name__
             )
+            # gh#1483: expose OHMIncQF under the storage_heat selector while
+            # preserving the flat field used by the internal/Fortran state.
+            values = fold_storage_heat_ohm_inc_qf(values, cls.__name__)
             # gh#1456: fold the legacy flat STEBBS switches into the nested
             # `stebbs` object. Runs after the key renames so a YAML carrying
             # either fused or snake_case legacy spellings lands here. The fold

--- a/src/supy/data_model/core/physics_families.py
+++ b/src/supy/data_model/core/physics_families.py
@@ -24,12 +24,12 @@ continues to validate and round-trips byte-identically.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import suppress
 from enum import Enum
 from numbers import Integral, Real
 from typing import Any
 
-from .physics_orthogonal import coerce_orthogonal_to_flat
-
+from .physics_orthogonal import coerce_orthogonal_to_flat, fold_storage_heat_ohm_inc_qf
 
 PHYSICS_FAMILIES: dict[str, dict[str, frozenset[int]]] = {
     "net_radiation": {
@@ -54,6 +54,17 @@ PHYSICS_FAMILIES: dict[str, dict[str, frozenset[int]]] = {
         "biogenic_bellucco_general": frozenset({31, 32, 33, 34, 35, 36}),
         "biogenic_conductance": frozenset({41, 42, 43, 44, 45, 46}),
     },
+}
+
+PHYSICS_PUBLIC_KEY_ALIASES: dict[str, str] = {
+    # Public sample/config surface names that fold to long-standing internal
+    # ModelPhysics fields without changing the Fortran-facing state columns.
+    "leaf_area_index": "laimethod",
+    "snow": "snow_use",
+}
+
+STEBBS_PUBLIC_KEY_ALIASES: dict[str, str] = {
+    "parameter_source": "parameters",
 }
 
 _PHYSICS_NAME_SPECS: dict[str, list[tuple[int, str, tuple[str, ...]]]] = {
@@ -137,18 +148,21 @@ _PHYSICS_NAME_SPECS: dict[str, list[tuple[int, str, tuple[str, ...]]]] = {
         (4, "businger_hoegstrom", ("bh71",)),
     ],
     "soil_moisture_deficit": [
-        (0, "modelled", ()),
+        (0, "model", ("modelled",)),
         (1, "observed_volumetric", ()),
         (2, "observed_gravimetric", ()),
     ],
-    "water_use": [(0, "modelled", ()), (1, "observed", ())],
-    "laimethod": [(0, "observed", ()), (1, "calculated", ())],
+    "water_use": [(0, "model", ("modelled",)), (1, "observed", ())],
+    "laimethod": [(0, "observed", ()), (1, "model", ())],
     "roughness_sublayer": [
         (0, "most", ()),
         (1, "rst", ("t19",)),
         (2, "variable", ()),
     ],
-    "frontal_area_index": [(0, "use_provided", ()), (1, "simple_scheme", ())],
+    "frontal_area_index": [
+        (0, "observed", ("provided", "use_provided")),
+        (1, "model", ("simple_scheme",)),
+    ],
     "roughness_sublayer_level": [
         (0, "none", ()),
         (1, "basic", ()),
@@ -236,6 +250,34 @@ def _build_lookup_tables() -> tuple[
 
 
 _CODE_TO_CANONICAL, _ALIAS_TO_CODE = _build_lookup_tables()
+
+
+def fold_public_physics_key_aliases(values: dict, class_name: str) -> dict:
+    """Fold public-facing physics key aliases to canonical internal fields."""
+    for public_name, canonical_name in PHYSICS_PUBLIC_KEY_ALIASES.items():
+        if public_name not in values:
+            continue
+        if canonical_name in values:
+            raise ValueError(
+                f"{class_name}: both '{public_name}' and '{canonical_name}' are "
+                f"present. Use only '{public_name}'."
+            )
+        values[canonical_name] = values.pop(public_name)
+    return values
+
+
+def fold_stebbs_public_key_aliases(values: dict, class_name: str) -> dict:
+    """Fold public-facing nested STEBBS aliases to canonical internal leaves."""
+    for public_name, canonical_name in STEBBS_PUBLIC_KEY_ALIASES.items():
+        if public_name not in values:
+            continue
+        if canonical_name in values:
+            raise ValueError(
+                f"{class_name}: both '{public_name}' and '{canonical_name}' are "
+                f"present. Use only '{public_name}'."
+            )
+        values[canonical_name] = values.pop(public_name)
+    return values
 
 
 def resolve_scalar_name(field_name: str, name: str) -> int:
@@ -357,6 +399,11 @@ def flatten_physics_in_config(data: Any) -> Any:
     if not isinstance(physics, dict):
         return data
 
+    fold_public_physics_key_aliases(physics, "ModelPhysics")
+
+    with suppress(TypeError, ValueError):
+        fold_storage_heat_ohm_inc_qf(physics, "ModelPhysics")
+
     for field_name in MODEL_PHYSICS_ENUM_FIELDS:
         if field_name not in physics:
             continue
@@ -368,6 +415,7 @@ def flatten_physics_in_config(data: Any) -> Any:
 
     stebbs = physics.get("stebbs")
     if isinstance(stebbs, dict) and "value" not in stebbs:
+        fold_stebbs_public_key_aliases(stebbs, "StebbsPhysics")
         for field_name in STEBBS_PHYSICS_ENUM_FIELDS:
             if field_name not in stebbs:
                 continue

--- a/src/supy/data_model/core/physics_families.py
+++ b/src/supy/data_model/core/physics_families.py
@@ -148,12 +148,11 @@ _PHYSICS_NAME_SPECS: dict[str, list[tuple[int, str, tuple[str, ...]]]] = {
         (4, "businger_hoegstrom", ("bh71",)),
     ],
     "soil_moisture_deficit": [
-        (0, "model", ("modelled",)),
-        (1, "observed_volumetric", ()),
-        (2, "observed_gravimetric", ()),
+        (0, "modelled", ()),
+        (1, "observed", ()),
     ],
-    "water_use": [(0, "model", ("modelled",)), (1, "observed", ())],
-    "laimethod": [(0, "observed", ()), (1, "model", ())],
+    "water_use": [(0, "modelled", ()), (1, "observed", ())],
+    "laimethod": [(0, "observed", ()), (1, "modelled", ())],
     "roughness_sublayer": [
         (0, "most", ()),
         (1, "rst", ("t19",)),
@@ -161,7 +160,7 @@ _PHYSICS_NAME_SPECS: dict[str, list[tuple[int, str, tuple[str, ...]]]] = {
     ],
     "frontal_area_index": [
         (0, "observed", ("provided", "use_provided")),
-        (1, "model", ("simple_scheme",)),
+        (1, "modelled", ("simple_scheme",)),
     ],
     "roughness_sublayer_level": [
         (0, "none", ()),

--- a/src/supy/data_model/core/physics_orthogonal.py
+++ b/src/supy/data_model/core/physics_orthogonal.py
@@ -50,6 +50,12 @@ _EMISSIONS_BIOGENIC_OFFSETS: dict[str, int] = {
     "conductance": 40,
 }
 
+_STORAGE_HEAT_FAMILIES = frozenset(
+    {"observed", "ohm", "anohm", "estm", "ehc", "dyohm", "stebbs"}
+)
+_REFVALUE_KEYS = frozenset({"value", "ref"})
+_STORAGE_HEAT_QF_KEYS = ("include_qf", "ohm_inc_qf", "ohmincqf")
+
 
 def _token(mapping: Mapping[str, Any], key: str, context: str) -> str | None:
     raw = mapping.get(key, _MISSING)
@@ -70,7 +76,150 @@ def _reject_foreign_keys(
         )
 
 
+def fold_storage_heat_ohm_inc_qf(values: dict, class_name: str) -> dict:
+    """Move ``storage_heat.ohm_inc_qf`` to the canonical flat field.
+
+    ``OHMIncQF`` is a sub-choice of the storage heat calculation, but the
+    stable internal and Fortran-facing surface still stores it as the flat
+    ``ohm_inc_qf`` field. This fold lets YAML expose the semantic ownership
+    without changing downstream state layout.
+    """
+    storage = values.get("storage_heat")
+    if not isinstance(storage, Mapping):
+        return values
+
+    if "ohm" in storage and isinstance(storage["ohm"], Mapping):
+        folded = _fold_storage_heat_ohm_block(storage, values, class_name)
+        if folded:
+            return values
+
+    qf_keys = [key for key in ("ohm_inc_qf", "ohmincqf") if key in storage]
+    if not qf_keys:
+        return values
+    if len(qf_keys) > 1:
+        raise ValueError(
+            f"{class_name}: storage_heat contains multiple OHMIncQF spellings "
+            f"({', '.join(qf_keys)}). Use only 'storage_heat.ohm.include_qf'."
+        )
+    flat_qf_keys = [key for key in ("ohm_inc_qf", "ohmincqf") if key in values]
+    if flat_qf_keys:
+        raise ValueError(
+            f"{class_name}: both flat '{flat_qf_keys[0]}' and nested "
+            "'storage_heat.ohm.include_qf' are present. Use only the nested form."
+        )
+
+    block = dict(storage)
+    qf_key = qf_keys[0]
+    qf_value = block.pop(qf_key)
+
+    if "scheme" in block:
+        _reject_foreign_keys(block, {"scheme", "ref"}, "storage_heat")
+        folded: dict[str, Any] = {"value": block["scheme"]}
+        if "ref" in block:
+            folded["ref"] = block["ref"]
+        values["ohm_inc_qf"] = qf_value
+        values["storage_heat"] = folded
+        return values
+
+    keys = set(block)
+    if not keys:
+        raise ValueError(
+            f"{class_name}: nested 'storage_heat.ohm_inc_qf' requires either "
+            "'storage_heat.scheme', a storage heat family tag, or "
+            "'storage_heat.value'."
+        )
+    if keys <= _REFVALUE_KEYS:
+        values["ohm_inc_qf"] = qf_value
+        values["storage_heat"] = block
+        return values
+
+    matched = keys & _STORAGE_HEAT_FAMILIES
+    if matched:
+        foreign = keys - matched - {"ref"}
+        if foreign:
+            raise ValueError(
+                f"{class_name}: 'storage_heat' family form cannot be combined "
+                f"with sibling keys {sorted(foreign)}."
+            )
+        values["ohm_inc_qf"] = qf_value
+        values["storage_heat"] = block
+        return values
+
+    raise ValueError(
+        f"{class_name}: nested 'storage_heat.ohm_inc_qf' requires either "
+        "'storage_heat.scheme', a storage heat family tag, or 'storage_heat.value'."
+    )
+
+
+def _fold_storage_heat_ohm_block(
+    storage: Mapping[str, Any], values: dict, class_name: str
+) -> bool:
+    """Fold ``storage_heat.ohm.include_qf`` to storage heat + OHMIncQF."""
+    ohm_block = dict(storage["ohm"])
+    qf_keys = [key for key in _STORAGE_HEAT_QF_KEYS if key in ohm_block]
+    if not qf_keys:
+        return False
+    if len(qf_keys) > 1:
+        raise ValueError(
+            f"{class_name}: storage_heat.ohm contains multiple OHMIncQF spellings "
+            f"({', '.join(qf_keys)}). Use only 'storage_heat.ohm.include_qf'."
+        )
+    flat_qf_keys = [key for key in ("ohm_inc_qf", "ohmincqf") if key in values]
+    if flat_qf_keys:
+        raise ValueError(
+            f"{class_name}: both flat '{flat_qf_keys[0]}' and nested "
+            "'storage_heat.ohm.include_qf' are present. Use only the nested form."
+        )
+
+    outer_foreign = [key for key in storage if key not in {"ohm", "ref"}]
+    if outer_foreign:
+        raise ValueError(
+            f"{class_name}: 'storage_heat.ohm' cannot be combined with sibling "
+            f"keys {sorted(outer_foreign)}."
+        )
+
+    qf_key = qf_keys[0]
+    qf_value = ohm_block.pop(qf_key)
+    if qf_key == "include_qf":
+        qf_value = _normalise_include_qf(qf_value, class_name)
+
+    inner_foreign = [key for key in ohm_block if key != "ref"]
+    if inner_foreign:
+        raise ValueError(
+            f"{class_name}: 'storage_heat.ohm' cannot be combined with sibling "
+            f"keys {sorted(inner_foreign)}."
+        )
+
+    folded: dict[str, Any] = {"value": "ohm"}
+    if "ref" in ohm_block:
+        folded["ref"] = ohm_block["ref"]
+    elif "ref" in storage:
+        folded["ref"] = storage["ref"]
+    values["storage_heat"] = folded
+    values["ohm_inc_qf"] = qf_value
+    return True
+
+
+def _normalise_include_qf(value: Any, class_name: str) -> Any:
+    """Map public ``include_qf`` predicate values to the OHMIncQF selector."""
+    if isinstance(value, bool):
+        return "include" if value else "exclude"
+    if isinstance(value, int) and value in {0, 1}:
+        return "include" if value else "exclude"
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in {"include", "included", "true", "yes", "y", "on", "1"}:
+            return "include"
+        if token in {"exclude", "excluded", "false", "no", "n", "off", "0"}:
+            return "exclude"
+    raise ValueError(
+        f"{class_name}: 'storage_heat.ohm.include_qf' expects a boolean or one of "
+        "'include'/'exclude'."
+    )
+
+
 def _coerce_net_radiation(value: Mapping[str, Any]) -> dict[str, Any]:
+    value = _normalise_net_radiation_shape(value)
     scheme = _token(value, "scheme", "net_radiation")
     if scheme is None:
         raise ValueError("'net_radiation.scheme' is required.")
@@ -121,6 +270,38 @@ def _coerce_net_radiation(value: Mapping[str, Any]) -> dict[str, Any]:
     if ref is not None:
         flat["ref"] = ref
     return flat
+
+
+def _normalise_net_radiation_shape(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Accept ``net_radiation.<scheme>`` in addition to ``scheme: <name>``."""
+    if "scheme" in value:
+        return value
+
+    scheme_keys = [key for key in ("forcing", "narp", "spartacus") if key in value]
+    if not scheme_keys:
+        return value
+    if len(scheme_keys) > 1:
+        raise ValueError(
+            "'net_radiation' received multiple scheme keys "
+            f"({', '.join(scheme_keys)}); supply exactly one."
+        )
+
+    scheme = scheme_keys[0]
+    raw_options = value[scheme]
+    if not isinstance(raw_options, Mapping) or "value" in raw_options:
+        return value
+
+    foreign = [key for key in value if key not in {scheme, "ref"}]
+    if foreign:
+        raise ValueError(
+            f"'net_radiation.{scheme}' cannot be combined with sibling keys "
+            f"{sorted(foreign)}."
+        )
+
+    normalised = {"scheme": scheme, **raw_options}
+    if "ref" in value and "ref" not in normalised:
+        normalised["ref"] = value["ref"]
+    return normalised
 
 
 def _emissions_code(heat: str, anthropogenic: str, biogenic: str) -> int:
@@ -209,8 +390,11 @@ def coerce_orthogonal_to_flat(field_name: str, value: Any) -> Any:
     if not isinstance(value, Mapping):
         return value
 
-    if field_name == "net_radiation" and "scheme" in value:
-        return _coerce_net_radiation(value)
+    if field_name == "net_radiation":
+        normalised = _normalise_net_radiation_shape(value)
+        if "scheme" in normalised:
+            return _coerce_net_radiation(normalised)
+        return value
 
     if field_name == "emissions" and ("heat" in value or "co2" in value):
         return _coerce_emissions(value)

--- a/src/supy/sample_data/sample_config.yml
+++ b/src/supy/sample_data/sample_config.yml
@@ -20,55 +20,36 @@ model:
     # the chosen physics family or axis is explicit in the sample. Round-trip
     # serializers still emit the canonical flat {value: N} representation.
     net_radiation:
-      scheme: narp
-      ldown: air
+      narp:
+        ldown: air
     emissions:
-      heat: j11
+      heat: J11
       co2:
         anthropogenic: none
         biogenic: none
-    storage_heat: ohm
-    ohm_inc_qf:
-      value: 0
-    roughness_length_momentum:
-      value: 1
-    roughness_length_heat:
-      value: 2
-    stability:
-      value: 3
-    soil_moisture_deficit:
-      value: 0
-    water_use:
-      value: 0
-    roughness_sublayer:
-      value: 2
-    frontal_area_index:
-      value: 0
-    roughness_sublayer_level:
-      value: 1
-    surface_conductance:
-        value: 2
-    laimethod:
-      value: 1
-    snow_use:
-      value: 0
+    storage_heat:
+      ohm:
+        include_qf: false
+    roughness_length_momentum: fixed
+    roughness_length_heat: K09
+    stability: CN98
+    soil_moisture_deficit: model
+    water_use: model
+    roughness_sublayer: variable
+    frontal_area_index: observed
+    roughness_sublayer_level: basic
+    surface_conductance: W16
+    leaf_area_index: model
+    snow: disabled
     stebbs:
-      enabled:
-        value: false
-      parameters:
-        value: 1
-      capacitance:
-        value: 0
-      setpoint:
-        value: 0
-      same_albedo_wall:
-        value: 0
-      same_albedo_roof:
-        value: 0
-      same_emissivity_wall:
-        value: 0
-      same_emissivity_roof:
-        value: 0
+      enabled: false
+      parameter_source: default
+      capacitance: default
+      setpoint: constant
+      same_albedo_wall: disabled
+      same_albedo_roof: disabled
+      same_emissivity_wall: disabled
+      same_emissivity_roof: disabled
 sites:
 - name: KCL
   gridiv: 1

--- a/src/supy/sample_data/sample_config.yml
+++ b/src/supy/sample_data/sample_config.yml
@@ -33,13 +33,13 @@ model:
     roughness_length_momentum: fixed
     roughness_length_heat: K09
     stability: CN98
-    soil_moisture_deficit: model
-    water_use: model
+    soil_moisture_deficit: modelled
+    water_use: modelled
     roughness_sublayer: variable
     frontal_area_index: observed
     roughness_sublayer_level: basic
     surface_conductance: W16
-    leaf_area_index: model
+    leaf_area_index: modelled
     snow: disabled
     stebbs:
       enabled: false

--- a/test/data_model/test_field_renames.py
+++ b/test/data_model/test_field_renames.py
@@ -947,7 +947,7 @@ class TestRawDictCompatibility:
 
     def test_public_physics_aliases_are_scoped_to_model_physics(self):
         payload = {
-            "model": {"physics": {"leaf_area_index": "model", "snow": "disabled"}},
+            "model": {"physics": {"leaf_area_index": "modelled", "snow": "disabled"}},
             "sites": [{"properties": {"snow": {"initially": {"value": 0}}}}],
         }
 

--- a/test/data_model/test_field_renames.py
+++ b/test/data_model/test_field_renames.py
@@ -13,6 +13,7 @@ Verifies:
 import warnings
 
 import pytest
+
 from supy.validation import analyze_config_methods
 
 pytestmark = pytest.mark.api
@@ -24,7 +25,6 @@ from supy.data_model.core.field_renames import (
     ARCHETYPEPROPERTIES_DEV7_RENAMES,
     ARCHETYPEPROPERTIES_DEV12_RENAMES,
     ARCHETYPEPROPERTIES_RENAMES,
-    ARCHETYPEPROPERTIES_PASCAL_RENAMES,
     ATMOSPHERE_RENAMES,
     DECTRPROPERTIES_RENAMES,
     EHC_RENAMES,
@@ -35,11 +35,9 @@ from supy.data_model.core.field_renames import (
     LAIPARAMS_RENAMES,
     LANDCOVER_RENAMES,
     MODELPHYSICS_RENAMES,
-    MODELPHYSICS_SUFFIX_RENAMES,
     PHENOLOGYSTATE_RENAMES,
     RAW_YAML_FIELD_RENAMES,
     SNOWPARAMS_RENAMES,
-    SNOWPARAMS_INTERMEDIATE_RENAMES,
     SNOWSTATE_RENAMES,
     STEBBSPROPERTIES_RENAMES,
     STEBBSSTATE_RENAMES,
@@ -47,6 +45,7 @@ from supy.data_model.core.field_renames import (
     SURFACEPROPERTIES_RENAMES,
     VEGETATEDSURFACEPROPERTIES_RENAMES,
     WATERDIST_RENAMES,
+    normalise_yaml_renames,
     read_physics_key,
     rename_keys_recursive,
 )
@@ -61,7 +60,6 @@ from supy.data_model.core.site import (
 )
 from supy.data_model.core.surface import SurfaceProperties
 from supy.data_model.validation.core.controller import ValidationController
-
 
 # (ModelClass, rename_dict) pairs covering every class that got renames.
 _RENAMED_CLASSES = [
@@ -946,6 +944,21 @@ class TestRawDictCompatibility:
         assert "wall_external_thickness" not in archetype
         assert "wall_thickness" not in archetype
         assert "window_to_wall_ratio" not in archetype
+
+    def test_public_physics_aliases_are_scoped_to_model_physics(self):
+        payload = {
+            "model": {"physics": {"leaf_area_index": "model", "snow": "disabled"}},
+            "sites": [{"properties": {"snow": {"initially": {"value": 0}}}}],
+        }
+
+        normalised = normalise_yaml_renames(payload)
+
+        physics = normalised["model"]["physics"]
+        assert physics["laimethod"]["value"] == 1
+        assert physics["snow_use"]["value"] == 0
+        properties = normalised["sites"][0]["properties"]
+        assert "snow" in properties
+        assert "snow_use" not in properties
 
     def test_raw_yaml_stebbs_straggler_renames_reach_current_names(self):
         """dev11 -> dev12 STEBBS straggler reorder must resolve in the raw-YAML

--- a/test/data_model/test_field_renames.py
+++ b/test/data_model/test_field_renames.py
@@ -861,8 +861,12 @@ class TestRawDictCompatibility:
 
         assert read_physics_key(physics, "net_radiation") == 3
 
-    def test_read_physics_key_accepts_storage_heat_owned_qf_axis(self):
-        physics = {"storage_heat": {"ohm": {"include_qf": False}}}
+    @pytest.mark.parametrize(
+        "storage_key",
+        ["storage_heat", "storage_heat_method", "storageheatmethod"],
+    )
+    def test_read_physics_key_accepts_storage_heat_owned_qf_axis(self, storage_key):
+        physics = {storage_key: {"ohm": {"include_qf": False}}}
 
         assert read_physics_key(physics, "storage_heat") == 1
         assert read_physics_key(physics, "ohm_inc_qf") == 0

--- a/test/data_model/test_field_renames.py
+++ b/test/data_model/test_field_renames.py
@@ -10,9 +10,11 @@ Verifies:
   deprecation warning via MODELPHYSICS_SUFFIX_RENAMES (#1321).
 """
 
+from pathlib import Path
 import warnings
 
 import pytest
+import yaml
 
 from supy.validation import analyze_config_methods
 
@@ -858,6 +860,22 @@ class TestRawDictCompatibility:
         physics = {"netradiationmethod": {"scheme": "narp", "ldown": "air"}}
 
         assert read_physics_key(physics, "net_radiation") == 3
+
+    def test_read_physics_key_accepts_storage_heat_owned_qf_axis(self):
+        physics = {"storage_heat": {"ohm": {"include_qf": False}}}
+
+        assert read_physics_key(physics, "storage_heat") == 1
+        assert read_physics_key(physics, "ohm_inc_qf") == 0
+
+    def test_legacy_analyze_config_methods_accepts_sample_config(self):
+        path = Path(__file__).resolve().parents[2] / "src/supy/sample_data/sample_config.yml"
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+        methods = analyze_config_methods(config)
+
+        assert methods
+        assert methods["storage_estm"] is False
+        assert methods["emissions_advanced"] is False
 
     def test_analyze_config_methods_accepts_orthogonal_emissions(self):
         config = {

--- a/test/data_model/test_physics_families.py
+++ b/test/data_model/test_physics_families.py
@@ -218,6 +218,21 @@ class TestCoerceScalarNames:
         assert coerce_nested_to_flat("net_radiation", "ldown_air") == {"value": 3}
         assert coerce_nested_to_flat("net_radiation", "forcing") == {"value": 0}
 
+    def test_source_choice_names_are_consistent(self):
+        assert coerce_nested_to_flat("laimethod", "model") == {"value": 1}
+        assert coerce_nested_to_flat("frontal_area_index", "observed") == {
+            "value": 0
+        }
+        assert coerce_nested_to_flat("frontal_area_index", "model") == {"value": 1}
+        assert coerce_nested_to_flat("water_use", "model") == {"value": 0}
+        assert coerce_nested_to_flat("soil_moisture_deficit", "model") == {
+            "value": 0
+        }
+
+    def test_lai_calculated_name_is_not_public(self):
+        with pytest.raises(ValueError, match="calculated"):
+            coerce_nested_to_flat("laimethod", "calculated")
+
     def test_unknown_scalar_name_rejected(self):
         with pytest.raises(ValueError, match="unknown scheme name"):
             coerce_nested_to_flat("storage_heat", "not_a_scheme")
@@ -234,14 +249,24 @@ class TestReadableNamesInModels:
         physics = ModelPhysics(
             storage_heat="ohm",
             stability="cn98",
-            snow_use="enabled",
+            snow="enabled",
+            leaf_area_index="model",
             emissions="biogen_conductance_j11_detailed",
         )
 
         assert physics.storage_heat.value.value == 1
         assert physics.stability.value.value == 3
         assert physics.snow_use.value.value == 1
+        assert physics.laimethod.value.value == 1
         assert physics.emissions.value.value == 45
+
+    def test_public_physics_key_aliases_reject_duplicates(self):
+        from supy.data_model.core.model import ModelPhysics
+
+        with pytest.raises(ValueError, match="leaf_area_index"):
+            ModelPhysics(leaf_area_index="model", laimethod="model")
+        with pytest.raises(ValueError, match="snow"):
+            ModelPhysics(snow="disabled", snow_use="disabled")
 
     def test_model_physics_accepts_nested_stebbs_readable_names(self):
         from supy.data_model.core.model import ModelPhysics
@@ -249,7 +274,7 @@ class TestReadableNamesInModels:
         physics = ModelPhysics(
             stebbs={
                 "enabled": True,
-                "parameters": "provided",
+                "parameter_source": "provided",
                 "capacitance": "parameterise",
                 "setpoint": {"value": "scheduled"},
                 "same_albedo_wall": "enabled",
@@ -261,13 +286,20 @@ class TestReadableNamesInModels:
         assert physics.stebbs.setpoint.value.value == 2
         assert physics.stebbs.same_albedo_wall.value.value == 1
 
+    def test_nested_stebbs_public_alias_rejects_duplicate(self):
+        from supy.data_model.core.model import ModelPhysics
+
+        with pytest.raises(ValueError, match="parameter_source"):
+            ModelPhysics(
+                stebbs={"parameter_source": "default", "parameters": "default"}
+            )
+
 
 class TestRegistryEnumParity:
     """The hardcoded readable-name codes must match the live Enum definitions."""
 
     def test_codes_match_enum_values(self):
-        from supy.data_model.core import model as m
-        from supy.data_model.core import physics_families as pf
+        from supy.data_model.core import model as m, physics_families as pf
 
         field_to_enum = {
             "net_radiation": m.NetRadiationMethod,

--- a/test/data_model/test_physics_families.py
+++ b/test/data_model/test_physics_families.py
@@ -219,19 +219,33 @@ class TestCoerceScalarNames:
         assert coerce_nested_to_flat("net_radiation", "forcing") == {"value": 0}
 
     def test_source_choice_names_are_consistent(self):
-        assert coerce_nested_to_flat("laimethod", "model") == {"value": 1}
+        assert coerce_nested_to_flat("laimethod", "modelled") == {"value": 1}
         assert coerce_nested_to_flat("frontal_area_index", "observed") == {
             "value": 0
         }
-        assert coerce_nested_to_flat("frontal_area_index", "model") == {"value": 1}
-        assert coerce_nested_to_flat("water_use", "model") == {"value": 0}
-        assert coerce_nested_to_flat("soil_moisture_deficit", "model") == {
+        assert coerce_nested_to_flat("frontal_area_index", "modelled") == {
+            "value": 1
+        }
+        assert coerce_nested_to_flat("water_use", "modelled") == {"value": 0}
+        assert coerce_nested_to_flat("soil_moisture_deficit", "modelled") == {
             "value": 0
+        }
+        assert coerce_nested_to_flat("soil_moisture_deficit", "observed") == {
+            "value": 1
         }
 
     def test_lai_calculated_name_is_not_public(self):
         with pytest.raises(ValueError, match="calculated"):
             coerce_nested_to_flat("laimethod", "calculated")
+
+    def test_source_choice_model_name_is_not_public(self):
+        with pytest.raises(ValueError, match="modelled"):
+            coerce_nested_to_flat("laimethod", "model")
+
+    @pytest.mark.parametrize("name", ["observed_volumetric", "observed_gravimetric"])
+    def test_smd_unit_specific_names_are_not_public(self, name):
+        with pytest.raises(ValueError, match="observed"):
+            coerce_nested_to_flat("soil_moisture_deficit", name)
 
     def test_unknown_scalar_name_rejected(self):
         with pytest.raises(ValueError, match="unknown scheme name"):
@@ -250,7 +264,7 @@ class TestReadableNamesInModels:
             storage_heat="ohm",
             stability="cn98",
             snow="enabled",
-            leaf_area_index="model",
+            leaf_area_index="modelled",
             emissions="biogen_conductance_j11_detailed",
         )
 
@@ -264,7 +278,7 @@ class TestReadableNamesInModels:
         from supy.data_model.core.model import ModelPhysics
 
         with pytest.raises(ValueError, match="leaf_area_index"):
-            ModelPhysics(leaf_area_index="model", laimethod="model")
+            ModelPhysics(leaf_area_index="modelled", laimethod="modelled")
         with pytest.raises(ValueError, match="snow"):
             ModelPhysics(snow="disabled", snow_use="disabled")
 
@@ -331,10 +345,18 @@ class TestRegistryEnumParity:
         assert set(MODEL_PHYSICS_ENUM_FIELDS).issubset(PHYSICS_ENUM_FIELDS)
         assert set(STEBBS_PHYSICS_ENUM_FIELDS).issubset(PHYSICS_ENUM_FIELDS)
 
+        # gh#1422/#1447: SMD's historical code 2 remains a numeric
+        # compatibility path while the public readable surface converges on a
+        # single observed soil-moisture source.
+        public_name_coverage_exceptions = {"soil_moisture_deficit": {2}}
+
         for field, enum_cls in field_to_enum.items():
             valid = {member.value for member in enum_cls}
             for code in pf._ALIAS_TO_CODE[field].values():
                 assert code in valid, f"{field}: code {code} not in {enum_cls}"
-            assert set(pf._CODE_TO_CANONICAL[field]) == valid, (
+            assert (
+                set(pf._CODE_TO_CANONICAL[field])
+                == valid - public_name_coverage_exceptions.get(field, set())
+            ), (
                 f"{field}: canonical names do not cover every enum value"
             )

--- a/test/data_model/test_physics_orthogonal.py
+++ b/test/data_model/test_physics_orthogonal.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from pydantic import ValidationError
 import pytest
 import yaml
 
-from supy._env import trv_supy_module
 from supy.data_model.core.field_renames import read_physics_key
 from supy.data_model.core.model import ModelPhysics
+from supy.data_model.core.physics_families import flatten_physics_in_config
 from supy.data_model.core.physics_orthogonal import coerce_orthogonal_to_flat
 
 pytestmark = pytest.mark.api
@@ -48,6 +50,12 @@ def test_orthogonal_form_preserves_ref():
     assert result == {"value": 3, "ref": {"doi": "10.example/ref"}}
 
 
+def test_orthogonal_net_radiation_accepts_scheme_scoped_options():
+    assert coerce_orthogonal_to_flat("net_radiation", {"narp": {"ldown": "air"}}) == {
+        "value": 3
+    }
+
+
 def test_non_orthogonal_shapes_pass_through_for_existing_normalisers():
     family = {"spartacus": {"value": 1001}}
     flat = {"value": 3}
@@ -65,20 +73,165 @@ def test_model_physics_accepts_orthogonal_narp_default_variant():
 
 
 def test_sample_config_prefers_nested_readable_physics_defaults():
-    path = trv_supy_module / "sample_data" / "sample_config.yml"
+    path = Path(__file__).resolve().parents[2] / "src/supy/sample_data/sample_config.yml"
     physics = yaml.safe_load(path.read_text(encoding="utf-8"))["model"]["physics"]
 
-    assert physics["net_radiation"] == {"scheme": "narp", "ldown": "air"}
+    assert physics["net_radiation"] == {"narp": {"ldown": "air"}}
     assert physics["emissions"] == {
-        "heat": "j11",
+        "heat": "J11",
         "co2": {"anthropogenic": "none", "biogenic": "none"},
     }
-    assert physics["storage_heat"] == "ohm"
+    assert physics["storage_heat"] == {"ohm": {"include_qf": False}}
+    assert {
+        key: physics[key]
+        for key in (
+            "roughness_length_momentum",
+            "roughness_length_heat",
+            "stability",
+            "soil_moisture_deficit",
+            "water_use",
+            "roughness_sublayer",
+            "frontal_area_index",
+            "roughness_sublayer_level",
+            "surface_conductance",
+            "leaf_area_index",
+            "snow",
+        )
+    } == {
+        "roughness_length_momentum": "fixed",
+        "roughness_length_heat": "K09",
+        "stability": "CN98",
+        "soil_moisture_deficit": "model",
+        "water_use": "model",
+        "roughness_sublayer": "variable",
+        "frontal_area_index": "observed",
+        "roughness_sublayer_level": "basic",
+        "surface_conductance": "W16",
+        "leaf_area_index": "model",
+        "snow": "disabled",
+    }
+    assert physics["stebbs"] == {
+        "enabled": False,
+        "parameter_source": "default",
+        "capacitance": "default",
+        "setpoint": "constant",
+        "same_albedo_wall": "disabled",
+        "same_albedo_roof": "disabled",
+        "same_emissivity_wall": "disabled",
+        "same_emissivity_roof": "disabled",
+    }
 
     parsed = ModelPhysics.model_validate(physics)
-    assert int(_unwrap(parsed.net_radiation)) == 3
-    assert int(_unwrap(parsed.emissions)) == 2
-    assert int(_unwrap(parsed.storage_heat)) == 1
+    assert {
+        "net_radiation": int(_unwrap(parsed.net_radiation)),
+        "emissions": int(_unwrap(parsed.emissions)),
+        "storage_heat": int(_unwrap(parsed.storage_heat)),
+        "ohm_inc_qf": int(_unwrap(parsed.ohm_inc_qf)),
+        "roughness_length_momentum": int(_unwrap(parsed.roughness_length_momentum)),
+        "roughness_length_heat": int(_unwrap(parsed.roughness_length_heat)),
+        "stability": int(_unwrap(parsed.stability)),
+        "soil_moisture_deficit": int(_unwrap(parsed.soil_moisture_deficit)),
+        "water_use": int(_unwrap(parsed.water_use)),
+        "roughness_sublayer": int(_unwrap(parsed.roughness_sublayer)),
+        "frontal_area_index": int(_unwrap(parsed.frontal_area_index)),
+        "roughness_sublayer_level": int(_unwrap(parsed.roughness_sublayer_level)),
+        "surface_conductance": int(_unwrap(parsed.surface_conductance)),
+        "laimethod": int(_unwrap(parsed.laimethod)),
+        "snow_use": int(_unwrap(parsed.snow_use)),
+        "stebbs.enabled": bool(_unwrap(parsed.stebbs.enabled)),
+        "stebbs.parameters": int(_unwrap(parsed.stebbs.parameters)),
+        "stebbs.capacitance": int(_unwrap(parsed.stebbs.capacitance)),
+        "stebbs.setpoint": int(_unwrap(parsed.stebbs.setpoint)),
+        "stebbs.same_albedo_wall": int(_unwrap(parsed.stebbs.same_albedo_wall)),
+        "stebbs.same_albedo_roof": int(_unwrap(parsed.stebbs.same_albedo_roof)),
+        "stebbs.same_emissivity_wall": int(
+            _unwrap(parsed.stebbs.same_emissivity_wall)
+        ),
+        "stebbs.same_emissivity_roof": int(
+            _unwrap(parsed.stebbs.same_emissivity_roof)
+        ),
+    } == {
+        "net_radiation": 3,
+        "emissions": 2,
+        "storage_heat": 1,
+        "ohm_inc_qf": 0,
+        "roughness_length_momentum": 1,
+        "roughness_length_heat": 2,
+        "stability": 3,
+        "soil_moisture_deficit": 0,
+        "water_use": 0,
+        "roughness_sublayer": 2,
+        "frontal_area_index": 0,
+        "roughness_sublayer_level": 1,
+        "surface_conductance": 2,
+        "laimethod": 1,
+        "snow_use": 0,
+        "stebbs.enabled": False,
+        "stebbs.parameters": 1,
+        "stebbs.capacitance": 0,
+        "stebbs.setpoint": 0,
+        "stebbs.same_albedo_wall": 0,
+        "stebbs.same_albedo_roof": 0,
+        "stebbs.same_emissivity_wall": 0,
+        "stebbs.same_emissivity_roof": 0,
+    }
+
+
+def test_storage_heat_owns_ohm_inc_qf_nested_axis():
+    phys = ModelPhysics(storage_heat={"ohm": {"include_qf": True}})
+
+    assert int(_unwrap(phys.storage_heat)) == 1
+    assert int(_unwrap(phys.ohm_inc_qf)) == 1
+
+
+def test_storage_heat_scheme_scoped_include_qf_accepts_yes_no():
+    phys = ModelPhysics(storage_heat={"ohm": {"include_qf": "no"}})
+
+    assert int(_unwrap(phys.storage_heat)) == 1
+    assert int(_unwrap(phys.ohm_inc_qf)) == 0
+
+
+def test_storage_heat_legacy_nested_ohm_inc_qf_stays_accepted():
+    phys = ModelPhysics(storage_heat={"scheme": "ohm", "ohm_inc_qf": "include"})
+
+    assert int(_unwrap(phys.storage_heat)) == 1
+    assert int(_unwrap(phys.ohm_inc_qf)) == 1
+
+
+def test_storage_heat_nested_ohm_inc_qf_rejects_flat_duplicate():
+    with pytest.raises(ValidationError, match="storage_heat\\.ohm\\.include_qf"):
+        ModelPhysics(
+            storage_heat={"ohm": {"include_qf": False}},
+            ohm_inc_qf="include",
+        )
+
+
+def test_storage_heat_scheme_scoped_qf_rejects_sibling_scheme():
+    with pytest.raises(
+        ValidationError,
+        match="storage_heat\\.ohm.*cannot be combined",
+    ):
+        ModelPhysics(storage_heat={"ohm": {"include_qf": False}, "anohm": {}})
+
+
+def test_storage_heat_invalid_nested_qf_is_not_partially_folded():
+    data = {
+        "model": {
+            "physics": {
+                "storage_heat": {
+                    "ohm": {
+                        "include_qf": False,
+                        "unexpected": True,
+                    },
+                }
+            }
+        }
+    }
+    expected = yaml.safe_load(yaml.safe_dump(data))
+
+    flatten_physics_in_config(data)
+
+    assert data == expected
 
 
 def test_model_physics_accepts_orthogonal_spartacus():

--- a/test/data_model/test_physics_orthogonal.py
+++ b/test/data_model/test_physics_orthogonal.py
@@ -101,13 +101,13 @@ def test_sample_config_prefers_nested_readable_physics_defaults():
         "roughness_length_momentum": "fixed",
         "roughness_length_heat": "K09",
         "stability": "CN98",
-        "soil_moisture_deficit": "model",
-        "water_use": "model",
+        "soil_moisture_deficit": "modelled",
+        "water_use": "modelled",
         "roughness_sublayer": "variable",
         "frontal_area_index": "observed",
         "roughness_sublayer_level": "basic",
         "surface_conductance": "W16",
-        "leaf_area_index": "model",
+        "leaf_area_index": "modelled",
         "snow": "disabled",
     }
     assert physics["stebbs"] == {


### PR DESCRIPTION
## Summary

- replace numeric `model.physics` selector defaults in `sample_config.yml` with accepted readable values, public key aliases, and nested forms where that clarifies ownership
- use scheme-scoped nested examples for options owned by a specific family: `net_radiation.narp.ldown` and `storage_heat.ohm.include_qf`
- use citation-style aliases for literature-backed scheme values in the public sample (`J11`, `K09`, `CN98`, `W16`)
- standardise source-choice readable tokens on `observed` / `modelled`, including LAI, FAI, water use, and SMD
- preserve legacy internal/Fortran-facing fields by folding the new public spellings back to existing model fields in both Python and the Rust YAML bridge, with `leaf_area_index`/`snow` aliases scoped to `model.physics` so site `properties.snow` is preserved
- keep raw validation helpers aligned with Pydantic/Rust for `storage_heat.ohm.include_qf`, including `storage_heat_method` and `storageheatmethod` aliases

## Naming Decisions

- `leaf_area_index` is accepted and shown publicly, folding to the existing internal `laimethod` field; its model-derived option is now `modelled`, and `calculated` / `model` are not retained as readable public tokens.
- `snow` is accepted and shown publicly, folding to the existing internal `snow_use` field.
- Source-choice physics switches use `observed` and `modelled` where the option is about whether a quantity is supplied or internally derived.
- `soil_moisture_deficit` exposes only `modelled` and `observed` as readable public names. The historical numeric SMD code `2` remains an internal compatibility path while the water/soil-moisture unit unification work in #1422/#1447 is settled, but `observed_volumetric` / `observed_gravimetric` are not exposed as new readable YAML names.
- `frontal_area_index` now shows `observed` for the current provided-input default, and accepts `modelled` for the simple internally derived option. Existing aliases `provided`, `use_provided`, and `simple_scheme` remain accepted.
- `stebbs.parameter_source` is accepted and shown publicly, folding to `stebbs.parameters`.
- Literature-backed scheme choices use citation tokens in the sample where registered aliases already exist: `J11`, `K09`, `CN98`, `W16`.
- `roughness_sublayer: variable` stays as-is because the registered citation token `T19` maps to the different RST option/code 1, not the current variable/code 2 default.

Closes #1483.
Refs #1482.
Refs #1481.
Refs #1422.
Refs #1447.

## Validation

Latest head `4afb6f9cff`:

- `uv run python -m pytest test/data_model/test_field_renames.py test/data_model/test_physics_families.py test/data_model/test_physics_orthogonal.py -q` -> 241 passed
- `uv run python scripts/lint/check_rust_yaml_aliases.py`
- `uv run ruff check src/supy/data_model/core/field_renames.py test/data_model/test_field_renames.py src/supy/data_model/core/physics_families.py test/data_model/test_physics_families.py test/data_model/test_physics_orthogonal.py --select F,E9,I001`
- `rustfmt --check src/suews_bridge/src/field_renames.rs`
- `git diff --check`
- `uv run suews validate --dry-run --format json src/supy/sample_data/sample_config.yml`
- `uv run suews inspect src/supy/sample_data/sample_config.yml --format json`
- Direct raw-helper probe: `storage_heat`, `storage_heat_method`, and `storageheatmethod` all read `storage_heat.ohm.include_qf: false` as `storage_heat=1`, `ohm_inc_qf=0`
- GitHub required checks: schema version audit, Rust/Python registry parity, and knowledge-pack freshness all pass on `4afb6f9cff`

Review iteration:

- Independent Codex review initially found two P2 issues: Rust public `leaf_area_index` alias token collapse before legacy rename, and raw validation for `storage_heat.ohm.include_qf`. Both were fixed.
- Independent Codex re-review found one remaining P2 alias gap for `storage_heat_method` / `storageheatmethod`; fixed and re-reviewed clean on `4afb6f9cff`.
- Local Claude review was attempted with a raised timeout on the latest head but remained non-responsive and produced no usable review result; it is not counted as approval. Proceeding under the explicit fallback rule for non-responsive Claude with the clean Codex/native review path.

Earlier validation on this PR also covered:

- `uv run python -m pytest test/data_model/test_physics_orthogonal.py test/data_model/test_physics_families.py -q`
- `uv run python -m pytest test/data_model/test_field_renames.py test/data_model/test_physics_orthogonal.py test/data_model/test_physics_families.py -q`
- `uv run python -m pytest test/cmd/test_validate_config.py::test_validate_sample_config_emits_envelope test/data_model/test_to_yaml_roundtrip.py test/data_model/test_from_yaml_errors.py::TestFromYamlDriftHints::test_valid_yaml_still_parses -q`

Attempted but local-environment blocked:

- `cargo test field_renames --lib` from `src/suews_bridge` fails in the build script before Rust tests because `gfortran` cannot find `module_type_hydro.mod` while compiling `c_api/hydro_state.f95`.
