### PR TITLE
Improve KCL benchmark page: full versions, release compare, reorder

### DIFF
--- a/site/benchmark/index.html
+++ b/site/benchmark/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/base.css">
     <link rel="stylesheet" href="/css/subpage.css">
-    <link rel="stylesheet" href="/css/benchmark.css?v=5">
+    <link rel="stylesheet" href="/css/benchmark.css?v=14">
 </head>
 <body>
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
@@ -41,7 +41,7 @@
             <div class="subpage-label">Regression benchmark</div>
             <h1 class="subpage-title">The <em>benchmark suite</em></h1>
             <p class="subpage-lede">SUEWS releases scored against eddy-covariance observations at urban flux sites.</p>
-            <p class="subpage-intro">Each site scores the modelled energy balance and air temperature against tower observations across SUEWS releases. One site is benchmarked so far &mdash; London, across five releases (<span class="mono" style="font-family:'JetBrains Mono',monospace;font-size:0.85rem">2025.7 &ndash; 2026.4</span>), with no energy-balance regression detected. Open a site to compare releases. Further sites are planned.</p>
+            <p class="subpage-intro">Each site scores the modelled energy balance and air temperature against tower observations across SUEWS releases. One site is benchmarked so far &mdash; London, across six releases (<span class="mono" style="font-family:'JetBrains Mono',monospace;font-size:0.85rem">2025.7 &ndash; 2026.6</span>), with no energy-balance regression detected. Open a site to compare releases. Further sites are planned.</p>
         </header>
 
         <section class="subpage-group">

--- a/site/benchmark/uk-lo-kcl/index.html
+++ b/site/benchmark/uk-lo-kcl/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/base.css">
     <link rel="stylesheet" href="/css/subpage.css">
-    <link rel="stylesheet" href="/css/benchmark.css?v=5">
+    <link rel="stylesheet" href="/css/benchmark.css?v=14">
 </head>
 <body>
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
@@ -44,32 +44,23 @@
             <div class="subpage-label">Regression benchmark <span class="bm-crumb"><span class="sep">/</span> UK-LO-KCL</span></div>
             <h1 class="subpage-title">Energy balance at <em>King&rsquo;s College London</em></h1>
             <p class="subpage-lede">Modelled energy-balance fluxes at the Kc1 tower, scored against eddy-covariance observations across SUEWS releases.</p>
-            <p class="subpage-intro">Reference observations: <a href="https://doi.org/10.1016/j.uclim.2016.05.001">Ward&nbsp;et&nbsp;al.&nbsp;(2016)</a>. Each release is run on the same forcing and observations over the same period, with a config valid in its own schema; only the SUEWS version changes. Every release&rsquo;s statistics reproduce a byte-identical fingerprint on re-run. Select a release to view its statistics.</p>
-
-            <div class="bm-releases" role="group" aria-label="Model release">
-                <span class="bm-releases-label">Release</span>
-                <button class="bm-release" type="button" data-ver="2025.7.6">2025.7</button>
-                <button class="bm-release" type="button" data-ver="2025.10.15">2025.10</button>
-                <button class="bm-release" type="button" data-ver="2025.11.20">2025.11</button>
-                <button class="bm-release" type="button" data-ver="2026.1.28">2026.1</button>
-                <button class="bm-release" type="button" data-ver="2026.4.3">2026.4</button>
-                <button class="bm-release" type="button" data-ver="2026.6.5" aria-current="true">2026.6 <span class="latest">latest</span></button>
-            </div>
+            <p class="subpage-intro">Reference observations: <a href="https://doi.org/10.1016/j.uclim.2016.05.001">Ward&nbsp;et&nbsp;al.&nbsp;(2016)</a>. Each release is run on the same forcing and observations over the same period, with a config valid in its own schema; only the SUEWS version changes. Every release&rsquo;s statistics reproduce a byte-identical fingerprint on re-run.</p>
 
             <!-- Overview panel: verdict + at-a-glance error across all releases -->
             <div class="bm-verdict" data-state="pass" role="status">
                 <span class="bm-status"><span class="disc" aria-hidden="true"></span><span class="glyph" aria-hidden="true">&#10003;</span> No energy-balance regression across releases</span>
