### PR TITLE
Add SUEWS agent plugin distribution

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -12,7 +12,7 @@
         "path": "./plugins/suews"
       },
       "policy": {
-        "installation": "AVAILABLE",
+        "installation": "NOT_AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -130,6 +130,9 @@ These have been replaced by the unified `auto-format.yml` workflow that runs onl
     ```
 - `CLAUDE_CODE_OAUTH_TOKEN`: OAuth token used by Claude Code workflows
 - `RTD_PUSH_TOKEN`: PAT used only for syncing the protected `rtd` branch
+- `SUEWS_AGENT_PUSH_TOKEN`: fine-grained PAT used only by
+  `sync-agent-plugin.yml` to publish the generated `UMEP-dev/suews-agent`
+  repository. Scope it to `UMEP-dev/suews-agent` with Contents read/write.
 
 
 ## Security Configuration

--- a/.github/workflows/sync-agent-plugin.yml
+++ b/.github/workflows/sync-agent-plugin.yml
@@ -1,0 +1,113 @@
+name: Sync SUEWS agent plugin
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.claude/skills/suews/**'
+      - '.claude-plugin/marketplace.json'
+      - '.agents/plugins/marketplace.json'
+      - '.mcp.json'
+      - 'plugins/suews/.mcp.json'
+      - 'plugins/suews/.codex-plugin/**'
+      - 'plugins/suews/assets/**'
+      - 'scripts/build_agent_plugin.py'
+      - 'LICENSE'
+      - '.github/workflows/sync-agent-plugin.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: sync-agent-plugin
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Publish generated agent repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout SUEWS source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout generated agent repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: UMEP-dev/suews-agent
+          path: suews-agent
+          token: ${{ secrets.SUEWS_AGENT_PUSH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Generate agent repository
+        run: python scripts/build_agent_plugin.py --output suews-agent
+
+      - name: Validate generated layout
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          source = Path(".claude/skills/suews")
+          output = Path("suews-agent")
+
+          def manifest(root: Path) -> dict[str, str]:
+              return {
+                  str(path.relative_to(root)): hashlib.sha256(path.read_bytes()).hexdigest()
+                  for path in sorted(root.rglob("*"))
+                  if path.is_file()
+                  and "__pycache__" not in path.parts
+                  and path.suffix != ".pyc"
+              }
+
+          codex_marketplace = json.loads(
+              (output / ".agents/plugins/marketplace.json").read_text()
+          )
+          codex_plugin = codex_marketplace["plugins"][0]
+          assert codex_plugin["name"] == "suews"
+          assert codex_plugin["source"]["path"] == "./plugins/suews"
+          assert codex_plugin["policy"]["installation"] == "AVAILABLE"
+
+          claude_marketplace = json.loads(
+              (output / ".claude-plugin/marketplace.json").read_text()
+          )
+          assert "version" not in claude_marketplace["metadata"]
+          assert [plugin["name"] for plugin in claude_marketplace["plugins"]] == ["suews"]
+
+          required = [
+              output / ".mcp.json",
+              output / "plugins/suews/.mcp.json",
+              output / "plugins/suews/.codex-plugin/plugin.json",
+              output / "plugins/suews/assets/icon.png",
+          ]
+          for path in required:
+              assert path.exists(), f"missing generated file: {path}"
+
+          assert manifest(output / ".claude/skills/suews") == manifest(source)
+          assert manifest(output / "plugins/suews/skills/suews") == manifest(source)
+          PY
+
+      - name: Publish if changed
+        working-directory: suews-agent
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "SUEWS agent sync"
+          git config user.email "actions@github.com"
+
+          git add .
+          if git diff --cached --quiet; then
+            echo "suews-agent is already up to date."
+            exit 0
+          fi
+
+          git commit \
+            -m "Sync generated SUEWS agent plugin" \
+            -m "Generated from UMEP-dev/SUEWS commit ${SOURCE_SHA}."
+          git push origin HEAD:main

--- a/.github/workflows/sync-agent-plugin.yml
+++ b/.github/workflows/sync-agent-plugin.yml
@@ -110,4 +110,8 @@ jobs:
           git commit \
             -m "Sync generated SUEWS agent plugin" \
             -m "Generated from UMEP-dev/SUEWS commit ${SOURCE_SHA}."
+          # SUEWS_AGENT_PUSH_TOKEN must be a fine-grained PAT with Contents
+          # read/write on UMEP-dev/suews-agent, owned by an account that holds
+          # the bypass on the protected main branch (currently sunt05).
+          # Otherwise this push fails with an opaque 403.
           git push origin HEAD:main

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # SUEWS Simplified Makefile - Essential recipes only
-.PHONY: help setup submodules dev docs-setup reinstall test test-smoke test-all audit-deps docs livehtml clean format bridge plugin
+.PHONY: help setup submodules dev docs-setup reinstall test test-smoke test-all audit-deps docs livehtml clean format bridge plugin agent-plugin
 
 # Default Python
 PYTHON := python
@@ -299,3 +299,9 @@ format:
 # parity test in test/mcp/test_packaging_manifests.py guards against drift.
 plugin:
 	$(PYTHON) scripts/build_plugin.py
+
+# Generate the standalone SUEWS agent marketplace repository. Override
+# AGENT_PLUGIN_OUT to point at an existing checkout of UMEP-dev/suews-agent.
+AGENT_PLUGIN_OUT ?= ../suews-agent
+agent-plugin:
+	$(PYTHON) scripts/build_agent_plugin.py --output $(AGENT_PLUGIN_OUT)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -215,11 +215,11 @@ not install SuPy itself.
 
 **Claude Code**
 
-Add the SUEWS marketplace and install the plugin:
+Add the SUEWS agent marketplace and install the plugin:
 
 .. code-block:: text
 
-    /plugin marketplace add UMEP-dev/SUEWS
+    /plugin marketplace add UMEP-dev/suews-agent
     /plugin install suews@suews
 
 Run ``/reload-plugins`` to activate the plugin in the current session.
@@ -243,11 +243,12 @@ Run ``/reload-plugins`` to activate the plugin in the current session.
 
    Requires Codex CLI v0.117.0 or later (released 26 March 2026).
 
-Add the SUEWS marketplace:
+Add the SUEWS agent marketplace:
 
 .. code-block:: bash
 
-    codex plugin marketplace add UMEP-dev/SUEWS
+    codex plugin marketplace add UMEP-dev/suews-agent
+    codex plugin add suews@suews
 
 Then install the plugin from the plugin browser: open Codex, run
 ``/plugins``, select the ``SUEWS`` marketplace, and choose the ``SUEWS``
@@ -262,4 +263,3 @@ Goose, JetBrains Junie, etc.). Tracking issue:
 `gh#1364 <https://github.com/UMEP-dev/SUEWS/issues/1364>`_. Until that lands,
 MCP-only users can clone the repository and point their MCP client at the
 bundled CLI surface manually.
-

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -250,9 +250,7 @@ Add the SUEWS agent marketplace:
     codex plugin marketplace add UMEP-dev/suews-agent
     codex plugin add suews@suews
 
-Then install the plugin from the plugin browser: open Codex, run
-``/plugins``, select the ``SUEWS`` marketplace, and choose the ``SUEWS``
-plugin. The same plugin works across the Codex CLI, the Codex Desktop App
+The same plugin works across the Codex CLI, the Codex Desktop App
 (macOS / Windows), and the Codex IDE extensions for VS Code and JetBrains.
 
 **Cursor and other MCP-only tools**

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -157,12 +157,11 @@ suews-mcp --help                   # should print "--root" usage
 suews knowledge manifest           # confirms the bundled pack version
 ```
 
-## Recommended path: install via the SUEWS plugin
+## Recommended path: install via the SUEWS agent plugin
 
-The `suews` plugin in `.claude-plugin/marketplace.json` (Claude Code) and
-`.codex-plugin/plugin.json` (Codex) **already references this MCP server**
-via the bundled `.mcp.json` files. Those files spawn the server through
-`uvx` (uv's tool runner):
+The generated `UMEP-dev/suews-agent` marketplace ships the `suews` plugin
+for Claude Code and Codex. Its bundled `.mcp.json` files reference this MCP
+server and spawn it through `uvx` (uv's tool runner):
 
 ```json
 { "mcpServers": { "suews": { "command": "uvx",
@@ -190,7 +189,7 @@ the published git source, not a local editable install.
 Add the marketplace once, then install the plugin:
 
 ```
-/plugin marketplace add UMEP-dev/SUEWS
+/plugin marketplace add UMEP-dev/suews-agent
 /plugin install suews@suews
 ```
 

--- a/scripts/build_agent_plugin.py
+++ b/scripts/build_agent_plugin.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Generate the SUEWS agent-plugin distribution repository.
+
+The main SUEWS repository keeps `.claude/skills/suews/` as the single source of
+truth. This script writes a self-contained marketplace repository for agent
+hosts that need different packaging layouts:
+
+- Claude Code reads `.claude-plugin/marketplace.json` and `.claude/skills/suews/`.
+- Codex reads `.agents/plugins/marketplace.json` and installs `plugins/suews/`.
+
+The output directory may already be a Git checkout; its `.git/` directory is
+preserved while the generated payload is refreshed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+PLUGIN_NAME = "suews"
+MARKETPLACE_REPO = "UMEP-dev/suews-agent"
+SOURCE_REPO = "UMEP-dev/SUEWS"
+
+MANAGED_PATHS = (
+    ".agents",
+    ".claude",
+    ".claude-plugin",
+    "plugins",
+    ".mcp.json",
+    "LICENSE",
+    "README.md",
+)
+
+IGNORE = shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _copy_file(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def _copy_tree(src: Path, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, ignore=IGNORE)
+
+
+def _clean_output(output: Path) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    for rel_path in MANAGED_PATHS:
+        target = output / rel_path
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(REPO), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _codex_marketplace() -> dict[str, Any]:
+    return {
+        "name": "suews",
+        "interface": {
+            "displayName": "SUEWS",
+            "shortDescription": "Urban climate modelling tools for AI assistants",
+        },
+        "plugins": [
+            {
+                "name": PLUGIN_NAME,
+                "source": {
+                    "source": "local",
+                    "path": "./plugins/suews",
+                },
+                "policy": {
+                    "installation": "AVAILABLE",
+                    "authentication": "ON_INSTALL",
+                },
+                "category": "Productivity",
+            }
+        ],
+    }
+
+
+def _claude_marketplace() -> dict[str, Any]:
+    source = _read_json(REPO / ".claude-plugin" / "marketplace.json")
+    suews = next(
+        plugin for plugin in source["plugins"] if plugin["name"] == PLUGIN_NAME
+    )
+    return {
+        "name": "suews",
+        "owner": source["owner"],
+        "metadata": {
+            **source["metadata"],
+            "repository": f"https://github.com/{MARKETPLACE_REPO}",
+        },
+        "plugins": [suews],
+    }
+
+
+def _readme(source_commit: str) -> str:
+    return f"""# SUEWS Agent Plugin
+
+Self-contained SUEWS plugin marketplace for Claude Code and Codex.
+
+This repository is generated from
+[`{SOURCE_REPO}`](https://github.com/{SOURCE_REPO}). Do not edit generated
+plugin contents by hand; update the canonical SUEWS skill in the source
+repository and regenerate this distribution.
+
+## Install
+
+Claude Code:
+
+```text
+/plugin marketplace add {MARKETPLACE_REPO}
+/plugin install suews@suews
+```
+
+Codex:
+
+```bash
+codex plugin marketplace add {MARKETPLACE_REPO}
+codex plugin add suews@suews
+```
+
+## Contents
+
+- `.claude-plugin/marketplace.json` and `.claude/skills/suews/` for Claude Code.
+- `.agents/plugins/marketplace.json` and `plugins/suews/` for Codex.
+- `.mcp.json` files that launch `suews-mcp` through `uvx`.
+
+Generated from `{SOURCE_REPO}` commit `{source_commit}`.
+"""
+
+
+def _build(output: Path) -> None:
+    _clean_output(output)
+
+    source_commit = _git_commit()
+
+    _copy_file(REPO / "LICENSE", output / "LICENSE")
+    _copy_file(REPO / ".mcp.json", output / ".mcp.json")
+    _copy_file(
+        REPO / "plugins" / "suews" / ".mcp.json",
+        output / "plugins" / "suews" / ".mcp.json",
+    )
+    _copy_tree(
+        REPO / ".claude" / "skills" / "suews",
+        output / ".claude" / "skills" / "suews",
+    )
+    _copy_tree(
+        REPO / ".claude" / "skills" / "suews",
+        output / "plugins" / "suews" / "skills" / "suews",
+    )
+    _copy_tree(
+        REPO / "plugins" / "suews" / "assets",
+        output / "plugins" / "suews" / "assets",
+    )
+    _copy_tree(
+        REPO / "plugins" / "suews" / ".codex-plugin",
+        output / "plugins" / "suews" / ".codex-plugin",
+    )
+
+    _write_json(
+        output / ".agents" / "plugins" / "marketplace.json", _codex_marketplace()
+    )
+    _write_json(
+        output / ".claude-plugin" / "marketplace.json", _claude_marketplace()
+    )
+    (output / "README.md").write_text(_readme(source_commit), encoding="utf-8")
+
+    print(f"agent plugin distribution written to {output}")
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate the SUEWS agent-plugin distribution repository."
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Output directory, usually a checkout of UMEP-dev/suews-agent.",
+    )
+    args = parser.parse_args()
+    _build(args.output.resolve())
+
+
+if __name__ == "__main__":
+    _main()

--- a/scripts/build_agent_plugin.py
+++ b/scripts/build_agent_plugin.py
@@ -132,6 +132,15 @@ This repository is generated from
 plugin contents by hand; update the canonical SUEWS skill in the source
 repository and regenerate this distribution.
 
+## Repository Governance
+
+This is a generated distribution mirror, not a development repository. Treat it
+as read-only for human edits: changes should be made in `{SOURCE_REPO}`, merged
+to `master`, and then published here by the SUEWS agent-plugin sync workflow.
+
+The `main` branch should be protected so direct pushes are limited to the
+dedicated sync automation identity used by `{SOURCE_REPO}`.
+
 ## Install
 
 Claude Code:

--- a/scripts/build_agent_plugin.py
+++ b/scripts/build_agent_plugin.py
@@ -138,8 +138,11 @@ This is a generated distribution mirror, not a development repository. Treat it
 as read-only for human edits: changes should be made in `{SOURCE_REPO}`, merged
 to `master`, and then published here by the SUEWS agent-plugin sync workflow.
 
-The `main` branch should be protected so direct pushes are limited to the
-dedicated sync automation identity used by `{SOURCE_REPO}`.
+The `main` branch should be protected. In the current low-friction setup, the
+sync workflow pushes with a fine-grained `SUEWS_AGENT_PUSH_TOKEN` stored only in
+`{SOURCE_REPO}`, with the token owner kept as the temporary maintainer
+exception. Do not push manual content edits here; they will be overwritten by
+the next generated sync.
 
 ## Install
 

--- a/scripts/build_agent_plugin.py
+++ b/scripts/build_agent_plugin.py
@@ -109,13 +109,15 @@ def _claude_marketplace() -> dict[str, Any]:
     suews = next(
         plugin for plugin in source["plugins"] if plugin["name"] == PLUGIN_NAME
     )
+    metadata = {
+        **source["metadata"],
+        "repository": f"https://github.com/{MARKETPLACE_REPO}",
+    }
+    metadata.pop("version", None)
     return {
         "name": "suews",
         "owner": source["owner"],
-        "metadata": {
-            **source["metadata"],
-            "repository": f"https://github.com/{MARKETPLACE_REPO}",
-        },
+        "metadata": metadata,
         "plugins": [suews],
     }
 
@@ -148,7 +150,8 @@ codex plugin add suews@suews
 
 ## Contents
 
-- `.claude-plugin/marketplace.json` and `.claude/skills/suews/` for Claude Code.
+- `.claude-plugin/marketplace.json` and `.claude/skills/suews/` for Claude Code
+  (git commit identifies the installed plugin version).
 - `.agents/plugins/marketplace.json` and `plugins/suews/` for Codex.
 - `.mcp.json` files that launch `suews-mcp` through `uvx`.
 

--- a/test/mcp/MANUAL_SMOKE.md
+++ b/test/mcp/MANUAL_SMOKE.md
@@ -8,8 +8,8 @@ up with a working MCP server that answers Sue's canonical questions
 with cited evidence.
 
 Run before each release that touches anything under `mcp/`,
-`.claude-plugin/`, `.codex-plugin/`, `plugins/suews/`, or any
-`suews knowledge` surface.
+`.claude-plugin/`, `.codex-plugin/`, `plugins/suews/`,
+`scripts/build_agent_plugin.py`, or any `suews knowledge` surface.
 
 ---
 
@@ -30,6 +30,7 @@ misleading results.
 ### Install
 
 - [ ] Claude Code is on the version that supports plugin marketplaces.
+- [ ] The SUEWS agent marketplace is installed from `UMEP-dev/suews-agent`.
 - [ ] `/plugin install suews` (or equivalent marketplace UI) completes
       without error.
 - [ ] After install, restart Claude Code so the MCP server is spawned
@@ -85,6 +86,8 @@ pack contents need investigation — see "Failure templates" below.
 
 - [ ] Codex CLI is on the version that supports `.codex-plugin/`
       manifests.
+- [ ] The SUEWS agent marketplace is installed with
+      `codex plugin marketplace add UMEP-dev/suews-agent`.
 - [ ] Plugin install / enable for `suews` completes without error.
 - [ ] Restart the Codex session so the MCP server is registered.
 

--- a/test/mcp/test_packaging_manifests.py
+++ b/test/mcp/test_packaging_manifests.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -135,6 +135,22 @@ def test_codex_plugin_references_mcp_servers_in_camelcase(rel_path: str) -> None
     )
 
 
+def test_source_codex_marketplace_disables_raw_repo_install() -> None:
+    """Raw `UMEP-dev/SUEWS` is not the Codex install surface.
+
+    Codex installs only the marketplace plugin source directory
+    (`plugins/suews/`), so the self-contained installable bundle lives in the
+    generated `UMEP-dev/suews-agent` distribution repo instead.
+    """
+    data = _load_json(".agents/plugins/marketplace.json")
+    plugins = data.get("plugins", [])
+    suews = next((p for p in plugins if p.get("name") == "suews"), None)
+
+    assert suews is not None
+    assert suews["source"]["path"] == "./plugins/suews"
+    assert suews["policy"]["installation"] == "NOT_AVAILABLE"
+
+
 def test_claude_marketplace_lists_suews_plugin() -> None:
     """The Claude Code marketplace entry for `suews` references the bundled
     plugin's MCP file."""
@@ -193,6 +209,58 @@ def _skill_manifest(root: Path) -> dict[str, str]:
         if p.is_file() and "__pycache__" not in p.parts and p.suffix != ".pyc":
             out[str(p.relative_to(root))] = hashlib.sha256(p.read_bytes()).hexdigest()
     return out
+
+
+def test_build_agent_plugin_generates_installable_distribution(tmp_path: Path) -> None:
+    """The generated `suews-agent` repo is the self-contained install surface.
+
+    It carries Claude Code's canonical `.claude/skills/suews/` path and Codex's
+    required `plugins/suews/skills/suews/` path, both byte-identical to the
+    source skill.
+    """
+    output = tmp_path / "suews-agent"
+    subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "build_agent_plugin.py"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    codex_marketplace = json.loads(
+        (output / ".agents" / "plugins" / "marketplace.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    codex_plugin = codex_marketplace["plugins"][0]
+    assert codex_plugin["name"] == "suews"
+    assert codex_plugin["source"]["path"] == "./plugins/suews"
+    assert codex_plugin["policy"]["installation"] == "AVAILABLE"
+
+    claude_marketplace = json.loads(
+        (output / ".claude-plugin" / "marketplace.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert [plugin["name"] for plugin in claude_marketplace["plugins"]] == ["suews"]
+
+    assert (output / ".mcp.json").exists()
+    assert (output / "plugins" / "suews" / ".mcp.json").exists()
+    assert (
+        output / "plugins" / "suews" / ".codex-plugin" / "plugin.json"
+    ).exists()
+    assert (output / "plugins" / "suews" / "assets" / "icon.png").exists()
+
+    source = _skill_manifest(REPO_ROOT / ".claude" / "skills" / "suews")
+    claude_skill = _skill_manifest(output / ".claude" / "skills" / "suews")
+    codex_skill = _skill_manifest(
+        output / "plugins" / "suews" / "skills" / "suews"
+    )
+    assert claude_skill == source
+    assert codex_skill == source
 
 
 def test_build_plugin_generates_single_skill_bundle_from_source() -> None:

--- a/test/mcp/test_packaging_manifests.py
+++ b/test/mcp/test_packaging_manifests.py
@@ -245,6 +245,7 @@ def test_build_agent_plugin_generates_installable_distribution(tmp_path: Path) -
             encoding="utf-8"
         )
     )
+    assert "version" not in claude_marketplace["metadata"]
     assert [plugin["name"] for plugin in claude_marketplace["plugins"]] == ["suews"]
 
     assert (output / ".mcp.json").exists()

--- a/test/mcp/test_packaging_manifests.py
+++ b/test/mcp/test_packaging_manifests.py
@@ -255,6 +255,10 @@ def test_build_agent_plugin_generates_installable_distribution(tmp_path: Path) -
     ).exists()
     assert (output / "plugins" / "suews" / "assets" / "icon.png").exists()
 
+    readme = (output / "README.md").read_text(encoding="utf-8")
+    assert "generated distribution mirror" in readme
+    assert "SUEWS agent-plugin sync workflow" in readme
+
     source = _skill_manifest(REPO_ROOT / ".claude" / "skills" / "suews")
     claude_skill = _skill_manifest(output / ".claude" / "skills" / "suews")
     codex_skill = _skill_manifest(


### PR DESCRIPTION
## Summary
- add a generator for the standalone `UMEP-dev/suews-agent` marketplace repository
- add `.github/workflows/sync-agent-plugin.yml` to regenerate and publish `suews-agent` after relevant merges to `master`
- mark raw `UMEP-dev/SUEWS` Codex marketplace installs unavailable so users install the generated bundle instead
- update install docs, generated README governance, and packaging tests for the Claude Code + Codex distribution path

## Operational setup
- `UMEP-dev/suews-agent/main` is protected with direct pushes restricted to `sunt05` for the temporary PAT-backed phase
- add a fine-grained `SUEWS_AGENT_PUSH_TOKEN` secret to `UMEP-dev/SUEWS`, scoped only to `UMEP-dev/suews-agent` with Contents read/write
- the sync workflow uses that token to push generated updates; human content edits should still go through `UMEP-dev/SUEWS`

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sync-agent-plugin.yml")'`
- `uv run --extra dev ruff check scripts/build_agent_plugin.py test/mcp/test_packaging_manifests.py`
- `uv run --extra dev python -m pytest --confcutdir=test/mcp test/mcp/test_packaging_manifests.py`
- `python3 /Users/tingsun/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py <generated>/plugins/suews`
- clean Codex install from `UMEP-dev/suews-agent`: `codex plugin marketplace add UMEP-dev/suews-agent` then `codex plugin add suews@suews`, confirmed cached skill content
- `make PYTHON="$PWD/.venv/bin/python" test-smoke`

Fixes #1476
