### PR TITLE
Add Conductor TOML settings

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,7 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "./scripts/conductor/setup.sh"
+run = "./scripts/conductor/run.sh"
+archive = "./scripts/conductor/archive.sh"
+run_mode = "concurrent"

--- a/.gitignore
+++ b/.gitignore
@@ -660,8 +660,11 @@ docs/source/api/_autosummary/
 test/fixtures/gh846/*.zip
 
 
-# Conductor worktree workspaces
-.conductor/
+# Conductor project settings and local worktree state
+.conductor/*
+!.conductor/
+!.conductor/settings.toml
+.conductor/settings.local.toml
 
 # Conductor agent collaboration directory
 .context/


### PR DESCRIPTION
## Summary
- Add shared Conductor repository settings in .conductor/settings.toml using the current repo settings schema.
- Preserve the historical setup, run, and archive script hooks from conductor.json and mark run scripts as concurrent.
- Narrow .gitignore so the shared settings file is tracked while local Conductor state remains ignored.

## Validation
- python3 TOML parse check
- git diff --check