### PR TITLE
Force UTF-8 on safe_stdout_stderr devnull stream (fix Windows nightly)

### DIFF
--- a/src/supy/util/_era5.py
+++ b/src/supy/util/_era5.py
@@ -278,8 +278,10 @@ def safe_stdout_stderr():
         yield
         return
 
-    # Replace None streams with devnull
-    devnull = open(os.devnull, "w")
+    # Replace None streams with devnull. Force UTF-8 so libraries that emit
+    # Unicode (e.g. tqdm progress bars) don't crash on Windows, whose default
+    # cp1252 codec cannot encode them (see gh#1097, gh#902).
+    devnull = open(os.devnull, "w", encoding="utf-8")
     try:
         if stdout_was_none:
             sys.stdout = devnull


### PR DESCRIPTION
## What

`safe_stdout_stderr()` in `src/supy/util/_era5.py` opened `os.devnull` without an explicit encoding, inheriting the platform default. On Windows that is `cp1252`. One-line fix:

```diff
-    devnull = open(os.devnull, "w")
+    devnull = open(os.devnull, "w", encoding="utf-8")
```

## Why (root cause of the 2026-06-06 nightly failure)

The nightly wheel build failed on a single matrix leg — **API cross-CPython tests / cp312-win AMD64** — with:

```
FAILED test/umep/test_environment.py::TestQGISEnvironment::test_tqdm_with_none_stdout
  - UnicodeEncodeError: 'charmap' codec can't encode characters in position 15-24
```

Causal chain, verified end-to-end:

- **Why Windows only** — `open(os.devnull, "w")` uses `cp1252` on Windows; macOS/Linux default to UTF-8 and never trip it.
- **Why cp312 only** — `test/umep/conftest.py` deliberately gates the QGIS-environment tests to **Windows + Python 3.12** (QGIS bundles Python 3.12). Every other Windows leg *skips* the whole `TestQGISEnvironment` class, so cp312-win is the only configuration that runs the test at all. Not a flake.
- **Why today and not yesterday** — `tqdm` released **4.68.1** overnight; the unpinned nightly picked it up (the 2026-06-05 nightly ran **4.67.3**). 4.68.1 emits Unicode progress-bar glyphs even when the target stream reports a non-UTF encoding, whereas 4.67.3 did not. The missing `encoding="utf-8"` was a latent bug all along — the tqdm release merely exposed it.

Local confirmation against a forced `cp1252` stream:

- `tqdm 4.67.3` -> no error; `tqdm 4.68.1` -> `UnicodeEncodeError` (same `position 15-24` as CI).
- `cp1252` -> 50/50 raise; `utf-8` -> 0/50 raise.

## Impact beyond the test

This also hardens the real QGIS Processing path (gh#902): any Windows user whose wrapped library writes Unicode through this devnull stream would have hit the same crash. Aligns with the project UTF-8 file-encoding convention (gh#1097).

🤖 Generated with [Claude Code](https://claude.com/claude-code)