### PR TITLE
Benchmark: Zenodo-backed data supply + scheduled regression workflow (stage 1)

### DIFF
--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -1,0 +1,95 @@
+# SUEWS regression benchmark (esmae) — see benchmark/README.md.
+#
+# Stage 1 (active): prove the sensitive-data supply path end-to-end in CI —
+#   a GitHub secret unlocks a RESTRICTED Zenodo record holding the evaluation
+#   dataset; the dataset is fetched on the ephemeral runner and schema-checked.
+#   Uses the SANDBOX record + synthetic (fabricated) data, so no real sensitive
+#   observations and no data-governance dependency.
+# Stage 2 (disabled below): build the current model, run the benchmark against
+#   the real restricted observations, emit the password-protected site.
+name: Benchmark regression
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *" # daily 03:17 UTC (off-minute, per CI conventions)
+  # Run on PRs that touch the benchmark itself, so changes here are validated.
+  # (Same-repo branch -> has secrets access; fork PRs do not and will skip cleanly.)
+  pull_request:
+    paths:
+      - "benchmark/**"
+      - ".github/workflows/benchmark-regression.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-regression
+  cancel-in-progress: false
+
+jobs:
+  # Stage 1 — data-supply proof (restricted Zenodo via a GitHub secret).
+  supply-proof:
+    runs-on: ubuntu-latest
+    # Fork PRs cannot read secrets; skip rather than fail.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install minimal deps
+        run: python -m pip install --no-input pandas
+
+      - name: Fetch restricted evaluation dataset from Zenodo and validate schema
+        working-directory: benchmark
+        env:
+          # Map the SANDBOX secret to the generic var the resolver reads.
+          ZENODO_TOKEN: ${{ secrets.ZENODO_SANDBOX_TOKEN }}
+          ZENODO_BASE: https://sandbox.zenodo.org
+          OBS_SOURCE: zenodo:${{ vars.BENCHMARK_SANDBOX_RECID || '508290' }}/synthetic_eb_obs.csv
+          BENCHMARK_OUT: ${{ github.workspace }}/benchmark_supply_out
+        run: python check_supply.py
+
+      - name: Upload supply summary (non-sensitive)
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: benchmark-supply-summary
+          path: benchmark_supply_out/
+
+  # Stage 2 — full regression of the CURRENT model against the REAL restricted
+  # observations. DISABLED until: (a) data-governance sign-off to host the KCL
+  # observations on a restricted production Zenodo record, and (b) esmae is
+  # pinned to a stable commit. Shown here so the target shape is reviewable.
+  full-benchmark:
+    if: false
+    runs-on: ubuntu-latest
+    needs: supply-proof
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Build current SUEWS (Fortran + Rust) + install supy
+        uses: ./.github/actions/build-suews
+      - name: Install benchmark requirements
+        # Benchmark metrics/logic are vendored under benchmark/ (after esmae review);
+        # only third-party runtime deps are installed here.
+        run: uv pip install --system xarray pandas matplotlib
+      - name: Fetch real evaluation observations (restricted production Zenodo)
+        env:
+          ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+          OBS_SOURCE: zenodo:${{ vars.BENCHMARK_PROD_RECID }}/Kc1_Obs.csv
+        run: python benchmark/data_supply.py fetch "$OBS_SOURCE" "$RUNNER_TEMP/obs"
+      - name: Run benchmark + regression verdict (fail on regression)
+        run: python benchmark/run_benchmark.py --obs-dir "$RUNNER_TEMP/obs" --out _site/benchmark --fail-on-regression
+      - name: Password-protect the page (staticrypt) and hand off to Pages deploy
+        env:
+          BENCHMARK_PAGE_PASSWORD: ${{ secrets.BENCHMARK_PAGE_PASSWORD }}
+        run: npx staticrypt "_site/benchmark/**/*.html" --password "$BENCHMARK_PAGE_PASSWORD" --short -d _site/benchmark

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,61 @@
+# SUEWS regression benchmark
+
+A scheduled regression check that evaluates the **current** SUEWS code against
+reference observations and flags any decline in accuracy.
+
+## Approach
+
+The benchmark **metrics and logic** (bias/error statistics, the pass/fail
+regression verdict) are the core; they will be vendored into this `benchmark/`
+package after review of the prototype esmae suite, so SUEWS owns them and has no
+external private dependency. The surrounding **plumbing** — sensitive-data
+supply, CI, and the results page — is maintained here directly.
+
+## Why a separate data-supply layer
+
+The evaluation **observations are sensitive** and must never live in this public
+repository. They are hosted on a **restricted Zenodo record** and fetched at CI
+runtime via a bearer token (a GitHub Actions secret), used only on the ephemeral
+runner. Only **derived statistics and plots** are ever published. This is the
+purpose of `data_supply.py`.
+
+## Components
+
+- `data_supply.py` — resolves an evaluation-data `source` to a local path:
+  - `local:/path/to/file.csv` for local development;
+  - `zenodo:<recid>[/<file>]` for CI, with `Authorization: Bearer $ZENODO_TOKEN`
+    for restricted records. `ZENODO_BASE` switches between production and sandbox.
+- `check_supply.py` — CI proof that the restricted dataset can be fetched via a
+  secret and has the expected energy-balance schema (non-sensitive summary only).
+- `run_benchmark.py` — full benchmark runner (Stage 2). It currently drives the
+  prototype benchmark engine; the metrics are to be vendored here so this becomes
+  self-contained.
+
+## Secrets and variables (repo settings)
+
+- `ZENODO_TOKEN` — production Zenodo token (read access to the real restricted record).
+- `ZENODO_SANDBOX_TOKEN` — sandbox token (used by the Stage 1 supply proof).
+- `vars.BENCHMARK_SANDBOX_RECID` — sandbox record id of the synthetic test dataset.
+- `vars.BENCHMARK_PROD_RECID` — production record id of the real observations (Stage 2).
+- `BENCHMARK_PAGE_PASSWORD` — staticrypt password for the published page (Stage 2).
+
+## Rollout stages (`.github/workflows/benchmark-regression.yml`)
+
+1. **Supply proof (active).** Fetches a **fabricated, same-format** dataset from a
+   **restricted sandbox** Zenodo record using `ZENODO_SANDBOX_TOKEN` and validates
+   its schema. No real data, no governance dependency — it proves the
+   secret -> restricted Zenodo -> benchmark-input path works in GitHub Actions.
+2. **Full regression (disabled).** Builds the current model, fetches the **real**
+   restricted observations via `ZENODO_TOKEN`, runs the benchmark, fails on
+   regression beyond threshold, and publishes a password-protected page on
+   suews.io. Enabled once (a) data-governance sign-off is in place to host the
+   observations on a restricted production Zenodo record, and (b) the benchmark
+   metrics are vendored here.
+
+## Known limitations / TODO
+
+- **Metrics vendoring.** Incorporate the benchmark metrics/logic into this package
+  (after review) so there is no external dependency.
+- **Presentation.** The emitted HTML is functional but not presentation-quality.
+  A dedicated page consistent with the suews.io design system is a follow-up,
+  done once the pipeline works end-to-end. Not a blocker for the regression logic.

