### PR TITLE
Fix validate-tutorial hook: resolve python interpreter (no bare `python`)

### DIFF
--- a/.claude/hooks/validate-tutorial.sh
+++ b/.claude/hooks/validate-tutorial.sh
@@ -7,6 +7,19 @@ set -euo pipefail
 # Fallback to git root if CLAUDE_PROJECT_DIR is not set
 CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 
+# Resolve a Python interpreter. Hooks run without an activated venv, so do NOT
+# rely on a bare `python` being on PATH (it usually is not). Prefer the repo
+# venv, then fall back to python3/python from PATH.
+if [[ -x "$CLAUDE_PROJECT_DIR/.venv/bin/python" ]]; then
+    PYTHON="$CLAUDE_PROJECT_DIR/.venv/bin/python"
+else
+    PYTHON="$(command -v python3 || command -v python || true)"
+fi
+# No interpreter available: nothing we can validate, and we must not block the edit.
+if [[ -z "$PYTHON" ]]; then
+    exit 0
+fi
+
 # Get the edited file path from stdin (JSON format)
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
@@ -23,8 +36,8 @@ else
     CANDIDATE_PATH="$CLAUDE_PROJECT_DIR/$FILE_PATH"
 fi
 
-CANONICAL_PATH=$(python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CANDIDATE_PATH" 2>/dev/null || true)
-PROJECT_ROOT=$(python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CLAUDE_PROJECT_DIR")
+CANONICAL_PATH=$("$PYTHON" -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CANDIDATE_PATH" 2>/dev/null || true)
+PROJECT_ROOT=$("$PYTHON" -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CLAUDE_PROJECT_DIR")
 
 # Only validate tutorial Python files inside this repository
 if [[ -z "$CANONICAL_PATH" ]] || [[ ! "$CANONICAL_PATH" =~ ^$PROJECT_ROOT/docs/source/tutorials/[^/]+\.py$ ]]; then
@@ -36,12 +49,7 @@ if [[ ! -f "$CANONICAL_PATH" ]]; then
     exit 0
 fi
 
-# Activate virtual environment if available
-if [[ -f "$CLAUDE_PROJECT_DIR/.venv/bin/activate" ]]; then
-    source "$CLAUDE_PROJECT_DIR/.venv/bin/activate"
-fi
-
 # Validate syntax only without executing untrusted tutorial code
-python -m py_compile "$CANONICAL_PATH"
+"$PYTHON" -m py_compile "$CANONICAL_PATH"
 
 echo "Tutorial syntax validated: $(basename "$CANONICAL_PATH")"


### PR DESCRIPTION
The `validate-tutorial.sh` PostToolUse hook called bare `python`, which is not on
PATH in most shells here (only `python3` / uv venvs). It failed with
`python: command not found` at the realpath step — *before* the venv-activation
block — so it errored on essentially every relevant edit.

Fix: resolve a Python interpreter up front (prefer the repo `.venv`, else
`python3`/`python` from PATH) and use it for the realpath checks and `py_compile`;
exit cleanly if none is found. The now-redundant activation block is removed.

Validated locally: non-tutorial edits exit 0 silently; a tutorial `.py` is
syntax-checked and reported; no bare `python` calls remain.