-                <p class="bm-verdict-summary">Energy-balance error is <b style="font-style:normal;color:var(--text-primary)">unchanged</b> across all five benchmarked releases (2025.7 &rarr; 2026.4); the largest shift in any flux is <b style="font-style:normal;color:var(--text-primary)">0.03&nbsp;W&nbsp;m<sup>&minus;2</sup></b> (Q<sub>E</sub>). Sensible heat Q<sub>H</sub>, the residual, carries the largest absolute error throughout.</p>
+                <p class="bm-verdict-summary">Energy-balance error is <b style="font-style:normal;color:var(--text-primary)">unchanged</b> across all six benchmarked releases (2025.7 &rarr; 2026.6); the largest shift in any flux is <b style="font-style:normal;color:var(--text-primary)">0.03&nbsp;W&nbsp;m<sup>&minus;2</sup></b> (Q<sub>E</sub>). Sensible heat Q<sub>H</sub>, the residual, carries the largest absolute error throughout.</p>
                 <div class="bm-chips">
                     <span class="bm-chip">site <b>UK&#8209;LO&#8209;KCL</b></span>
                     <span class="bm-chip">period <b>2011&ndash;2013</b></span>
-                    <span class="bm-chip">releases <b>5</b></span>
+                    <span class="bm-chip">releases <b>6</b></span>
                     <span class="bm-chip">latest <b>v2026.6.5</b></span>
                 </div>
             </div>
         </header>
 
-        <section class="subpage-group">
+        <section class="subpage-group bm-act-break">
+            <div class="bm-act-eyebrow">Every version, side by side</div>
             <div class="subpage-group-header">
                 <span class="subpage-group-label">Error across releases</span>
                 <span class="subpage-group-line"></span>
@@ -77,11 +68,12 @@
             <p class="bm-summary-lead">Full-period mean absolute error (W m&#8315;&#178;) by release &mdash; the at-a-glance regression view. Each row is a flux; cell shade tracks error size. A regression would appear as a row <b>darkening</b> left-to-right; instead every row is a flat band &mdash; no drift across releases.</p>
             <div class="bm-matrix bm-matrix-releases" role="table" aria-label="Mean absolute error by flux and release, watts per square metre; cell shade increases with error">
                 <div class="corner"></div>
-                <div class="col-h" role="columnheader">2025.7</div>
-                <div class="col-h" role="columnheader">2025.10</div>
-                <div class="col-h" role="columnheader">2025.11</div>
-                <div class="col-h" role="columnheader">2026.1</div>
-                <div class="col-h" role="columnheader">2026.4</div>
+                <div class="col-h" role="columnheader">2025.7.6</div>
+                <div class="col-h" role="columnheader">2025.10.15</div>
+                <div class="col-h" role="columnheader">2025.11.20</div>
+                <div class="col-h" role="columnheader">2026.1.28</div>
+                <div class="col-h" role="columnheader">2026.4.3</div>
+                <div class="col-h" role="columnheader">2026.6.5</div>
 
                 <div class="row-h">K<sub>up</sub></div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 3%,transparent)">2.45</div>
@@ -89,8 +81,10 @@
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 3%,transparent)">2.45</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 3%,transparent)">2.45</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 3%,transparent)">2.46</div>
+                <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 3%,transparent)">2.46</div>
 
                 <div class="row-h">L<sub>up</sub></div>
+                <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 6%,transparent)">4.48</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 6%,transparent)">4.48</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 6%,transparent)">4.48</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 6%,transparent)">4.48</div>
@@ -103,12 +97,14 @@
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 11%,transparent)">8.54</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 11%,transparent)">8.54</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 11%,transparent)">8.54</div>
+                <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 11%,transparent)">8.54</div>
 
                 <div class="row-h">Q<sub>H</sub></div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 53%,transparent)">39.53</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 53%,transparent)">39.53</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 53%,transparent)">39.53</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 53%,transparent)">39.53</div>
+                <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 53%,transparent)">39.52</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 53%,transparent)">39.52</div>
 
                 <div class="row-h">Q<sub>E</sub></div>
