### PR TITLE
Fix legacy STEBBS df_state defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 77 | 84 | 30 | 81 | 40 | 313 |
+| 2026 | 77 | 83 | 30 | 81 | 40 | 312 |
 | 2025 | 60 | 68 | 22 | 71 | 36 | 256 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
@@ -54,16 +54,18 @@ EXAMPLES:
 
 ## 2026
 
+### 4 Jun 2026
+
+- [bugfix] Legacy SUEWS table to YAML conversion no longer aborts on a missing `stebbsmethod` df_state column (#1500)
+  - `ModelPhysics.from_df_state` now defaults a missing `stebbsmethod` column to `0` (STEBBS disabled) instead of raising `Missing attribute 'stebbsmethod'`, consistent with how the adjacent newer STEBBS columns (`setpointmethod`, `rcmethod`) already default; a present-but-invalid value is still rejected
+  - The originally reported `setpointmethod` symptom was already resolved by the #1456 STEBBS relocation; this completes the issue by hardening the last hard-required STEBBS column and adds regression tests covering both the `setpointmethod` and `stebbsmethod` legacy-DataFrame cases
+
 ### 3 Jun 2026
 
 - [change][experimental] Align physics method selectors on the observed/modelled axis (#1501)
   - `model.physics.frontal_area_index` now exposes only the canonical readable names `observed` and `modelled`; the synonym aliases `provided`, `use_provided`, and `simple_scheme` are removed so it matches `laimethod`, `water_use`, and `soil_moisture_deficit`
   - Internal source-of-input enums aligned to one vocabulary: `LAIMethod.CALCULATED` becomes `MODELLED`, and `FAIMethod.USE_PROVIDED` / `SIMPLE_SCHEME` become `OBSERVED` / `MODELLED`; integer values are unchanged, so existing YAML and `df_state` round-trip identically
   - `net_radiation` scalar-name errors now point scheme families (`narp`, `spartacus`) at the nested family form rather than only listing the `ldown_*` names
-
-- [bugfix] Legacy SUEWS table to YAML conversion no longer aborts on a missing `stebbsmethod` df_state column (#1500)
-  - `ModelPhysics.from_df_state` now defaults a missing `stebbsmethod` column to `0` (STEBBS disabled) instead of raising `Missing attribute 'stebbsmethod'`, consistent with how the adjacent newer STEBBS columns (`setpointmethod`, `rcmethod`) already default; a present-but-invalid value is still rejected
-  - The originally reported `setpointmethod` symptom was already resolved by the #1456 STEBBS relocation; this completes the issue by hardening the last hard-required STEBBS column and adds regression tests covering both the `setpointmethod` and `stebbsmethod` legacy-DataFrame cases
 
 ### 1 Jun 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 77 | 83 | 30 | 81 | 40 | 312 |
+| 2026 | 77 | 84 | 30 | 81 | 40 | 313 |
 | 2025 | 60 | 68 | 22 | 71 | 36 | 256 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
@@ -60,6 +60,10 @@ EXAMPLES:
   - `model.physics.frontal_area_index` now exposes only the canonical readable names `observed` and `modelled`; the synonym aliases `provided`, `use_provided`, and `simple_scheme` are removed so it matches `laimethod`, `water_use`, and `soil_moisture_deficit`
   - Internal source-of-input enums aligned to one vocabulary: `LAIMethod.CALCULATED` becomes `MODELLED`, and `FAIMethod.USE_PROVIDED` / `SIMPLE_SCHEME` become `OBSERVED` / `MODELLED`; integer values are unchanged, so existing YAML and `df_state` round-trip identically
   - `net_radiation` scalar-name errors now point scheme families (`narp`, `spartacus`) at the nested family form rather than only listing the `ldown_*` names
+
+- [bugfix] Legacy SUEWS table to YAML conversion no longer aborts on a missing `stebbsmethod` df_state column (#1500)
+  - `ModelPhysics.from_df_state` now defaults a missing `stebbsmethod` column to `0` (STEBBS disabled) instead of raising `Missing attribute 'stebbsmethod'`, consistent with how the adjacent newer STEBBS columns (`setpointmethod`, `rcmethod`) already default; a present-but-invalid value is still rejected
+  - The originally reported `setpointmethod` symptom was already resolved by the #1456 STEBBS relocation; this completes the issue by hardening the last hard-required STEBBS column and adds regression tests covering both the `setpointmethod` and `stebbsmethod` legacy-DataFrame cases
 
 ### 1 Jun 2026
 

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -1145,13 +1145,16 @@ class ModelPhysics(BaseModel):
             except KeyError:
                 properties[attr] = RefValue(int(default_enum))
 
-        # gh#1456: reconstruct the nested StebbsPhysics from the unchanged
-        # fused columns. `stebbsmethod` is required; the rest fall back to
-        # their defaults if absent from a legacy DataFrame.
+        # gh#1456 / gh#1500: reconstruct the nested StebbsPhysics from the
+        # unchanged fused columns. A DataFrame predating STEBBS lacks the
+        # `stebbsmethod` column entirely (the premise of legacy-table
+        # conversion), so default it to 0 (STEBBS disabled) -- consistent with
+        # `dict_RunControl_default` and the other newer STEBBS columns below --
+        # rather than aborting. A present-but-invalid value is still rejected.
         try:
             stebbsmethod = int(df.loc[grid_id, ("stebbsmethod", "0")])
         except KeyError:
-            raise ValueError("Missing attribute 'stebbsmethod' in the DataFrame")
+            stebbsmethod = int(StebbsMethod.NONE)
         if stebbsmethod not in (0, 1, 2):
             raise ValueError(
                 f"Invalid stebbsmethod value {stebbsmethod}; expected 0, 1, or 2"

--- a/test/data_model/test_data_model.py
+++ b/test/data_model/test_data_model.py
@@ -23,7 +23,7 @@ from supy.data_model import (
     SiteProperties,
     SUEWSConfig,
 )
-from supy.data_model.core.model import ModelControl
+from supy.data_model.core.model import ModelControl, ModelPhysics, SetpointMethod
 
 pytestmark = pytest.mark.api
 
@@ -324,6 +324,61 @@ def test_refvalue_equality(value_a, value_b, should_equal):
         assert value_a == value_b
     else:
         assert value_a != value_b
+
+
+class TestLegacyDfStateStebbsDefaults(unittest.TestCase):
+    """gh#1500: ``ModelPhysics.from_df_state`` must default the newer STEBBS
+    method columns that legacy / pre-STEBBS DataFrames lack, rather than
+    aborting with ``Missing attribute '...'``.
+
+    The reported regression was ``setpointmethod`` (added in the 2026.1.28
+    setpoint split, #1317) being treated as a required df_state column, so
+    converting a legacy table set predating it failed. gh#1456 already moved
+    ``setpointmethod`` / ``rcmethod`` into the defaulting STEBBS-column set;
+    ``stebbsmethod`` is hardened here so a DataFrame predating STEBBS entirely
+    (the premise of legacy-table conversion) reconstructs with STEBBS disabled
+    instead of raising.
+    """
+
+    def setUp(self):
+        path = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        self.df_physics = SUEWSConfig.from_yaml(path).model.physics.to_df_state(
+            grid_id=1
+        )
+
+    def test_missing_setpointmethod_defaults_to_constant(self):
+        """Dropping ``setpointmethod`` defaults the setpoint scheme rather than
+        raising (the exact gh#1500 minimal repro at the ModelPhysics level)."""
+        df = self.df_physics.drop(columns=[("setpointmethod", "0")])
+        phys = ModelPhysics.from_df_state(df, grid_id=1)
+        self.assertEqual(phys.stebbs.setpoint.value, SetpointMethod.CONSTANT)
+
+    def test_missing_stebbsmethod_defaults_to_disabled(self):
+        """A pre-STEBBS DataFrame (no ``stebbsmethod`` column) reconstructs with
+        STEBBS disabled instead of aborting."""
+        df = self.df_physics.drop(columns=[("stebbsmethod", "0")])
+        phys = ModelPhysics.from_df_state(df, grid_id=1)
+        self.assertFalse(phys.stebbs.enabled.value)
+        self.assertEqual(int(phys.stebbs.parameters.value), 1)
+
+    def test_invalid_stebbsmethod_still_rejected(self):
+        """A present-but-invalid ``stebbsmethod`` value is still rejected; only
+        the missing-column case defaults."""
+        df = self.df_physics.copy()
+        df.loc[1, ("stebbsmethod", "0")] = 3
+        with self.assertRaises(ValueError):
+            ModelPhysics.from_df_state(df, grid_id=1)
+
+    def test_issue_minimal_repro_via_suews_config(self):
+        """The gh#1500 symptom at config level: drop ``setpointmethod`` from a
+        full df_state and round-trip through ``SUEWSConfig.from_df_state``."""
+        path = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        df = SUEWSConfig.from_yaml(path).to_df_state()
+        df_legacy = df.drop(columns=[("setpointmethod", "0")])
+        config = SUEWSConfig.from_df_state(df_legacy)
+        self.assertEqual(
+            config.model.physics.stebbs.setpoint.value, SetpointMethod.CONSTANT
+        )
 
 
 class TestGrididErrorTransformation(unittest.TestCase):

--- a/test/data_model/test_data_model.py
+++ b/test/data_model/test_data_model.py
@@ -23,7 +23,12 @@ from supy.data_model import (
     SiteProperties,
     SUEWSConfig,
 )
-from supy.data_model.core.model import ModelControl, ModelPhysics, SetpointMethod
+from supy.data_model.core.model import (
+    ModelControl,
+    ModelPhysics,
+    SetpointMethod,
+    StebbsParameterSource,
+)
 
 pytestmark = pytest.mark.api
 
@@ -359,7 +364,9 @@ class TestLegacyDfStateStebbsDefaults(unittest.TestCase):
         df = self.df_physics.drop(columns=[("stebbsmethod", "0")])
         phys = ModelPhysics.from_df_state(df, grid_id=1)
         self.assertFalse(phys.stebbs.enabled.value)
-        self.assertEqual(int(phys.stebbs.parameters.value), 1)
+        self.assertEqual(
+            phys.stebbs.parameters.value, StebbsParameterSource.DEFAULT
+        )
 
     def test_invalid_stebbsmethod_still_rejected(self):
         """A present-but-invalid ``stebbsmethod`` value is still rejected; only


### PR DESCRIPTION
## Summary

- Default missing `stebbsmethod` df_state columns to STEBBS disabled for legacy/pre-STEBBS table conversions.
- Preserve rejection of present-but-invalid `stebbsmethod` values.
- Add regression coverage for missing `setpointmethod`, missing `stebbsmethod`, and invalid `stebbsmethod` round-trips.

Closes #1500

## Validation

- `.venv/bin/python -m pytest test/data_model/test_data_model.py::TestLegacyDfStateStebbsDefaults -q`
- `.venv/bin/python -m pytest test/data_model/test_data_model.py -v --tb=short`
- `make PYTHON=.venv/bin/python test-smoke`
- `git diff --check`

Note: `make test-smoke` without `PYTHON=.venv/bin/python` is blocked in this shell because there is no bare `python` on PATH.
