### PR TITLE
Force UTF-8 on all text I/O and add an encoding-audit CI gate

### DIFF
--- a/.claude/rules/python/conventions.md
+++ b/.claude/rules/python/conventions.md
@@ -66,7 +66,16 @@ SUEWS-specific Python conventions. Complements ruff for standard linting.
    ```
    **Why**: Windows uses locale-specific encodings by default (e.g., cp1252, cp1253).
    Unicode characters like `→` cause `UnicodeEncodeError` and produce empty files.
-   See issue #1097 for details.
+   See issue #1097 for details. This also covers `read_text`/`write_text` and
+   text-mode `tempfile.NamedTemporaryFile`.
+
+   **Enforced in CI**: `.github/workflows/encoding-audit.yml` runs ruff
+   `PLW1514` (`unspecified-encoding`) over the repo on every PR touching a
+   `.py` file. The rule is preview-only, so the workflow passes `--preview`
+   explicitly. Most violations autofix with
+   `ruff check --preview --select PLW1514 --fix --unsafe-fixes .`; a
+   maintainer can label a PR `0-ci:encoding-audit-ok` to bypass when a
+   flagged call is genuinely correct without UTF-8.
 
 ---
 

--- a/.claude/rules/python/conventions.md
+++ b/.claude/rules/python/conventions.md
@@ -77,10 +77,13 @@ SUEWS-specific Python conventions. Complements ruff for standard linting.
      the workflow passes `--preview` explicitly. Most violations autofix
      with `ruff check --preview --select PLW1514 --fix --unsafe-fixes .`.
    - `scripts/lint/check_pathlib_encoding.py` — an AST check that flags
-     `read_text`/`write_text` on *any* receiver (e.g. `p.write_text(...)`
-     where `p` is a plain variable), which PLW1514 silently skips because
-     it cannot infer the type. These method names are pathlib-specific, so
-     the check is high precision.
+     `read_text`/`write_text`, and text-mode `Path.open()`, on *any*
+     receiver (e.g. `p.write_text(...)` or `with p.open() as f:` where `p`
+     is a plain variable), which PLW1514 silently skips because it cannot
+     infer the type. The `.open()` check is mode-aware: it skips binary
+     modes and `zipfile`/`tarfile`-style `.open(name)` calls (non-mode
+     first arg) to avoid false positives. `read_text`/`write_text` are
+     pathlib-specific names, so those are flagged unconditionally.
 
    A maintainer can label a PR `0-ci:encoding-audit-ok` to bypass when a
    flagged call is genuinely correct without UTF-8.

--- a/.claude/rules/python/conventions.md
+++ b/.claude/rules/python/conventions.md
@@ -69,12 +69,20 @@ SUEWS-specific Python conventions. Complements ruff for standard linting.
    See issue #1097 for details. This also covers `read_text`/`write_text` and
    text-mode `tempfile.NamedTemporaryFile`.
 
-   **Enforced in CI**: `.github/workflows/encoding-audit.yml` runs ruff
-   `PLW1514` (`unspecified-encoding`) over the repo on every PR touching a
-   `.py` file. The rule is preview-only, so the workflow passes `--preview`
-   explicitly. Most violations autofix with
-   `ruff check --preview --select PLW1514 --fix --unsafe-fixes .`; a
-   maintainer can label a PR `0-ci:encoding-audit-ok` to bypass when a
+   **Enforced in CI**: `.github/workflows/encoding-audit.yml` runs two
+   complementary checks over the repo on every PR touching a `.py` file:
+   - ruff `PLW1514` (`unspecified-encoding`) — covers builtin `open()`,
+     text-mode `tempfile.NamedTemporaryFile`, and `read_text`/`write_text`
+     whose receiver type ruff can resolve. The rule is preview-only, so
+     the workflow passes `--preview` explicitly. Most violations autofix
+     with `ruff check --preview --select PLW1514 --fix --unsafe-fixes .`.
+   - `scripts/lint/check_pathlib_encoding.py` — an AST check that flags
+     `read_text`/`write_text` on *any* receiver (e.g. `p.write_text(...)`
+     where `p` is a plain variable), which PLW1514 silently skips because
+     it cannot infer the type. These method names are pathlib-specific, so
+     the check is high precision.
+
+   A maintainer can label a PR `0-ci:encoding-audit-ok` to bypass when a
    flagged call is genuinely correct without UTF-8.
 
 ---

--- a/.claude/scripts/validate-claude-md.py
+++ b/.claude/scripts/validate-claude-md.py
@@ -161,7 +161,7 @@ def save_snapshot(filepath: Path, snapshot_dir: Path):
     }
 
     metadata_path = snapshot_dir / f"CLAUDE.md.{timestamp}.json"
-    metadata_path.write_text(json.dumps(metadata, indent=2))
+    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 
     return snapshot_path
 

--- a/.claude/scripts/validate-claude-md.py
+++ b/.claude/scripts/validate-claude-md.py
@@ -68,7 +68,7 @@ def check_file_integrity(filepath: Path) -> dict:
             "stats": {},
         }
 
-    content = filepath.read_text()
+    content = filepath.read_text(encoding="utf-8")
     lines = content.splitlines()
 
     warnings = []
@@ -149,7 +149,7 @@ def save_snapshot(filepath: Path, snapshot_dir: Path):
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     snapshot_path = snapshot_dir / f"CLAUDE.md.{timestamp}"
 
-    content = filepath.read_text()
+    content = filepath.read_text(encoding="utf-8")
     snapshot_path.write_text(content)
 
     # Also save metadata

--- a/.claude/scripts/validate-claude-md.py
+++ b/.claude/scripts/validate-claude-md.py
@@ -150,7 +150,7 @@ def save_snapshot(filepath: Path, snapshot_dir: Path):
     snapshot_path = snapshot_dir / f"CLAUDE.md.{timestamp}"
 
     content = filepath.read_text(encoding="utf-8")
-    snapshot_path.write_text(content)
+    snapshot_path.write_text(content, encoding="utf-8")
 
     # Also save metadata
     metadata = {

--- a/.claude/skills/log-changes/scripts/changelog_helper.py
+++ b/.claude/skills/log-changes/scripts/changelog_helper.py
@@ -326,7 +326,7 @@ class ChangelogRestructurer:
 
     def save_json_debug(self, data: Dict, filename: str = "changelog_debug.json"):
         """Save parsed data to JSON for debugging"""
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             # Convert datetime objects to strings for JSON serialization
             json_data = data.copy()
             json.dump(json_data, f, indent=2, default=str)

--- a/.claude/skills/log-changes/scripts/changelog_helper.py
+++ b/.claude/skills/log-changes/scripts/changelog_helper.py
@@ -32,7 +32,7 @@ class ChangelogRestructurer:
         if not self.changelog_path.exists():
             raise FileNotFoundError(f"{self.changelog_path} not found")
 
-        content = self.changelog_path.read_text()
+        content = self.changelog_path.read_text(encoding="utf-8")
         lines = content.split("\n")
 
         # Structure to hold parsed data
@@ -363,7 +363,7 @@ class ChangelogRestructurer:
         print(f"\nOriginal backed up to: {backup_path}")
 
         # Write new changelog
-        self.changelog_path.write_text(markdown)
+        self.changelog_path.write_text(markdown, encoding="utf-8")
         print(f"✓ Restructured CHANGELOG saved to: {self.changelog_path}")
 
         # Summary statistics

--- a/.github/scripts/classify_pyproject.py
+++ b/.github/scripts/classify_pyproject.py
@@ -32,7 +32,7 @@ import sys
 
 def _write_outputs(build: bool, package: bool) -> None:
     output = os.environ["GITHUB_OUTPUT"]
-    with open(output, "a") as f:
+    with open(output, "a", encoding="utf-8") as f:
         f.write(f"build_relevant={'true' if build else 'false'}\n")
         f.write(f"package_relevant={'true' if package else 'false'}\n")
 

--- a/.github/workflows/encoding-audit.yml
+++ b/.github/workflows/encoding-audit.yml
@@ -65,7 +65,7 @@ jobs:
         if: steps.bypass.outputs.bypass != 'true'
         run: python -m pip install 'ruff==0.15.16'
 
-      - name: Run encoding audit
+      - name: Run encoding audit (ruff PLW1514)
         if: steps.bypass.outputs.bypass != 'true'
         run: |
           set -eu
@@ -76,3 +76,11 @@ jobs:
             echo "See .claude/rules/python/conventions.md (rule 6) and gh#1097."
             exit 1
           fi
+
+      - name: Run pathlib encoding audit (read_text/write_text)
+        if: steps.bypass.outputs.bypass != 'true'
+        # Complements PLW1514, which only flags calls whose receiver type ruff
+        # can resolve. This AST check catches read_text/write_text on any
+        # receiver (e.g. `p.write_text(...)` where `p` is a variable) -- the
+        # gap that hid the original snapshot-write bug.
+        run: python scripts/lint/check_pathlib_encoding.py

--- a/.github/workflows/encoding-audit.yml
+++ b/.github/workflows/encoding-audit.yml
@@ -17,6 +17,11 @@ name: Encoding audit
 
 on:
   pull_request:
+    # Include labeled/unlabeled so adding the bypass label after a failed run
+    # re-triggers the gate. Default types (opened/synchronize/reopened) do not
+    # fire on label changes -- that is why the schema-audit gate needs a
+    # close/reopen to pick a label up; this gate does not.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - '**.py'
       - '.github/workflows/encoding-audit.yml'

--- a/.github/workflows/encoding-audit.yml
+++ b/.github/workflows/encoding-audit.yml
@@ -1,0 +1,73 @@
+name: Encoding audit
+
+# Block any text-mode file operation that omits an explicit `encoding`.
+#
+# Without `encoding=`, `open()` / `read_text()` / `write_text()` /
+# `tempfile.NamedTemporaryFile()` inherit the platform default, which is
+# cp1252 on Windows. Writing Unicode (degree signs, accented site names,
+# tqdm progress bars) through such a stream raises UnicodeEncodeError.
+# This bit us in the 2026-06-06 nightly (a tqdm 4.68.1 release exposed a
+# long-latent `open(os.devnull, "w")`), and the same class recurred from
+# gh#1097. The ruff rule that catches it (PLW1514, unspecified-encoding)
+# is preview-only, so `--preview` is passed explicitly rather than relying
+# on the `preview = true` flag in .ruff.toml.
+#
+# Maintainers can label a PR `0-ci:encoding-audit-ok` to bypass when a
+# flagged call is genuinely correct without UTF-8 (rare).
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/encoding-audit.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-encoding:
+    name: Require explicit encoding on text I/O
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether to skip (PR has bypass label)
+        id: bypass
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -eu
+          echo "Labels on this PR: $LABELS"
+          if printf '%s' "$LABELS" | grep -q '"0-ci:encoding-audit-ok"'; then
+            echo "bypass=true" >> "$GITHUB_OUTPUT"
+            echo "PR carries label '0-ci:encoding-audit-ok'; skipping encoding audit."
+          else
+            echo "bypass=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.bypass.outputs.bypass != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        if: steps.bypass.outputs.bypass != 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        if: steps.bypass.outputs.bypass != 'true'
+        run: python -m pip install 'ruff==0.15.16'
+
+      - name: Run encoding audit
+        if: steps.bypass.outputs.bypass != 'true'
+        run: |
+          set -eu
+          if ! ruff check --preview --select PLW1514 --output-format github .; then
+            echo "::error::Text-mode file I/O without explicit encoding detected."
+            echo "Add encoding=\"utf-8\" to the flagged call(s). Most can be fixed automatically:"
+            echo "    ruff check --preview --select PLW1514 --fix --unsafe-fixes ."
+            echo "See .claude/rules/python/conventions.md (rule 6) and gh#1097."
+            exit 1
+          fi

--- a/benchmark/assemble_index.py
+++ b/benchmark/assemble_index.py
@@ -19,7 +19,7 @@ index = {
 
 shared = {}
 for V in VERSIONS:
-    prov = json.load(open(RES / V / "provenance.json"))
+    prov = json.load(open(RES / V / "provenance.json", encoding="utf-8"))
     entry = {
         "status": prov["status"],
         "reproducible": prov.get("reproducible"),
@@ -33,7 +33,7 @@ for V in VERSIONS:
     entry["config_hash"] = prov.get("config_hash")
     entry["config_file"] = f"inputs/config_{V}.yml"
     if prov["status"] == "ok":
-        sj = json.load(open(RES / V / "stats.json"))
+        sj = json.load(open(RES / V / "stats.json", encoding="utf-8"))
         stats = sj["stats"]
         entry["full"] = {f: stats[f]["full"]["all"] for f in FLUXES}
         entry["seasonal"] = {f: stats[f]["seasonal"] for f in FLUXES}

--- a/benchmark/assemble_index.py
+++ b/benchmark/assemble_index.py
@@ -56,7 +56,7 @@ for V in VERSIONS:
     index["versions"][V] = entry
 
 index["shared_inputs"] = shared
-(RES / "index.json").write_text(json.dumps(index, indent=2, sort_keys=True))
+(RES / "index.json").write_text(json.dumps(index, indent=2, sort_keys=True), encoding="utf-8")
 print("index.json written; shared input hashes identical across all OK versions.")
 
 print("\n=== full-period MAE/MBE per version ===")

--- a/benchmark/check_supply.py
+++ b/benchmark/check_supply.py
@@ -56,7 +56,7 @@ def main() -> int:
             "required_present": not missing,
             "missing_required": missing,
         }
-        (out_dir / "supply_summary.json").write_text(json.dumps(summary, indent=2))
+        (out_dir / "supply_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
         print("[supply] summary:", json.dumps(summary))
 
         if missing:

--- a/benchmark/data_supply.py
+++ b/benchmark/data_supply.py
@@ -31,7 +31,7 @@ def get_token():
     if tok:
         return tok.strip()
     if os.path.exists(_TOKEN_FILE):
-        return Path(_TOKEN_FILE).read_text().strip()
+        return Path(_TOKEN_FILE).read_text(encoding="utf-8").strip()
     return None
 
 

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -264,7 +264,7 @@ def main() -> int:
                 "fingerprint": rfp1,
                 "stats": bench_rsl.to_nested_json(rtab1),
             }
-        (outdir / "stats.json").write_text(json.dumps(stats_json, indent=2, sort_keys=True))
+        (outdir / "stats.json").write_text(json.dumps(stats_json, indent=2, sort_keys=True), encoding="utf-8")
         tab1.to_csv(outdir / "stats_table.csv", index=False)
         if rtab1 is not None:
             rtab1.to_csv(outdir / "rsl_table.csv", index=False)
@@ -273,7 +273,7 @@ def main() -> int:
         prov["status"] = "failed"
         prov["error"] = f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
 
-    (outdir / "provenance.json").write_text(json.dumps(prov, indent=2, sort_keys=True))
+    (outdir / "provenance.json").write_text(json.dumps(prov, indent=2, sort_keys=True), encoding="utf-8")
     # freeze is written by the caller; just confirm path here
     print(f"[{args.version}] status={prov['status']} "
           f"eb_fp={(prov['fingerprint'] or '-')[:12]} eb_repro={prov['reproducible']} "

--- a/docs/table.py
+++ b/docs/table.py
@@ -94,7 +94,7 @@ def readfile(infile):
     """
     infile = path.realpath(infile)
     try:
-        with open(infile, "r") as f:
+        with open(infile, "r", encoding="utf-8") as f:
             data = f.read()
         return data
     except Exception as e:
@@ -113,7 +113,7 @@ def writefile(outfile, data):
     """
     outfile = path.realpath(outfile)
     try:
-        with open(outfile, "w") as f:
+        with open(outfile, "w", encoding="utf-8") as f:
             f.write(data)
         return 0
     except Exception as e:

--- a/scripts/lint/check_pathlib_encoding.py
+++ b/scripts/lint/check_pathlib_encoding.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Flag pathlib ``read_text`` / ``write_text`` calls that omit ``encoding=``.
+
+This complements ruff ``PLW1514`` (``unspecified-encoding``). PLW1514 only
+flags calls whose receiver type it can resolve -- builtin ``open()`` and
+``Path(...).read_text()`` where the ``Path`` is directly constructed. It
+silently skips the very common form where the receiver is a variable or a
+chained expression, e.g.::
+
+    p = some_dir / "x.json"
+    p.write_text(payload)            # ruff does NOT flag this
+    cfg = resource.read_text()       # nor this
+
+On Windows those inherit the cp1252 default encoding and raise
+``UnicodeEncodeError`` on Unicode content -- the exact failure class that
+hit the 2026-06-06 nightly (gh#1097, gh#902). Because ``read_text`` /
+``write_text`` are pathlib-specific method names, flagging *every* such
+call without ``encoding=`` is high precision (virtually no non-Path class
+defines them), so this AST check needs no type inference.
+
+Usage::
+
+    python scripts/lint/check_pathlib_encoding.py [PATH ...]
+
+With no PATH, scans the repository tree from the current directory.
+Exits 1 if any offending call is found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+METHODS = {"read_text", "write_text"}
+
+# Directories that never contain first-party source to lint.
+EXCLUDE_DIRS = {
+    ".git",
+    ".ruff_cache",
+    ".venv",
+    "venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "docs/_build",
+    ".claude/worktrees",
+}
+
+# Generated files (mirror the ruff exclude list).
+EXCLUDE_FILES = {"_version.py", "_suews_driver.py"}
+
+
+def _has_encoding(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        # kw.arg is None for **kwargs splat -- treat as "cannot prove missing"
+        # and accept it, to avoid false positives on dynamic kwargs.
+        if kw.arg in (None, "encoding"):
+            return True
+    return False
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    findings: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in METHODS
+            and not _has_encoding(node)
+        ):
+            findings.append((node.lineno, node.func.attr))
+    return findings
+
+
+def _iter_py_files(root: Path):
+    for p in root.rglob("*.py"):
+        rel = p.relative_to(root).as_posix()
+        if any(part in EXCLUDE_DIRS for part in p.parts):
+            continue
+        if any(rel.startswith(d + "/") or rel == d for d in EXCLUDE_DIRS):
+            continue
+        if p.name in EXCLUDE_FILES:
+            continue
+        yield p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="files or dirs to scan")
+    args = parser.parse_args(argv)
+
+    targets: list[Path] = []
+    if args.paths:
+        for raw in args.paths:
+            p = Path(raw)
+            if p.is_dir():
+                targets.extend(_iter_py_files(p))
+            elif p.suffix == ".py":
+                targets.append(p)
+    else:
+        targets.extend(_iter_py_files(Path(".")))
+
+    total = 0
+    for path in sorted(set(targets)):
+        for lineno, method in check_file(path):
+            total += 1
+            print(
+                f"{path}:{lineno}: `{method}` without explicit `encoding=` "
+                f"(add encoding=\"utf-8\")"
+            )
+
+    if total:
+        print(
+            f"\n[X] {total} pathlib text-I/O call(s) missing encoding. "
+            "Add encoding=\"utf-8\". See .claude/rules/python/conventions.md (rule 6)."
+        )
+        return 1
+    print("[OK] All pathlib read_text/write_text calls specify an encoding.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint/check_pathlib_encoding.py
+++ b/scripts/lint/check_pathlib_encoding.py
@@ -35,6 +35,9 @@ from pathlib import Path
 
 METHODS = {"read_text", "write_text"}
 
+# Characters that make up a file-mode string (e.g. "r", "w", "rb", "a+").
+_MODE_CHARS = set("rwxabt+")
+
 # Directories that never contain first-party source to lint.
 EXCLUDE_DIRS = {
     ".git",
@@ -61,6 +64,49 @@ def _has_encoding(call: ast.Call) -> bool:
     return False
 
 
+def _looks_like_mode(s: str) -> bool:
+    """True if ``s`` looks like a file-mode string (``"r"``, ``"w"``, ``"rb"``)."""
+    return bool(s) and all(c in _MODE_CHARS for c in s)
+
+
+def _open_is_unencoded_text(call: ast.Call) -> bool:
+    """Decide whether a ``.open(...)`` call is an unencoded *text-mode* open.
+
+    Returns True only when we can prove the call opens in text mode without an
+    explicit encoding. This deliberately skips:
+      - binary modes (``"rb"``/``"wb"``) -- encoding is illegal there;
+      - calls whose first arg is a non-mode string (``zf.open("x.txt")``) or a
+        non-constant -- almost certainly ``zipfile``/``tarfile``/``importlib``
+        style, not ``pathlib.Path.open``, so flagging would be a false positive.
+    """
+    if _has_encoding(call):
+        return False
+
+    mode = None
+    if call.args:
+        first = call.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            mode = first.value
+        else:
+            # non-constant / non-str first arg -> can't prove text; skip.
+            return False
+    else:
+        for kw in call.keywords:
+            if kw.arg == "mode":
+                if isinstance(kw.value, ast.Constant) and isinstance(
+                    kw.value.value, str
+                ):
+                    mode = kw.value.value
+                else:
+                    return False
+        if mode is None:
+            mode = "r"  # pathlib default
+
+    if not _looks_like_mode(mode):
+        return False  # e.g. "data.csv" -> zipfile-style name, not a mode
+    return "b" not in mode
+
+
 def check_file(path: Path) -> list[tuple[int, str]]:
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -68,13 +114,13 @@ def check_file(path: Path) -> list[tuple[int, str]]:
         return []
     findings: list[tuple[int, str]] = []
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr in METHODS
-            and not _has_encoding(node)
-        ):
-            findings.append((node.lineno, node.func.attr))
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        attr = node.func.attr
+        if attr in METHODS and not _has_encoding(node):
+            findings.append((node.lineno, attr))
+        elif attr == "open" and _open_is_unencoded_text(node):
+            findings.append((node.lineno, "open"))
     return findings
 
 

--- a/scripts/lint/check_test_markers.py
+++ b/scripts/lint/check_test_markers.py
@@ -78,7 +78,7 @@ def main(argv: list[str]) -> int:
             auto_applied += 1
             continue
         checked += 1
-        if file_has_nature_marker(path.read_text()):
+        if file_has_nature_marker(path.read_text(encoding="utf-8")):
             continue
         missing.append(rel.as_posix())
 

--- a/scripts/suews/check_naming_conventions.py
+++ b/scripts/suews/check_naming_conventions.py
@@ -504,7 +504,7 @@ def main():
         print_results(results, show_info=args.show_info)
         sys.stdout = sys.__stdout__
 
-        with open(args.report, "w") as f:
+        with open(args.report, "w", encoding="utf-8") as f:
             f.write(output.getvalue())
         print(f"Report written to: {args.report}")
     else:

--- a/scripts/suews/demo_deprecation_warning.py
+++ b/scripts/suews/demo_deprecation_warning.py
@@ -23,7 +23,7 @@ MODULE_PATH = ROOT / "src" / "supy" / "_supy_module.py"
 
 def _load_warn_helper():
     """Compile `_warn_functional_deprecation` without importing supy."""
-    module_ast = ast.parse(MODULE_PATH.read_text(), filename=str(MODULE_PATH))
+    module_ast = ast.parse(MODULE_PATH.read_text(encoding="utf-8"), filename=str(MODULE_PATH))
 
     deprecations = None
     warn_func_node = None

--- a/src/supy/_check.py
+++ b/src/supy/_check.py
@@ -26,7 +26,7 @@ path_rules_indiv = trv_supy_module.joinpath("checker_rules_indiv.json")
 
 # opening the check list file
 def load_rules(path_rules) -> Dict:
-    with open(path_rules) as cf:
+    with open(path_rules, encoding="utf-8") as cf:
         dict_rules = json.load(cf)
 
     # making the keys lowercase to be consistent with supy

--- a/src/supy/cmd/schema_cli.py
+++ b/src/supy/cmd/schema_cli.py
@@ -69,7 +69,7 @@ def read_yaml_file(file_path: Path) -> Tuple[dict, Optional[str]]:
         Tuple of (config_dict, schema_version)
     """
     try:
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
         schema_version = config.get("schema_version")
         return config, schema_version
@@ -291,7 +291,7 @@ def version(ctx, files, update, target_version, backup):
                             f".backup-{datetime.now():%Y%m%d-%H%M%S}.yml"
                         )
                         path.rename(backup_path)
-                        with open(path, "w") as f:
+                        with open(path, "w", encoding="utf-8") as f:
                             config["schema_version"] = new_version
                             yaml.dump(
                                 config, f, default_flow_style=False, sort_keys=False
@@ -299,7 +299,7 @@ def version(ctx, files, update, target_version, backup):
                         action = f"Updated → {new_version}"
                     else:
                         config["schema_version"] = new_version
-                        with open(path, "w") as f:
+                        with open(path, "w", encoding="utf-8") as f:
                             yaml.dump(
                                 config, f, default_flow_style=False, sort_keys=False
                             )
@@ -386,7 +386,7 @@ def migrate(ctx, files, target_version, output_dir, backup, dry_run):
                     out_file = path.with_suffix(".migrated.yml")
 
                 # Save migrated configuration
-                with open(out_file, "w") as f:
+                with open(out_file, "w", encoding="utf-8") as f:
                     yaml.dump(migrated, f, default_flow_style=False, sort_keys=False)
 
                 # Validate migrated config
@@ -472,7 +472,7 @@ def export(ctx, output, version, format):
         # Write to file or stdout
         if output:
             output_path = Path(output)
-            output_path.write_text(output_content)
+            output_path.write_text(output_content, encoding="utf-8")
             if not quiet:
                 console.print(f"[green]✓[/green] Schema exported to {output_path}")
         else:

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -114,7 +114,7 @@ def validate_single_file(
 
     try:
         # Load configuration
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
         flatten_physics_in_config(config)
 
@@ -691,7 +691,7 @@ def migrate(file, output, to_version):
 
     try:
         # Load configuration
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
         # Detect current version
@@ -712,7 +712,7 @@ def migrate(file, output, to_version):
         )
 
         # Save
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             yaml.dump(migrated, f, default_flow_style=False, sort_keys=False)
 
         console.print(f"\n[green]✓ Migration complete![/green]")
@@ -804,7 +804,7 @@ def version(files, update, target_version, backup):
     for file_path in files:
         path = Path(file_path)
         try:
-            with open(path, "r") as f:
+            with open(path, "r", encoding="utf-8") as f:
                 cfg = yaml.safe_load(f) or {}
             current = cfg.get("schema_version") or "not specified"
 
@@ -823,7 +823,7 @@ def version(files, update, target_version, backup):
                         backup_path = path.with_suffix(".backup.yml")
                         path.rename(backup_path)
                     cfg["schema_version"] = new_version
-                    with open(path, "w") as f:
+                    with open(path, "w", encoding="utf-8") as f:
                         yaml.dump(cfg, f, default_flow_style=False, sort_keys=False)
                     action = f"Updated -> {new_version}"
                 else:
@@ -878,7 +878,7 @@ def export(output, version, fmt):
             default_name = f"suews-schema-v{schema_version}.json"
 
         if output:
-            Path(output).write_text(content)
+            Path(output).write_text(content, encoding="utf-8")
             console.print(f"[green]✓ Schema exported to {output}[/green]")
         else:
             console.print(
@@ -904,7 +904,7 @@ def _experimental_features_restriction(user_yaml_file, mode):
         return True, [], None  # Dev mode allows all features
 
     try:
-        with open(user_yaml_file, "r") as f:
+        with open(user_yaml_file, "r", encoding="utf-8") as f:
             user_yaml_data = yaml.safe_load(f)
     except Exception as e:
         return False, [], f"Error reading YAML file: {e}"
@@ -1298,7 +1298,7 @@ def _execute_pipeline(
 
     # Write to a persistent temp file that won't be deleted during pipeline execution
     with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".yml", delete=False
+        encoding="utf-8", mode="w", suffix=".yml", delete=False
     ) as tmp_standard:
         tmp_standard.write(standard_config_content)
         standard_yaml_file = tmp_standard.name

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -1294,7 +1294,7 @@ def _execute_pipeline(
     import tempfile
 
     sample_data_files = importlib.resources.files("supy") / "sample_data"
-    standard_config_content = (sample_data_files / "sample_config.yml").read_text()
+    standard_config_content = (sample_data_files / "sample_config.yml").read_text(encoding="utf-8")
 
     # Write to a persistent temp file that won't be deleted during pipeline execution
     with tempfile.NamedTemporaryFile(

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -1493,7 +1493,7 @@ class SUEWSConfig(BaseModel):
         try:
             import yaml
 
-            with open(yaml_path, "r") as f:
+            with open(yaml_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
             # Navigate to the surface using path like "sites[0]/properties/land_cover/paved"
@@ -4334,7 +4334,7 @@ class SUEWSConfig(BaseModel):
         Returns:
             SUEWSConfig: Instance of SUEWSConfig initialized from YAML
         """
-        with open(path, "r") as file:
+        with open(path, "r", encoding="utf-8") as file:
             config_data = yaml.load(file, Loader=yaml.FullLoader)
 
         # Snapshot the raw user YAML so site-level completeness checks can
@@ -4397,7 +4397,7 @@ class SUEWSConfig(BaseModel):
 
     def create_multi_index_columns(self, columns_file: str) -> pd.MultiIndex:
         """Create MultiIndex from df_state_columns.txt"""
-        with open(columns_file, "r") as f:
+        with open(columns_file, "r", encoding="utf-8") as f:
             lines = f.readlines()
 
         tuples = []

--- a/src/supy/data_model/schema/migration.py
+++ b/src/supy/data_model/schema/migration.py
@@ -278,7 +278,7 @@ def migrate_config_file(
         raise FileNotFoundError(f"Input file not found: {input_path}")
 
     # Load configuration
-    with open(input_file, "r") as f:
+    with open(input_file, "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     # Migrate
@@ -287,7 +287,7 @@ def migrate_config_file(
 
     # Save
     output_file = Path(output_path) if output_path else input_file
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         yaml.dump(migrated, f, default_flow_style=False, sort_keys=False)
 
     logger.info(f"Migrated configuration saved to {output_file}")
@@ -303,7 +303,7 @@ def check_migration_needed(config_path: str) -> bool:
     Returns:
         True if migration is needed, False otherwise
     """
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     migrator = SchemaMigrator()

--- a/src/supy/data_model/schema/publisher.py
+++ b/src/supy/data_model/schema/publisher.py
@@ -176,10 +176,10 @@ def save_schema(
     if format == "yaml":
         import yaml
 
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             yaml.dump(schema, f, default_flow_style=False, sort_keys=False)
     else:
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(schema, f, indent=2)
 
     print(f"Schema saved to {output_path}")
@@ -202,22 +202,22 @@ def create_schema_bundle(output_dir: Path, version: Optional[str] = None) -> Non
 
     # Save in multiple formats
     # JSON format
-    with open(output_dir / "schema.json", "w") as f:
+    with open(output_dir / "schema.json", "w", encoding="utf-8") as f:
         json.dump(schema, f, indent=2)
 
     # YAML format
     import yaml
 
-    with open(output_dir / "schema.yaml", "w") as f:
+    with open(output_dir / "schema.yaml", "w", encoding="utf-8") as f:
         yaml.dump(schema, f, default_flow_style=False, sort_keys=False)
 
     # Minified JSON
-    with open(output_dir / "schema.min.json", "w") as f:
+    with open(output_dir / "schema.min.json", "w", encoding="utf-8") as f:
         json.dump(schema, f, separators=(",", ":"))
 
     # Internal schema (with internal fields)
     internal_schema = generate_json_schema(version, include_internal=True)
-    with open(output_dir / "schema-internal.json", "w") as f:
+    with open(output_dir / "schema-internal.json", "w", encoding="utf-8") as f:
         json.dump(internal_schema, f, indent=2)
 
     # Create README
@@ -284,7 +284,7 @@ For issues or questions about the schema, please visit:
 https://github.com/UMEP-dev/SUEWS
 """
 
-    with open(output_dir / "README.md", "w") as f:
+    with open(output_dir / "README.md", "w", encoding="utf-8") as f:
         f.write(readme_content)
 
     print(f"Schema bundle created in {output_dir}")
@@ -311,12 +311,12 @@ def validate_config_against_schema(
     import jsonschema
 
     # Load configuration
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     # Load or generate schema
     if schema_path:
-        with open(schema_path, "r") as f:
+        with open(schema_path, "r", encoding="utf-8") as f:
             if schema_path.suffix == ".yaml":
                 schema = yaml.safe_load(f)
             else:

--- a/src/supy/data_model/schema/registry.py
+++ b/src/supy/data_model/schema/registry.py
@@ -34,7 +34,7 @@ class SchemaRegistry:
         """Load existing registry or create new one."""
         if self.registry_path.exists():
             try:
-                return json.loads(self.registry_path.read_text())
+                return json.loads(self.registry_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, FileNotFoundError):
                 pass
 
@@ -73,7 +73,7 @@ class SchemaRegistry:
 
     def _save_registry(self):
         """Save the registry to disk."""
-        self.registry_path.write_text(json.dumps(self._registry, indent=2))
+        self.registry_path.write_text(json.dumps(self._registry, indent=2), encoding="utf-8")
 
     def get_all_versions(self) -> List[str]:
         """Get list of all registered schema versions."""

--- a/src/supy/data_model/schema/updater.py
+++ b/src/supy/data_model/schema/updater.py
@@ -60,7 +60,7 @@ def update_yaml_schema_version(
         return False
 
     try:
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
         if not isinstance(config, dict):
@@ -114,7 +114,7 @@ def update_yaml_schema_version(
                     config["description"] = desc
 
         # Write back to file
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             yaml.dump(
                 config, f, default_flow_style=False, sort_keys=False, allow_unicode=True
             )
@@ -168,7 +168,7 @@ def find_yaml_configs(
         if not any(excluded in f.parts for excluded in excluded_dirs):
             # Try to detect if it's a SUEWS config
             try:
-                with open(f, "r") as file:
+                with open(f, "r", encoding="utf-8") as file:
                     content = yaml.safe_load(file)
                     if isinstance(content, dict) and (
                         "model" in content or "sites" in content

--- a/src/supy/data_model/validation/core/yaml_helpers.py
+++ b/src/supy/data_model/validation/core/yaml_helpers.py
@@ -1958,7 +1958,7 @@ def run_precheck(path: str) -> dict:
     """
 
     # ---- Step 0: Load yaml from path into a dict ----
-    with open(path, "r") as file:
+    with open(path, "r", encoding="utf-8") as file:
         data = yaml.load(file, Loader=yaml.FullLoader)
 
     original_data = deepcopy(data)

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -84,7 +84,7 @@ def detect_nlayer_from_user_yaml(user_yaml_file: str) -> int:
         nlayer value (defaults to 3 if not found or on error)
     """
     try:
-        with open(user_yaml_file, "r") as f:
+        with open(user_yaml_file, "r", encoding="utf-8") as f:
             user_data = yaml.safe_load(f)
 
         # Navigate: sites[0].properties.vertical_layers.nlayer.value
@@ -306,7 +306,7 @@ def validate_input_file(user_yaml_file: str) -> str:
         )
 
     try:
-        with open(user_yaml_file, "r") as f:
+        with open(user_yaml_file, "r", encoding="utf-8") as f:
             f.read(1)
     except PermissionError:
         raise PermissionError(f"Cannot read input file: {user_yaml_file}")
@@ -1018,7 +1018,7 @@ def _run_phase_c_legacy(
                     with importlib.resources.as_file(
                         sample_data_files / "sample_config.yml"
                     ) as standard_yaml_path:
-                        with open(standard_yaml_path, "r") as f:
+                        with open(standard_yaml_path, "r", encoding="utf-8") as f:
                             standard_data = yaml.safe_load(f)
                         flatten_physics_in_config(standard_data)
                 except FileNotFoundError:
@@ -1552,7 +1552,7 @@ Modes:
             try:
                 import yaml
 
-                with open(user_yaml_file, "r") as f:
+                with open(user_yaml_file, "r", encoding="utf-8") as f:
                     user_yaml_data = yaml.safe_load(f)
                 flatten_physics_in_config(user_yaml_data)
 

--- a/src/supy/data_model/validation/pipeline/phase_a.py
+++ b/src/supy/data_model/validation/pipeline/phase_a.py
@@ -1543,7 +1543,7 @@ def validate_forcing_data(user_yaml_file: str, physics: dict = None) -> tuple:
 
     try:
         # Load user YAML to extract forcing file path
-        with open(user_yaml_file, "r") as f:
+        with open(user_yaml_file, "r", encoding="utf-8") as f:
             user_data = yaml.safe_load(f)
 
         # Navigate to model.control.forcing_file
@@ -2013,7 +2013,7 @@ def annotate_missing_parameters(
     forcing="on",
 ):
     try:
-        with open(user_file, "r") as f:
+        with open(user_file, "r", encoding="utf-8") as f:
             original_yaml_content = f.read()
         original_yaml_content, renamed_replacements = handle_renamed_parameters(
             original_yaml_content
@@ -2044,7 +2044,7 @@ def annotate_missing_parameters(
                 allow_unicode=True,
             )
             original_yaml_content = stream.getvalue()
-        with open(standard_file, "r") as f:
+        with open(standard_file, "r", encoding="utf-8") as f:
             standard_data = yaml.safe_load(f)
         # Collapse readable physics names in both trees before structure diffs.
         flatten_physics_in_config(user_data)

--- a/src/supy/data_model/validation/pipeline/phase_b.py
+++ b/src/supy/data_model/validation/pipeline/phase_b.py
@@ -306,7 +306,7 @@ def validate_phase_b_inputs(
     try:
         from ...core.physics_families import flatten_physics_in_config
 
-        with open(uptodate_yaml_file, "r") as f:
+        with open(uptodate_yaml_file, "r", encoding="utf-8") as f:
             uptodate_content = f.read()
             # Normalise legacy field spellings to current names so the science
             # checks below match configs that bypass Phase A's normalisation
@@ -320,7 +320,7 @@ def validate_phase_b_inputs(
 
         user_data = load_user_yaml_normalised(user_yaml_file)
 
-        with open(standard_yaml_file, "r") as f:
+        with open(standard_yaml_file, "r", encoding="utf-8") as f:
             standard_data = yaml.safe_load(f)
 
         # Collapse readable physics names for raw-dict science checks.

--- a/src/supy/data_model/validation/pipeline/phase_c.py
+++ b/src/supy/data_model/validation/pipeline/phase_c.py
@@ -126,7 +126,7 @@ def convert_pydantic_location_to_gridid_path(loc_tuple, input_yaml_file):
             site_index = loc_tuple[i + 1]
             try:
                 # Load YAML to get the actual GRIDID
-                with open(input_yaml_file, "r") as f:
+                with open(input_yaml_file, "r", encoding="utf-8") as f:
                     yaml_data = yaml.safe_load(f)
 
                 if (
@@ -328,7 +328,7 @@ def generate_phase_c_report(
                     if field_name in ["lat", "lon", "alt"]:
                         # Try to get GRIDID for first site as fallback
                         try:
-                            with open(input_yaml_file, "r") as f:
+                            with open(input_yaml_file, "r", encoding="utf-8") as f:
                                 yaml_data = yaml.safe_load(f)
                             if (
                                 "sites" in yaml_data

--- a/src/supy/data_model/validation/pipeline/yaml_annotator.py
+++ b/src/supy/data_model/validation/pipeline/yaml_annotator.py
@@ -202,7 +202,7 @@ class JsonYamlAnnotator:
     ) -> Path:
         """Generate annotated YAML file with validation feedback."""
         # Read original YAML
-        with open(input_path, "r") as f:
+        with open(input_path, "r", encoding="utf-8") as f:
             yaml_content = f.read()
 
         # Parse to data structure

--- a/src/supy/util/_UMEP2epw.py
+++ b/src/supy/util/_UMEP2epw.py
@@ -333,7 +333,7 @@ def patchup_epw(df_data, df_header, path_epw, lat, lon, tz, alt):
     df_header[7] = line_last
 
     # OverWRITE epw
-    filenew = open(path_epw, "w")
+    filenew = open(path_epw, "w", encoding="utf-8")
     for i in range(len(df_header)):
         filenew.write(df_header[i] + "\n")
     filenew.close()

--- a/src/supy/util/_debug.py
+++ b/src/supy/util/_debug.py
@@ -37,7 +37,7 @@ def save_zip_debug(df_forcing, df_state_init, error_info=None):
     # save error information if provided
     if error_info is not None:
         path_error = path_dir_save / "error_info.md"
-        with open(path_error, "w") as f:
+        with open(path_error, "w", encoding="utf-8") as f:
             # Write timestamp as header
             f.write(f"# SuPy Error Report\n\n")
             f.write(f"## Timestamp\n")

--- a/src/supy/util/_state_io.py
+++ b/src/supy/util/_state_io.py
@@ -56,11 +56,11 @@ def save_final_state(
     yaml_path = output_dir / f"{run_id}_next_initial.yml"
     user_state = extract_user_facing_state(df_state_final, config)
 
-    with open(yaml_path, "w") as f:
+    with open(yaml_path, "w", encoding="utf-8") as f:
         yaml.dump(user_state, f, default_flow_style=False, sort_keys=False)
 
     # Add informative header to YAML file
-    with open(yaml_path, "r") as f:
+    with open(yaml_path, "r", encoding="utf-8") as f:
         content = f.read()
 
     header = f"""# SUEWS Initial State Configuration
@@ -77,7 +77,7 @@ def save_final_state(
 
 """
 
-    with open(yaml_path, "w") as f:
+    with open(yaml_path, "w", encoding="utf-8") as f:
         f.write(header + content)
 
     return pickle_path, yaml_path
@@ -266,7 +266,7 @@ def load_initial_state(
             raise FileNotFoundError(f"Pickle file not found: {pickle_path}")
 
     # Override with user-provided YAML values
-    with open(yaml_path, "r") as f:
+    with open(yaml_path, "r", encoding="utf-8") as f:
         # Skip comment header
         lines = f.readlines()
         yaml_content = "".join([

--- a/src/supy/util/_tmy.py
+++ b/src/supy/util/_tmy.py
@@ -669,7 +669,7 @@ def gen_epw(
         path_epw.parent.mkdir(parents=True)
     path_epw.touch(exist_ok=True)
     df_epw.to_csv(path_epw, index=None, header=None)
-    text_data = path_epw.read_text().split("\n")
+    text_data = path_epw.read_text(encoding="utf-8").split("\n")
     # delete the csv file
     path_epw.unlink()
 
@@ -697,7 +697,7 @@ DATA PERIODS,1,1,Data,Sunday,1/1,12/31
     #     s = ''.join(lines)
 
     # write out the actual EPW file
-    path_epw.write_text(text_epw)
+    path_epw.write_text(text_epw, encoding="utf-8")
     # with open(path_epw, "w") as fp:
     #     fp.write(text_epw)
 

--- a/src/supy/util/code_manager.py
+++ b/src/supy/util/code_manager.py
@@ -431,7 +431,7 @@ class TemplateSystem:
         df.set_index("Code", inplace=True)
 
         # Write to file
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             # Write header
             f.write("    ".join(template["header"]) + "\n")
             # Write data
@@ -550,7 +550,7 @@ class UniversalCodeManager:
         df.set_index("Code", inplace=True)
 
         # Write to file
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write("    ".join(fields) + "\n")
             for idx, row in df.iterrows():
                 values = "    ".join(
@@ -595,7 +595,7 @@ class UniversalCodeManager:
             df = df.sort_index()
 
             # Write back to file
-            with open(file_path, "w") as f:
+            with open(file_path, "w", encoding="utf-8") as f:
                 # Write header
                 f.write("Code    " + "    ".join(df.columns) + "\n")
                 # Write data

--- a/src/supy/util/converter/table/profile_manager.py
+++ b/src/supy/util/converter/table/profile_manager.py
@@ -174,7 +174,7 @@ class ProfileManager:
         profiles_df = profiles_df.sort_index()
 
         # Write to file with proper header (matching legacy column naming 0-23)
-        with open(profiles_file, "w") as f:
+        with open(profiles_file, "w", encoding="utf-8") as f:
             # Write first line: column numbers (load_SUEWS_table skips this line)
             f.write("    ".join([str(i) for i in range(1, 26)]) + "\n")
 

--- a/test/cmd/test_df_state_conversion.py
+++ b/test/cmd/test_df_state_conversion.py
@@ -26,7 +26,7 @@ class TestDfStateDetection:
     def test_detect_nml_input(self, tmp_path):
         """Test detection of RunControl.nml input."""
         nml_file = tmp_path / "RunControl.nml"
-        nml_file.write_text("&runcontrol\n/\n")
+        nml_file.write_text("&runcontrol\n/\n", encoding="utf-8")
 
         assert detect_input_type(nml_file) == "nml"
 

--- a/test/cmd/test_df_state_conversion.py
+++ b/test/cmd/test_df_state_conversion.py
@@ -168,7 +168,7 @@ class TestCsvFileConversion:
         # Check it's valid YAML
         import yaml
 
-        with open(output_yaml) as f:
+        with open(output_yaml, encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
         assert "sites" in config

--- a/test/core/test_check_schema_version_bump.py
+++ b/test/core/test_check_schema_version_bump.py
@@ -146,7 +146,7 @@ def test_main_entry_chdirs_to_repo_root(branched_repo: Path) -> None:
     target_dir = branched_repo / "scripts" / "lint"
     target_dir.mkdir(parents=True)
     script_copy = target_dir / SCRIPT_PATH.name
-    script_copy.write_text(SCRIPT_PATH.read_text(), encoding="utf-8")
+    script_copy.write_text(SCRIPT_PATH.read_text(encoding="utf-8"), encoding="utf-8")
     nested = branched_repo / "src"
     assert nested.is_dir()
 

--- a/test/core/test_cli_run.py
+++ b/test/core/test_cli_run.py
@@ -113,7 +113,8 @@ model:
 sites:
   - name: TestSite
     gridiv: 1
-"""
+""",
+            encoding="utf-8",
         )
 
         result = self.run_suews_run(cli_runner, str(minimal_yaml), check=False)
@@ -159,7 +160,7 @@ sites:
         # Use CliRunner's isolated_filesystem for clean working directory
         with cli_runner.isolated_filesystem():
             # Copy sample YAML to config.yml in isolated dir
-            Path("config.yml").write_text(sample_yaml.read_text(), encoding="utf-8")
+            Path("config.yml").write_text(sample_yaml.read_text(encoding="utf-8"), encoding="utf-8")
 
             result = self.run_suews_run(cli_runner, check=False)
             if result.returncode == 0:
@@ -185,7 +186,7 @@ sites:
     def test_invalid_yaml_syntax(self, cli_runner, tmp_path):
         """Test error handling for malformed YAML."""
         bad_yaml = tmp_path / "bad.yml"
-        bad_yaml.write_text("model:\n  control\n    invalid yaml")
+        bad_yaml.write_text("model:\n  control\n    invalid yaml", encoding="utf-8")
 
         result = self.run_suews_run(cli_runner, str(bad_yaml), check=False)
         assert result.returncode != 0

--- a/test/core/test_cli_run.py
+++ b/test/core/test_cli_run.py
@@ -159,7 +159,7 @@ sites:
         # Use CliRunner's isolated_filesystem for clean working directory
         with cli_runner.isolated_filesystem():
             # Copy sample YAML to config.yml in isolated dir
-            Path("config.yml").write_text(sample_yaml.read_text())
+            Path("config.yml").write_text(sample_yaml.read_text(), encoding="utf-8")
 
             result = self.run_suews_run(cli_runner, check=False)
             if result.returncode == 0:

--- a/test/core/test_forcing_path_resolution.py
+++ b/test/core/test_forcing_path_resolution.py
@@ -28,7 +28,7 @@ def temp_config_setup(config_content, forcing_location="next_to_config"):
 
         # Write config
         config_path = config_dir / "config.yml"
-        config_path.write_text(config_content)
+        config_path.write_text(config_content, encoding="utf-8")
 
         # Place forcing file based on test needs
         if forcing_location == "next_to_config":

--- a/test/core/test_load.py
+++ b/test/core/test_load.py
@@ -367,7 +367,7 @@ FileCode='test'
 FileInputPath="./Input/"
 FileOutputPath="./Output/"
 /
-""")
+""", encoding="utf-8")
 
             # Deliberately do NOT create SPARTACUS.nml
             # This simulates old (pre-2018) runcontrol files
@@ -524,7 +524,7 @@ FileOutputPath="./Output/"
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create malformed YAML
             bad_yaml = Path(temp_dir) / "bad.yml"
-            bad_yaml.write_text("{{invalid yaml")
+            bad_yaml.write_text("{{invalid yaml", encoding="utf-8")
 
             with self.assertRaises((ValueError, RuntimeError, yaml.YAMLError)):
                 sp.init_supy(bad_yaml)

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -953,7 +953,7 @@ class TestPathResolution:
         """Test that absolute paths are returned unchanged."""
         # Create config file
         config_file = tmp_path / "config.yml"
-        config_file.write_text("sites:\n  - name: test\n")
+        config_file.write_text("sites:\n  - name: test\n", encoding="utf-8")
 
         sim = SUEWSSimulation()
         sim._config_path = config_file
@@ -967,9 +967,9 @@ class TestPathResolution:
         """Test that relative paths are resolved relative to config file."""
         # Create config file and forcing file
         config_file = tmp_path / "config.yml"
-        config_file.write_text("sites:\n  - name: test\n")
+        config_file.write_text("sites:\n  - name: test\n", encoding="utf-8")
         forcing_file = tmp_path / "forcing.txt"
-        forcing_file.write_text("# forcing data")
+        forcing_file.write_text("# forcing data", encoding="utf-8")
 
         sim = SUEWSSimulation()
         sim._config_path = config_file
@@ -981,7 +981,7 @@ class TestPathResolution:
     def test_resolve_relative_path_list(self, tmp_path):
         """Test that list of relative paths are all resolved."""
         config_file = tmp_path / "config.yml"
-        config_file.write_text("sites:\n  - name: test\n")
+        config_file.write_text("sites:\n  - name: test\n", encoding="utf-8")
 
         sim = SUEWSSimulation()
         sim._config_path = config_file
@@ -997,7 +997,7 @@ class TestPathResolution:
     def test_resolve_mixed_absolute_relative_list(self, tmp_path):
         """Test list with mixed absolute and relative paths."""
         config_file = tmp_path / "config.yml"
-        config_file.write_text("sites:\n  - name: test\n")
+        config_file.write_text("sites:\n  - name: test\n", encoding="utf-8")
 
         sim = SUEWSSimulation()
         sim._config_path = config_file
@@ -1017,7 +1017,7 @@ class TestPathResolution:
         forcing_dir.mkdir()
 
         config_file = config_dir / "config.yml"
-        config_file.write_text("sites:\n  - name: test\n")
+        config_file.write_text("sites:\n  - name: test\n", encoding="utf-8")
 
         sim = SUEWSSimulation()
         sim._config_path = config_file
@@ -1159,7 +1159,7 @@ class TestContinuationRuns:
     def test_from_state_unsupported_format(self, tmp_path):
         """Test error handling for unsupported file format."""
         invalid_file = tmp_path / "state.txt"
-        invalid_file.write_text("dummy content")
+        invalid_file.write_text("dummy content", encoding="utf-8")
 
         with pytest.raises(ValueError, match="Unsupported state file format"):
             SUEWSSimulation.from_state(invalid_file)

--- a/test/data_model/test_data_model.py
+++ b/test/data_model/test_data_model.py
@@ -525,7 +525,7 @@ def test_flexible_refvalue_with_cleaning():
     sample_config_resource = supy_resources / "sample_data" / "sample_config.yml"
 
     # Load the config data
-    original_data = yaml.safe_load(sample_config_resource.read_text())
+    original_data = yaml.safe_load(sample_config_resource.read_text(encoding="utf-8"))
 
     # Create a cleaned version
     cleaned_data = copy.deepcopy(original_data)
@@ -875,7 +875,7 @@ class TestSUEWSSimulationRefValue:
         sample_config_resource = supy_resources / "sample_data" / "sample_config.yml"
 
         # Load sample config
-        original_data = yaml.safe_load(sample_config_resource.read_text())
+        original_data = yaml.safe_load(sample_config_resource.read_text(encoding="utf-8"))
 
         # Create RefValue list with the sample forcing file
         forcing_list = [str(sample_forcing)]
@@ -908,7 +908,7 @@ class TestSUEWSSimulationRefValue:
         sample_config_resource = supy_resources / "sample_data" / "sample_config.yml"
 
         # Load sample config
-        original_data = yaml.safe_load(sample_config_resource.read_text())
+        original_data = yaml.safe_load(sample_config_resource.read_text(encoding="utf-8"))
 
         # Create RefValue string with the sample forcing file
         ref_forcing = RefValue(str(sample_forcing))

--- a/test/data_model/test_data_model.py
+++ b/test/data_model/test_data_model.py
@@ -412,7 +412,7 @@ class TestGrididErrorTransformation(unittest.TestCase):
             for i, gid in enumerate(gridid_values)
         ]
         config_path = Path(self.temp_dir) / "config_test.yml"
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump({"name": "Test Config", "sites": sites}, f)
         return config_path
 
@@ -462,7 +462,7 @@ class TestGrididErrorTransformation(unittest.TestCase):
 
         sites = [{"gridiv": {"value": 777}, "properties": {"lat": None, "lng": 0.0}}]
         config_path = Path(self.temp_dir) / "config_refvalue.yml"
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump({"name": "Test", "sites": sites}, f)
 
         with self.assertRaises(ValueError) as cm:
@@ -705,7 +705,7 @@ model:
     diagnose: 0
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(yaml_content)
         yaml_path = Path(f.name)
 
@@ -740,7 +740,7 @@ model:
         desc: "Full diagnostics enabled"
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(yaml_content)
         yaml_path = Path(f.name)
 
@@ -777,7 +777,7 @@ model:
         desc: "Basic diagnostics"
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(yaml_content)
         yaml_path = Path(f.name)
 

--- a/test/data_model/test_forcing_validation.py
+++ b/test/data_model/test_forcing_validation.py
@@ -228,9 +228,9 @@ def test_python_rust_whitelist_parity():
     )
 
     rust_src = Path(__file__).resolve().parents[2] / "src" / "suews_bridge" / "src" / "forcing.rs"
-    text = rust_src.read_text()
+    text = rust_src.read_text(encoding="utf-8")
     rust_io_src = Path(__file__).resolve().parents[2] / "src" / "suews_bridge" / "src" / "forcing_io.rs"
-    text_io = rust_io_src.read_text()
+    text_io = rust_io_src.read_text(encoding="utf-8")
 
     def _list(name: str) -> set[str]:
         import re

--- a/test/data_model/test_from_yaml_errors.py
+++ b/test/data_model/test_from_yaml_errors.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.api
 def sample_config_dict() -> dict:
     """Load the packaged sample configuration as a mutable dict."""
     path = trv_supy_module / "sample_data" / "sample_config.yml"
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 

--- a/test/data_model/test_nested_physics.py
+++ b/test/data_model/test_nested_physics.py
@@ -59,13 +59,13 @@ class TestModelPhysicsNested:
 
 class TestYamlRoundTrip:
     def test_flat_yaml_loads(self):
-        cfg = yaml.safe_load((_FIXTURES / "flat.yml").read_text())
+        cfg = yaml.safe_load((_FIXTURES / "flat.yml").read_text(encoding="utf-8"))
         phys = ModelPhysics(**cfg["model"]["physics"])
         assert int(_unwrap(phys.net_radiation)) == 1001
 
     def test_nested_yaml_loads_to_same_internal_state(self):
-        flat_cfg = yaml.safe_load((_FIXTURES / "flat.yml").read_text())
-        nested_cfg = yaml.safe_load((_FIXTURES / "nested.yml").read_text())
+        flat_cfg = yaml.safe_load((_FIXTURES / "flat.yml").read_text(encoding="utf-8"))
+        nested_cfg = yaml.safe_load((_FIXTURES / "nested.yml").read_text(encoding="utf-8"))
 
         flat = ModelPhysics(**flat_cfg["model"]["physics"])
         nested = ModelPhysics(**nested_cfg["model"]["physics"])
@@ -74,7 +74,7 @@ class TestYamlRoundTrip:
         assert flat.model_dump(mode="json") == nested.model_dump(mode="json")
 
     def test_nested_yaml_dumps_to_flat(self):
-        nested_cfg = yaml.safe_load((_FIXTURES / "nested.yml").read_text())
+        nested_cfg = yaml.safe_load((_FIXTURES / "nested.yml").read_text(encoding="utf-8"))
         phys = ModelPhysics(**nested_cfg["model"]["physics"])
 
         dumped_text = yaml.safe_dump(phys.model_dump(mode="json"))
@@ -84,7 +84,7 @@ class TestYamlRoundTrip:
         assert "simple:" not in dumped_text
 
     def test_mixed_reject_yaml_raises(self):
-        cfg = yaml.safe_load((_FIXTURES / "mixed_reject.yml").read_text())
+        cfg = yaml.safe_load((_FIXTURES / "mixed_reject.yml").read_text(encoding="utf-8"))
         with pytest.raises(ValidationError) as exc:
             ModelPhysics(**cfg["model"]["physics"])
         assert "expects one of" in str(exc.value)

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -51,7 +51,7 @@ def test_phase_a_emits_json_sidecar(tmp_path, sample_config_path):
     json_path = report_file.with_suffix(".json")
     assert json_path.exists(), "Phase A should write a JSON sidecar"
 
-    payload = json.loads(json_path.read_text())
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert payload["phase"] == "A"
     assert payload["status"] in {"PASSED", "WARNING", "FAILED"}
     assert isinstance(payload["issues"], list)
@@ -85,7 +85,7 @@ def test_phase_b_emits_json_sidecar(tmp_path, sample_config_path):
     json_path = science_report.with_suffix(".json")
     assert json_path.exists(), "Phase B should write a JSON sidecar"
 
-    payload = json.loads(json_path.read_text())
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert payload["phase"] == "B"
     assert payload["status"] in {"PASSED", "WARNING", "FAILED"}
     assert isinstance(payload["issues"], list)
@@ -114,7 +114,7 @@ def test_phase_c_emits_json_for_passing_config(tmp_path, sample_config_path):
     assert report.phase == "C"
     json_path = pydantic_report.with_suffix(".json")
     assert json_path.exists()
-    payload = json.loads(json_path.read_text())
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert payload["phase"] == "C"
     # Sample config should pass; status is PASSED unless there are
     # legitimate warnings in the sample.
@@ -130,7 +130,8 @@ def test_phase_c_emits_structured_pydantic_errors_for_bad_config(tmp_path):
         "  control:\n"
         "    tstep: not_an_int\n"
         "    forcing_file: forcing.txt\n"
-        "sites: []\n"
+        "sites: []\n",
+        encoding="utf-8",
     )
     pydantic_yaml = tmp_path / "pydantic.yml"
     pydantic_report = tmp_path / "pydantic_report.txt"
@@ -144,7 +145,7 @@ def test_phase_c_emits_structured_pydantic_errors_for_bad_config(tmp_path):
     )
 
     assert report.has_errors, "A malformed config must produce errors"
-    payload = json.loads(pydantic_report.with_suffix(".json").read_text())
+    payload = json.loads(pydantic_report.with_suffix(".json").read_text(encoding="utf-8"))
     assert payload["phase"] == "C"
     assert payload["status"] == "FAILED"
     # At least one issue should be a structured Pydantic error.
@@ -169,7 +170,7 @@ def test_phase_b_text_report_unchanged(tmp_path, sample_config_path):
     )
 
     assert science_report.exists()
-    text = science_report.read_text()
+    text = science_report.read_text(encoding="utf-8")
     assert len(text) > 0
     # The text report still uses the historical section markers.
     # Downstream tooling that greps these strings must continue to work.

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -228,7 +228,7 @@ def test_pipeline_writes_json_sidecars_alongside_text_reports(tmp_path, sample_c
 
     # Each sidecar carries the same canonical schema.
     for r in (a_report, b_report, c_report):
-        payload = json.loads(Path(r.json_report_path).read_text())
+        payload = json.loads(Path(r.json_report_path).read_text(encoding="utf-8"))
         assert set(payload.keys()) == {
             "phase", "status", "issues", "yaml_in", "yaml_out",
             "text_report_path", "json_report_path", "extra",

--- a/test/data_model/test_schema_versioning.py
+++ b/test/data_model/test_schema_versioning.py
@@ -44,7 +44,7 @@ def write_temp_sparse_schema_file(schema_version: str) -> Path:
     sparse_config = Path(__file__).parent.parent / "fixtures" / "sparse_site.yml"
     sparse_text = sparse_config.read_text()
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(f"schema_version: '{schema_version}'\n{sparse_text}")
         return Path(f.name)
 
@@ -184,7 +184,7 @@ class TestSchemaVersioning:
     def test_from_yaml_with_schema_version(self):
         """Test loading YAML with schema version."""
         # Create a temporary YAML file
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
             yaml_content = {
                 "name": "test_config",
                 "schema_version": "1.0",
@@ -351,7 +351,7 @@ class TestSchemaVersionUtility:
     def test_update_yaml_schema_version(self):
         """Test updating schema version in YAML file."""
         # Create a temporary YAML file
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
             yaml_content = {
                 "name": "test_config",
                 "description": "Test configuration",
@@ -367,7 +367,7 @@ class TestSchemaVersionUtility:
             assert result is True
 
             # Read back and verify
-            with open(yaml_path, "r") as f:
+            with open(yaml_path, "r", encoding="utf-8") as f:
                 updated = yaml.safe_load(f)
 
             assert updated["schema_version"] == "1.0"
@@ -381,7 +381,7 @@ class TestSchemaVersionUtility:
     def test_migrate_from_dual_version(self):
         """Test migration from old dual-version system."""
         # Create a file with old dual-version system
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
             yaml_content = {
                 "name": "test_config_v1.0",
                 "version": "2025.8.1.dev0",
@@ -399,7 +399,7 @@ class TestSchemaVersionUtility:
             assert result is True
 
             # Read back and verify
-            with open(yaml_path, "r") as f:
+            with open(yaml_path, "r", encoding="utf-8") as f:
                 updated = yaml.safe_load(f)
 
             # New field added

--- a/test/data_model/test_schema_versioning.py
+++ b/test/data_model/test_schema_versioning.py
@@ -36,13 +36,13 @@ def load_supy_resource(resource_path: str) -> str:
     resource = supy_resources
     for part in parts:
         resource = resource / part
-    return resource.read_text()
+    return resource.read_text(encoding="utf-8")
 
 
 def write_temp_sparse_schema_file(schema_version: str) -> Path:
     """Write the sparse fixture with an explicit schema stamp."""
     sparse_config = Path(__file__).parent.parent / "fixtures" / "sparse_site.yml"
-    sparse_text = sparse_config.read_text()
+    sparse_text = sparse_config.read_text(encoding="utf-8")
 
     with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(f"schema_version: '{schema_version}'\n{sparse_text}")

--- a/test/data_model/test_timezone_enum.py
+++ b/test/data_model/test_timezone_enum.py
@@ -34,7 +34,7 @@ def test_timezone_enum_support():
     }
 
     # Write config to temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(config_dict, f)
         temp_config_path = f.name
 
@@ -103,7 +103,7 @@ def test_timezone_boundary_values(tz_value):
         ],
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(config_dict, f)
         temp_config_path = f.name
 
@@ -163,7 +163,7 @@ def test_timezone_validation_errors(tz_value):
         ],
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(config_dict, f)
         temp_config_path = f.name
 

--- a/test/data_model/test_to_yaml_roundtrip.py
+++ b/test/data_model/test_to_yaml_roundtrip.py
@@ -44,14 +44,14 @@ class TestToYamlRoundTrip:
         """Clean export should not add parameters absent from sample_config (#1288)."""
         # ARRANGE
         with tempfile.NamedTemporaryFile(
-            suffix=".yml", delete=False, mode="w"
+            encoding="utf-8", suffix=".yml", delete=False, mode="w"
         ) as tmp:
             tmp_path = tmp.name
 
         # ACT
         sample_config.to_yaml(tmp_path, include_internal=False)
 
-        with open(tmp_path) as f:
+        with open(tmp_path, encoding="utf-8") as f:
             user_data = yaml.safe_load(f)
 
         extra = find_extra_parameters(user_data, standard_data)
@@ -68,14 +68,14 @@ class TestToYamlRoundTrip:
         """to_yaml() should not include _yaml_path or _auto_generate_annotated."""
         # ARRANGE
         with tempfile.NamedTemporaryFile(
-            suffix=".yml", delete=False, mode="w"
+            encoding="utf-8", suffix=".yml", delete=False, mode="w"
         ) as tmp:
             tmp_path = tmp.name
 
         # ACT
         sample_config.to_yaml(tmp_path)
 
-        with open(tmp_path) as f:
+        with open(tmp_path, encoding="utf-8") as f:
             user_data = yaml.safe_load(f)
 
         # ASSERT
@@ -88,14 +88,14 @@ class TestToYamlRoundTrip:
         """to_yaml(include_internal=False) should exclude internal_only fields."""
         # ARRANGE
         with tempfile.NamedTemporaryFile(
-            suffix=".yml", delete=False, mode="w"
+            encoding="utf-8", suffix=".yml", delete=False, mode="w"
         ) as tmp:
             tmp_path = tmp.name
 
         # ACT
         sample_config.to_yaml(tmp_path, include_internal=False)
 
-        with open(tmp_path) as f:
+        with open(tmp_path, encoding="utf-8") as f:
             user_data = yaml.safe_load(f)
 
         # ASSERT - sample_config always includes at least one site
@@ -139,7 +139,7 @@ class TestToYamlRoundTrip:
         sample_config.sites[0].initial_states.qn_surfs = [1.0] * 7
 
         with tempfile.NamedTemporaryFile(
-            suffix=".yml", delete=False, mode="w"
+            encoding="utf-8", suffix=".yml", delete=False, mode="w"
         ) as tmp:
             tmp_path = tmp.name
 

--- a/test/data_model/test_to_yaml_roundtrip.py
+++ b/test/data_model/test_to_yaml_roundtrip.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.api
 def standard_data():
     """Load the standard sample_config.yml as reference."""
     path = trv_supy_module / "sample_data" / "sample_config.yml"
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -4185,7 +4185,7 @@ def test_dls_consistency_validation_in_suews_config():
     import yaml
 
     sample_path = trv_supy_module / "sample_data" / "sample_config.yml"
-    with sample_path.open() as f:
+    with sample_path.open(encoding="utf-8") as f:
         config_data = yaml.safe_load(f)
 
     # Test 1: Both None - valid
@@ -4223,7 +4223,7 @@ def test_dls_leap_year_validation_in_suews_config():
     from supy.data_model.core import SUEWSConfig
 
     sample_path = trv_supy_module / "sample_data" / "sample_config.yml"
-    with sample_path.open() as f:
+    with sample_path.open(encoding="utf-8") as f:
         config_data = yaml.safe_load(f)
 
     # Set DLS values
@@ -4250,7 +4250,7 @@ def test_dls_location_based_informational_messages_in_suews_config():
     from supy.data_model.core import SUEWSConfig
 
     sample_path = trv_supy_module / "sample_data" / "sample_config.yml"
-    with sample_path.open() as f:
+    with sample_path.open(encoding="utf-8") as f:
         config_data = yaml.safe_load(f)
 
     # Set year to 2024 (leap year) and add site name

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -2403,7 +2403,7 @@ sites:
                 SUEWSConfig.from_yaml(yaml_path, auto_generate_annotated=True)
 
             assert annotated_path.exists()
-            content = annotated_path.read_text()
+            content = annotated_path.read_text(encoding="utf-8")
 
             # Should have missing parameter annotations
             assert "[ERROR] MISSING:" in content
@@ -2462,7 +2462,7 @@ sites:
                 "Annotated YAML should be generated even when load raises, "
                 "provided auto_generate_annotated=True"
             )
-            content = annotated_path.read_text()
+            content = annotated_path.read_text(encoding="utf-8")
             assert "ANNOTATED SUEWS CONFIGURATION" in content
             assert "bldgh" in content
             annotated_path.unlink()
@@ -4453,7 +4453,7 @@ sites:
           faibldg: {value: 0.3}
 """
         config_path = tmp_path / "partial_land_cover.yml"
-        config_path.write_text(config_yaml)
+        config_path.write_text(config_yaml, encoding="utf-8")
 
         with pytest.raises(ValueError) as exc_info:
             SUEWSConfig.from_yaml(str(config_path))
@@ -4536,7 +4536,7 @@ sites:
           sfr: {value: 0.0}
 """
         config_path = tmp_path / "fai_simple_scheme.yml"
-        config_path.write_text(config_yaml)
+        config_path.write_text(config_yaml, encoding="utf-8")
 
         config = SUEWSConfig.from_yaml(str(config_path))
         assert config is not None
@@ -4626,7 +4626,7 @@ sites:
           sfr: {value: 0.0}
 """
         config_path = tmp_path / "lai_observed.yml"
-        config_path.write_text(config_yaml)
+        config_path.write_text(config_yaml, encoding="utf-8")
 
         config = SUEWSConfig.from_yaml(str(config_path))
         assert config is not None

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -2362,7 +2362,7 @@ sites:
           # Missing critical params
 """
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
             f.write(config_yaml)
             yaml_path = Path(f.name)
 
@@ -2393,7 +2393,7 @@ sites:
           sfr: {value: 0.3}
 """
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
             f.write(config_yaml)
             yaml_path = Path(f.name)
         annotated_path = yaml_path.parent / f"{yaml_path.stem}_annotated.yml"
@@ -2448,7 +2448,7 @@ sites:
           # Missing bldgh and faibldg parameters
 """
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
             f.write(config_yaml)
             yaml_path = Path(f.name)
         annotated_path = yaml_path.parent / f"{yaml_path.stem}_annotated.yml"
@@ -2534,7 +2534,7 @@ sites:
           sfr: {value: 0.2}
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(yaml_content)
         yaml_path = Path(f.name)
 
@@ -3131,7 +3131,7 @@ def test_nlayer_height_array_dimension_error():
     sample_data_dir = Path(sp.__file__).parent / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Set nlayer=3 but truncate height array to 2 elements
@@ -3172,7 +3172,7 @@ def test_nlayer_veg_frac_array_dimension_error():
     sample_data_dir = Path(sp.__file__).parent / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Set nlayer=5 but truncate veg_frac to 3 elements
@@ -3213,7 +3213,7 @@ def test_nlayer_multiple_arrays_dimension_errors():
     sample_data_dir = Path(sp.__file__).parent / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Set nlayer=4 but truncate multiple arrays
@@ -3248,7 +3248,7 @@ def test_nlayer_no_errors_when_correct():
     sample_data_dir = Path(sp.__file__).parent / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Detect nlayer from the config
@@ -3278,7 +3278,7 @@ def test_nlayer_roofs_walls_dimension_error_with_templates():
     sample_data_dir = Path(sp.__file__).parent / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Set nlayer to 2 but keep only 1 roof and 1 wall element
@@ -3353,7 +3353,7 @@ def test_forcing_validation_missing_file():
         "model": {"control": {"forcing_file": {"value": "nonexistent_forcing.txt"}}}
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(test_config, f)
         config_path = f.name
 
@@ -3403,7 +3403,7 @@ def test_forcing_validation_valid_forcing_file():
         "wdir": [180.0] * 5,
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".txt", delete=False) as f:
         df = pd.DataFrame(forcing_data)
         df.to_csv(f, sep=" ", index=False)
         forcing_path = f.name
@@ -3411,7 +3411,7 @@ def test_forcing_validation_valid_forcing_file():
     # Create test config
     test_config = {"model": {"control": {"forcing_file": {"value": forcing_path}}}}
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(test_config, f)
         config_path = f.name
 
@@ -3460,7 +3460,7 @@ def test_forcing_validation_invalid_ranges():
         "wdir": [180.0] * 5,
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".txt", delete=False) as f:
         df = pd.DataFrame(forcing_data)
         df.to_csv(f, sep=" ", index=False)
         forcing_path = f.name
@@ -3468,7 +3468,7 @@ def test_forcing_validation_invalid_ranges():
     # Create test config
     test_config = {"model": {"control": {"forcing_file": {"value": forcing_path}}}}
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(test_config, f)
         config_path = f.name
 
@@ -3497,7 +3497,7 @@ def test_forcing_validation_no_forcing_file_in_config():
     # Create config without forcing_file
     test_config = {"model": {"control": {}}}
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(test_config, f)
         config_path = f.name
 
@@ -3583,7 +3583,7 @@ def test_forcing_validation_can_be_disabled():
         )
 
         # Verify report does not contain forcing validation errors
-        with open(report_path, "r") as f:
+        with open(report_path, "r", encoding="utf-8") as f:
             report_content = f.read()
 
         assert "forcing data validation error" not in report_content.lower()
@@ -3629,7 +3629,7 @@ def test_forcing_validation_line_number_accuracy():
         "wdir": [180.0] * 10,
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".txt", delete=False) as f:
         df = pd.DataFrame(forcing_data)
         df.to_csv(f, sep=" ", index=False)
         forcing_path = f.name
@@ -3637,7 +3637,7 @@ def test_forcing_validation_line_number_accuracy():
     # Create test config
     test_config = {"model": {"control": {"forcing_file": {"value": forcing_path}}}}
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(test_config, f)
         config_path = f.name
 
@@ -3699,7 +3699,7 @@ def test_forcing_validation_refvalue_format():
         "wdir": [180.0] * 3,
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".txt", delete=False) as f:
         df = pd.DataFrame(forcing_data)
         df.to_csv(f, sep=" ", index=False)
         forcing_path = f.name
@@ -3717,7 +3717,7 @@ def test_forcing_validation_refvalue_format():
         }
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(test_config, f)
         config_path = f.name
 
@@ -3767,7 +3767,7 @@ def test_forcing_validation_multiple_files():
         "wdir": [180.0] * 3,
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".txt", delete=False) as f:
         df1 = pd.DataFrame(forcing_data1)
         df1.to_csv(f, sep=" ", index=False)
         forcing_path1 = f.name
@@ -3776,7 +3776,7 @@ def test_forcing_validation_multiple_files():
     forcing_data2 = forcing_data1.copy()
     forcing_data2["rain"] = [-1.0, -2.0, -3.0]
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".txt", delete=False) as f:
         df2 = pd.DataFrame(forcing_data2)
         df2.to_csv(f, sep=" ", index=False)
         forcing_path2 = f.name
@@ -3786,7 +3786,7 @@ def test_forcing_validation_multiple_files():
         "model": {"control": {"forcing_file": [forcing_path1, forcing_path2]}}
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         yaml.dump(test_config, f)
         config_path = f.name
 
@@ -3828,7 +3828,7 @@ def test_forcing_validation_cli_integration(cli_runner):
     sample_config = sample_data_dir / "sample_config.yml"
 
     # Read sample config and get forcing file path
-    with open(sample_config, "r") as f:
+    with open(sample_config, "r", encoding="utf-8") as f:
         config_data = yaml.safe_load(f)
 
     # Create a temporary config with invalid forcing data
@@ -3875,7 +3875,7 @@ def test_forcing_validation_cli_integration(cli_runner):
         }
 
         test_config_path = tmpdir_path / "test_config.yml"
-        with open(test_config_path, "w") as f:
+        with open(test_config_path, "w", encoding="utf-8") as f:
             yaml.dump(test_config_data, f)
 
         # Test 1: Default behavior (forcing validation enabled)
@@ -3886,7 +3886,7 @@ def test_forcing_validation_cli_integration(cli_runner):
         assert len(report_files) == 1, (
             f"Expected 1 report file, found {len(report_files)}: {list(tmpdir_path.iterdir())}"
         )
-        with open(report_files[0], "r") as f:
+        with open(report_files[0], "r", encoding="utf-8") as f:
             report_content = f.read()
         assert "forcing data validation error" in report_content.lower(), (
             f"Expected forcing validation error in report, but got:\n{report_content[:500]}"
@@ -3906,7 +3906,7 @@ def test_forcing_validation_cli_integration(cli_runner):
         assert len(report_files) == 1, (
             f"Expected 1 report file, found {len(report_files)}"
         )
-        with open(report_files[0], "r") as f:
+        with open(report_files[0], "r", encoding="utf-8") as f:
             report_content = f.read()
         assert "forcing data validation error" not in report_content.lower(), (
             f"Expected no forcing validation errors when disabled, but got:\n{report_content[:500]}"
@@ -4543,7 +4543,7 @@ sites:
 
         annotated_path = Path(config.generate_annotated_yaml(str(config_path)))
         try:
-            annotated = annotated_path.read_text()
+            annotated = annotated_path.read_text(encoding="utf-8")
             assert "faibldg:" not in annotated
         finally:
             annotated_path.unlink(missing_ok=True)

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -78,7 +78,7 @@ class TestUptodateYaml(unittest.TestCase):
         cls.standard_file = trv_supy_module / "sample_data" / "sample_config.yml"
 
         # Load the standard configuration
-        with cls.standard_file.open() as f:
+        with cls.standard_file.open(encoding="utf-8") as f:
             cls.standard_data = yaml.safe_load(f)
 
         # Create test data scenarios
@@ -1008,7 +1008,7 @@ class TestRealWorldScenarios(unittest.TestCase):
     def setUp(self):
         """Set up with real standard configuration."""
         self.standard_file = trv_supy_module / "sample_data" / "sample_config.yml"
-        with self.standard_file.open() as f:
+        with self.standard_file.open(encoding="utf-8") as f:
             self.standard_data = yaml.safe_load(f)
 
     def test_benchmark_configuration_compatibility(self):

--- a/test/data_model/test_yaml_processing.py
+++ b/test/data_model/test_yaml_processing.py
@@ -866,7 +866,7 @@ sites:
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create temporary user file with issues
             user_file = os.path.join(temp_dir, "user.yml")
-            with open(user_file, "w") as f:
+            with open(user_file, "w", encoding="utf-8") as f:
                 yaml.dump(self.missing_physics_yaml, f)
 
             # Create output file paths
@@ -886,7 +886,7 @@ sites:
             self.assertTrue(os.path.exists(report_file))
 
             # Verify uptodate file content
-            with open(uptodate_file) as f:
+            with open(uptodate_file, encoding="utf-8") as f:
                 uptodate_content = f.read()
 
             self.assertIn("Updated YAML", uptodate_content)
@@ -894,7 +894,7 @@ sites:
             self.assertIn("value: null", uptodate_content)
 
             # Verify report file content
-            with open(report_file) as f:
+            with open(report_file, encoding="utf-8") as f:
                 report_content = f.read()
 
             self.assertIn("# SUEWS Validation Report", report_content)
@@ -1155,7 +1155,7 @@ sites:
 
             # Write the problematic user config
             user_file = os.path.join(temp_dir, "comprehensive_user.yml")
-            with open(user_file, "w") as f:
+            with open(user_file, "w", encoding="utf-8") as f:
                 f.write(problematic_yaml_content.strip())
 
             # Define output files
@@ -1184,7 +1184,7 @@ sites:
             )
 
             # === VERIFY UPTODATE YAML CONTENT ===
-            with open(uptodate_file) as f:
+            with open(uptodate_file, encoding="utf-8") as f:
                 uptodate_content = f.read()
 
             # Should contain header
@@ -1255,7 +1255,7 @@ sites:
             )
 
             # === VERIFY REPORT CONTENT ===
-            with open(report_file) as f:
+            with open(report_file, encoding="utf-8") as f:
                 report_content = f.read()
 
             # Should contain all sections
@@ -1328,7 +1328,7 @@ sites:
 
             # === VERIFY DATA COMPLETENESS ===
             # Load both original and updated YAML for comparison
-            with open(user_file) as f:
+            with open(user_file, encoding="utf-8") as f:
                 original_data = yaml.safe_load(f.read())
 
             updated_data = yaml.safe_load(uptodate_content)
@@ -1476,7 +1476,7 @@ sites:
 
             # Write large config
             user_file = os.path.join(temp_dir, "large_user.yml")
-            with open(user_file, "w") as f:
+            with open(user_file, "w", encoding="utf-8") as f:
                 yaml.dump(large_config, f)
 
             uptodate_file = os.path.join(temp_dir, "uptodate_large_user.yml")
@@ -1506,7 +1506,7 @@ sites:
             self.assertTrue(os.path.exists(report_file))
 
             # Verify content correctness even with larger scale
-            with open(uptodate_file) as f:
+            with open(uptodate_file, encoding="utf-8") as f:
                 uptodate_content = f.read()
 
             # Should handle all sites correctly
@@ -3531,10 +3531,10 @@ class TestProcessorFixtures:
         user_file = Path(temp_directory) / "user_config.yml"
         standard_file = Path(temp_directory) / "standard_config.yml"
 
-        with open(user_file, "w") as f:
+        with open(user_file, "w", encoding="utf-8") as f:
             yaml.dump(minimal_user_config, f, default_flow_style=False)
 
-        with open(standard_file, "w") as f:
+        with open(standard_file, "w", encoding="utf-8") as f:
             yaml.dump(sample_standard_config, f, default_flow_style=False)
 
         return {
@@ -3980,12 +3980,12 @@ class TestPhaseAUptoDateYaml(TestProcessorFixtures):
         """Test mode-dependent extra parameter handling."""
         # Add extra parameter to user config
         user_file = temp_yaml_files["user_file"]
-        with open(user_file) as f:
+        with open(user_file, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         data["model"]["control"]["custom_param"] = "test_value"
 
-        with open(user_file, "w") as f:
+        with open(user_file, "w", encoding="utf-8") as f:
             yaml.dump(data, f)
 
         # Run Phase A with specified mode
@@ -4009,7 +4009,7 @@ class TestPhaseAUptoDateYaml(TestProcessorFixtures):
         assert os.path.exists(report_file), "Report file should be created"
 
         # Check output file content for mode-dependent behavior
-        with open(output_file) as f:
+        with open(output_file, encoding="utf-8") as f:
             output_data = yaml.safe_load(f)
 
         if expected_behavior in [
@@ -4023,7 +4023,7 @@ class TestPhaseAUptoDateYaml(TestProcessorFixtures):
             )
 
             # Check that the report contains ACTION NEEDED section with extra parameter warning
-            with open(report_file) as f:
+            with open(report_file, encoding="utf-8") as f:
                 report_content = f.read()
             assert "## ACTION NEEDED" in report_content, (
                 "Report should have ACTION NEEDED section in public mode"
@@ -4766,7 +4766,7 @@ class TestPhaseCReporting(TestProcessorFixtures):
         assert result is None
         assert os.path.exists(output_file), "Report file should be created"
 
-        with open(output_file) as f:
+        with open(output_file, encoding="utf-8") as f:
             report_content = f.read()
 
         assert "# SUEWS Validation Report" in report_content
@@ -4776,7 +4776,7 @@ class TestPhaseCReporting(TestProcessorFixtures):
     def test_report_consolidation_with_previous_phases(self, temp_directory):
         """Test report consolidation with Phase A and B information."""
         phase_a_report = os.path.join(temp_directory, "reportA_test.txt")
-        with open(phase_a_report, "w") as f:
+        with open(phase_a_report, "w", encoding="utf-8") as f:
             f.write("# SUEWS - Phase A Report\n")
             f.write("## ACTION NEEDED\n")
             f.write("- Found (1) missing parameter: gsmodel\n")
@@ -4798,7 +4798,7 @@ class TestPhaseCReporting(TestProcessorFixtures):
 
         assert result is None
 
-        with open(output_file) as f:
+        with open(output_file, encoding="utf-8") as f:
             report_content = f.read()
 
         assert "# SUEWS Validation Report" in report_content
@@ -5007,7 +5007,7 @@ class TestSuewsYamlProcessorOrchestrator(TestProcessorFixtures):
         """Test error handling with invalid YAML syntax."""
         invalid_yaml_file = Path(temp_directory) / "invalid.yml"
 
-        with open(invalid_yaml_file, "w") as f:
+        with open(invalid_yaml_file, "w", encoding="utf-8") as f:
             f.write("invalid: yaml: content: [unclosed bracket")
 
         try:
@@ -5037,7 +5037,7 @@ class TestSuewsYamlProcessorOrchestrator(TestProcessorFixtures):
 
         # Test creating a test file to verify write permissions
         test_file = output_dir / "test_cleanup.yml"
-        with open(test_file, "w") as f:
+        with open(test_file, "w", encoding="utf-8") as f:
             f.write("test: cleanup_validation")
 
         assert test_file.exists(), "Should be able to create files in output directory"

--- a/test/io_tests/test_named_column_forcing.py
+++ b/test/io_tests/test_named_column_forcing.py
@@ -33,12 +33,12 @@ def test_missing_baseline_column_raises(tmp_path):
     raises ValueError whose message contains the canonical name."""
     from supy.util._io import read_forcing
 
-    text = CANONICAL_FIXTURE.read_text()
+    text = CANONICAL_FIXTURE.read_text(encoding="utf-8")
     lines = text.splitlines()
     header = lines[0].replace("Tair", "temperature")
     bad = "\n".join([header, *lines[1:]])
     bad_path = tmp_path / "bad.txt"
-    bad_path.write_text(bad)
+    bad_path.write_text(bad, encoding="utf-8")
     with pytest.raises(ValueError, match=r"\bTair\b"):
         read_forcing(str(bad_path), tstep_mod=None)
 
@@ -47,13 +47,13 @@ def test_unknown_column_warns(tmp_path):
     """T6: an unknown column produces a UserWarning but the run continues."""
     from supy.util._io import read_forcing
 
-    text = CANONICAL_FIXTURE.read_text()
+    text = CANONICAL_FIXTURE.read_text(encoding="utf-8")
     lines = text.splitlines()
     header = lines[0] + " weird_var"
     rows = [line + " 0.0" for line in lines[1:]]
     augmented = "\n".join([header, *rows])
     path = tmp_path / "with_weird.txt"
-    path.write_text(augmented)
+    path.write_text(augmented, encoding="utf-8")
     with pytest.warns(UserWarning, match="weird_var"):
         df = read_forcing(str(path), tstep_mod=None)
     assert "weird_var" not in df.columns
@@ -63,7 +63,7 @@ def test_missing_optional_column_filled_with_sentinel(tmp_path):
     """Missing optional canonical columns are filled with -999."""
     from supy.util._io import read_forcing
 
-    text = CANONICAL_FIXTURE.read_text()
+    text = CANONICAL_FIXTURE.read_text(encoding="utf-8")
     lines = text.splitlines()
     header_tokens = lines[0].split()
     drop_idx = header_tokens.index("snow")
@@ -74,7 +74,7 @@ def test_missing_optional_column_filled_with_sentinel(tmp_path):
         new_rows.append(" ".join(t for i, t in enumerate(toks) if i != drop_idx))
     text_out = "\n".join([new_header, *new_rows])
     path = tmp_path / "no_snow.txt"
-    path.write_text(text_out)
+    path.write_text(text_out, encoding="utf-8")
     df = read_forcing(str(path), tstep_mod=None)
     assert "snow" in df.columns
     assert (df["snow"] == -999.0).all()
@@ -85,14 +85,14 @@ def test_per_landcover_columns_separated_into_extras(tmp_path):
     not in the kernel-facing DataFrame; main DataFrame shape unchanged."""
     from supy.suews_forcing import SUEWSForcing
 
-    text = CANONICAL_FIXTURE.read_text()
+    text = CANONICAL_FIXTURE.read_text(encoding="utf-8")
     lines = text.splitlines()
     header = lines[0] + " lai_evetr lai_dectr lai_grass wuh_paved"
     new_lines = [header]
     for row in lines[1:]:
         new_lines.append(row + " 1.5 2.5 3.5 0.25")
     p = tmp_path / "kc_per_landcover.txt"
-    p.write_text("\n".join(new_lines))
+    p.write_text("\n".join(new_lines), encoding="utf-8")
 
     forcing = SUEWSForcing.from_file(str(p))
     assert hasattr(forcing, "extras")
@@ -116,14 +116,14 @@ def test_lai_per_landcover_rejected_for_non_vegetated_surface(tmp_path):
     plumbed through extras."""
     from supy.suews_forcing import SUEWSForcing
 
-    text = CANONICAL_FIXTURE.read_text()
+    text = CANONICAL_FIXTURE.read_text(encoding="utf-8")
     lines = text.splitlines()
     header = lines[0] + " lai_paved lai_water"
     new_lines = [header]
     for row in lines[1:]:
         new_lines.append(row + " 0.1 0.2")
     p = tmp_path / "kc_lai_nonveg.txt"
-    p.write_text("\n".join(new_lines))
+    p.write_text("\n".join(new_lines), encoding="utf-8")
 
     with pytest.warns(UserWarning):
         forcing = SUEWSForcing.from_file(str(p))
@@ -137,14 +137,14 @@ def test_wuh_per_landcover_accepts_every_surface(tmp_path):
     and ornamental water features on the open-water surface."""
     from supy.suews_forcing import SUEWSForcing
 
-    text = CANONICAL_FIXTURE.read_text()
+    text = CANONICAL_FIXTURE.read_text(encoding="utf-8")
     lines = text.splitlines()
     header = lines[0] + " wuh_paved wuh_grass wuh_water"
     new_lines = [header]
     for row in lines[1:]:
         new_lines.append(row + " 0.05 0.30 0.10")
     p = tmp_path / "kc_wuh_mixed.txt"
-    p.write_text("\n".join(new_lines))
+    p.write_text("\n".join(new_lines), encoding="utf-8")
 
     forcing = SUEWSForcing.from_file(str(p))
     assert "wuh_paved" in forcing.extras
@@ -160,10 +160,11 @@ def test_per_landcover_extras_survive_resampling(tmp_path):
     from supy.suews_forcing import SUEWSForcing
 
     sample = files("supy") / "sample_data" / "Kc_2012_data_60.txt"
-    lines = sample.read_text().splitlines()
+    lines = sample.read_text(encoding="utf-8").splitlines()
     path = tmp_path / "hourly_extra.txt"
     path.write_text(
-        "\n".join([lines[0] + " lai_evetr", *[line + " 1.5" for line in lines[1:5]]])
+        "\n".join([lines[0] + " lai_evetr", *[line + " 1.5" for line in lines[1:5]]]),
+        encoding="utf-8",
     )
 
     forcing = SUEWSForcing.from_file(str(path))
@@ -178,10 +179,11 @@ def test_wuh_per_landcover_extras_resample_as_timestep_sum(tmp_path):
     from supy.suews_forcing import SUEWSForcing
 
     sample = files("supy") / "sample_data" / "Kc_2012_data_60.txt"
-    lines = sample.read_text().splitlines()
+    lines = sample.read_text(encoding="utf-8").splitlines()
     path = tmp_path / "hourly_wuh_extra.txt"
     path.write_text(
-        "\n".join([lines[0] + " wuh_grass", *[line + " 12.0" for line in lines[1:4]]])
+        "\n".join([lines[0] + " wuh_grass", *[line + " 12.0" for line in lines[1:4]]]),
+        encoding="utf-8",
     )
 
     forcing = SUEWSForcing.from_file(str(path))
@@ -194,7 +196,7 @@ def test_per_landcover_extras_survive_time_slicing(tmp_path):
     """Sliced SUEWSForcing objects keep time-aligned extras."""
     from supy.suews_forcing import SUEWSForcing
 
-    text = CANONICAL_FIXTURE.read_text()
+    text = CANONICAL_FIXTURE.read_text(encoding="utf-8")
     lines = text.splitlines()
     path = tmp_path / "kc_extra_slice.txt"
     data_rows = [
@@ -202,7 +204,8 @@ def test_per_landcover_extras_survive_time_slicing(tmp_path):
         for i, line in enumerate(lines[1:])
     ]
     path.write_text(
-        "\n".join([lines[0] + " lai_evetr wuh_grass", *data_rows])
+        "\n".join([lines[0] + " lai_evetr wuh_grass", *data_rows]),
+        encoding="utf-8",
     )
 
     forcing = SUEWSForcing.from_file(str(path), tstep_mod=None)
@@ -221,11 +224,12 @@ def test_mixed_case_headers_across_files_coalesce(tmp_path):
     """Case-insensitive matching works across concatenated forcing files."""
     from supy.util._io import read_forcing
 
-    text = CANONICAL_FIXTURE.read_text()
+    text = CANONICAL_FIXTURE.read_text(encoding="utf-8")
     lines = text.splitlines()
-    (tmp_path / "a.txt").write_text("\n".join(lines[:3]))
+    (tmp_path / "a.txt").write_text("\n".join(lines[:3]), encoding="utf-8")
     (tmp_path / "b.txt").write_text(
-        "\n".join([lines[0].replace("Tair", "TAIR"), *lines[3:5]])
+        "\n".join([lines[0].replace("Tair", "TAIR"), *lines[3:5]]),
+        encoding="utf-8",
     )
 
     df = read_forcing(str(tmp_path / "*.txt"), tstep_mod=None)

--- a/test/io_tests/test_save_supy.py
+++ b/test/io_tests/test_save_supy.py
@@ -56,7 +56,7 @@ class TestSaveSuPy:
             assert suews_file.stat().st_size > 0, "SUEWS file is empty"
 
             # Read and verify content
-            with open(suews_file, "r") as f:
+            with open(suews_file, "r", encoding="utf-8") as f:
                 lines = f.readlines()
                 assert len(lines) > 1, "SUEWS file has no data rows"
                 # Check header contains expected columns

--- a/test/io_tests/test_yaml_annotation.py
+++ b/test/io_tests/test_yaml_annotation.py
@@ -126,7 +126,7 @@ sites:
             SUEWSConfig.from_yaml(test_file, auto_generate_annotated=True)
 
         assert annotated_path.exists()
-        annotated_content = annotated_path.read_text()
+        annotated_content = annotated_path.read_text(encoding="utf-8")
         assert "bldgh:" in annotated_content
         assert "faibldg:" in annotated_content
 
@@ -140,14 +140,14 @@ def test_annotation_includes_tree_and_lai_requirements_from_sparse_fixture(tmp_p
     """Annotated sparse fixture should include the new tree and LAI placeholders."""
     sparse_fixture = Path("test/fixtures/sparse_site.yml")
     test_file = tmp_path / sparse_fixture.name
-    test_file.write_text(sparse_fixture.read_text(encoding="utf-8"))
+    test_file.write_text(sparse_fixture.read_text(encoding="utf-8"), encoding="utf-8")
     annotated_path = tmp_path / f"{test_file.stem}_annotated.yml"
 
     with pytest.raises(ValueError):
         SUEWSConfig.from_yaml(test_file, auto_generate_annotated=True)
 
     assert annotated_path.exists()
-    annotated_content = annotated_path.read_text()
+    annotated_content = annotated_path.read_text(encoding="utf-8")
     assert "fai_evergreen_tree:" in annotated_content
     assert "height_evergreen_tree:" in annotated_content
     assert "fai_deciduous_tree:" in annotated_content

--- a/test/io_tests/test_yaml_annotation.py
+++ b/test/io_tests/test_yaml_annotation.py
@@ -42,7 +42,7 @@ sites:
 """
 
     # Create temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(yaml_content)
         test_file = Path(f.name)
 
@@ -59,7 +59,7 @@ sites:
         # Check if annotation was successful (Windows compatibility)
         if annotated_path.exists():
             # Read annotated content
-            with open(annotated_path, "r") as f:
+            with open(annotated_path, "r", encoding="utf-8") as f:
                 annotated_content = f.read()
 
             # Verify annotations are present
@@ -116,7 +116,7 @@ sites:
           sfr: {value: 0.01}
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(yaml_content)
         test_file = Path(f.name)
 
@@ -140,7 +140,7 @@ def test_annotation_includes_tree_and_lai_requirements_from_sparse_fixture(tmp_p
     """Annotated sparse fixture should include the new tree and LAI placeholders."""
     sparse_fixture = Path("test/fixtures/sparse_site.yml")
     test_file = tmp_path / sparse_fixture.name
-    test_file.write_text(sparse_fixture.read_text())
+    test_file.write_text(sparse_fixture.read_text(encoding="utf-8"))
     annotated_path = tmp_path / f"{test_file.stem}_annotated.yml"
 
     with pytest.raises(ValueError):
@@ -175,7 +175,7 @@ def test_annotation_with_sample_config():
         output_file = Path(tmpdir) / "sample_annotated.yml"
         annotated_file = config.generate_annotated_yaml(sample_config, output_file)
 
-        with open(annotated_file, "r") as f:
+        with open(annotated_file, "r", encoding="utf-8") as f:
             content = f.read()
 
         # Should have header
@@ -198,7 +198,7 @@ sites:
       alt: {value: 10.0}
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(yaml_content)
         test_file = Path(f.name)
 
@@ -241,7 +241,7 @@ sites:
       # Missing required land_cover
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
         f.write(yaml_content)
         test_file = Path(f.name)
 
@@ -262,7 +262,7 @@ sites:
         annotated_path = Path(str(test_file).replace(".yml", "_annotated.yml"))
         if annotated_path.exists():
             # Verify content
-            with open(annotated_path, "r") as f:
+            with open(annotated_path, "r", encoding="utf-8") as f:
                 content = f.read()
             assert "[ERROR] MISSING:" in content
             # Cleanup

--- a/test/mcp/test_backend_cli.py
+++ b/test/mcp/test_backend_cli.py
@@ -154,8 +154,8 @@ def test_resolve_suews_executable_prefers_sibling_of_sys_executable(
     bin_dir.mkdir()
     fake_python = bin_dir / "python3"
     fake_suews = bin_dir / "suews"
-    fake_python.write_text("#!/bin/sh\nexit 0\n")
-    fake_suews.write_text("#!/bin/sh\nexit 0\n")
+    fake_python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_suews.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     fake_python.chmod(0o755)
     fake_suews.chmod(0o755)
 
@@ -182,14 +182,14 @@ def test_resolve_suews_executable_falls_back_to_path(
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_python = bin_dir / "python3"
-    fake_python.write_text("#!/bin/sh\nexit 0\n")
+    fake_python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     fake_python.chmod(0o755)
 
     # PATH-only suews lives elsewhere.
     path_dir = tmp_path / "system" / "bin"
     path_dir.mkdir(parents=True)
     path_suews = path_dir / "suews"
-    path_suews.write_text("#!/bin/sh\nexit 0\n")
+    path_suews.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     path_suews.chmod(0o755)
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
@@ -213,7 +213,7 @@ def test_resolve_suews_executable_returns_name_when_unreachable(
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_python = bin_dir / "python3"
-    fake_python.write_text("")
+    fake_python.write_text("", encoding="utf-8")
     fake_python.chmod(0o755)
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
@@ -238,8 +238,8 @@ def test_run_suews_cli_uses_resolver_by_default(
     bin_dir.mkdir()
     fake_python = bin_dir / "python3"
     fake_suews = bin_dir / "suews"
-    fake_python.write_text("")
-    fake_suews.write_text("")
+    fake_python.write_text("", encoding="utf-8")
+    fake_suews.write_text("", encoding="utf-8")
     fake_python.chmod(0o755)
     fake_suews.chmod(0o755)
 

--- a/test/mcp/test_tool_readiness.py
+++ b/test/mcp/test_tool_readiness.py
@@ -49,11 +49,11 @@ def test_customised_location_leaves_assumed_list(tmp_path: Path) -> None:
     """Changing the location moves it from assumed to looks_customised."""
     from suews_mcp.tools import assess_readiness
 
-    cfg = yaml.safe_load(_sample().read_text())
+    cfg = yaml.safe_load(_sample().read_text(encoding="utf-8"))
     cfg["sites"][0]["properties"]["lat"]["value"] = 33.45  # Phoenix-ish
     cfg["sites"][0]["properties"]["lng"]["value"] = -112.07
     out = tmp_path / "phoenix.yml"
-    out.write_text(yaml.safe_dump(cfg))
+    out.write_text(yaml.safe_dump(cfg), encoding="utf-8")
 
     env = assess_readiness(str(out), project_root=str(tmp_path))
     assert env["status"] == "success", env.get("errors")

--- a/test/mcp/test_version.py
+++ b/test/mcp/test_version.py
@@ -34,7 +34,7 @@ def test_mcp_runtime_version_matches_supy() -> None:
 
 def test_mcp_pyproject_uses_generated_dynamic_version() -> None:
     pyproject = REPO_ROOT / "mcp" / "pyproject.toml"
-    text = pyproject.read_text()
+    text = pyproject.read_text(encoding="utf-8")
 
     assert 'dynamic = ["version"]' in text
     assert 'version = "0.1.0"' not in text
@@ -61,7 +61,7 @@ def test_version_script_writes_supy_and_mcp_version_files(
         Path("mcp/src/suews_mcp/_version_scm.py"),
     ):
         generated = tmp_path / rel_path
-        text = generated.read_text()
+        text = generated.read_text(encoding="utf-8")
         assert "__version__ = version = '2026.5.1.dev2'" in text
         assert "__version_tuple__ = version_tuple = (2026, 5, 1, 'dev2')" in text
         # gh#1401: the build-time commit hash is baked in so the envelope

--- a/test/umep/test_preprocessor.py
+++ b/test/umep/test_preprocessor.py
@@ -141,7 +141,7 @@ class TestDatabasePrepareAPI(TestCase):
         schema = generate_json_schema(version="2026.5.dev5")
 
         with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
-            f.write(f"schema_version: '2026.5.dev5'\n{sparse_config.read_text()}")
+            f.write(f"schema_version: '2026.5.dev5'\n{sparse_config.read_text(encoding='utf-8')}")
             temp_path = Path(f.name)
 
         try:

--- a/test/umep/test_preprocessor.py
+++ b/test/umep/test_preprocessor.py
@@ -104,7 +104,7 @@ class TestDatabasePrepareAPI(TestCase):
 
         schema = generate_json_schema()
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
             # Malformed YAML to test parse error handling (unclosed brackets)
             f.write("invalid: yaml: content: [[[")
             temp_path = Path(f.name)
@@ -140,7 +140,7 @@ class TestDatabasePrepareAPI(TestCase):
         sparse_config = Path(__file__).parent.parent / "fixtures" / "sparse_site.yml"
         schema = generate_json_schema(version="2026.5.dev5")
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", suffix=".yml", delete=False) as f:
             f.write(f"schema_version: '2026.5.dev5'\n{sparse_config.read_text()}")
             temp_path = Path(f.name)
 


### PR DESCRIPTION
Systematic follow-up to #1519 (the devnull/tqdm nightly hotfix). **Stacked on #1519** — until that merges, this PR's diff also shows the one-line `_era5.py` change; it drops out automatically once #1519 lands.

## Why

The nightly failure was one instance of a recurring class: text-mode file I/O without an explicit `encoding`, which inherits **cp1252 on Windows** and raises `UnicodeEncodeError` on any Unicode content (degree signs, accented site names, tqdm bars). The same class was fixed before in gh#1097 but kept reappearing.

Audit with ruff `PLW1514` (`unspecified-encoding`) found **~140 more call sites**: 55 in shipped `src/supy`, 83 in `test/`, plus a handful in `scripts/`, `benchmark/`, `docs/`, `.claude/`.

The root hole was **not** a missing rule — `.ruff.toml` already sets `preview = true` and selects `PL`, so the project's own `ruff check` flags every one. The gap is that **no CI workflow runs ruff at all**, so the violations accumulated silently. (PLW1514 is preview-only, which compounds it.)

## What

1. **Fix** — `encoding="utf-8"` added to every flagged text-mode `open()` / `read_text()` / `write_text()` / `NamedTemporaryFile()`, applied mechanically:
   ```
   ruff check --preview --select PLW1514 --fix --unsafe-fixes .
   ```
   The rule is mode-aware, so binary streams (`"rb"`/`"wb"`, default-binary `NamedTemporaryFile`) are untouched. Verified: no binary-mode call received an encoding, no double-encoding, all 37 changed files compile, `0` PLW1514 remaining repo-wide.

2. **Gate** — `.github/workflows/encoding-audit.yml` runs `ruff check --preview --select PLW1514` over the repo on every PR touching a `.py` file, blocking new violations. `--preview` is passed explicitly so the gate can't silently no-op if the config flag changes. Actions SHA-pinned; bypass label `0-ci:encoding-audit-ok` for the rare genuinely-non-UTF-8 case.

3. **Docs** — `conventions.md` rule 6 records the CI enforcement.

## Verification

- `ruff check --preview --select PLW1514 .` -> `All checks passed!`
- Binary-mode / double-encoding audits of the diff: clean.
- All 37 changed `.py` files compile.
- Functional behaviour is unchanged on macOS/Linux (already UTF-8); the fix matters on Windows, which the PR CI matrix (incl. the Windows + Python 3.12 leg) exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)