### PR TITLE
Document physics method dependencies

### DIFF
--- a/docs/generate_datamodel_rst.py
+++ b/docs/generate_datamodel_rst.py
@@ -30,6 +30,23 @@ except ImportError:
 class RSTGenerator:
     """Generate RST documentation from extracted model documentation."""
 
+    RELATIONSHIP_REF_TARGETS = frozenset(
+        {
+            "net_radiation",
+            "emissions",
+            "storage_heat",
+            "ohm_inc_qf",
+            "roughness_length_momentum",
+            "roughness_length_heat",
+            "stability",
+            "roughness_sublayer",
+            "roughness_sublayer_level",
+            "surface_conductance",
+            "snow_use",
+            "stebbs",
+        }
+    )
+
     def __init__(self, doc_data: dict[str, Any]):
         """
         Initialize the RST generator with extracted documentation data.
@@ -165,6 +182,20 @@ class RSTGenerator:
             "method-code fields before SUEWS runs. Registered selector tokens are "
             "case-insensitive; citation-style choices are shown in their preferred "
             "case.",
+            "",
+            ".. rubric:: Method dependency graph",
+            "",
+            "The main method interactions are:",
+            "",
+            "- ``snow_use`` -> ``net_radiation`` -> ``storage_heat`` -> ``energy_balance``",
+            "- ``emissions`` -> ``ohm_inc_qf`` -> ``storage_heat``",
+            "- ``storage_heat`` -> ``stebbs`` -> ``stebbs.capacitance``",
+            "- ``roughness_length_momentum`` -> ``roughness_length_heat`` -> ``stability`` -> ``roughness_sublayer`` -> ``roughness_sublayer_level`` -> ``surface_conductance``",
+            "",
+            "Conditional compatibility checks enforce the critical branches: EHC "
+            "storage heat requires SPARTACUS net radiation, STEBBS storage heat "
+            "requires STEBBS enabled, and non-default STEBBS capacitance choices "
+            "require the STEBBS branch.",
             "",
             ".. list-table:: Net radiation",
             "   :header-rows: 1",
@@ -347,7 +378,7 @@ class RSTGenerator:
 
         # Add reference label for physics method fields with relationships
         # Note: diagmethod→rslmethod, localclimatemethod→rsllevel (legacy rename)
-        if field_name in {
+        if field_name in RSTGenerator.RELATIONSHIP_REF_TARGETS or field_name in {
             "stabilitymethod",
             "rslmethod",  # was diagmethod
             "rsllevel",  # was localclimatemethod
@@ -357,6 +388,17 @@ class RSTGenerator:
             lines.append("")
 
         return lines
+
+    @classmethod
+    def _format_relationship_targets(cls, targets: list[str]) -> str:
+        """Format relationship targets as RST refs only when labels exist."""
+        refs = []
+        for target in targets:
+            if target in cls.RELATIONSHIP_REF_TARGETS:
+                refs.append(f":ref:`{target} <{target}>`")
+            else:
+                refs.append(f"``{target}``")
+        return ", ".join(refs)
 
     @staticmethod
     def _format_field_description(field_doc: dict[str, Any]) -> list[str]:
@@ -513,13 +555,13 @@ class RSTGenerator:
             # Add depends_on
             depends = relationships.get("depends_on", [])
             if depends:
-                refs = ", ".join(f":ref:`{d} <{d}>`" for d in depends)
+                refs = self._format_relationship_targets(depends)
                 lines.append(f"      **Depends on:** {refs}")
 
             # Add provides_to
             provides = relationships.get("provides_to", [])
             if provides:
-                refs = ", ".join(f":ref:`{p} <{p}>`" for p in provides)
+                refs = self._format_relationship_targets(provides)
                 lines.append(f"      **Provides to:** {refs}")
 
         return lines

--- a/docs/source/inputs/tables/schema.json
+++ b/docs/source/inputs/tables/schema.json
@@ -7180,7 +7180,14 @@
             }
           ],
           "default": 3,
+          "depends_on": [
+            "snow_use"
+          ],
           "description": "Method for calculating net all-wave radiation (Q*). Options: 0 (OBSERVED) = Uses observed Q* values from forcing file; 1 (LDOWN_OBSERVED) = Models Q* using NARP (Net All-wave Radiation Parameterization; Offerle et al. 2003, Loridan et al. 2011) with observed longwave down radiation (L\u2193) from forcing file; 2 (LDOWN_CLOUD) = Models Q* using NARP with L\u2193 estimated from cloud cover fraction; 3 (LDOWN_AIR) = Models Q* using NARP with L\u2193 estimated from air temperature and relative humidity; 11 (LDOWN_SURFACE) = Surface temperature variant of method 1 (not recommended); 12 (LDOWN_CLOUD_SURFACE) = Surface temperature variant of method 2 (not recommended); 13 (LDOWN_AIR_SURFACE) = Surface temperature variant of method 3 (not recommended); 100 (LDOWN_ZENITH) = Zenith angle correction variant of method 1 (not recommended); 200 (LDOWN_CLOUD_ZENITH) = Zenith angle correction variant of method 2 (not recommended); 300 (LDOWN_AIR_ZENITH) = Zenith angle correction variant of method 3 (not recommended); 1001 (LDOWN_SS_OBSERVED) = SPARTACUS-Surface integration with observed L\u2193 (experimental); 1002 (LDOWN_SS_CLOUD) = SPARTACUS-Surface integration with L\u2193 from cloud fraction (experimental); 1003 (LDOWN_SS_AIR) = SPARTACUS-Surface integration with L\u2193 from air temperature/humidity (experimental)",
+          "note": "Values above 1000 activate SPARTACUS-Surface and provide facet radiation required by EHC storage heat.",
+          "provides_to": [
+            "storage_heat"
+          ],
           "title": "Net Radiation",
           "unit": "dimensionless"
         },
@@ -7195,6 +7202,11 @@
           ],
           "default": 2,
           "description": "Method for calculating anthropogenic heat flux (QF) and CO2 emissions. Options: 0 (OBSERVED) = Uses observed QF values from forcing file (set to zero to exclude QF from energy balance); 1 (L11) = Loridan et al. (2011) SAHP method with air temperature and population density; 2 (J11) = J\u00e4rvi et al. (2011) SAHP_2 method with heating/cooling degree days; 3 (L11_UPDATED) = Modified Loridan method using daily mean air temperature; 4 (J19) = Detailed anthropogenic heat branch with L11 heat basis; CO2 output disabled by the driver for non-biogenic codes; 5 (J19_UPDATED) = Detailed anthropogenic heat branch with J11 heat basis; CO2 output disabled by the driver for non-biogenic codes; 6 (L11_UPDATED_DETAILED) = Detailed anthropogenic heat branch with L11_UPDATED heat basis; CO2 output disabled by the driver for non-biogenic codes; 11 (BIOGEN_RECT_L11) = Rectangular hyperbola biogenic CO2 + QF-linked anthropogenic CO2 + L11 heat (experimental); 12 (BIOGEN_RECT_J11) = Rectangular hyperbola biogenic CO2 + QF-linked anthropogenic CO2 + J11 heat (experimental); 13 (BIOGEN_RECT_L11_UPDATED) = Rectangular hyperbola biogenic CO2 + QF-linked anthropogenic CO2 + L11_UPDATED heat (experimental); 14 (BIOGEN_RECT_L11_DETAILED) = Rectangular hyperbola biogenic CO2 + detailed anthropogenic CO2 + L11 heat (experimental); 15 (BIOGEN_RECT_J11_DETAILED) = Rectangular hyperbola biogenic CO2 + detailed anthropogenic CO2 + J11 heat (experimental); 16 (BIOGEN_RECT_L11_UPDATED_DETAILED) = Rectangular hyperbola biogenic CO2 + detailed anthropogenic CO2 + L11_UPDATED heat (experimental); 21 (BIOGEN_BELLUCCO_LOCAL_L11) = Bellucco local biogenic CO2 + QF-linked anthropogenic CO2 + L11 heat (experimental); 22 (BIOGEN_BELLUCCO_LOCAL_J11) = Bellucco local biogenic CO2 + QF-linked anthropogenic CO2 + J11 heat (experimental); 23 (BIOGEN_BELLUCCO_LOCAL_L11_UPDATED) = Bellucco local biogenic CO2 + QF-linked anthropogenic CO2 + L11_UPDATED heat (experimental); 24 (BIOGEN_BELLUCCO_LOCAL_L11_DETAILED) = Bellucco local biogenic CO2 + detailed anthropogenic CO2 + L11 heat (experimental); 25 (BIOGEN_BELLUCCO_LOCAL_J11_DETAILED) = Bellucco local biogenic CO2 + detailed anthropogenic CO2 + J11 heat (experimental); 26 (BIOGEN_BELLUCCO_LOCAL_L11_UPDATED_DETAILED) = Bellucco local biogenic CO2 + detailed anthropogenic CO2 + L11_UPDATED heat (experimental); 31 (BIOGEN_BELLUCCO_GENERAL_L11) = Bellucco general biogenic CO2 + QF-linked anthropogenic CO2 + L11 heat (experimental); 32 (BIOGEN_BELLUCCO_GENERAL_J11) = Bellucco general biogenic CO2 + QF-linked anthropogenic CO2 + J11 heat (experimental); 33 (BIOGEN_BELLUCCO_GENERAL_L11_UPDATED) = Bellucco general biogenic CO2 + QF-linked anthropogenic CO2 + L11_UPDATED heat (experimental); 34 (BIOGEN_BELLUCCO_GENERAL_L11_DETAILED) = Bellucco general biogenic CO2 + detailed anthropogenic CO2 + L11 heat (experimental); 35 (BIOGEN_BELLUCCO_GENERAL_J11_DETAILED) = Bellucco general biogenic CO2 + detailed anthropogenic CO2 + J11 heat (experimental); 36 (BIOGEN_BELLUCCO_GENERAL_L11_UPDATED_DETAILED) = Bellucco general biogenic CO2 + detailed anthropogenic CO2 + L11_UPDATED heat (experimental); 41 (BIOGEN_CONDUCTANCE_L11) = Conductance-based biogenic CO2 + QF-linked anthropogenic CO2 + L11 heat (experimental); 42 (BIOGEN_CONDUCTANCE_J11) = Conductance-based biogenic CO2 + QF-linked anthropogenic CO2 + J11 heat (experimental); 43 (BIOGEN_CONDUCTANCE_L11_UPDATED) = Conductance-based biogenic CO2 + QF-linked anthropogenic CO2 + L11_UPDATED heat (experimental); 44 (BIOGEN_CONDUCTANCE_L11_DETAILED) = Conductance-based biogenic CO2 + detailed anthropogenic CO2 + L11 heat (experimental); 45 (BIOGEN_CONDUCTANCE_J11_DETAILED) = Conductance-based biogenic CO2 + detailed anthropogenic CO2 + J11 heat (experimental); 46 (BIOGEN_CONDUCTANCE_L11_UPDATED_DETAILED) = Conductance-based biogenic CO2 + detailed anthropogenic CO2 + L11_UPDATED heat (experimental)",
+          "note": "Determines anthropogenic heat flux (QF) used by the energy balance and OHM QF-inclusion switch.",
+          "provides_to": [
+            "ohm_inc_qf",
+            "energy_balance"
+          ],
           "title": "Emissions",
           "unit": "dimensionless"
         },
@@ -7208,7 +7220,17 @@
             }
           ],
           "default": 1,
+          "depends_on": [
+            "net_radiation",
+            "ohm_inc_qf",
+            "snow_use",
+            "stebbs"
+          ],
           "description": "Method for calculating storage heat flux (\u0394QS). Options: 0 (OBSERVED) = Uses observed \u0394QS values from forcing file; 1 (OHM_WITHOUT_QF) = Objective Hysteresis Model using Q* only (use with OhmIncQf=0); 3 (ANOHM) = Analytical OHM (Sun et al., 2017) - not recommended; 4 (ESTM) = Element Surface Temperature Method (Offerle et al., 2005) - not recommended; 5 (EHC) = Explicit Heat Conduction model with separate roof/wall/ground temperatures; 6 (DyOHM) = Dynamic Objective Hysteresis Model (Liu et al., 2025) with dynamic coefficients; 7 (STEBBS) = use STEBBS storage heat flux for building, others use OHM",
+          "note": "EHC (5) requires SPARTACUS net radiation; STEBBS storage heat (7) requires STEBBS enabled; OHM-like paths use OhmIncQf.",
+          "provides_to": [
+            "energy_balance"
+          ],
           "title": "Storage Heat",
           "unit": "dimensionless"
         },
@@ -7222,7 +7244,15 @@
             }
           ],
           "default": 0,
+          "depends_on": [
+            "emissions",
+            "storage_heat"
+          ],
           "description": "Controls inclusion of anthropogenic heat flux in OHM storage heat calculations. Options: 0 (EXCLUDE) = Use Q* only (required when StorageHeatMethod=1); 1 (INCLUDE) = Use Q*+QF (for other OHM-based storage heat methods)",
+          "note": "Controls whether QF from emissions is added to Q* in OHM-based storage heat calculations.",
+          "provides_to": [
+            "storage_heat"
+          ],
           "title": "Ohm Inc Qf",
           "unit": "dimensionless"
         },
@@ -7237,6 +7267,11 @@
           ],
           "default": 2,
           "description": "Method for calculating momentum roughness length (z0m). Options: 1 (FIXED) = Fixed roughness length from site parameters; 2 (VARIABLE) = Variable based on vegetation LAI using rule of thumb (Grimmond & Oke 1999); 3 (MACDONALD) = MacDonald et al. (1998) morphometric method based on building geometry; 4 (LAMBDAP_DEPENDENT) = Varies with plan area fraction \u03bbp (Grimmond & Oke 1999); 5 (ALTERNATIVE) = Alternative variable method",
+          "note": "Calculates momentum roughness length (z0m), which feeds heat roughness length and stability corrections.",
+          "provides_to": [
+            "roughness_length_heat",
+            "stability"
+          ],
           "title": "Roughness Length Momentum",
           "unit": "dimensionless"
         },
@@ -7250,7 +7285,14 @@
             }
           ],
           "default": 2,
+          "depends_on": [
+            "roughness_length_momentum"
+          ],
           "description": "Method for calculating thermal roughness length (z0h). Options: 1 (BRUTSAERT) = Brutsaert (1982) z0h = z0m/10 (see Grimmond & Oke 1986); 2 (KAWAI) = Kawai et al. (2009) formulation; 3 (VOOGT_GRIMMOND) = Voogt and Grimmond (2000) formulation; 4 (KANDA) = Kanda et al. (2007) formulation; 5 (ADAPTIVE) = Adaptively using z0m based on pervious coverage: if fully pervious, use method 1; otherwise, use method 2",
+          "note": "Calculates heat roughness length (z0h) from z0m for stability corrections.",
+          "provides_to": [
+            "stability"
+          ],
           "title": "Roughness Length Heat",
           "unit": "dimensionless"
         },
@@ -7265,8 +7307,10 @@
           ],
           "default": 3,
           "description": "Atmospheric stability correction functions for momentum and heat fluxes. Options: 0 (NOT_USED) = Reserved; 1 (NOT_USED2) = Reserved; 2 (HOEGSTROM) = Dyer (1974)/H\u00f6gstr\u00f6m (1988) for momentum, Van Ulden & Holtslag (1985) for stable conditions (not recommended); 3 (CAMPBELL_NORMAN) = Campbell & Norman (1998) formulations for both momentum and heat; 4 (BUSINGER_HOEGSTROM) = Businger et al. (1971)/H\u00f6gstr\u00f6m (1988) formulations (not recommended)",
-          "note": "Provides stability correction functions used by roughness_sublayer calculations",
+          "note": "Provides stability correction functions used by roughness-length and roughness_sublayer calculations.",
           "provides_to": [
+            "roughness_length_momentum",
+            "roughness_length_heat",
             "roughness_sublayer"
           ],
           "title": "Stability",
@@ -7400,12 +7444,25 @@
           ],
           "default": 0,
           "description": "Controls snow process calculations (J\u00e4rvi et al. 2014). Options: 0 (DISABLED) = Snow processes not included; 1 (ENABLED) = Snow accumulation, melt, and albedo effects included",
+          "note": "Controls snow processes that affect radiation dispatch, storage heat, and near-surface conductance adjustments.",
+          "provides_to": [
+            "net_radiation",
+            "storage_heat",
+            "roughness_sublayer_level"
+          ],
           "title": "Snow Use",
           "unit": "dimensionless"
         },
         "stebbs": {
           "$ref": "#/$defs/StebbsPhysics",
-          "description": "STEBBS physics switches (gh#1456): master toggle (enabled + parameters), capacitance method, setpoint method, and the same-albedo / same-emissivity wall/roof switches."
+          "depends_on": [
+            "storage_heat"
+          ],
+          "description": "STEBBS physics switches (gh#1456): master toggle (enabled + parameters), capacitance method, setpoint method, and the same-albedo / same-emissivity wall/roof switches.",
+          "note": "When storage_heat selects STEBBS (7), this block enables and parameterises the STEBBS contribution to storage heat.",
+          "provides_to": [
+            "stebbs.capacitance"
+          ]
         },
         "ref": {
           "anyOf": [
@@ -10098,6 +10155,10 @@
           ],
           "default": false,
           "description": "Master on/off switch for STEBBS. When false, STEBBS calculations are disabled and `parameters` is ignored.",
+          "note": "Enables the STEBBS branch; capacitance/RC options are only meaningful when STEBBS is enabled.",
+          "provides_to": [
+            "stebbs.capacitance"
+          ],
           "title": "Enabled",
           "unit": "dimensionless"
         },
@@ -10125,7 +10186,11 @@
             }
           ],
           "default": 0,
+          "depends_on": [
+            "stebbs.enabled"
+          ],
           "description": "Method to determine the two weighting factors (wall_outer_heat_capacity_fraction and roof_outer_heat_capacity_fraction) splitting heat capacity of building envelope into two nodes in STEBBS. Options: 0 (DEFAULT) = Default value of 0.5 is used; 1 (PROVIDED) = Use user defined value (wall_outer_heat_capacity_fraction and roof_outer_heat_capacity_fraction) between 0 and 1; 2 (PARAMETERISE) = Use building material thermal property to parameterise the weighting factor",
+          "note": "Only meaningful when STEBBS is enabled; controls building-envelope heat-capacity splitting.",
           "title": "Capacitance",
           "unit": "dimensionless"
         },

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -769,7 +769,11 @@ class StebbsPhysics(BaseModel):
             "Master on/off switch for STEBBS. When false, STEBBS calculations "
             "are disabled and `parameters` is ignored."
         ),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "provides_to": ["stebbs.capacitance"],
+            "note": "Enables the STEBBS branch; capacitance/RC options are only meaningful when STEBBS is enabled.",
+        },
     )
     parameters: FlexibleRefValue(StebbsParameterSource) = Field(
         default=StebbsParameterSource.DEFAULT,
@@ -779,7 +783,11 @@ class StebbsPhysics(BaseModel):
     capacitance: FlexibleRefValue(RCMethod) = Field(
         default=RCMethod.DEFAULT,
         description=_enum_description(RCMethod),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "depends_on": ["stebbs.enabled"],
+            "note": "Only meaningful when STEBBS is enabled; controls building-envelope heat-capacity splitting.",
+        },
     )
     setpoint: FlexibleRefValue(SetpointMethod) = Field(
         default=SetpointMethod.CONSTANT,
@@ -874,40 +882,72 @@ class ModelPhysics(BaseModel):
     net_radiation: FlexibleRefValue(NetRadiationMethod) = Field(
         default=NetRadiationMethod.LDOWN_AIR,
         description=_enum_description(NetRadiationMethod),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "depends_on": ["snow_use"],
+            "provides_to": ["storage_heat"],
+            "note": "Values above 1000 activate SPARTACUS-Surface and provide facet radiation required by EHC storage heat.",
+        },
     )
     emissions: FlexibleRefValue(EmissionsMethod) = Field(
         default=EmissionsMethod.J11,
         description=_enum_description(EmissionsMethod),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "provides_to": ["ohm_inc_qf", "energy_balance"],
+            "note": "Determines anthropogenic heat flux (QF) used by the energy balance and OHM QF-inclusion switch.",
+        },
     )
     storage_heat: FlexibleRefValue(StorageHeatMethod) = Field(
         default=StorageHeatMethod.OHM_WITHOUT_QF,
         description=_enum_description(StorageHeatMethod),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "depends_on": ["net_radiation", "ohm_inc_qf", "snow_use", "stebbs"],
+            "provides_to": ["energy_balance"],
+            "note": "EHC (5) requires SPARTACUS net radiation; STEBBS storage heat (7) requires STEBBS enabled; OHM-like paths use OhmIncQf.",
+        },
     )
     ohm_inc_qf: FlexibleRefValue(OhmIncQf) = Field(
         default=OhmIncQf.EXCLUDE,
         description=_enum_description(OhmIncQf),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "depends_on": ["emissions", "storage_heat"],
+            "provides_to": ["storage_heat"],
+            "note": "Controls whether QF from emissions is added to Q* in OHM-based storage heat calculations.",
+        },
     )
     roughness_length_momentum: FlexibleRefValue(MomentumRoughnessMethod) = Field(
         default=MomentumRoughnessMethod.VARIABLE,
         description=_enum_description(MomentumRoughnessMethod),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "provides_to": ["roughness_length_heat", "stability"],
+            "note": "Calculates momentum roughness length (z0m), which feeds heat roughness length and stability corrections.",
+        },
     )
     roughness_length_heat: FlexibleRefValue(HeatRoughnessMethod) = Field(
         default=HeatRoughnessMethod.KAWAI,
         description=_enum_description(HeatRoughnessMethod),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "depends_on": ["roughness_length_momentum"],
+            "provides_to": ["stability"],
+            "note": "Calculates heat roughness length (z0h) from z0m for stability corrections.",
+        },
     )
     stability: FlexibleRefValue(StabilityMethod) = Field(
         default=StabilityMethod.CAMPBELL_NORMAN,
         description=_enum_description(StabilityMethod),
         json_schema_extra={
             "unit": "dimensionless",
-            "provides_to": ["roughness_sublayer"],
-            "note": "Provides stability correction functions used by roughness_sublayer calculations",
+            "provides_to": [
+                "roughness_length_momentum",
+                "roughness_length_heat",
+                "roughness_sublayer",
+            ],
+            "note": "Provides stability correction functions used by roughness-length and roughness_sublayer calculations.",
         },
     )
     soil_moisture_deficit: FlexibleRefValue(SMDMethod) = Field(
@@ -965,7 +1005,15 @@ class ModelPhysics(BaseModel):
     snow_use: FlexibleRefValue(SnowUse) = Field(
         default=SnowUse.DISABLED,
         description=_enum_description(SnowUse),
-        json_schema_extra={"unit": "dimensionless"},
+        json_schema_extra={
+            "unit": "dimensionless",
+            "provides_to": [
+                "net_radiation",
+                "storage_heat",
+                "roughness_sublayer_level",
+            ],
+            "note": "Controls snow processes that affect radiation dispatch, storage heat, and near-surface conductance adjustments.",
+        },
     )
     stebbs: StebbsPhysics = Field(
         default_factory=StebbsPhysics,
@@ -974,6 +1022,11 @@ class ModelPhysics(BaseModel):
             "parameters), capacitance method, setpoint method, and the "
             "same-albedo / same-emissivity wall/roof switches."
         ),
+        json_schema_extra={
+            "depends_on": ["storage_heat"],
+            "provides_to": ["stebbs.capacitance"],
+            "note": "When storage_heat selects STEBBS (7), this block enables and parameterises the STEBBS contribution to storage heat.",
+        },
     )
 
     ref: Optional[Reference] = None

--- a/src/supy/data_model/validation/pipeline/phase_b_rules/physics_rules.py
+++ b/src/supy/data_model/validation/pipeline/phase_b_rules/physics_rules.py
@@ -6,8 +6,10 @@ from ...core.yaml_helpers import get_value_safe
 from ...core.yaml_helpers import unwrap_nested_value as _unwrap_nested_value
 from ...core.yaml_helpers import get_stebbs_block, get_stebbsmethod_value
 from ...core.yaml_helpers import read_physics_key
+from ....core.physics_families import resolve_scalar_name
 
 from collections.abc import Mapping
+from numbers import Integral, Real
 from typing import Dict, List, Optional, Union, Any, Tuple
 
 
@@ -210,7 +212,41 @@ def validate_rslmethod_dependency(rslmethod, stabilitymethod):
     )
 
 
+def _method_code(value, field_name: Optional[str] = None):
+    """Return an integer method code from raw, RefValue, enum, or readable input."""
+    if value is None:
+        return None
+    if isinstance(value, Mapping) and "value" in value:
+        value = value["value"]
+    if hasattr(value, "value"):
+        value = value.value
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, Real) and float(value).is_integer():
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if field_name is not None:
+            return resolve_scalar_name(field_name, stripped)
+        return int(stripped)
+    return value
+
+
 def validate_storageheatmethod_dependency(storageheatmethod, ohmincqf):
+    """Validate the legacy StorageHeatMethod-OhmIncQf pair."""
+    return validate_storageheatmethod_dependencies(storageheatmethod, ohmincqf)[0]
+
+
+def validate_storageheatmethod_dependencies(
+    storageheatmethod,
+    ohmincqf,
+    netradiationmethod=None,
+    stebbsmethod=None,
+):
     """
     Validate the dependency between StorageHeatMethod and OhmIncQf model options.
 