--- a/benchmark/check_supply.py
+++ b/benchmark/check_supply.py
@@ -1,0 +1,74 @@
+"""CI proof of the restricted-Zenodo data supply.
+
+Fetches the (restricted) evaluation dataset from Zenodo using a bearer token
+(GitHub Actions secret mapped to $ZENODO_TOKEN), validates that it has the
+expected energy-balance observation schema, and writes a small NON-SENSITIVE
+summary artefact (column list + row counts only -- never the raw data).
+
+Exit non-zero on any failure so the workflow fails loudly. This proves the
+secret -> restricted Zenodo record -> benchmark-input path that the full
+regression job depends on, without using any real sensitive data (the test
+record holds a fabricated, same-format synthetic dataset).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from data_supply import BASE, fetch_eval_data, get_token
+
+# Energy-balance obs columns the benchmark consumes (Kup/Lup/QN/QH/QE <- kup/lup/qn/qh/qe).
+REQUIRED = ["DateTime", "qn", "qh", "qe", "kdown", "ldown", "kup", "lup", "Tair"]
+
+
+def main() -> int:
+    source = os.environ.get("OBS_SOURCE")
+    if not source:
+        print("ERROR: OBS_SOURCE not set (e.g. zenodo:<recid>/synthetic_eb_obs.csv)", file=sys.stderr)
+        return 2
+
+    out_dir = Path(os.environ.get("BENCHMARK_OUT", "benchmark_supply_out"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    token = get_token()
+    if source.startswith("zenodo:") and not token:
+        print("ERROR: zenodo: source needs a token in $ZENODO_TOKEN", file=sys.stderr)
+        return 2
+
+    print(f"[supply] base={BASE} source={source} token={'present' if token else 'none'}")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = fetch_eval_data(source, tmp, token=token)
+        df = pd.read_csv(path)
+        n = len(df)
+        cols = list(df.columns)
+        missing = [c for c in REQUIRED if c not in cols]
+
+        summary = {
+            "source": source if not source.startswith("zenodo:") else source.split("/")[0] + "/<file>",
+            "base": BASE,
+            "rows": int(n),
+            "n_columns": len(cols),
+            "required_present": not missing,
+            "missing_required": missing,
+        }
+        (out_dir / "supply_summary.json").write_text(json.dumps(summary, indent=2))
+        print("[supply] summary:", json.dumps(summary))
+
+        if missing:
+            print(f"ERROR: fetched dataset missing required columns: {missing}", file=sys.stderr)
+            return 1
+        if n <= 0:
+            print("ERROR: fetched dataset has no rows", file=sys.stderr)
+            return 1
+
+    print("[supply] OK: restricted Zenodo dataset fetched and schema validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/data_supply.py
+++ b/benchmark/data_supply.py
@@ -1,0 +1,100 @@
+"""Evaluation-data supply resolver for the SUEWS regression benchmark.
+
+The benchmark evaluates the model against observational datasets that are
+SENSITIVE and must never live in this public repository. They are hosted on a
+RESTRICTED Zenodo record and fetched at CI runtime via a token (a GitHub Actions
+secret). Only derived statistics/plots are ever published.
+
+Sources (used in place of an `evaluation.*.path` value):
+  local:/abs/path/to/file.csv     -> a file already on disk (local development)
+  zenodo:<recid>[/<filename>]     -> downloaded from Zenodo (CI / restricted)
+
+For a restricted record the download requires a bearer token, read from the
+ZENODO_TOKEN environment variable (map the appropriate secret to it in the
+workflow). Set ZENODO_BASE=https://sandbox.zenodo.org to use the sandbox.
+
+Stdlib only (urllib) so it runs on a bare GitHub runner.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+BASE = os.environ.get("ZENODO_BASE", "https://zenodo.org").rstrip("/")
+
+
+def get_token() -> str | None:
+    """Bearer token from $ZENODO_TOKEN (map the right secret to it in CI)."""
+    tok = os.environ.get("ZENODO_TOKEN")
+    return tok.strip() if tok else None
+
+
+def _req(url, token=None, method="GET", data=None, headers=None):
+    headers = dict(headers or {})
+    # A real User-Agent: Zenodo's edge 403s the default python-urllib UA on writes.
+    headers.setdefault("User-Agent", "suews-benchmark/1.0 (data-supply)")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        return urllib.request.urlopen(req)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "replace")[:500]
+        raise urllib.error.HTTPError(e.url, e.code, f"{e.reason} :: {body}", e.hdrs, None) from None
+
+
+def fetch_eval_data(source: str, dest_dir: str, token: str | None = None) -> str:
+    """Resolve an obs `source` to a concrete local file path under dest_dir."""
+    Path(dest_dir).mkdir(parents=True, exist_ok=True)
+
+    if source.startswith("local:"):
+        src = source[len("local:"):]
+        dst = Path(dest_dir) / Path(src).name
+        shutil.copyfile(src, dst)
+        return str(dst)
+
+    if source.startswith("zenodo:"):
+        token = token or get_token()
+        spec = source[len("zenodo:"):]
+        recid, _, fname = spec.partition("/")
+        with _req(f"{BASE}/api/records/{recid}", token=token) as r:
+            rec = json.load(r)
+        files = rec.get("files", [])
+        if not files:
+            raise RuntimeError(
+                f"No files visible on Zenodo record {recid}. "
+                "For a restricted record, check ZENODO_TOKEN has access."
+            )
+        entry = next(
+            (f for f in files if not fname or (f.get("key") or f.get("filename")) == fname),
+            None,
+        )
+        if entry is None:
+            raise RuntimeError(f"File {fname!r} not found in Zenodo record {recid}")
+        key = entry.get("key") or entry.get("filename")
+        links = entry.get("links", {})
+        content_url = (
+            links.get("content")
+            or links.get("download")
+            or f"{BASE}/api/records/{recid}/files/{key}/content"
+        )
+        dst = Path(dest_dir) / key
+        with _req(content_url, token=token) as r, open(dst, "wb") as out:
+            shutil.copyfileobj(r, out)
+        return str(dst)
+
+    raise ValueError(f"Unsupported source scheme: {source!r} (use local: or zenodo:)")
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) >= 4 and sys.argv[1] == "fetch":
+        print(fetch_eval_data(sys.argv[2], sys.argv[3]))
+    else:
+        print("usage: python data_supply.py fetch <source> <dest_dir>", file=sys.stderr)
+        raise SystemExit(2)

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -1,0 +1,103 @@
+"""Full benchmark runner (Stage 2).
+
+Resolves the evaluation observations from a swappable source (`local:` or a
+restricted `zenodo:` record), runs the esmae benchmark for the configured site,
+writes the HTML report, and returns a non-zero exit code on regression when
+``--fail-on-regression`` is set.
+
+This encodes the flow validated locally against the Ward-2016 KCL case. It is
+wired into CI by the (currently disabled) ``full-benchmark`` job once the real
+restricted production record and data-governance sign-off are in place. The
+site config + benchmark setup YAML are added under ``benchmark/configs`` and
+``benchmark/setups`` in the Stage-2 enablement PR.
+
+Several esmae dev-branch quirks are routed around here rather than patched
+upstream (tracked for report to the esmae maintainer):
+  * BenchmarkInfo lacks save_stats/load_stats on the recompute path;
+  * BenchmarkWebsite.save_site re-saves model forcing and crashes when supy
+    could not load the (wider-than-expected) forcing file -> write HTML only.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from data_supply import fetch_eval_data  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_SETUP = HERE / "setups" / "benchmark_kcl.yaml"
+
+
+def _shim_benchmark_info() -> None:
+    """Add attrs esmae's recompute path reads but its BenchmarkInfo omits."""
+    from esmae._benchmark._core import BenchmarkInfo as BI
+
+    for attr in ("save_stats", "load_stats", "compare_stats",
+                 "save_plots", "load_plots", "compare_plots"):
+        if not hasattr(BI, attr):
+            setattr(BI, attr, False)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Run the SUEWS regression benchmark")
+    ap.add_argument("--obs-source", required=True,
+                    help="local:/path/to.csv or zenodo:<recid>/<file>")
+    ap.add_argument("--setup", default=str(DEFAULT_SETUP),
+                    help="benchmark setup YAML")
+    ap.add_argument("--out", default="site", help="output site directory")
+    ap.add_argument("--title", default=None, help="model-version label / results subdir")
+    ap.add_argument("--fail-on-regression", action="store_true",
+                    help="exit non-zero if the benchmark status is a regression")
+    args = ap.parse_args()
+
+    import esmae as em
+    from esmae._quicklook import WebsiteBase
+
+    _shim_benchmark_info()
+
+    setup = Path(args.setup)
+    if not setup.exists():
+        print(f"ERROR: setup YAML not found: {setup}\n"
+              "Add the site config + setup under benchmark/ (Stage-2 enablement).",
+              file=sys.stderr)
+        return 2
+
+    # Resolve the (sensitive) observations into a temp dir and point the setup at it.
+    tmp = tempfile.mkdtemp(prefix="obs_")
+    resolved = fetch_eval_data(args.obs_source, tmp)
+    print(f"[supply] {args.obs_source} -> {resolved}")
+
+    cfg = yaml.safe_load(setup.read_text())
+    cfg.setdefault("evaluation", {}).setdefault("energy_balance", {})["path"] = resolved
+    run_setup = Path(tmp) / "setup_resolved.yaml"
+    run_setup.write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+    title = args.title or f"v{__import__('supy').__version__}"
+    site = em.BenchmarkWebsite(title=title, exist_okay=True, working_dir=args.out)
+    site.benchmarker.register(benchmark_cls=em.presets.CustomBase, name="benchmark")
+    site.benchmark(name="benchmark", benchmarkID=cfg.get("info", {}).get("benchmarkID", "bm"),
+                   setup_path=str(run_setup), save=False)
+
+    bm = site.benchmarker.get_benchmark("benchmark")
+    status = bool(getattr(bm, "_status", False))
+    print(f"[benchmark] status (passed)={status}")
+
+    # Write HTML only (avoid esmae save_all's forcing re-save crash).
+    try:
+        site.save_site()
+    except AttributeError:
+        WebsiteBase.save_site(site, save_dir=Path(site.info.website_dir))
+
+    if args.fail_on_regression and not status:
+        print("REGRESSION: benchmark status did not pass.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,11 @@ tmy = [
     "metpy",  # Required for UMEP EPW conversion (util/_UMEP2epw.py)
 ]
 
