### PR TITLE
Fold legacy STEBBS physics during validation

### DIFF
--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -13,6 +13,7 @@ from ...core.field_renames import (
 )
 from ...core.physics_families import (
     STEBBS_PUBLIC_KEY_ALIASES,
+    coerce_nested_to_flat,
     flatten_physics_in_config,
 )
 
@@ -216,6 +217,11 @@ def _decompose_stebbs_master_for_phase_a(
     entry: object,
 ) -> Optional[tuple[dict, dict]]:
     """Split legacy ``stebbs`` 0/1/2 into nested enabled/parameters values."""
+    try:
+        entry = coerce_nested_to_flat("stebbs", entry)
+    except (TypeError, ValueError):
+        return None
+
     ref = entry.get("ref") if isinstance(entry, dict) else None
     raw = (
         entry.get("value")
@@ -272,6 +278,9 @@ def _normalise_model_physics_stebbs(
 
     replacements: list[tuple[str, str]] = []
     existing = physics.get("stebbs")
+    flat_stebbs_keys_present = [
+        key for key in STEBBS_PHYSICS_LEAF_RENAMES if key in physics
+    ]
     nested_already = (
         isinstance(existing, dict)
         and not _is_stebbs_master_scalar(existing)
@@ -293,6 +302,16 @@ def _normalise_model_physics_stebbs(
             _set_if_missing_or_nullish(stebbs_block, "enabled", enabled)
             _set_if_missing_or_nullish(stebbs_block, "parameters", parameters)
             replacements.append(("stebbs.value", "stebbs.enabled/parameters"))
+        elif nested_already and _is_nullish_tree(existing.get("value")):
+            stebbs_block.pop("value", None)
+            stebbs_block.pop("ref", None)
+            replacements.append(("stebbs.value", "stebbs.enabled/parameters"))
+        elif (
+            flat_stebbs_keys_present
+            and not nested_already
+            and not _is_nullish_tree(existing)
+        ):
+            stebbs_block = dict(existing)
     elif "stebbs" in physics and not nested_already:
         decomposed = _decompose_stebbs_master_for_phase_a(existing)
         if decomposed is not None:
@@ -300,6 +319,12 @@ def _normalise_model_physics_stebbs(
             stebbs_block["enabled"] = enabled
             stebbs_block["parameters"] = parameters
             replacements.append(("stebbs", "stebbs.enabled/parameters"))
+        elif flat_stebbs_keys_present:
+            if isinstance(existing, dict):
+                if not _is_nullish_tree(existing):
+                    stebbs_block = dict(existing)
+            elif existing is not None:
+                stebbs_block = {"value": existing}
 
     for public_key, canonical_key in STEBBS_PUBLIC_KEY_ALIASES.items():
         if public_key not in stebbs_block:

--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -4,10 +4,17 @@ import subprocess
 from copy import deepcopy
 import pandas as pd
 from pathlib import Path
+from typing import Optional
 
 from .report_writer import REPORT_WRITER
-from ...core.field_renames import RAW_YAML_FIELD_RENAMES
-from ...core.physics_families import flatten_physics_in_config
+from ...core.field_renames import (
+    RAW_YAML_FIELD_RENAMES,
+    STEBBS_PHYSICS_LEAF_RENAMES,
+)
+from ...core.physics_families import (
+    STEBBS_PUBLIC_KEY_ALIASES,
+    flatten_physics_in_config,
+)
 
 RENAMED_PARAMS = {
     "cp": "rho_cp",
@@ -174,6 +181,160 @@ def _normalise_model_control_subobjects(
         # ModelControl._coerce_legacy_output_file).
         replacements.append(("output_file", "output"))
 
+    return normalised, replacements
+
+
+_STEBBS_REFVALUE_KEYS = frozenset({"value", "ref"})
+_STEBBS_NESTED_KEYS = frozenset(
+    {
+        "enabled",
+        "parameters",
+        *STEBBS_PUBLIC_KEY_ALIASES,
+        *STEBBS_PHYSICS_LEAF_RENAMES.keys(),
+        *STEBBS_PHYSICS_LEAF_RENAMES.values(),
+    }
+)
+
+
+def _is_stebbs_master_scalar(entry: object) -> bool:
+    """Return True when ``stebbs`` is the legacy RefValue master toggle."""
+    return (
+        isinstance(entry, dict)
+        and "value" in entry
+        and set(entry) <= _STEBBS_REFVALUE_KEYS
+    )
+
+
+def _wrapped_stebbs_value(value: object, ref: object = None) -> dict:
+    wrapped = {"value": value}
+    if ref is not None:
+        wrapped["ref"] = ref
+    return wrapped
+
+
+def _decompose_stebbs_master_for_phase_a(
+    entry: object,
+) -> Optional[tuple[dict, dict]]:
+    """Split legacy ``stebbs`` 0/1/2 into nested enabled/parameters values."""
+    ref = entry.get("ref") if isinstance(entry, dict) else None
+    raw = (
+        entry.get("value")
+        if isinstance(entry, dict) and "value" in entry
+        else entry
+    )
+
+    if isinstance(raw, bool):
+        code = int(raw)
+    elif isinstance(raw, int):
+        code = raw
+    elif isinstance(raw, float) and raw.is_integer():
+        code = int(raw)
+    else:
+        return None
+
+    if code == 0:
+        return _wrapped_stebbs_value(False, ref), _wrapped_stebbs_value(1)
+    if code == 1:
+        return _wrapped_stebbs_value(True, ref), _wrapped_stebbs_value(1)
+    if code == 2:
+        return _wrapped_stebbs_value(True, ref), _wrapped_stebbs_value(2)
+    return None
+
+
+def _set_if_missing_or_nullish(target: dict, key: str, value: object) -> bool:
+    """Set ``target[key]`` only when absent or carrying a null placeholder."""
+    if key not in target or _is_nullish_tree(target.get(key)):
+        target[key] = value
+        return True
+    return False
+
+
+def _normalise_model_physics_stebbs(
+    config_data: object,
+) -> tuple[object, list[tuple[str, str]]]:
+    """Fold legacy flat STEBBS physics switches before Phase A comparison.
+
+    Phase A writes the user-facing updated YAML from parsed data. Mirror the
+    runtime STEBBS fold here so old flat siblings are migrated into the nested
+    ``model.physics.stebbs`` block instead of being reported as extras while
+    null nested placeholders are inserted.
+    """
+    if not isinstance(config_data, dict):
+        return config_data, []
+
+    normalised = deepcopy(config_data)
+    model = normalised.get("model")
+    if not isinstance(model, dict):
+        return normalised, []
+    physics = model.get("physics")
+    if not isinstance(physics, dict):
+        return normalised, []
+
+    replacements: list[tuple[str, str]] = []
+    existing = physics.get("stebbs")
+    nested_already = (
+        isinstance(existing, dict)
+        and not _is_stebbs_master_scalar(existing)
+        and any(key in existing for key in _STEBBS_NESTED_KEYS)
+    )
+
+    stebbs_block: dict = (
+        dict(existing) if isinstance(existing, dict) and nested_already else {}
+    )
+
+    if isinstance(existing, dict) and "value" in existing:
+        decomposed = _decompose_stebbs_master_for_phase_a(existing)
+        if decomposed is not None:
+            enabled, parameters = decomposed
+            stebbs_block.pop("value", None)
+            # A RefValue-style ``ref`` belongs to the legacy master toggle and
+            # is carried onto ``enabled`` by ``_decompose_stebbs_master...``.
+            stebbs_block.pop("ref", None)
+            _set_if_missing_or_nullish(stebbs_block, "enabled", enabled)
+            _set_if_missing_or_nullish(stebbs_block, "parameters", parameters)
+            replacements.append(("stebbs.value", "stebbs.enabled/parameters"))
+    elif "stebbs" in physics and not nested_already:
+        decomposed = _decompose_stebbs_master_for_phase_a(existing)
+        if decomposed is not None:
+            enabled, parameters = decomposed
+            stebbs_block["enabled"] = enabled
+            stebbs_block["parameters"] = parameters
+            replacements.append(("stebbs", "stebbs.enabled/parameters"))
+
+    for public_key, canonical_key in STEBBS_PUBLIC_KEY_ALIASES.items():
+        if public_key not in stebbs_block:
+            continue
+        public_value = stebbs_block.pop(public_key)
+        _set_if_missing_or_nullish(stebbs_block, canonical_key, public_value)
+        replacements.append((f"stebbs.{public_key}", f"stebbs.{canonical_key}"))
+
+    for old_key, nested_leaf in STEBBS_PHYSICS_LEAF_RENAMES.items():
+        if old_key == nested_leaf or old_key not in stebbs_block:
+            continue
+        old_value = stebbs_block.pop(old_key)
+        _set_if_missing_or_nullish(stebbs_block, nested_leaf, old_value)
+        replacements.append((f"stebbs.{old_key}", f"stebbs.{nested_leaf}"))
+
+    for flat_key, nested_leaf in STEBBS_PHYSICS_LEAF_RENAMES.items():
+        if flat_key not in physics:
+            continue
+        flat_value = physics.pop(flat_key)
+        _set_if_missing_or_nullish(stebbs_block, nested_leaf, flat_value)
+        replacements.append((flat_key, f"stebbs.{nested_leaf}"))
+
+    if stebbs_block:
+        physics["stebbs"] = stebbs_block
+
+    return normalised, replacements
+
+
+def _normalise_phase_a_compatibility(
+    config_data: object,
+) -> tuple[object, list[tuple[str, str]]]:
+    """Apply compatibility folds Phase A must share with the runtime loader."""
+    normalised, replacements = _normalise_model_control_subobjects(config_data)
+    normalised, stebbs_replacements = _normalise_model_physics_stebbs(normalised)
+    replacements.extend(stebbs_replacements)
     return normalised, replacements
 
 
@@ -434,8 +595,8 @@ def find_extra_parameters(user_data, standard_data, current_path=""):
     """Find parameters that exist in user data but not in standard data."""
     extra_params = []
     if current_path == "":
-        user_data, _ = _normalise_model_control_subobjects(user_data)
-        standard_data, _ = _normalise_model_control_subobjects(standard_data)
+        user_data, _ = _normalise_phase_a_compatibility(user_data)
+        standard_data, _ = _normalise_phase_a_compatibility(standard_data)
         flatten_physics_in_config(user_data)
         flatten_physics_in_config(standard_data)
 
@@ -484,8 +645,8 @@ def find_extra_parameters_in_lists(user_list, standard_list, current_path=""):
 def find_missing_parameters(user_data, standard_data, current_path=""):
     missing_params = []
     if current_path == "":
-        user_data, _ = _normalise_model_control_subobjects(user_data)
-        standard_data, _ = _normalise_model_control_subobjects(standard_data)
+        user_data, _ = _normalise_phase_a_compatibility(user_data)
+        standard_data, _ = _normalise_phase_a_compatibility(standard_data)
         flatten_physics_in_config(user_data)
         flatten_physics_in_config(standard_data)
 
@@ -1834,13 +1995,14 @@ def annotate_missing_parameters(
         )
         user_data = yaml.safe_load(original_yaml_content)
         parsed_renames = handle_renamed_parameters_in_parsed_yaml(user_data)
-        normalised_user_data, control_replacements = _normalise_model_control_subobjects(
-            user_data
-        )
-        control_normalised = normalised_user_data != user_data
+        (
+            normalised_user_data,
+            compatibility_replacements,
+        ) = _normalise_phase_a_compatibility(user_data)
+        compatibility_normalised = normalised_user_data != user_data
         user_data = normalised_user_data
-        parsed_renames.extend(control_replacements)
-        if parsed_renames or control_normalised:
+        parsed_renames.extend(compatibility_replacements)
+        if parsed_renames or compatibility_normalised:
             seen_replacements = set(renamed_replacements)
             for replacement in parsed_renames:
                 if replacement not in seen_replacements:

--- a/test/cmd/test_validate_config.py
+++ b/test/cmd/test_validate_config.py
@@ -499,6 +499,57 @@ def test_validate_flat_stebbs_form_not_flagged_missing(tmp_path: Path) -> None:
     )
 
 
+def test_validate_pipeline_cleans_legacy_flat_stebbs_updated_yaml(
+    tmp_path: Path,
+) -> None:
+    """gh#1497: full validate output folds old flat STEBBS switches."""
+    from supy.cmd.validate_config import cli as validate_cli
+
+    payload = _load_sample_dict()
+    physics = payload["model"]["physics"]
+    physics["stebbs"] = {"value": 0}
+    physics["outer_cap_fraction"] = {"value": 0}
+    physics["setpoint"] = {"value": 1}
+    physics["same_albedo_wall"] = {"value": 0}
+    physics["same_albedo_roof"] = {"value": 0}
+    physics["same_emissivity_wall"] = {"value": 0}
+    physics["same_emissivity_roof"] = {"value": 0}
+
+    config_path = tmp_path / "legacy_stebbs.yml"
+    _write_yaml(config_path, payload)
+
+    runner = CliRunner()
+    result = runner.invoke(validate_cli, ["--forcing", "off", str(config_path)])
+
+    assert result.exit_code == 0, result.output
+    updated_path = tmp_path / "updated_legacy_stebbs.yml"
+    assert updated_path.exists(), result.output
+    updated = yaml.safe_load(updated_path.read_text(encoding="utf-8"))
+    updated_physics = updated["model"]["physics"]
+    updated_stebbs = updated_physics["stebbs"]
+
+    assert "value" not in updated_stebbs
+    for flat_key in (
+        "capacitance",
+        "outer_cap_fraction",
+        "setpoint",
+        "same_albedo_wall",
+        "same_albedo_roof",
+        "same_emissivity_wall",
+        "same_emissivity_roof",
+    ):
+        assert flat_key not in updated_physics
+
+    assert updated_stebbs["enabled"] == {"value": False}
+    assert updated_stebbs["parameters"] == {"value": 1}
+    assert updated_stebbs["capacitance"] == {"value": 0}
+    assert updated_stebbs["setpoint"] == {"value": 1}
+    assert updated_stebbs["same_albedo_wall"] == {"value": 0}
+    assert updated_stebbs["same_albedo_roof"] == {"value": 0}
+    assert updated_stebbs["same_emissivity_wall"] == {"value": 0}
+    assert updated_stebbs["same_emissivity_roof"] == {"value": 0}
+
+
 def test_validate_full_pipeline_emits_json_envelope(tmp_path: Path) -> None:
     """The non-dry-run pipeline path must honour ``--format json`` and
     emit a canonical envelope on stdout (gh#1409 follow-up).

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -51,6 +51,7 @@ from supy.data_model.validation.pipeline.phase_a import (
     PHYSICS_OPTIONS,
     RENAMED_PARAMS,
     _is_default_backed_control_path,
+    _normalise_phase_a_compatibility,
     annotate_missing_parameters,
     create_analysis_report,
     create_clean_missing_param_annotation,
@@ -669,6 +670,21 @@ sites:
             self.assertNotIn("model.physics.stebbs.value", report_content)
             self.assertNotIn("model.physics.capacitance", report_content)
             self.assertNotIn("model.physics.same_albedo_wall", report_content)
+
+    def test_gh1497_malformed_stebbs_value_is_not_silently_dropped(self):
+        """Phase A cleanup must not hide an invalid legacy master toggle."""
+        data = deepcopy(self.standard_data)
+        physics = data["model"]["physics"]
+        physics["stebbs"] = {"value": 9}
+        physics["outer_cap_fraction"] = {"value": 0}
+
+        normalised, _ = _normalise_phase_a_compatibility(data)
+        normalised_physics = normalised["model"]["physics"]
+        normalised_stebbs = normalised_physics["stebbs"]
+
+        self.assertEqual(normalised_stebbs["value"], 9)
+        self.assertEqual(normalised_stebbs["capacitance"], {"value": 0})
+        self.assertNotIn("outer_cap_fraction", normalised_physics)
 
     def test_gh1417_empty_current_output_wins_over_legacy_duplicate(self):
         """An empty current output block is valid and should not be overwritten."""

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -583,6 +583,93 @@ sites:
             self.assertIn("forcing_file changed to forcing.file", report_content)
             self.assertIn("output_file changed to output", report_content)
 
+    def test_gh1497_flat_stebbs_physics_is_folded_before_phase_a_output(self):
+        """Legacy flat STEBBS switches should not survive in updated YAML."""
+        data = deepcopy(self.standard_data)
+        physics = data["model"]["physics"]
+        physics["stebbs"] = {
+            "value": 0,
+            "capacitance": {"value": None},
+            "setpoint": {"value": None},
+            "same_albedo_wall": {"value": None},
+            "same_albedo_roof": {"value": None},
+            "same_emissivity_wall": {"value": None},
+            "same_emissivity_roof": {"value": None},
+        }
+        physics["outer_cap_fraction"] = {"value": 2}
+        physics["setpoint"] = {"value": 1}
+        physics["same_albedo_wall"] = {"value": 0}
+        physics["same_albedo_roof"] = {"value": 1}
+        physics["same_emissivity_wall"] = {"value": 0}
+        physics["same_emissivity_roof"] = {"value": 1}
+
+        missing_paths = {
+            path for path, _, _ in find_missing_parameters(data, self.standard_data)
+        }
+        extra_paths = set(find_extra_parameters(data, self.standard_data))
+
+        for leaf in (
+            "capacitance",
+            "setpoint",
+            "same_albedo_wall",
+            "same_albedo_roof",
+            "same_emissivity_wall",
+            "same_emissivity_roof",
+        ):
+            self.assertNotIn(f"model.physics.stebbs.{leaf}", missing_paths)
+            self.assertNotIn(f"model.physics.{leaf}", extra_paths)
+        self.assertNotIn("model.physics.outer_cap_fraction", extra_paths)
+        self.assertNotIn("model.physics.stebbs.value", extra_paths)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            user_file = tmp_path / "legacy-stebbs.yml"
+            standard_file = tmp_path / "standard.yml"
+            updated_file = tmp_path / "updated.yml"
+            report_file = tmp_path / "report.txt"
+
+            user_file.write_text(
+                yaml.safe_dump(data, sort_keys=False),
+                encoding="utf-8",
+            )
+            standard_file.write_text(
+                yaml.safe_dump(self.standard_data, sort_keys=False),
+                encoding="utf-8",
+            )
+
+            annotate_missing_parameters(
+                user_file=str(user_file),
+                standard_file=str(standard_file),
+                uptodate_file=str(updated_file),
+                report_file=str(report_file),
+                mode="public",
+                phase="A",
+                forcing="off",
+            )
+
+            updated_data = yaml.safe_load(updated_file.read_text(encoding="utf-8"))
+            updated_physics = updated_data["model"]["physics"]
+            updated_stebbs = updated_physics["stebbs"]
+
+            self.assertNotIn("value", updated_stebbs)
+            self.assertNotIn("capacitance", updated_physics)
+            self.assertNotIn("outer_cap_fraction", updated_physics)
+            self.assertNotIn("setpoint", updated_physics)
+            self.assertNotIn("same_albedo_wall", updated_physics)
+            self.assertEqual(updated_stebbs["enabled"], {"value": False})
+            self.assertEqual(updated_stebbs["parameters"], {"value": 1})
+            self.assertEqual(updated_stebbs["capacitance"], {"value": 2})
+            self.assertEqual(updated_stebbs["setpoint"], {"value": 1})
+            self.assertEqual(updated_stebbs["same_albedo_wall"], {"value": 0})
+            self.assertEqual(updated_stebbs["same_albedo_roof"], {"value": 1})
+            self.assertEqual(updated_stebbs["same_emissivity_wall"], {"value": 0})
+            self.assertEqual(updated_stebbs["same_emissivity_roof"], {"value": 1})
+
+            report_content = report_file.read_text(encoding="utf-8")
+            self.assertNotIn("model.physics.stebbs.value", report_content)
+            self.assertNotIn("model.physics.capacitance", report_content)
+            self.assertNotIn("model.physics.same_albedo_wall", report_content)
+
     def test_gh1417_empty_current_output_wins_over_legacy_duplicate(self):
         """An empty current output block is valid and should not be overwritten."""
         data = deepcopy(self.standard_data)


### PR DESCRIPTION
## Summary
- fold legacy flat STEBBS physics entries into `model.physics.stebbs` before Phase A writes updated YAML
- remove stale `stebbs.value` and flat STEBBS siblings from validation output
- normalise STEBBS compatibility for missing/extra parameter checks

Fixes #1497

## Validation
- pytest test/data_model/test_yaml_processing.py::TestUptodateYaml::test_gh1497_flat_stebbs_physics_is_folded_before_phase_a_output test/cmd/test_validate_config.py::test_validate_pipeline_cleans_legacy_flat_stebbs_updated_yaml -q
- pytest test/cmd/test_validate_config.py::test_validate_flat_stebbs_form_not_flagged_missing test/data_model/test_yaml_processing.py::TestUptodateYaml::test_stebbs_toggle_omission_not_flagged_critical -q
- pytest test/data_model/test_yaml_processing.py::TestUptodateYaml -q
- pytest test/cmd/test_validate_config.py -q
- make test-smoke