@@ -117,8 +113,54 @@
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 19%,transparent)">14.62</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 19%,transparent)">14.62</div>
                 <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 19%,transparent)">14.59</div>
+                <div class="bm-cell num" style="background:color-mix(in srgb,var(--bad) 19%,transparent)">14.59</div>
             </div>
             <p class="bm-matrix-note">Mean absolute error (W m&#8315;&#178;), full period (2011&ndash;2013). <b style="font-weight:500;color:var(--text-secondary)">Cell shade increases with error</b>; uniform shading across a row means the flux&rsquo;s error is unchanged across releases. Q<sub>H</sub> (the residual) carries the largest error throughout.</p>
+        </section>
+
+        <section class="subpage-group">
+            <div class="subpage-group-header">
+                <span class="subpage-group-label">Compare two releases</span>
+                <span class="subpage-group-line"></span>
+            </div>
+            <p class="bm-summary-lead">Pick any two releases to see how each error metric moved between them. <b style="font-weight:500;color:var(--veg-green)">Green</b> means the error shrank, <b style="font-weight:500;color:var(--energy-orange)">amber</b> means it grew; muted means the change is within the regression tolerance (0.05&nbsp;W&nbsp;m&#8315;&#178; / 0.05&nbsp;K).</p>
+            <div class="bm-cmp2" aria-label="Release-to-release comparison of error metrics">
+                <div class="bm-cmp2-col">
+                    <select id="cmp-a" class="bm-cmp-select" aria-label="Compare release on the left (baseline)"></select>
+                    <div class="bm-cmp2-card">
+                        <span class="bm-cmp2-ver" id="cmp2-ver-a"></span>
+                        <span class="bm-cmp2-tag" id="cmp2-tag-a"></span>
+                    </div>
+                    <div class="bm-cmp2-body" id="cmp2-body-a"></div>
+                </div>
+                <div class="bm-cmp2-col">
+                    <select id="cmp-b" class="bm-cmp-select" aria-label="Compare release on the right"></select>
+                    <div class="bm-cmp2-card">
+                        <span class="bm-cmp2-ver" id="cmp2-ver-b"></span>
+                        <span class="bm-cmp2-tag" id="cmp2-tag-b"></span>
+                    </div>
+                    <div class="bm-cmp2-body" id="cmp2-body-b"></div>
+                </div>
+            </div>
+            <p class="bm-table-note">Values are mean absolute error against the Ward&nbsp;et&nbsp;al. (2016) observations; &Delta; is To&nbsp;&minus;&nbsp;From, so a negative &Delta; (green) is an improvement and a positive &Delta; (amber) a regression. Energy-balance fluxes in W&nbsp;m&#8315;&#178;, RSL air temperature in K. Most release pairs are identical &mdash; the only non-trivial shift is the near-surface RSL profile at 2026.1.28&nbsp;&rarr;&nbsp;2026.4.3.</p>
+        </section>
+
+        <section class="subpage-group bm-act-break">
+            <div class="bm-act-eyebrow">One release in full</div>
+            <div class="subpage-group-header">
+                <span class="subpage-group-label">Inspect a single release</span>
+                <span class="subpage-group-line"></span>
+            </div>
+            <p class="bm-summary-lead">Everything above holds the releases up against <em>each other</em>. From here down the lens narrows to <b style="font-weight:500;color:var(--text-primary)">one</b> release &mdash; its full energy balance, the seasonal breakdown, and the near-surface air-temperature profile. Pick the release to dissect:</p>
+            <div class="bm-releases" role="group" aria-label="Model release">
+                <span class="bm-releases-label">Release</span>
+                <button class="bm-release" type="button" data-ver="2025.7.6">2025.7.6</button>
+                <button class="bm-release" type="button" data-ver="2025.10.15">2025.10.15</button>
+                <button class="bm-release" type="button" data-ver="2025.11.20">2025.11.20</button>
+                <button class="bm-release" type="button" data-ver="2026.1.28">2026.1.28</button>
+                <button class="bm-release" type="button" data-ver="2026.4.3">2026.4.3</button>
+                <button class="bm-release" type="button" data-ver="2026.6.5" aria-current="true">2026.6.5 <span class="latest">latest</span></button>
+            </div>
         </section>
 
         <section class="subpage-group">
@@ -233,25 +275,19 @@
 
         <section class="subpage-group">
             <div class="subpage-group-header">
-                <span class="subpage-group-label">Provenance &amp; configuration</span>
+                <span class="subpage-group-label">Site information</span>
                 <span class="subpage-group-line"></span>
             </div>
             <dl class="bm-prov">
                 <div><dt>Site</dt><dd>King&rsquo;s College London <span class="mono">UK-LO-KCL</span></dd></div>
+                <div><dt>Reference</dt><dd><a href="https://doi.org/10.1016/j.uclim.2016.05.001">Ward&nbsp;et&nbsp;al. (2016)</a></dd></div>
                 <div><dt>Evaluation period</dt><dd><span class="mono">2011-01-01 &ndash; 2013-12-31</span></dd></div>
                 <div><dt>Observations</dt><dd>Eddy-covariance fluxes, Kc1 <span class="mono">restricted</span></dd></div>
-                <div><dt>Reference</dt><dd>Ward&nbsp;et&nbsp;al. (2016)</dd></div>
-                <div><dt>Releases benchmarked</dt><dd><span class="mono">2025.7.6, 2025.10.15, 2025.11.20, 2026.1.28, 2026.4.3, 2026.6.5</span></dd></div>
-                <div><dt>Config</dt><dd>Per-release, each valid in its own schema</dd></div>
-                <div><dt>Reproducibility</dt><dd>Per-release fingerprint reproduces on re-run</dd></div>
-                <div><dt>Net radiation</dt><dd><span class="mono">NARP</span></dd></div>
-                <div><dt>Storage heat</dt><dd><span class="mono">OHM</span></dd></div>
-                <div><dt>Roughness sublayer</dt><dd><span class="mono">RSL (MOST)</span></dd></div>
             </dl>
         </section>
 
         <section class="subpage-notes">
-            <p>The evaluation observations and forcing are access-restricted and are fetched at run time from a protected archive; only the derived statistics above are published. See the <a href="https://docs.suews.io/stable/">SUEWS documentation</a> for the model description and the benchmarking methodology.</p>
+            <p>The evaluation observations and forcing are access-restricted; only the derived statistics on this page are published. Reproduction data is archived in the <a href="https://sandbox.zenodo.org/records/508290">Zenodo reproducibility record</a>, with the full reproduction recipe in <a href="https://github.com/UMEP-dev/SUEWS/blob/master/benchmark/REPRODUCE.md">REPRODUCE.md</a>. See the <a href="https://docs.suews.io/stable/">SUEWS documentation</a> for the model description and benchmarking methodology.</p>
         </section>
     </div>
 
@@ -338,6 +374,74 @@
             b.addEventListener("click", () => render(b.dataset.ver));
         });
         render("2026.6.5");
