### PR TITLE
Reject mixed nested physics family values

### DIFF
--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -1497,10 +1497,10 @@ fn collapse_nested_physics(root: &mut Value) -> Result<(), String> {
 
             let inner_foreign: Vec<String> = inner_map
                 .iter()
-                .filter_map(|(k, _)| {
-                    k.as_str()
-                        .filter(|s| *s != "value" && *s != "ref")
-                        .map(|s| s.to_string())
+                .filter_map(|(k, _)| match k.as_str() {
+                    Some("value" | "ref") => None,
+                    Some(s) => Some(s.to_string()),
+                    None => Some(format!("{k:?}")),
                 })
                 .collect();
             if !inner_foreign.is_empty() {
@@ -2670,6 +2670,15 @@ model:
         let mut root: Value = from_str(yaml).unwrap();
         let err = normalize_field_names(&mut root).expect_err("inner foreign key must fail");
         assert!(err.contains("inner keys"), "error was: {err}");
+    }
+
+    #[test]
+    fn nested_family_rejects_non_string_inner_foreign_keys() {
+        let yaml = "model:\n  physics:\n    storage_heat:\n      ohm:\n        value: 1\n        42: false\n";
+        let mut root: Value = from_str(yaml).unwrap();
+        let err = normalize_field_names(&mut root).expect_err("inner foreign key must fail");
+        assert!(err.contains("inner keys"), "error was: {err}");
+        assert!(err.contains("Number(42)"), "error was: {err}");
     }
 
     #[test]

--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -1249,7 +1249,7 @@ fn fold_storage_heat_ohm_inc_qf(root: &mut Value) -> Result<(), String> {
                     .collect();
                 if !inner_foreign.is_empty() {
                     return Err(format!(
-                        "'storage_heat.ohm' cannot be combined with sibling keys {inner_foreign:?}."
+                        "'storage_heat.ohm' cannot be combined with inner keys {inner_foreign:?}."
                     ));
                 }
 
@@ -1494,6 +1494,20 @@ fn collapse_nested_physics(root: &mut Value) -> Result<(), String> {
                 .ok_or_else(|| {
                     format!("'{field_name}.{family}' must be a mapping with a 'value' key")
                 })?;
+
+            let inner_foreign: Vec<String> = inner_map
+                .iter()
+                .filter_map(|(k, _)| {
+                    k.as_str()
+                        .filter(|s| *s != "value" && *s != "ref")
+                        .map(|s| s.to_string())
+                })
+                .collect();
+            if !inner_foreign.is_empty() {
+                return Err(format!(
+                    "'{field_name}.{family}' cannot be combined with inner keys {inner_foreign:?}."
+                ));
+            }
 
             let code = match code_value {
                 Value::Number(n) => n.as_i64().ok_or_else(|| {
@@ -2648,6 +2662,14 @@ model:
         let mut root: Value = from_str(yaml).unwrap();
         let err = normalize_field_names(&mut root).expect_err("wrong family must fail");
         assert!(err.contains("expects one of"), "error was: {err}");
+    }
+
+    #[test]
+    fn nested_family_rejects_inner_foreign_keys() {
+        let yaml = "model:\n  physics:\n    storage_heat:\n      ohm:\n        value: 1\n        include_qf: false\n";
+        let mut root: Value = from_str(yaml).unwrap();
+        let err = normalize_field_names(&mut root).expect_err("inner foreign key must fail");
+        assert!(err.contains("inner keys"), "error was: {err}");
     }
 
     #[test]

--- a/src/supy/data_model/core/physics_families.py
+++ b/src/supy/data_model/core/physics_families.py
@@ -392,6 +392,14 @@ def _coerce_family_tag(field_name: str, value: Mapping[str, Any]) -> Any:
             f"(got {type(inner).__name__})."
         )
 
+    inner_foreign = [key for key in inner if key not in {"value", "ref"}]
+    if inner_foreign:
+        raise ValueError(
+            f"'{field_name}.{family}' cannot be combined with inner keys "
+            f"{inner_foreign}. Move scheme-owned sub-options outside the "
+            f"family value form."
+        )
+
     code = inner["value"]
     if isinstance(code, Mapping):
         raise ValueError(

--- a/src/supy/data_model/core/physics_orthogonal.py
+++ b/src/supy/data_model/core/physics_orthogonal.py
@@ -186,7 +186,7 @@ def _fold_storage_heat_ohm_block(
     inner_foreign = [key for key in ohm_block if key != "ref"]
     if inner_foreign:
         raise ValueError(
-            f"{class_name}: 'storage_heat.ohm' cannot be combined with sibling "
+            f"{class_name}: 'storage_heat.ohm' cannot be combined with inner "
             f"keys {sorted(inner_foreign)}."
         )
 

--- a/test/cmd/test_validate_config.py
+++ b/test/cmd/test_validate_config.py
@@ -297,6 +297,27 @@ def test_validate_single_file_rejects_negative_sfr(tmp_path: Path) -> None:
     assert errors, "expected at least one error for a negative sfr"
 
 
+def test_validate_single_file_rejects_storage_value_plus_nested_qf(
+    tmp_path: Path,
+) -> None:
+    """Malformed storage-heat family values must not be partially folded."""
+    from supy.cmd.validate_config import validate_single_file
+    from supy.data_model.schema.publisher import generate_json_schema
+
+    payload = _load_sample_dict()
+    payload["model"]["physics"]["storage_heat"] = {
+        "ohm": {"value": 1, "include_qf": False}
+    }
+    config_path = tmp_path / "bad_storage_heat.yml"
+    _write_yaml(config_path, payload)
+
+    schema = generate_json_schema()
+    is_valid, errors = validate_single_file(config_path, schema, show_details=True)
+
+    assert not is_valid
+    assert any("storage_heat.ohm" in error.message for error in errors), errors
+
+
 # ---------------------------------------------------------------------------
 # Critical-physics structural-presence — gh#1409
 # ---------------------------------------------------------------------------

--- a/test/data_model/test_field_renames.py
+++ b/test/data_model/test_field_renames.py
@@ -871,6 +871,12 @@ class TestRawDictCompatibility:
         assert read_physics_key(physics, "storage_heat") == 1
         assert read_physics_key(physics, "ohm_inc_qf") == 0
 
+    def test_read_physics_key_rejects_storage_value_plus_nested_qf(self):
+        physics = {"storage_heat": {"ohm": {"value": 1, "include_qf": False}}}
+
+        with pytest.raises(ValueError, match="storage_heat\\.ohm.*inner keys"):
+            read_physics_key(physics, "storage_heat")
+
     def test_legacy_analyze_config_methods_accepts_sample_config(self):
         path = Path(__file__).resolve().parents[2] / "src/supy/sample_data/sample_config.yml"
         config = yaml.safe_load(path.read_text(encoding="utf-8"))

--- a/test/data_model/test_physics_families.py
+++ b/test/data_model/test_physics_families.py
@@ -160,6 +160,10 @@ class TestCoerceErrorPaths:
                 {"ohm": {"value": 1, "include_qf": False}},
             )
 
+    def test_non_string_inner_foreign_key_rejected(self):
+        with pytest.raises(ValueError, match="inner keys"):
+            coerce_nested_to_flat("storage_heat", {"ohm": {"value": 1, 42: False}})
+
     def test_inner_value_not_integerlike_rejected(self):
         with pytest.raises(ValueError, match="must be an integer code"):
             coerce_nested_to_flat("net_radiation", {"narp": {"value": "abc"}})

--- a/test/data_model/test_physics_families.py
+++ b/test/data_model/test_physics_families.py
@@ -153,6 +153,13 @@ class TestCoerceErrorPaths:
         with pytest.raises(ValueError, match="must be a scalar numeric code"):
             coerce_nested_to_flat("net_radiation", {"narp": {"value": {"nested": 3}}})
 
+    def test_inner_foreign_key_rejected(self):
+        with pytest.raises(ValueError, match="inner keys"):
+            coerce_nested_to_flat(
+                "storage_heat",
+                {"ohm": {"value": 1, "include_qf": False}},
+            )
+
     def test_inner_value_not_integerlike_rejected(self):
         with pytest.raises(ValueError, match="must be an integer code"):
             coerce_nested_to_flat("net_radiation", {"narp": {"value": "abc"}})

--- a/test/data_model/test_physics_orthogonal.py
+++ b/test/data_model/test_physics_orthogonal.py
@@ -234,6 +234,31 @@ def test_storage_heat_invalid_nested_qf_is_not_partially_folded():
     assert data == expected
 
 
+def test_storage_heat_value_plus_nested_qf_is_not_partially_folded():
+    data = {
+        "model": {
+            "physics": {
+                "storage_heat": {
+                    "ohm": {
+                        "value": 1,
+                        "include_qf": False,
+                    },
+                }
+            }
+        }
+    }
+    expected = yaml.safe_load(yaml.safe_dump(data))
+
+    flatten_physics_in_config(data)
+
+    assert data == expected
+
+
+def test_storage_heat_value_plus_nested_qf_rejected_by_model():
+    with pytest.raises(ValidationError, match="storage_heat\\.ohm.*inner keys"):
+        ModelPhysics(storage_heat={"ohm": {"value": 1, "include_qf": False}})
+
+
 def test_model_physics_accepts_orthogonal_spartacus():
     phys = ModelPhysics(net_radiation={"scheme": "spartacus", "ldown": "cloud"})
     assert int(_unwrap(phys.net_radiation)) == 1002


### PR DESCRIPTION
## Summary

Closes #1485.
Refs #1482.

- Reject nested family-tag mappings that combine `value`/`ref` with additional inner keys, instead of silently dropping scheme-owned options during flattening.
- Align the storage_heat OHM diagnostic with the same `inner keys` wording when `value` is mixed with `include_qf`.
- Add Python, raw-dict, validate_config, and Rust bridge regression coverage for the storage_heat OHM `value` plus `include_qf` edge case.

## Validation

- `PYTHONPATH=src python3 -m pytest test/data_model/test_physics_families.py test/data_model/test_physics_orthogonal.py test/data_model/test_field_renames.py test/cmd/test_validate_config.py -q` -> 272 passed.
- `python3 scripts/lint/check_rust_yaml_aliases.py` -> OK.
- `python3 scripts/lint/check_test_markers.py` -> OK.
- `git diff --check` on touched files -> OK.
- `cargo test --manifest-path src/suews_bridge/Cargo.toml nested_family_rejects_inner_foreign_keys -- --nocapture` could not complete locally because the bridge build cannot find the generated Fortran module `module_type_hydro.mod`; CI should exercise the compiled bridge path.