### PR TITLE
ci: publish supy only; ship suews-mcp via the agent plugin (git), not PyPI

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -524,6 +524,9 @@ jobs:
           path: dist/
           merge-multiple: true
 
+      - name: Exclude suews-mcp (shipped via the agent plugin from git, not PyPI)
+        run: rm -f dist/suews_mcp-* dist/suews-mcp-*
+
       - name: Publish wheels to Test PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1.14 (v1.14.0 tag commit lacks a published ghcr image)
         with:
@@ -564,6 +567,9 @@ jobs:
         with:
           path: dist/
           merge-multiple: true
+
+      - name: Exclude suews-mcp (shipped via the agent plugin from git, not PyPI)
+        run: rm -f dist/suews_mcp-* dist/suews-mcp-*
 
       - name: Publish all wheels to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1.14 (v1.14.0 tag commit lacks a published ghcr image)


### PR DESCRIPTION
Unblocks the 2026.6.5 release. The agent plugin runs the MCP server from git (`uvx --from git+...#subdirectory=mcp suews-mcp`), so `suews-mcp` does not need PyPI. Its first-time trusted-publish upload failed (PyPI 400: non-user identities cannot create new projects), which also blocked `supy`. This drops `suews-mcp` from the PyPI/TestPyPI deploy jobs so `supy` publishes on its own; `build_mcp` still validates the package. After this merges, the `2026.6.5` tag is moved to include it and re-pushed to publish `supy` only.