### PR TITLE
Expose physics selectors in inspect output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 76 | 83 | 30 | 81 | 40 | 311 |
+| 2026 | 77 | 83 | 30 | 81 | 40 | 312 |
 | 2025 | 60 | 68 | 22 | 71 | 36 | 256 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
@@ -55,6 +55,11 @@ EXAMPLES:
 ## 2026
 
 ### 1 Jun 2026
+
+- [feature][experimental] Expose active physics selectors in `suews inspect` output (#1484)
+  - `suews inspect --format json` now includes a structured `physics` block so CLI/MCP clients and AI agents can see each active `model.physics` selector, its numeric code, and accepted readable names without re-deriving them from schema internals
+  - The inspect surface uses public-facing keys such as `leaf_area_index`, `snow`, and `stebbs.parameter_source`, while carrying `internal_key` for the long-standing Fortran-facing names where useful
+  - `storage_heat.ohm.include_qf` is reported under the active OHM storage-heat branch rather than as a top-level `ohm_inc_qf` selector, and is hidden when OHM is not selected
 
 - [feature][experimental] Advertise readable sample-config physics defaults with nested orthogonal groupings (#1483)
   - `model.physics.storage_heat.ohm.include_qf` now represents the OHM QF inclusion choice under the storage heat selector in the sample config, while legacy flat `ohm_inc_qf` input remains accepted and normalised to the existing Fortran-facing state

--- a/src/supy/cmd/inspect_config.py
+++ b/src/supy/cmd/inspect_config.py
@@ -20,6 +20,15 @@ from typing import Any, Dict, List, Optional
 
 import click
 
+from ..data_model.core.physics_families import (
+    MODEL_PHYSICS_ENUM_FIELDS,
+    STEBBS_PHYSICS_ENUM_FIELDS,
+    accepted_physics_names,
+    canonical_physics_name,
+    preferred_physics_name,
+    public_model_physics_key,
+    public_stebbs_physics_key,
+)
 from .json_envelope import EXIT_USER_ERROR, Envelope, _now_iso, silent_supy_logger
 
 # Names of surface-cover sub-objects on ``LandCover`` — kept as a fixed list
@@ -52,6 +61,98 @@ def _ref_value(value: Any) -> Any:
     if isinstance(value, dict) and "value" in value:
         return value["value"]
     return value
+
+
+def _physics_code(value: Any) -> Optional[int]:
+    """Return an integer physics code from a dumped RefValue-like object."""
+    code = _ref_value(value)
+    if hasattr(code, "value"):
+        code = code.value
+    if isinstance(code, bool):
+        return int(code)
+    if isinstance(code, int):
+        return code
+    if isinstance(code, float) and code.is_integer():
+        return int(code)
+    return None
+
+
+def _selector_summary(field_name: str, value: Any) -> Dict[str, Any]:
+    """Build an agent-facing summary for one physics selector."""
+    code = _physics_code(value)
+    accepted = accepted_physics_names(field_name)
+    canonical = (
+        canonical_physics_name(field_name, code) if code is not None else None
+    )
+    selected = preferred_physics_name(field_name, code) if code is not None else None
+    summary: Dict[str, Any] = {
+        "code": code,
+        "selected": selected,
+        "accepted_names": list(accepted),
+    }
+    if (
+        canonical is not None
+        and selected is not None
+        and selected.lower() != canonical.lower()
+    ):
+        summary["canonical_name"] = canonical
+    if canonical is None and selected is not None:
+        summary["selected_name_is_lossy"] = True
+    return summary
+
+
+def _physics_summary(model_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Expose active ``model.physics`` selectors using public YAML names."""
+    physics_data = model_data.get("physics", {}) or {}
+    if not isinstance(physics_data, dict):
+        return {}
+
+    out: Dict[str, Any] = {}
+
+    for field_name in MODEL_PHYSICS_ENUM_FIELDS:
+        if field_name == "ohm_inc_qf" or field_name not in physics_data:
+            continue
+        public_name = public_model_physics_key(field_name)
+        summary = _selector_summary(field_name, physics_data[field_name])
+        if public_name != field_name:
+            summary["internal_key"] = field_name
+        out[public_name] = summary
+
+    ohm_inc_qf = physics_data.get("ohm_inc_qf")
+    storage_summary = out.get("storage_heat")
+    if (
+        ohm_inc_qf is not None
+        and isinstance(storage_summary, dict)
+        and storage_summary.get("code") == 1
+    ):
+        include_code = _physics_code(ohm_inc_qf)
+        storage_summary["ohm"] = {
+            "include_qf": bool(include_code) if include_code is not None else None,
+            "include_qf_code": include_code,
+            "include_qf_selected": preferred_physics_name(
+                "ohm_inc_qf", include_code
+            )
+            if include_code is not None
+            else None,
+            "include_qf_accepted_names": list(accepted_physics_names("ohm_inc_qf")),
+        }
+
+    stebbs_data = physics_data.get("stebbs")
+    if isinstance(stebbs_data, dict):
+        stebbs_out: Dict[str, Any] = {
+            "enabled": bool(_ref_value(stebbs_data.get("enabled"))),
+        }
+        for field_name in STEBBS_PHYSICS_ENUM_FIELDS:
+            if field_name not in stebbs_data:
+                continue
+            public_name = public_stebbs_physics_key(field_name)
+            summary = _selector_summary(field_name, stebbs_data[field_name])
+            if public_name != field_name:
+                summary["internal_key"] = field_name
+            stebbs_out[public_name] = summary
+        out["stebbs"] = stebbs_out
+
+    return out
 
 
 def _site_summary(site_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -203,6 +304,39 @@ def _build_text_message(data: Dict[str, Any], list_warnings: List[str]) -> str:
     lines.append("Forcing file: %s" % forcing.get("file"))
     if forcing.get("n_columns") is not None:
         lines.append("  columns: %d" % forcing["n_columns"])
+    physics = data.get("physics") or {}
+    if physics:
+        lines.append("")
+        lines.append("Physics selectors:")
+        for field_name, summary in physics.items():
+            if field_name == "stebbs":
+                lines.append("  stebbs.enabled: %s" % summary.get("enabled"))
+                for nested_name, nested_summary in summary.items():
+                    if nested_name == "enabled":
+                        continue
+                    lines.append(
+                        "  stebbs.%-18s %s (%s)"
+                        % (
+                            nested_name + ":",
+                            nested_summary.get("selected"),
+                            nested_summary.get("code"),
+                        )
+                    )
+                continue
+            lines.append(
+                "  %-28s %s (%s)"
+                % (
+                    field_name + ":",
+                    summary.get("selected"),
+                    summary.get("code"),
+                )
+            )
+            ohm = summary.get("ohm")
+            if isinstance(ohm, dict):
+                lines.append(
+                    "  storage_heat.ohm.include_qf: %s (%s)"
+                    % (ohm.get("include_qf_selected"), ohm.get("include_qf_code"))
+                )
     if list_warnings:
         lines.append("")
         lines.append("Warnings:")
@@ -292,6 +426,7 @@ def inspect_config_cmd(config_path: str, output_format: str) -> None:
 
     model_data = config_dict.get("model", {}) or {}
     forcing_summary = _forcing_summary(model_data, path_config.resolve().parent)
+    physics_summary = _physics_summary(model_data)
 
     schema_version = config_dict.get("schema_version")
 
@@ -301,6 +436,7 @@ def inspect_config_cmd(config_path: str, output_format: str) -> None:
         "sites": list_sites,
         "surface_cover_fraction": surface_cover_fraction,
         "forcing_summary": forcing_summary,
+        "physics": physics_summary,
         "derived": {},
         "warnings": list_warnings,
     }

--- a/src/supy/data_model/core/physics_families.py
+++ b/src/supy/data_model/core/physics_families.py
@@ -27,6 +27,7 @@ from collections.abc import Mapping
 from contextlib import suppress
 from enum import Enum
 from numbers import Integral, Real
+import re
 from typing import Any
 
 from .physics_orthogonal import coerce_orthogonal_to_flat, fold_storage_heat_ohm_inc_qf
@@ -249,6 +250,60 @@ def _build_lookup_tables() -> tuple[
 
 
 _CODE_TO_CANONICAL, _ALIAS_TO_CODE = _build_lookup_tables()
+_CITATION_ALIAS_RE = re.compile(r"^[a-z]{1,3}\d{2}$")
+_CITATION_PREFERRED_FIELDS = frozenset(
+    {
+        "emissions",
+        "roughness_length_momentum",
+        "roughness_length_heat",
+        "stability",
+        "surface_conductance",
+    }
+)
+_COMPATIBILITY_DISPLAY_NAMES = {
+    ("soil_moisture_deficit", 2): "observed",
+}
+_PHYSICS_CANONICAL_TO_PUBLIC = {
+    canonical_name: public_name
+    for public_name, canonical_name in PHYSICS_PUBLIC_KEY_ALIASES.items()
+}
+_STEBBS_CANONICAL_TO_PUBLIC = {
+    canonical_name: public_name
+    for public_name, canonical_name in STEBBS_PUBLIC_KEY_ALIASES.items()
+}
+
+
+def accepted_physics_names(field_name: str) -> tuple[str, ...]:
+    """Return registered readable names accepted for one physics selector."""
+    return tuple(sorted(_ALIAS_TO_CODE.get(field_name, ())))
+
+
+def canonical_physics_name(field_name: str, code: int) -> str | None:
+    """Return the canonical readable name for a physics selector code."""
+    return _CODE_TO_CANONICAL.get(field_name, {}).get(int(code))
+
+
+def preferred_physics_name(field_name: str, code: int) -> str | None:
+    """Return the preferred public readable name for a physics selector code."""
+    code_int = int(code)
+    if (field_name, code_int) in _COMPATIBILITY_DISPLAY_NAMES:
+        return _COMPATIBILITY_DISPLAY_NAMES[(field_name, code_int)]
+    if field_name in _CITATION_PREFERRED_FIELDS:
+        table = _ALIAS_TO_CODE.get(field_name, {})
+        for name, alias_code in table.items():
+            if alias_code == code_int and _CITATION_ALIAS_RE.match(name):
+                return name.upper()
+    return canonical_physics_name(field_name, code_int)
+
+
+def public_model_physics_key(field_name: str) -> str:
+    """Return the preferred public key for a top-level ModelPhysics field."""
+    return _PHYSICS_CANONICAL_TO_PUBLIC.get(field_name, field_name)
+
+
+def public_stebbs_physics_key(field_name: str) -> str:
+    """Return the preferred public key for a nested STEBBS physics field."""
+    return _STEBBS_CANONICAL_TO_PUBLIC.get(field_name, field_name)
 
 
 def fold_public_physics_key_aliases(values: dict, class_name: str) -> dict:

--- a/test/cmd/test_inspect_config.py
+++ b/test/cmd/test_inspect_config.py
@@ -54,6 +54,28 @@ def test_inspect_sample_config_returns_surface_fractions_summing_to_one() -> Non
     assert data["forcing_summary"]["n_columns"] == 24
     assert data["forcing_summary"]["columns"][0] == "iy"
 
+    physics = data["physics"]
+    assert physics["net_radiation"]["code"] == 3
+    assert physics["net_radiation"]["selected"] == "ldown_air"
+    assert "ldown_air" in physics["net_radiation"]["accepted_names"]
+    assert physics["emissions"]["selected"] == "J11"
+    assert "canonical_name" not in physics["emissions"]
+    assert physics["storage_heat"]["selected"] == "ohm"
+    assert physics["roughness_length_heat"]["selected"] == "K09"
+    assert physics["stability"]["selected"] == "CN98"
+    assert physics["surface_conductance"]["selected"] == "W16"
+    assert physics["surface_conductance"]["canonical_name"] == "ward"
+    assert "ohm_inc_qf" not in physics
+    storage_ohm = physics["storage_heat"]["ohm"]
+    assert storage_ohm["include_qf_selected"] == "exclude"
+    assert storage_ohm["include_qf"] is False
+    assert physics["leaf_area_index"]["internal_key"] == "laimethod"
+    assert physics["leaf_area_index"]["selected"] == "modelled"
+    assert physics["snow"]["internal_key"] == "snow_use"
+    assert physics["snow"]["selected"] == "disabled"
+    assert physics["stebbs"]["parameter_source"]["internal_key"] == "parameters"
+    assert physics["stebbs"]["parameter_source"]["selected"] == "default"
+
     fractions = data["surface_cover_fraction"]
     assert set(fractions) == {
         "paved",
@@ -103,6 +125,103 @@ def test_inspect_list_forcing_reports_each_file(tmp_path: Path) -> None:
     assert [item["n_columns"] for item in summary["files"]] == [24, 24]
 
 
+def test_inspect_only_reports_ohm_qf_axis_when_ohm_is_selected() -> None:
+    """OHMIncQF stays hidden unless storage_heat is actually OHM."""
+    from supy.cmd.inspect_config import _physics_summary
+
+    physics = _physics_summary(
+        {
+            "physics": {
+                "storage_heat": {"value": 5},
+                "ohm_inc_qf": {"value": 0},
+            }
+        }
+    )
+
+    assert physics["storage_heat"]["selected"] == "ehc"
+    assert "ohm" not in physics["storage_heat"]
+
+
+def test_inspect_reports_ohm_qf_include_branch() -> None:
+    """The OHM-owned QF axis reports the true/include case directly."""
+    from supy.cmd.inspect_config import _physics_summary
+
+    physics = _physics_summary(
+        {
+            "physics": {
+                "storage_heat": {"value": 1},
+                "ohm_inc_qf": {"value": 1},
+            }
+        }
+    )
+
+    ohm = physics["storage_heat"]["ohm"]
+    assert ohm["include_qf"] is True
+    assert ohm["include_qf_code"] == 1
+    assert ohm["include_qf_selected"] == "include"
+
+
+def test_inspect_handles_missing_physics_block() -> None:
+    """The new physics envelope key remains stable when physics is absent."""
+    from supy.cmd.inspect_config import _physics_summary
+
+    assert _physics_summary({}) == {}
+
+
+def test_inspect_unwraps_stebbs_enabled_refvalue() -> None:
+    """STEBBS enabled must unwrap RefValue-like dicts before bool conversion."""
+    from supy.cmd.inspect_config import _physics_summary
+
+    physics = _physics_summary(
+        {
+            "physics": {
+                "stebbs": {
+                    "enabled": {"value": False, "ref": {"DOI": "10.test/ref"}},
+                },
+            }
+        }
+    )
+
+    assert physics["stebbs"]["enabled"] is False
+
+
+def test_inspect_labels_smd_numeric_compatibility_code() -> None:
+    """SMD code 2 remains readable as the unified observed source choice."""
+    from supy.cmd.inspect_config import _physics_summary
+
+    physics = _physics_summary(
+        {
+            "physics": {
+                "soil_moisture_deficit": {"value": 2},
+            }
+        }
+    )
+
+    smd = physics["soil_moisture_deficit"]
+    assert smd["code"] == 2
+    assert smd["selected"] == "observed"
+    assert smd["selected_name_is_lossy"] is True
+    assert smd["accepted_names"] == ["modelled", "observed"]
+
+
+def test_inspect_distinguishes_smd_observed_codes() -> None:
+    """SMD observed codes share a public name but code 2 is marked lossy."""
+    from supy.cmd.inspect_config import _physics_summary
+
+    physics = _physics_summary(
+        {
+            "physics": {
+                "soil_moisture_deficit": {"value": 1},
+            }
+        }
+    )
+
+    smd = physics["soil_moisture_deficit"]
+    assert smd["code"] == 1
+    assert smd["selected"] == "observed"
+    assert "selected_name_is_lossy" not in smd
+
+
 def test_inspect_top_level_command_metadata_is_not_duplicated() -> None:
     """The unified ``suews inspect`` path records the command once."""
     from supy.cmd.suews_cli import cli
@@ -131,6 +250,9 @@ def test_inspect_text_format_prints_overview() -> None:
     assert result.exit_code == 0, result.output
     assert "Configuration:" in result.output
     assert "Sites" in result.output
+    assert "Physics selectors:" in result.output
+    assert "leaf_area_index:" in result.output
+    assert "storage_heat.ohm.include_qf:" in result.output
 
 
 def test_inspect_invalid_yaml_returns_error_envelope(tmp_path: Path) -> None:

--- a/test/cmd/test_validate_physics_names.py
+++ b/test/cmd/test_validate_physics_names.py
@@ -1,0 +1,53 @@
+"""Regression tests for readable physics-name validation diagnostics."""
+
+from __future__ import annotations
+
+from importlib.resources import files
+import json
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+import pytest
+import yaml
+
+pytestmark = pytest.mark.api
+
+
+def _load_sample_dict() -> dict[str, Any]:
+    resource = files("supy").joinpath("sample_data", "sample_config.yml")
+    if not resource.is_file():
+        pytest.skip(f"Sample config not available at {resource}")
+    return yaml.safe_load(resource.read_text(encoding="utf-8"))
+
+
+def test_validate_unknown_physics_name_lists_readable_names(tmp_path: Path) -> None:
+    """Readable physics-name errors list accepted agent-facing aliases."""
+    from supy.cmd.validate_config import cli as validate_cli
+
+    payload = _load_sample_dict()
+    payload["model"]["physics"]["surface_conductance"] = "not_a_scheme"
+    config_path = tmp_path / "bad_physics_name.yml"
+    config_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False), encoding="utf-8"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        validate_cli,
+        [
+            "--pipeline",
+            "ABC",
+            "--dry-run",
+            "--format",
+            "json",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    envelope = json.loads(result.stdout)
+    messages = "\n".join(error.get("message", "") for error in envelope["errors"])
+    assert "valid names" in messages
+    assert "w16" in messages
+    assert "ward" in messages

--- a/test/data_model/test_physics_families.py
+++ b/test/data_model/test_physics_families.py
@@ -255,6 +255,30 @@ class TestCoerceScalarNames:
         with pytest.raises(ValueError, match="campbell_norman"):
             coerce_nested_to_flat("stability", "bogus")
 
+    def test_registry_exposes_agent_facing_names(self):
+        from supy.data_model.core.physics_families import (
+            accepted_physics_names,
+            canonical_physics_name,
+            preferred_physics_name,
+            public_model_physics_key,
+            public_stebbs_physics_key,
+        )
+
+        assert canonical_physics_name("surface_conductance", 2) == "ward"
+        assert preferred_physics_name("surface_conductance", 2) == "W16"
+        assert preferred_physics_name("roughness_length_heat", 2) == "K09"
+        assert preferred_physics_name("stability", 3) == "CN98"
+        assert preferred_physics_name("laimethod", 1) == "modelled"
+        assert preferred_physics_name("storage_heat", 3) == "anohm"
+        assert preferred_physics_name("storage_heat", 4) == "estm"
+        assert preferred_physics_name("storage_heat", 6) == "dyohm"
+        assert preferred_physics_name("roughness_sublayer", 1) == "rst"
+        assert preferred_physics_name("soil_moisture_deficit", 2) == "observed"
+        assert "w16" in accepted_physics_names("surface_conductance")
+        assert public_model_physics_key("laimethod") == "leaf_area_index"
+        assert public_model_physics_key("snow_use") == "snow"
+        assert public_stebbs_physics_key("parameters") == "parameter_source"
+
 
 class TestReadableNamesInModels:
     def test_model_physics_accepts_top_level_readable_names(self):

--- a/test/mcp/test_real_cli_smoke.py
+++ b/test/mcp/test_real_cli_smoke.py
@@ -11,8 +11,8 @@ checkouts that have not run ``make dev`` legitimately do not have it.
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
+import shutil
 
 import pytest
 
@@ -68,6 +68,30 @@ def test_validate_sample_config_succeeds() -> None:
             f"Meta block missing required field {required!r}. "
             f"Got keys: {sorted(meta.keys())}"
         )
+
+
+@pytestmark_skipif
+def test_inspect_sample_config_reports_physics_methods() -> None:
+    """MCP inspect_config exposes active physics selectors for agents."""
+    from suews_mcp.tools import inspect_config
+
+    config_path = REPO_ROOT / "src" / "supy" / "sample_data" / "sample_config.yml"
+    assert config_path.exists(), (
+        f"Sample config missing at {config_path}. "
+        "Has src/supy/sample_data/ been moved?"
+    )
+
+    envelope = inspect_config(
+        str(config_path),
+        project_root=str(REPO_ROOT),
+    )
+
+    assert envelope["status"] in {"success", "warning"}, envelope
+    physics = (envelope.get("data") or {}).get("physics") or {}
+    assert physics["storage_heat"]["selected"] == "ohm"
+    assert physics["storage_heat"]["ohm"]["include_qf"] is False
+    assert physics["leaf_area_index"]["selected"] == "modelled"
+    assert physics["surface_conductance"]["selected"] == "W16"
 
 
 @pytestmark_skipif


### PR DESCRIPTION
## Summary

Closes #1484.
Refs #1482.

- Add registry helpers for accepted, canonical, preferred, and public physics selector names.
- Expose active `model.physics` selectors in `suews inspect --format json`, using public-facing keys such as `leaf_area_index`, `snow`, and `stebbs.parameter_source`.
- Keep `storage_heat.ohm.include_qf` represented as an OHM-owned sub-choice rather than leaking `ohm_inc_qf` as a top-level user-facing selector.
- Prefer citation-style selected names such as `J11`, `K09`, `CN98`, and `W16` in inspect output while still exposing accepted aliases.
- Keep acronym-style storage-heat/RSL selectors such as `anohm`, `estm`, `dyohm`, and `rst` as the preferred inspect labels.
- Mark SMD numeric compatibility code 2 as `selected_name_is_lossy` while presenting the unified public source choice `observed`.
- Add a changelog entry for the new CLI/MCP-facing inspect surface.

## Validation

- `uv run python -m pytest test/cmd/test_inspect_config.py test/cmd/test_validate_physics_names.py test/data_model/test_physics_families.py test/mcp/test_real_cli_smoke.py::test_inspect_sample_config_reports_physics_methods -q`
- `uv run ruff check src/supy/cmd/inspect_config.py src/supy/data_model/core/physics_families.py test/cmd/test_inspect_config.py test/cmd/test_validate_physics_names.py test/data_model/test_physics_families.py test/mcp/test_real_cli_smoke.py --select F,E9,I001`
- `uv run python scripts/lint/check_rust_yaml_aliases.py`
- `uv run suews validate --dry-run --format json src/supy/sample_data/sample_config.yml`
- `uv run suews inspect src/supy/sample_data/sample_config.yml --format json`

## Review gate

- Independent Codex review found one SMD compatibility-code issue; fixed and re-reviewed clean at final HEAD.
- Claude review found one `stebbs.enabled` RefValue unwrap issue plus low-risk shape/test comments; fixed and final Claude re-review returned no findings.
