### PR TITLE
ci(docs-sync): skip off-master tags gracefully

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -5,10 +5,11 @@ name: Sync rtd branch from master
 # directly from the pre-built HTML — no source compilation needed.
 # Branch is named `rtd` (not `docs`) to avoid ref conflict with existing docs/* branches.
 #
-# Release (versioned) docs are handled separately by docs-release.yml, which
-# builds at the clean CalVer tag and publishes to the `release` branch. This
-# workflow no longer creates `rtd/<tag>` tags (they produced ugly `rtd-*` RTD
-# slugs and dev-tainted version strings).
+# Release (versioned) docs are published by moving the release tag onto an
+# off-master docs commit that Read the Docs builds directly (see
+# dev-ref/RELEASE_MANUAL.md) — so the RTD switcher shows the clean version
+# number and native `stable` tracks the highest tag. This workflow does not
+# create `rtd/<tag>` tags.
 
 on:
   push:

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -35,7 +35,43 @@ permissions:
   issues: write
 
 jobs:
+  # ------------------------------------------------------------------
+  # Guard: on a tag push, proceed only if the tag is on master.
+  # Off-master tags are skipped GRACEFULLY (not failed) so they don't
+  # redden CI. This is expected for a release tag deliberately moved
+  # onto an off-master docs commit (see RELEASE_MANUAL.md) — RTD builds
+  # that tag directly; docs-sync has nothing to do for it.
+  # ------------------------------------------------------------------
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: check
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "${REF_TYPE}" != "tag" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch origin master 2>/dev/null || true
+          if git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/master; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Tag ${TAG_NAME} not on master — skipping docs sync (expected for a release tag moved onto a docs commit)"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   sync:
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: rtd-sync
@@ -49,20 +85,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
-
-      # ------------------------------------------------------------------
-      # 1a. Verify tag is on master (skip docs sync for non-master tags)
-      # ------------------------------------------------------------------
-      - name: Verify tag is on master
-        if: github.ref_type == 'tag'
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          git fetch origin master --depth=50
-          if ! git merge-base --is-ancestor $GITHUB_SHA refs/remotes/origin/master; then
-            echo "::error::Tag ${TAG_NAME} not on master — skipping docs sync"
-            exit 1
-          fi
 
       # ------------------------------------------------------------------
       # 2. Configure git identity


### PR DESCRIPTION
## Why

We're moving to the established "move the release tag onto an off-master docs commit" model for publishing/revising RTD docs of a release (the same approach used for `2026.1.28`). When a CalVer tag sits off-master, `docs-sync.yml`'s `Verify tag is on master` step did `exit 1` → a red CI run, even though docs-sync has nothing to do for such a tag.

## Change

- Move the on-master check into a small `guard` job that outputs `proceed`.
- `sync` now runs only when `needs.guard.outputs.proceed == 'true'`.
- Off-master tag pushes **skip gracefully** with a `::warning::` (mirroring `build-publish_to_pypi.yml`'s `verify-release-tag` job, which already skips off-master tags). Master pushes are unaffected.

Prep for the upcoming `2026.4.3` docs fix (moving its tag onto a docs commit so RTD shows a clean numbered version + native `stable`). A separate PR retires the `release`-branch pipeline from #1480.