+# NB: the regression-benchmark suite has no public dependency here on purpose.
+# The benchmark metrics/logic will be vendored into `benchmark/` after review;
+# any remaining third-party benchmark deps are installed inside the benchmark
+# workflow so this published package stays pip-installable for everyone.
+
 # Core development tooling (kept separate from docs to reduce supply-chain surface)
 dev = [
     # Testing


### PR DESCRIPTION
## What this is

Scaffolding for a **scheduled SUEWS regression benchmark** that evaluates the current code against reference observations and flags accuracy regressions.

The benchmark **metrics/logic** will be vendored into `benchmark/` after review so SUEWS owns them with no external dependency; the **plumbing** (sensitive-data supply, CI, results page) is maintained here. The evaluation **observations are sensitive** and never enter this repo — they are fetched at CI runtime from a **restricted Zenodo record** via a token (GitHub secret), used only on the ephemeral runner; only derived stats/plots are published.

## Stage 1 (active in this PR) — data-supply proof

`.github/workflows/benchmark-regression.yml` → job `supply-proof`: uses `secrets.ZENODO_SANDBOX_TOKEN` to fetch a **fabricated, same-format** dataset from a **restricted sandbox Zenodo record** and validates its schema. Proves the *secret → restricted Zenodo → benchmark-input* path in real GitHub Actions, with **no real data and no data-governance dependency**.

## Stage 2 (disabled — `if: false`) — full regression

Builds the current model, fetches the **real** restricted observations via `secrets.ZENODO_TOKEN`, runs the benchmark, fails on regression, and publishes the benchmark results page(s) on suews.io. The pages carry **only derived statistics** — the observations stay restricted and never reach the page — so no page-level password is required. Enabled once: (a) data-governance sign-off to host the observations on a restricted production Zenodo record, and (b) the benchmark metrics are vendored here.

## Repo config used
- secrets: `ZENODO_SANDBOX_TOKEN`, `ZENODO_TOKEN`
- vars: `BENCHMARK_SANDBOX_RECID` (=508290), later `BENCHMARK_PROD_RECID`

## Notes
- Actions SHA-pinned; `permissions: contents: read`; fork PRs skip (no secrets).
- No third-party benchmark dependency is declared in `pyproject.toml` (keeps the published package pip-installable); benchmark deps are installed in the workflow.
- Presentation-quality benchmark pages — a multi-version suite overview plus a per-site detail page (coloured visuals, release selector) — now exist on the `feat/benchmark-page-design` branch; they read the derived results and get wired into the deploy when Stage 2 lands.

Draft: for review of the architecture before vendoring metrics and enabling Stage 2.
