### PR TITLE
Make supy file logging opt-in (stop creating SuPy.log on import)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ EXAMPLES:
 
 ### 5 Jun 2026
 
+- [change][experimental] File logging is now opt-in: importing or using `supy` no longer drops an (often empty) `SuPy.log` into the current working directory (#1516)
+  - Previously a `TimedRotatingFileHandler` was attached at import time and eagerly created `SuPy.log` in the CWD the moment any submodule was used, whether or not anything was ever logged
+  - Console logging is unchanged; only the file handler is now off by default
+  - Enable file logging on demand with `supy.enable_file_logging()` (defaults to `SuPy.log` in the CWD, or pass a path/directory) and turn it off with `supy.disable_file_logging()`
+  - Or enable it without code via the `SUPY_LOGFILE` (explicit path) / `SUPY_LOG_DIR` (directory) environment variables
+  - When enabled, the file is created lazily on the first emitted record (`delay=True`), so no stray empty file appears
 - [change] Finalised the YAML configuration schema to `2026.5` for the 2026.6.5 release (#1256, #1321, #1327, #1333, #1334, #1337, #1372, #1392, #1394, #1452, #1456, #1495)
   - The `2026.5.dev1`..`2026.5.dev14` development-cycle labels are collapsed into the single released `2026.5` schema; `sample_config.yml`, the migration handlers, and the vendored release fixture now carry `2026.5`
   - User YAMLs from `2026.4` (or any earlier supported schema) upgrade in one step via `suews-schema migrate your_config.yml` -- the `(2026.4 -> 2026.5)` handler applies the full union of the cycle's renames and restructures and logs every field rename/drop

--- a/docs/source/api/core-functions.rst
+++ b/docs/source/api/core-functions.rst
@@ -43,3 +43,35 @@ The legacy functional API workflow consists of:
 4. **Save results**: :func:`save_supy` to write outputs to disk (deprecated)
 
 **Recommended**: See :doc:`simulation` for the modern object-oriented interface.
+
+Logging Controls
+----------------
+
+These functions are not deprecated; they control where SuPy writes its logs.
+
+.. autosummary::
+    :toctree: _autosummary
+
+    enable_file_logging
+    disable_file_logging
+
+By default SuPy logs only to the console; no ``SuPy.log`` file is created.
+Call :func:`enable_file_logging` to also write a log file (lazily created on
+the first message, so an unused logger leaves no stray file) and
+:func:`disable_file_logging` to stop it again:
+
+.. code-block:: python
+
+    import supy
+
+    supy.enable_file_logging()              # writes SuPy.log in the current directory
+    supy.enable_file_logging("~/supy-logs") # or into a chosen directory
+    supy.disable_file_logging()             # stop writing to the file
+
+File logging can also be enabled without code by setting an environment
+variable before importing supy:
+
+.. code-block:: bash
+
+    export SUPY_LOGFILE=~/supy-logs/run.log   # explicit file path
+    export SUPY_LOG_DIR=~/supy-logs           # directory; file is SuPy.log inside it

--- a/docs/source/api/core-functions.rst
+++ b/docs/source/api/core-functions.rst
@@ -64,14 +64,16 @@ the first message, so an unused logger leaves no stray file) and
 
     import supy
 
-    supy.enable_file_logging()              # writes SuPy.log in the current directory
-    supy.enable_file_logging("~/supy-logs") # or into a chosen directory
-    supy.disable_file_logging()             # stop writing to the file
+    supy.enable_file_logging()                  # writes SuPy.log in the current directory
+    supy.enable_file_logging("~/logs/run.log")  # a specific file (~ is expanded)
+    supy.disable_file_logging()                 # stop writing to the file
 
-File logging can also be enabled without code by setting an environment
-variable before importing supy:
+To log into a directory (created if needed), use the ``SUPY_LOG_DIR``
+environment variable, which always writes ``SuPy.log`` inside it. File logging
+can be enabled entirely without code by setting an environment variable before
+importing supy:
 
 .. code-block:: bash
 
-    export SUPY_LOGFILE=~/supy-logs/run.log   # explicit file path
-    export SUPY_LOG_DIR=~/supy-logs           # directory; file is SuPy.log inside it
+    export SUPY_LOGFILE=~/logs/run.log   # explicit file path
+    export SUPY_LOG_DIR=~/logs           # directory; file is SuPy.log inside it

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -55,7 +55,7 @@ First time steps of storage output could give NaN values during the initial conv
 
 First things to Check if the program seems to have problems
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--  Check the Python runtime logs (SuPy logger output). Legacy ``problems.txt``/``warnings.txt`` files are no longer written.
+-  Check the Python runtime logs (SuPy logger output). Legacy ``problems.txt``/``warnings.txt`` files are no longer written. SuPy logs to the console by default; to capture the output in a file, call :func:`supy.enable_file_logging` or set the ``SUPY_LOGFILE`` / ``SUPY_LOG_DIR`` environment variable (see :ref:`api_core_functions`).
 -  Check file options – in RunControl.nml.
 -  Look in the output directory for the SS_FileChoices.txt. This allows you to check all options that were used in the run. You may want to compare it with the original version supplied with the model.
 -  Note there can not be missing time steps in the data. If you need help with this you may want to checkout `UMEP <https://umep-docs.readthedocs.io/>`__

--- a/src/supy/__init__.py
+++ b/src/supy/__init__.py
@@ -56,6 +56,9 @@ __all__ = [
     "SUEWSOutput",
     # Exceptions
     "SUEWSKernelError",
+    # Logging (opt-in file logging)
+    "enable_file_logging",
+    "disable_file_logging",
     # Version
     "show_version",
     "__version__",
@@ -188,6 +191,14 @@ def __getattr__(name):
             return _lazy_cache[name]
         except ImportError:
             return None
+
+    # Opt-in file logging controls (lightweight: only touches `_env`)
+    if name in {"enable_file_logging", "disable_file_logging"}:
+        from ._env import disable_file_logging, enable_file_logging
+
+        _lazy_cache["enable_file_logging"] = enable_file_logging
+        _lazy_cache["disable_file_logging"] = disable_file_logging
+        return _lazy_cache[name]
 
     # Version info
     if name == "show_version":

--- a/src/supy/_env.py
+++ b/src/supy/_env.py
@@ -5,11 +5,13 @@ except ImportError:
     from importlib_resources import files
 
 
-from logging.handlers import TimedRotatingFileHandler
-import sys
 import logging
-from pathlib import Path
+import os
+import sys
 import tempfile
+import warnings
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
 
 
 ########################################################################
@@ -22,8 +24,15 @@ trv_supy_module = files("supy")
 # set up logger format, note `u` to guarantee UTF-8 encoding
 FORMATTER = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
-# log file name
+# default log file name; only written when file logging is opted into
 LOG_FILE = "SuPy.log"
+
+# Environment variables to opt in to file logging. By default supy logs only to
+# the console -- no SuPy.log is created -- unless one of these is set or
+# `enable_file_logging()` is called explicitly. This avoids dropping a stray
+# (often empty) SuPy.log into whatever directory a script happens to run from.
+ENV_LOGFILE = "SUPY_LOGFILE"  # explicit path to the log file
+ENV_LOG_DIR = "SUPY_LOG_DIR"  # directory; the file is <dir>/SuPy.log
 
 # issue reporting URL
 ISSUES_URL = "https://github.com/UMEP-dev/SUEWS/issues/new"
@@ -40,25 +49,87 @@ def get_console_handler():
         return logging.NullHandler()
 
 
-def get_file_handler():
-    try:
-        path_logfile = Path(LOG_FILE)
-        path_logfile.touch()
-    except Exception as e:
-        import warnings
+def _coerce_logfile_path(path):
+    """Resolve a user-supplied location to a concrete log-file path.
 
-        tempdir = tempfile.gettempdir()
-        path_logfile = Path(tempdir) / LOG_FILE
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        A log-file path, or a directory (existing, or written with a trailing
+        separator) in which the default ``SuPy.log`` name is used.
+
+    Returns
+    -------
+    pathlib.Path
+        The resolved log-file path.
+    """
+    path_logfile = Path(path)
+    if path_logfile.is_dir() or str(path).endswith((os.sep, "/")):
+        return path_logfile / LOG_FILE
+    return path_logfile
+
+
+def _resolve_env_logfile():
+    """Return the opt-in log-file path requested via environment, or ``None``.
+
+    Returns
+    -------
+    pathlib.Path or None
+        Path from ``SUPY_LOGFILE`` (preferred) or ``SUPY_LOG_DIR``; ``None``
+        when neither is set.
+    """
+    env_file = os.environ.get(ENV_LOGFILE)
+    if env_file:
+        return Path(env_file)
+    env_dir = os.environ.get(ENV_LOG_DIR)
+    if env_dir:
+        return Path(env_dir) / LOG_FILE
+    return None
+
+
+def get_file_handler(path=None):
+    """Build a rotating file handler that defers file creation.
+
+    ``delay=True`` means the underlying file is opened only when the first
+    record is emitted, so merely constructing the handler -- or importing
+    supy -- never leaves a stray empty ``SuPy.log`` behind.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path, optional
+        Target log file or directory. Defaults to ``SuPy.log`` in the current
+        working directory.
+
+    Returns
+    -------
+    logging.handlers.TimedRotatingFileHandler
+        A handler configured for daily rotation at midnight, UTF-8 encoded.
+    """
+    path_logfile = _coerce_logfile_path(path) if path is not None else Path(LOG_FILE)
+    log_dir = path_logfile.parent
+
+    # Best-effort: make sure the target directory exists when one was asked
+    # for. No log file is created here -- that is what `delay=True` guarantees.
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+
+    if not os.access(log_dir, os.W_OK):
+        path_fallback = Path(tempfile.gettempdir()) / path_logfile.name
         warnings.warn(
-            f"Could not create log file at {LOG_FILE} ({e}); using {path_logfile} instead",
+            f"Log directory '{log_dir}' is not writable; "
+            f"writing SuPy log to '{path_fallback}' instead",
             UserWarning,
             stacklevel=2,
         )
+        path_logfile = path_fallback
 
     file_handler = TimedRotatingFileHandler(
         path_logfile,
         when="midnight",
         encoding="utf-8",
+        delay=True,
     )
     file_handler.setFormatter(FORMATTER)
     return file_handler
@@ -69,7 +140,8 @@ def get_logger(logger_name, level=logging.DEBUG):
     # better to have too much log than not enough
     logger.setLevel(level)
     logger.addHandler(get_console_handler())
-    logger.addHandler(get_file_handler())
+    # File logging is opt-in: no file handler is attached by default (see
+    # `enable_file_logging` and the SUPY_LOGFILE / SUPY_LOG_DIR env vars).
 
     # with this pattern, it's rarely necessary to propagate the error up to parent
     logger.propagate = False
@@ -79,10 +151,62 @@ def get_logger(logger_name, level=logging.DEBUG):
 logger_supy = get_logger("SuPy", logging.INFO)
 logger_supy.debug("a debug message from SuPy")
 
+# Reference to the active opt-in file handler (None until file logging is on).
+_file_handler = None
+
+
+def enable_file_logging(path=None):
+    """Write SuPy log messages to a file (opt-in).
+
+    Parameters
+    ----------
+    path : str or pathlib.Path, optional
+        Target log file, or a directory in which a ``SuPy.log`` file is
+        written. Defaults to ``SuPy.log`` in the current working directory.
+
+    Returns
+    -------
+    pathlib.Path
+        The resolved log-file path. The file itself is not created until the
+        first log record is emitted (``delay=True``).
+
+    Notes
+    -----
+    Calling this again after file logging is already enabled is a no-op; the
+    existing handler's path is returned. Call :func:`disable_file_logging`
+    first to switch to a different file.
+    """
+    global _file_handler
+    if _file_handler is not None:
+        return Path(_file_handler.baseFilename)
+    handler = get_file_handler(path)
+    logger_supy.addHandler(handler)
+    _file_handler = handler
+    return Path(handler.baseFilename)
+
+
+def disable_file_logging():
+    """Detach and close the opt-in file handler, if one is active.
+
+    Returns
+    -------
+    None
+    """
+    global _file_handler
+    if _file_handler is not None:
+        logger_supy.removeHandler(_file_handler)
+        _file_handler.close()
+        _file_handler = None
+
+
+# Honour the opt-in environment variables at import time so users can enable
+# file logging without touching code (e.g. ``export SUPY_LOG_DIR=~/supy-logs``).
+_env_logfile = _resolve_env_logfile()
+if _env_logfile is not None:
+    enable_file_logging(_env_logfile)
+
 
 if sys.version_info >= (3, 8):
     from importlib import metadata
 else:
     from importlib_metadata import metadata
-
-

--- a/src/supy/_env.py
+++ b/src/supy/_env.py
@@ -52,19 +52,25 @@ def get_console_handler():
 def _coerce_logfile_path(path):
     """Resolve a user-supplied location to a concrete log-file path.
 
+    A leading ``~`` is expanded to the user's home directory. The path is
+    treated as a directory (the default ``SuPy.log`` name is appended) only
+    when it already exists as a directory or is written with a trailing
+    separator; otherwise it is taken as the log-file path itself.
+
     Parameters
     ----------
     path : str or pathlib.Path
-        A log-file path, or a directory (existing, or written with a trailing
-        separator) in which the default ``SuPy.log`` name is used.
+        A log-file path, or a directory in which the default ``SuPy.log`` name
+        is used.
 
     Returns
     -------
     pathlib.Path
         The resolved log-file path.
     """
-    path_logfile = Path(path)
-    if path_logfile.is_dir() or str(path).endswith((os.sep, "/")):
+    raw = str(path)
+    path_logfile = Path(path).expanduser()
+    if path_logfile.is_dir() or raw.endswith((os.sep, "/")):
         return path_logfile / LOG_FILE
     return path_logfile
 
@@ -161,8 +167,11 @@ def enable_file_logging(path=None):
     Parameters
     ----------
     path : str or pathlib.Path, optional
-        Target log file, or a directory in which a ``SuPy.log`` file is
-        written. Defaults to ``SuPy.log`` in the current working directory.
+        Target log file (a leading ``~`` is expanded to the home directory),
+        or an existing directory / a path with a trailing separator, in which
+        a ``SuPy.log`` file is written. Defaults to ``SuPy.log`` in the current
+        working directory. For a directory that may not exist yet, prefer the
+        ``SUPY_LOG_DIR`` environment variable.
 
     Returns
     -------

--- a/test/core/test_logging_optin.py
+++ b/test/core/test_logging_optin.py
@@ -91,3 +91,13 @@ def test_env_var_opt_in_writes_to_requested_dir(tmp_path):
     assert (log_dir / LOG_FILE).exists(), res.stderr
     # The current working directory must stay clean.
     assert not (tmp_path / LOG_FILE).exists()
+
+
+def test_logfile_path_expands_user():
+    """A leading ``~`` in the log path is expanded to the home directory."""
+    from supy._env import _coerce_logfile_path
+
+    resolved = str(_coerce_logfile_path("~/supy_logtest_dir/run.log"))
+    assert "~" not in resolved
+    assert resolved.startswith(os.path.expanduser("~"))
+    assert resolved.endswith("run.log")

--- a/test/core/test_logging_optin.py
+++ b/test/core/test_logging_optin.py
@@ -1,0 +1,93 @@
+"""Opt-in file logging: importing/using supy must not create SuPy.log.
+
+Regression guard for the opt-in file-logging behaviour. Historically
+``supy._env`` attached a ``TimedRotatingFileHandler`` at import time that
+eagerly ``touch()``-ed an empty ``SuPy.log`` in the current working
+directory the instant any heavy submodule was imported. File logging is now
+opt-in: a file is written only when the user sets ``SUPY_LOG_DIR`` /
+``SUPY_LOGFILE`` or calls :func:`supy.enable_file_logging`, and even then it
+is created only on the first emitted record (``delay=True``).
+
+Import-time behaviour is exercised in clean subprocesses because ``_env`` is
+imported only once per interpreter; an in-process test cannot observe the
+first import.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.api, pytest.mark.util]
+
+LOG_FILE = "SuPy.log"
+
+
+def _run(code, cwd, extra_env=None):
+    """Run ``code`` in a clean subprocess with the opt-in env vars stripped."""
+    env = dict(os.environ)
+    env.pop("SUPY_LOGFILE", None)
+    env.pop("SUPY_LOG_DIR", None)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_no_logfile_on_import_and_use(tmp_path):
+    """Importing supy and touching heavy modules must not create SuPy.log."""
+    code = (
+        "import supy\n"
+        "_ = supy.util\n"  # forces _env import via a heavy submodule
+        "from supy._env import logger_supy\n"  # direct _env import
+        "print('OK')\n"
+    )
+    res = _run(code, tmp_path)
+    assert res.returncode == 0, res.stderr
+    assert "OK" in res.stdout
+    assert not (tmp_path / LOG_FILE).exists(), (
+        f"SuPy.log must not be created merely by importing/using supy; "
+        f"stderr={res.stderr}"
+    )
+
+
+def test_enable_file_logging_is_delayed(tmp_path):
+    """enable_file_logging() attaches a handler but defers file creation."""
+    code = (
+        "from pathlib import Path\n"
+        "import supy\n"
+        "supy.enable_file_logging()\n"
+        "assert not Path('SuPy.log').exists(), 'delay=True: no file before first write'\n"
+        "from supy._env import logger_supy\n"
+        "logger_supy.info('hello from regression test')\n"
+        "assert Path('SuPy.log').exists(), 'file must appear after first INFO write'\n"
+        "print('OK')\n"
+    )
+    res = _run(code, tmp_path)
+    assert res.returncode == 0, res.stderr
+    assert "OK" in res.stdout
+    assert (tmp_path / LOG_FILE).exists()
+
+
+def test_env_var_opt_in_writes_to_requested_dir(tmp_path):
+    """SUPY_LOG_DIR routes the log file into the requested directory only."""
+    log_dir = tmp_path / "logs"
+    code = (
+        "import supy\n"
+        "from supy._env import logger_supy\n"  # env var read at _env import
+        "logger_supy.info('hello')\n"
+        "print('OK')\n"
+    )
+    res = _run(code, tmp_path, extra_env={"SUPY_LOG_DIR": str(log_dir)})
+    assert res.returncode == 0, res.stderr
+    assert "OK" in res.stdout
+    assert (log_dir / LOG_FILE).exists(), res.stderr
+    # The current working directory must stay clean.
+    assert not (tmp_path / LOG_FILE).exists()


### PR DESCRIPTION
## Summary

`supy` previously dropped a stray `SuPy.log` into the current working directory the moment any real attribute was used, even when nothing was logged (#1516). `_env.py` configured a `TimedRotatingFileHandler` at import time that `touch()`-ed the file and opened it without `delay`.

This makes file logging **opt-in**:

- Default: console logging only — no `SuPy.log` is created.
- `supy.enable_file_logging()` (defaults to `./SuPy.log`, or pass a path/directory) and `supy.disable_file_logging()`.
- `SUPY_LOGFILE` / `SUPY_LOG_DIR` environment variables, read at import.
- `delay=True` so the file is created only on the first emitted record — no stray empty file even when enabled.

Console output is unchanged, and nothing in the codebase reads `SuPy.log` back, so the blast radius is small.

## Changes

- `src/supy/_env.py`: opt-in file handler with `enable_file_logging` / `disable_file_logging`, `SUPY_LOGFILE` / `SUPY_LOG_DIR` support, `delay=True`; kept the tempdir writability fallback (now via `os.access`, no eager file creation).
- `src/supy/__init__.py`: expose the two controls through the lazy router and `__all__`.
- `test/core/test_logging_optin.py`: regression tests (no file on import/use; delayed creation; env-var routing).
- `CHANGELOG.md`, `docs/source/api/core-functions.rst`, `docs/source/troubleshooting.rst`.

## Verification

- New regression tests (3) pass; `make test-smoke` (9) and `test_api_surface.py` (2, validates the new public symbols) pass against a fresh build.
- Before/after on a real build: `import supy; supy.util` → no `SuPy.log`; `enable_file_logging()` then logging → file written.

Closes #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