+
+        // ----- Two-release compare (side-by-side spec cards) -----
+        const CMP_LATEST = "2026.6.5";
+        const CMP_TOL = 0.05;
+        const CMP_METRICS = [
+            { sec: "Energy balance &mdash; MAE (W m&#8315;&#178;)" },
+            { grp: "eb", k: "Kup", label: "K<sub>up</sub>", unit: "reflected SW" },
+            { grp: "eb", k: "Lup", label: "L<sub>up</sub>", unit: "outgoing LW" },
+            { grp: "eb", k: "QN", label: "Q<sub>N</sub>", unit: "net all-wave" },
+            { grp: "eb", k: "QH", label: "Q<sub>H</sub>", unit: "sensible heat" },
+            { grp: "eb", k: "QE", label: "Q<sub>E</sub>", unit: "latent heat" },
+            { sec: "Air temperature &mdash; RSL MAE (K)" },
+            { grp: "rsl", k: "16.0", label: "16.0 m" },
+            { grp: "rsl", k: "12.5", label: "12.5 m" },
+            { grp: "rsl", k: "6.5", label: "6.5 m" }
+        ];
+        function fmtDelta(d, tol) {
+            const zero = Math.abs(d) < 0.005;
+            const cls = (zero || Math.abs(d) <= tol) ? "same" : (d < 0 ? "better" : "worse");
+            const s = zero ? "0.00" : (d > 0 ? "+" : "−") + Math.abs(d).toFixed(2);
+            return { cls: cls, s: s };
+        }
+        function statOf(ver, m) { return m.grp === "eb" ? BENCH[ver].full[m.k][0] : RSL[ver][m.k][0]; }
+        function buildBody(ver, baseVer, withDelta) {
+            let html = "", shifts = 0;
+            CMP_METRICS.forEach(m => {
+                if (m.sec) { html += '<div class="bm-cmp2-sub">' + m.sec + '</div>'; return; }
+                const val = statOf(ver, m);
+                let deltaHtml = "";
+                if (withDelta) {
+                    const d = +(val - statOf(baseVer, m)).toFixed(2);
+                    const r = fmtDelta(d, CMP_TOL);
+                    if (r.cls !== "same") shifts++;
+                    deltaHtml = '<span class="bm-cmp2-delta ' + r.cls + '">' + r.s + '</span>';
+                }
+                const unit = m.unit ? ' <span class="unit">' + m.unit + '</span>' : '';
+                html += '<div class="bm-cmp2-row"><span class="bm-cmp2-label">' + m.label + unit + '</span>'
+                    + '<span class="bm-cmp2-val">' + val.toFixed(2) + deltaHtml + '</span></div>';
+            });
+            return { html: html, shifts: shifts };
+        }
+        function setCard(side, ver, isRight) {
+            const ve = document.getElementById("cmp2-ver-" + side);
+            const te = document.getElementById("cmp2-tag-" + side);
+            if (ve) ve.textContent = ver;
+            if (te) {
+                const isLatest = ver === CMP_LATEST;
+                te.textContent = isLatest ? "latest" : (isRight ? "comparison" : "baseline");
+                te.className = "bm-cmp2-tag" + (isLatest ? " latest" : "");
+            }
+        }
+        function cmpRender(a, b) {
+            setCard("a", a, false);
+            setCard("b", b, true);
+            document.getElementById("cmp2-body-a").innerHTML = buildBody(a, b, false).html;
+            document.getElementById("cmp2-body-b").innerHTML = buildBody(b, a, true).html;
+        }
+        (function initCompare() {
+            const vers = Object.keys(BENCH);
+            const selA = document.getElementById("cmp-a"), selB = document.getElementById("cmp-b");
+            if (!selA || !selB) return;
+            vers.forEach(v => { selA.add(new Option(v, v)); selB.add(new Option(v, v)); });
+            selA.value = vers[0];
+            selB.value = vers[vers.length - 1];
+            selA.addEventListener("change", () => cmpRender(selA.value, selB.value));
+            selB.addEventListener("change", () => cmpRender(selA.value, selB.value));
+            cmpRender(selA.value, selB.value);
+        })();
     </script>
 </body>
 </html>