@@ -220,32 +256,144 @@ def validate_storageheatmethod_dependency(storageheatmethod, ohmincqf):
         The value of the StorageHeatMethod parameter.
     ohmincqf : int
         The value of the OhmIncQf parameter.
+    netradiationmethod : int, optional
+        The value of the NetRadiationMethod parameter.
+    stebbsmethod : int, optional
+        The composed STEBBS method value.
 
     Returns
     -------
-    ValidationResult
-        The result of the validation, including status, category, parameter,
-        message, and suggested value if applicable.
+    list of ValidationResult
+        Validation results for the storage heat dependency checks.
 
     Notes
     -----
     - If StorageHeatMethod == 1, OhmIncQf must be 0.
-    - If this dependency is not satisfied, an error is returned with a suggested fix.
+    - If OhmIncQf == 1, an OHM-like storage heat branch must be active.
+    - If StorageHeatMethod == 5, NetRadiationMethod must be a SPARTACUS code.
+    - If StorageHeatMethod == 7, STEBBS must be active.
     """
+    storageheatmethod = _method_code(storageheatmethod, "storage_heat")
+    ohmincqf = _method_code(ohmincqf, "ohm_inc_qf")
+    netradiationmethod = _method_code(netradiationmethod, "net_radiation")
+    stebbsmethod = _method_code(stebbsmethod, "stebbs")
+
+    results: List[ValidationResult] = []
+
     if storageheatmethod == 1 and ohmincqf != 0:
-        return ValidationResult(
-            status="ERROR",
-            category="MODEL_OPTIONS",
-            parameter="storageheatmethod-ohmincqf",
-            message=f"StorageHeatMethod is set to {storageheatmethod} and OhmIncQf is set to {ohmincqf}. You should switch to OhmIncQf=0.",
-            suggested_value="Set OhmIncQf to 0",
+        results.append(
+            ValidationResult(
+                status="ERROR",
+                category="MODEL_OPTIONS",
+                parameter="storageheatmethod-ohmincqf",
+                message=f"StorageHeatMethod is set to {storageheatmethod} and OhmIncQf is set to {ohmincqf}. You should switch to OhmIncQf=0.",
+                suggested_value="Set OhmIncQf to 0",
+            )
         )
-    return ValidationResult(
-        status="PASS",
-        category="MODEL_OPTIONS",
-        parameter="storageheatmethod-ohmincqf",
-        message="StorageHeatMethod-OhmIncQf compatibility validated",
-    )
+    elif ohmincqf == 1 and storageheatmethod not in {6, 7}:
+        results.append(
+            ValidationResult(
+                status="ERROR",
+                category="MODEL_OPTIONS",
+                parameter="storageheatmethod-ohmincqf",
+                message=(
+                    "OhmIncQf=1 is only meaningful for OHM-like storage heat "
+                    "branches that include QF. StorageHeatMethod=1 is documented "
+                    "as OHM without QF and must use OhmIncQf=0."
+                ),
+                suggested_value="Use StorageHeatMethod 6 or 7 with OhmIncQf=1, or set OhmIncQf to 0.",
+            )
+        )
+    else:
+        results.append(
+            ValidationResult(
+                status="PASS",
+                category="MODEL_OPTIONS",
+                parameter="storageheatmethod-ohmincqf",
+                message="StorageHeatMethod-OhmIncQf compatibility validated",
+            )
+        )
+
+    if storageheatmethod == 5:
+        if netradiationmethod is None or netradiationmethod <= 1000:
+            results.append(
+                ValidationResult(
+                    status="ERROR",
+                    category="MODEL_OPTIONS",
+                    parameter="storageheatmethod-netradiationmethod",
+                    message=(
+                        "StorageHeatMethod=5 (EHC) requires a SPARTACUS "
+                        "NetRadiationMethod code greater than 1000 so facet "
+                        "radiation is available."
+                    ),
+                    suggested_value="Set net_radiation to a SPARTACUS method such as 1003 or net_radiation.spartacus.ldown=air.",
+                )
+            )
+        else:
+            results.append(
+                ValidationResult(
+                    status="PASS",
+                    category="MODEL_OPTIONS",
+                    parameter="storageheatmethod-netradiationmethod",
+                    message="StorageHeatMethod EHC-SPARTACUS compatibility validated",
+                )
+            )
+
+    if storageheatmethod == 7:
+        if stebbsmethod not in {1, 2}:
+            results.append(
+                ValidationResult(
+                    status="ERROR",
+                    category="MODEL_OPTIONS",
+                    parameter="storageheatmethod-stebbsmethod",
+                    message=(
+                        "StorageHeatMethod=7 uses STEBBS storage heat and "
+                        "requires STEBBS to be enabled."
+                    ),
+                    suggested_value="Set model.physics.stebbs.enabled=true with parameters default or provided.",
+                )
+            )
+        else:
+            results.append(
+                ValidationResult(
+                    status="PASS",
+                    category="MODEL_OPTIONS",
+                    parameter="storageheatmethod-stebbsmethod",
+                    message="StorageHeatMethod-STEBBS compatibility validated",
+                )
+            )
+
+    return results
+
+
+def validate_rcmethod_stebbs_dependency(rcmethod, stebbsmethod):
+    """Validate that non-default RC/capacitance choices are used with STEBBS."""
+    rcmethod = _method_code(rcmethod, "capacitance")
+    stebbsmethod = _method_code(stebbsmethod, "stebbs")
+
+    if rcmethod in (None, 0):
+        return []
+    if stebbsmethod not in {1, 2}:
+        return [
+            ValidationResult(
+                status="ERROR",
+                category="MODEL_OPTIONS",
+                parameter="rcmethod-stebbsmethod",
+                message=(
+                    "Non-default stebbs.capacitance (rcmethod) is only "
+                    "meaningful when STEBBS is enabled."
+                ),
+                suggested_value="Set model.physics.stebbs.enabled=true, or use stebbs.capacitance=default.",
+            )
+        ]
+    return [
+        ValidationResult(
+            status="PASS",
+            category="MODEL_OPTIONS",
+            parameter="rcmethod-stebbsmethod",
+            message="RC/capacitance-STEBBS compatibility validated",
+        )
+    ]
 
 
 def validate_smdmethod_dependency(smdmethod, yaml_data):
@@ -343,20 +491,40 @@ def validate_model_option_dependencies(context) -> List[ValidationResult]:
     
     results = []
     physics = yaml_data.get("model", {}).get("physics", {})
+    if not isinstance(physics, Mapping):
+        physics = {}
 
-    rslmethod = get_value_safe(physics, "roughness_sublayer")
-    stabilitymethod = get_value_safe(physics, "stability")
-    storageheatmethod = get_value_safe(physics, "storage_heat")
-    ohmincqf = get_value_safe(physics, "ohm_inc_qf")
-    smdmethod = get_value_safe(physics, "soil_moisture_deficit")
+    rslmethod = read_physics_key(physics, "roughness_sublayer")
+    stabilitymethod = read_physics_key(physics, "stability")
+    storageheatmethod = read_physics_key(physics, "storage_heat")
+    ohmincqf = read_physics_key(physics, "ohm_inc_qf")
+    smdmethod = read_physics_key(physics, "soil_moisture_deficit")
+    netradiationmethod = read_physics_key(physics, "net_radiation")
+    stebbsmethod = get_stebbsmethod_value(physics)
+    rcmethod = get_value_safe(get_stebbs_block(physics), "capacitance")
 
     # RSL method and stability method dependencies
     result = validate_rslmethod_dependency(rslmethod=rslmethod, stabilitymethod=stabilitymethod)
-    if result is not None: results.append(result)
+    if result is not None:
+        results.append(result)
 
     # Storage heat method and OhmIncQf compatibility check
-    result = validate_storageheatmethod_dependency(storageheatmethod=storageheatmethod, ohmincqf=ohmincqf)
-    if result is not None: results.append(result)
+    results.extend(
+        validate_storageheatmethod_dependencies(
+            storageheatmethod=storageheatmethod,
+            ohmincqf=ohmincqf,
+            netradiationmethod=netradiationmethod,
+            stebbsmethod=stebbsmethod,
+        )
+    )
+
+    # RC/capacitance method and STEBBS compatibility check
+    results.extend(
+        validate_rcmethod_stebbs_dependency(
+            rcmethod=rcmethod,
+            stebbsmethod=stebbsmethod,
+        )
+    )
 
     # SMDMethod and soil_observation dependency
     results.extend(validate_smdmethod_dependency(smdmethod=smdmethod, yaml_data=yaml_data))

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -2563,6 +2563,13 @@ sites:
 
 def test_phase_b_storageheatmethod_ohmincqf_validation(registry):
     """Test StorageHeatMethod-OhmIncQf validation in Phase B."""
+    from supy.data_model.validation.pipeline.phase_b_rules.physics_rules import (
+        validate_storageheatmethod_dependency,
+    )
+
+    legacy_result = validate_storageheatmethod_dependency(1, 0)
+    assert legacy_result.parameter == "storageheatmethod-ohmincqf"
+    assert legacy_result.status == "PASS"
 
     # Test incompatible combination: StorageHeatMethod=1 requires OhmIncQf=0
     yaml_data_incompatible = {
@@ -2610,6 +2617,159 @@ def test_phase_b_storageheatmethod_ohmincqf_validation(registry):
         "StorageHeatMethod-OhmIncQf compatibility validated"
         in storage_results[0].message
     )
+
+
+def test_phase_b_storageheatmethod_ehc_requires_spartacus(registry):
+    """EHC storage heat needs SPARTACUS facet radiation."""
+    yaml_data_incompatible = {
+        "model": {
+            "physics": {
+                "storage_heat": "ehc",
+                "net_radiation": {"narp": {"ldown": "air"}},
+                "ohm_inc_qf": "exclude",
+            }
+        }
+    }
+
+    results = registry["option_dependencies"](
+        ValidationContext(yaml_data=yaml_data_incompatible)
+    )
+
+    storage_results = [
+        r for r in results if r.parameter == "storageheatmethod-netradiationmethod"
+    ]
+    assert len(storage_results) == 1
+    assert storage_results[0].status == "ERROR"
+    assert "requires a SPARTACUS NetRadiationMethod" in storage_results[0].message
+
+    yaml_data_compatible = {
+        "model": {
+            "physics": {
+                "storage_heat": "ehc",
+                "net_radiation": {"spartacus": {"ldown": "air"}},
+                "ohm_inc_qf": "exclude",
+            }
+        }
+    }
+
+    results = registry["option_dependencies"](
+        ValidationContext(yaml_data=yaml_data_compatible)
+    )
+
+    storage_results = [
+        r for r in results if r.parameter == "storageheatmethod-netradiationmethod"
+    ]
+    assert len(storage_results) == 1
+    assert storage_results[0].status == "PASS"
+
+
+def test_phase_b_storageheatmethod_stebbs_requires_stebbs_enabled(registry):
+    """STEBBS storage heat requires the nested STEBBS branch to be active."""
+    yaml_data_incompatible = {
+        "model": {
+            "physics": {
+                "storage_heat": "stebbs",
+                "ohm_inc_qf": "exclude",
+                "stebbs": {"enabled": False},
+            }
+        }
+    }
+
+    results = registry["option_dependencies"](
+        ValidationContext(yaml_data=yaml_data_incompatible)
+    )
+
+    storage_results = [
+        r for r in results if r.parameter == "storageheatmethod-stebbsmethod"
+    ]
+    assert len(storage_results) == 1
+    assert storage_results[0].status == "ERROR"
+    assert "requires STEBBS to be enabled" in storage_results[0].message
+
+    yaml_data_compatible = {
+        "model": {
+            "physics": {
+                "storage_heat": "stebbs",
+                "ohm_inc_qf": "include",
+                "stebbs": {"enabled": True, "parameters": "default"},
+            }
+        }
+    }
+
+    results = registry["option_dependencies"](
+        ValidationContext(yaml_data=yaml_data_compatible)
+    )
+
+    storage_results = [
+        r for r in results if r.parameter == "storageheatmethod-stebbsmethod"
+    ]
+    assert len(storage_results) == 1
+    assert storage_results[0].status == "PASS"
+
+
+def test_phase_b_ohmincqf_include_requires_ohm_like_storage(registry):
+    """The QF inclusion switch is invalid outside OHM-like storage heat paths."""
+    yaml_data = {
+        "model": {
+            "physics": {
+                "storage_heat": "ehc",
+                "net_radiation": {"spartacus": {"ldown": "air"}},
+                "ohm_inc_qf": "include",
+            }
+        }
+    }
+
+    results = registry["option_dependencies"](ValidationContext(yaml_data=yaml_data))
+
+    storage_results = [
+        r for r in results if r.parameter == "storageheatmethod-ohmincqf"
+    ]
+    assert len(storage_results) == 1
+    assert storage_results[0].status == "ERROR"
+    assert "OhmIncQf=1 is only meaningful" in storage_results[0].message
+
+
+def test_phase_b_rcmethod_requires_stebbs_enabled(registry):
+    """Non-default STEBBS capacitance/RC choices require STEBBS enabled."""
+    yaml_data_incompatible = {
+        "model": {
+            "physics": {
+                "stebbs": {
+                    "enabled": False,
+                    "capacitance": "provided",
+                }
+            }
+        }
+    }
+
+    results = registry["option_dependencies"](
+        ValidationContext(yaml_data=yaml_data_incompatible)
+    )
+
+    rcmethod_results = [r for r in results if r.parameter == "rcmethod-stebbsmethod"]
+    assert len(rcmethod_results) == 1
+    assert rcmethod_results[0].status == "ERROR"
+    assert "only meaningful when STEBBS is enabled" in rcmethod_results[0].message
+
+    yaml_data_compatible = {
+        "model": {
+            "physics": {
+                "stebbs": {
+                    "enabled": True,
+                    "parameters": "provided",
+                    "capacitance": "provided",
+                }
+            }
+        }
+    }
+
+    results = registry["option_dependencies"](
+        ValidationContext(yaml_data=yaml_data_compatible)
+    )
+
+    rcmethod_results = [r for r in results if r.parameter == "rcmethod-stebbsmethod"]
+    assert len(rcmethod_results) == 1
+    assert rcmethod_results[0].status == "PASS"
 
 
 def test_phase_b_rsl_stabilitymethod_validation(registry):

--- a/test/docs/test_generate_datamodel_rst.py
+++ b/test/docs/test_generate_datamodel_rst.py
@@ -53,6 +53,28 @@ def test_modelphysics_selector_guide_lists_registered_edge_tokens() -> None:
     assert resolve_scalar_name("roughness_sublayer", "rst") == 1
 
 
+def test_modelphysics_selector_guide_includes_dependency_graph() -> None:
+    module = _load_generator_module()
+
+    guide = "\n".join(module.RSTGenerator._format_modelphysics_selector_guide())
+
+    assert ".. rubric:: Method dependency graph" in guide
+    assert "``emissions`` -> ``ohm_inc_qf`` -> ``storage_heat``" in guide
+    assert "EHC storage heat requires SPARTACUS net radiation" in guide
+
+
+def test_relationship_targets_ref_only_documented_fields() -> None:
+    module = _load_generator_module()
+
+    rendered = module.RSTGenerator._format_relationship_targets(
+        ["storage_heat", "energy_balance", "stebbs.capacitance"]
+    )
+
+    assert ":ref:`storage_heat <storage_heat>`" in rendered
+    assert "``energy_balance``" in rendered
+    assert "``stebbs.capacitance``" in rendered
+
+
 def _documented_choice_rows(lines: list[str]) -> list[tuple[str, str]]:
     rows: list[tuple[str, str]] = []
     for index, line in enumerate(lines[:-1]):


### PR DESCRIPTION
Closes #860.

## Summary
- Add relationship metadata for the remaining ModelPhysics method selectors, including storage heat, net radiation, emissions/QF, snow, roughness, and STEBBS/RC dependencies.
- Add Phase B compatibility validators for EHC requiring SPARTACUS net radiation, STEBBS storage heat requiring STEBBS enabled, OHM QF inclusion scope, and non-default STEBBS capacitance requiring STEBBS.
- Extend the generated config-reference guide with a method dependency graph and refresh the checked-in schema metadata.

## Validation
- `.venv/bin/python -m pytest test/data_model/test_validation.py -q`
- `.venv/bin/python -m pytest test/docs/test_generate_datamodel_rst.py -q`
- `PYTHONPATH=src .venv/bin/python docs/generate_datamodel_rst.py --output-dir /tmp/suews-config-reference-gh860 --style hybrid --save-json /tmp/suews-doc-data-gh860.json`
- `scripts/lint/check_test_markers.py`
- `scripts/lint/check_rust_yaml_aliases.py`
- `git diff --check`
