### PR TITLE
Silence zizmor artipacked on the agent push-token checkout

### DIFF
--- a/.github/workflows/sync-agent-plugin.yml
+++ b/.github/workflows/sync-agent-plugin.yml
@@ -35,7 +35,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Checkout generated agent repository
+      # The SUEWS_AGENT_PUSH_TOKEN must persist so the generated plugin can be pushed
+      # back to UMEP-dev/suews-agent; persist-credentials:false is not applicable here.
+      - name: Checkout generated agent repository # zizmor: ignore[artipacked]
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: UMEP-dev/suews-agent


### PR DESCRIPTION
The **Advisory workflow audit** (zizmor) reports `artipacked` on the
`Checkout generated agent repository` step in `sync-agent-plugin.yml`. That step
**intentionally** persists credentials — `SUEWS_AGENT_PUSH_TOKEN` is needed to push
the generated plugin back to `UMEP-dev/suews-agent`, so `persist-credentials: false`
is not applicable.

Fix: a justified inline `# zizmor: ignore[artipacked]` on that step. The finding
surfaces on **every** PR (zizmor scans all workflows, not just changed ones), so
suppressing this legitimate case clears the audit repo-wide.

Verified locally: `zizmor --no-online-audits .github/workflows .github/actions`
→ *No findings to report (1 ignored, 54 suppressed)*.

After this merges, open PRs (e.g. #1502) clear the advisory audit once rebased onto master.