--- a/site/css/benchmark.css
+++ b/site/css/benchmark.css
@@ -402,14 +402,128 @@
 
 /* release heat-map: same cells, five release columns */
 .bm-matrix-releases {
-  grid-template-columns: minmax(96px, auto) repeat(5, minmax(54px, 1fr));
-  max-width: 640px;
+  grid-template-columns: minmax(80px, auto) repeat(6, minmax(72px, 1fr));
+  max-width: 780px;
+}
+.bm-matrix-releases .col-h {
+  font-size: 0.6rem;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
 }
 .bm-matrix-note {
   margin-top: 16px;
   font-size: 0.82rem;
   font-style: italic;
   color: var(--text-muted);
+}
+
+/* ========== Two-release compare (side-by-side spec cards) ========== */
+.bm-cmp-select {
+  width: 100%;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  padding: 9px 12px;
+  background: none;
+  color: var(--text-primary);
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color var(--transition-standard);
+}
+.bm-cmp-select:hover,
+.bm-cmp-select:focus-visible { border-color: var(--border-medium); }
+.bm-cmp2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  max-width: 760px;
+}
+.bm-cmp2-col { display: flex; flex-direction: column; gap: 14px; }
+.bm-cmp2-card {
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: 22px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  align-items: center;
+  text-align: center;
+}
+.bm-cmp2-ver {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+.bm-cmp2-tag {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.56rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+.bm-cmp2-tag.latest { color: var(--accent-label); }
+.bm-cmp2-body { display: flex; flex-direction: column; }
+.bm-cmp2-sub {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.56rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  padding: 4px 0 6px;
+  border-bottom: 1px solid var(--border-medium);
+  margin-bottom: 2px;
+}
+.bm-cmp2-body .bm-cmp2-sub ~ .bm-cmp2-sub { padding-top: 20px; }
+.bm-cmp2-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+.bm-cmp2-row:last-child { border-bottom: none; }
+.bm-cmp2-label {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 1.02rem;
+  color: var(--text-primary);
+}
+.bm-cmp2-label .unit {
+  font-family: 'Instrument Sans', system-ui, sans-serif;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  margin-left: 5px;
+}
+.bm-cmp2-val {
+  font-family: 'JetBrains Mono', monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.bm-cmp2-delta { font-size: 0.78rem; margin-left: 8px; color: var(--text-muted); }
+.bm-cmp2-delta.same { color: var(--text-muted); }
+.bm-cmp2-delta.better { color: var(--veg-green); }
+.bm-cmp2-delta.worse { color: var(--energy-orange); }
+@media (max-width: 560px) {
+  .bm-cmp2 { grid-template-columns: 1fr; gap: 18px; }
+  .bm-cmp2-label .unit { display: none; }
+}
+
+/* ========== Act break: across-releases vs single-release ========== */
+.bm-act-break {
+  margin-top: 44px;
+  padding-top: 34px;
+  border-top: 1px solid var(--border-medium);
+}
+.bm-act-eyebrow {
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 1.7rem;
+  font-weight: 500;
+  line-height: 1.2;
+  color: var(--text-primary);
+  margin-bottom: 12px;
 }
 
 /* ========== Release-regression chart ========== */


### PR DESCRIPTION
Site-only improvements to the UK-LO-KCL regression benchmark page (`site/benchmark/uk-lo-kcl/`) and the suite index, prompted by recording release 2026.6.5.

## What changed

- **Full version numbers** on the release selector and the across-releases matrix headers (previously truncated to `major.minor`, e.g. `2025.7`).
- **Six-release consistency** after #1515 recorded 2026.6.5: the verdict sentence and the `releases` chip now read six; the "Error across releases" matrix gains the missing `2026.6` column (and the CSS grid widens to six); the suite index intro reads `six releases (2025.7 - 2026.6)`.
- **Two-release comparison panel** — A/B spec cards (OpenAI-compare style, adapted to the SUEWS palette) showing side-by-side MAE for the five energy-balance fluxes and the three RSL heights, with a colour-coded delta (green = error shrank, amber = grew, muted = within the 0.05 tolerance). Defaults to first -> latest, so it surfaces the one real change on load: the near-surface RSL profile at `2026.1.28 -> 2026.4.3` (6.5 m: +0.12 K).
- **Page reorder into a two-act narrative**: the verdict now leads; act 1 "Every version, side by side" (matrix + compare); act 2 "One release in full" with the release selector relocated to head the single-release detail it drives. Serif act headings distinguish acts from the gold mono section labels.
- **Provenance slimmed to essential site info** (site, reference, period, observations). Reproduction now points to the sandbox Zenodo record (`BENCHMARK_SANDBOX_RECID` = `508290`, per `benchmark-regression.yml`) plus `REPRODUCE.md`. When the production data-governance record is minted (`BENCHMARK_PROD_RECID`), swap `sandbox.zenodo.org/records/508290` -> `zenodo.org/records/<prod-id>`.

## Scope / notes

- HTML + CSS only; no Python, Fortran, or benchmark-data changes. The displayed statistics are unchanged from #1515.
- `benchmark.css` cache-buster bumped to `?v=14` on both pages.
- The two-version compare reuses the page's existing `BENCH`/`RSL` data — no new data embedded.

## Verification

Rendered headless at multiple widths and verified the computed compare cells via a post-load DOM dump (deltas and better/worse/within-tolerance classes match the data both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
