### PR TITLE
Clarify that forcing data uses local standard time, not civil time with DST

### DIFF
--- a/docs/source/data-structures/df_state.rst
+++ b/docs/source/data-structures/df_state.rst
@@ -2062,7 +2062,7 @@
 .. option:: timezone
 
     :Description:
-        Time zone [h] for site relative to UTC (east is positive). This should be set according to the times given in the meteorological forcing file(s).
+        Fixed time zone offset [h] from UTC (east is positive), e.g. 0 for UK/GMT, 1 for France/CET. This is a standard-time offset that does not change with daylight saving. Forcing data timestamps must use this same fixed offset year-round.
     :Dimensionality:
         0
     :Dimensionality Remarks:

--- a/docs/source/inputs/forcing-data.rst
+++ b/docs/source/inputs/forcing-data.rst
@@ -193,6 +193,8 @@ Important Requirements
 
    The :input:option:`timezone` parameter in the YAML configuration is this same fixed offset (``0`` for the UK, ``1`` for France). SUEWS accounts for daylight saving internally through the :input:option:`startdls` and :input:option:`enddls` parameters, which adjust diurnal activity profiles for anthropogenic heat and water use -- the forcing timestamps themselves always stay in standard time.
 
+   When comparing SUEWS output against observational data, verify that both datasets use the same time convention. Observations recorded in civil time (with DST) must be converted to local standard time before comparison.
+
 **File Naming**
 
 Files should follow this naming convention:

--- a/docs/source/inputs/forcing-data.rst
+++ b/docs/source/inputs/forcing-data.rst
@@ -182,8 +182,16 @@ Important Requirements
   - For hourly data at 13:00, the measurement covers 12:00-13:00
   - For 5-minute data at 10:05, the measurement covers 10:00-10:05
 
-- **Time zone**: Use **local time**, not UTC
+- **Time zone**: Use **local standard time** (i.e. a fixed UTC offset), not UTC and not civil time with daylight-saving transitions
 - **Complete days**: Files must contain whole days of data
+
+.. important:: **Local standard time, not civil time**
+
+   "Local time" in SUEWS means **local standard time** -- the fixed UTC offset for the site's time zone, applied uniformly throughout the year. Do **not** use civil time that includes daylight-saving (summer-time) transitions.
+
+   For example, a UK site uses GMT (UTC+0) year-round. Converting to ``Europe/London`` would introduce DST shifts that create one missing row in spring and one duplicate row in autumn, causing SUEWS to reject the forcing file. For a site in France, use CET (UTC+1) year-round, not CEST in summer.
+
+   The :input:option:`timezone` parameter in the YAML configuration is this same fixed offset (``0`` for the UK, ``1`` for France). SUEWS accounts for daylight saving internally through the :input:option:`startdls` and :input:option:`enddls` parameters, which adjust diurnal activity profiles for anthropogenic heat and water use -- the forcing timestamps themselves always stay in standard time.
 
 **File Naming**
 
@@ -531,7 +539,7 @@ Check your data for:
 
 - **"Division by zero"**: Wind speed < 0.01 m/s
 - **"Negative radiation"**: Check kdown is always ≥ 0
-- **"Time mismatch"**: Ensure local time is used
+- **"Time mismatch"**: Ensure local standard time is used (see note above)
 - **"Missing data"**: Use -999, not blank or NaN
 
 Validating Forcing Data

--- a/docs/source/inputs/tables/SUEWS_SiteInfo/Input_Options.rst
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/Input_Options.rst
@@ -3747,7 +3747,7 @@ Input Options
 .. option:: Timezone
 
 	:Description:
-		Time zone [h] for site relative to UTC (east is positive). This should be set according to the times given in the meteorological forcing file(s).
+		Fixed time zone offset [h] from UTC (east is positive), e.g. 0 for UK/GMT, 1 for France/CET. This is a standard-time offset that does not change with daylight saving. Forcing data timestamps must use this same fixed offset year-round.
 
 	:Configuration:
 		.. csv-table::

--- a/docs/source/inputs/tables/met_input.rst
+++ b/docs/source/inputs/tables/met_input.rst
@@ -8,7 +8,7 @@ SUEWS is designed to run using commonly measured meteorological variables (e.g. 
 When preparing this input file, please note the following:
 
 -  Required inputs must be continuous – i.e. **gap fill** any missing data.
--  Temporal information (i.e., ``iy``, ``id``, ``it`` and ``imin``) should be in **local time** and indicate the ending timestamp of corresponding periods: e.g. for hourly data, ``2021-09-12 13:00`` indicates a record for the period between ``2021-09-12 12:00`` (inclusive) and ``2021-09-12 13:00`` (exclusive).
+-  Temporal information (i.e., ``iy``, ``id``, ``it`` and ``imin``) should be in **local standard time** (i.e. a fixed UTC offset with no daylight-saving transitions; see :ref:`met_forcing`) and indicate the ending timestamp of corresponding periods: e.g. for hourly data, ``2021-09-12 13:00`` indicates a record for the period between ``2021-09-12 12:00`` (inclusive) and ``2021-09-12 13:00`` (exclusive).
 -  The `table <SSss_YYYY_data_tt.txt>` below gives the must-use (`MU`) and optional (`O`) additional input variables. If an optional input variable (`O`) is not available or will not be used by the model, enter ‘-999’ for this column.
 
 
@@ -255,7 +255,7 @@ Complete example for processing weather station data:
 **Common Issues and Solutions**
 
 - **Missing longwave radiation**: Use empirical relationships based on air temperature and humidity
-- **Inconsistent time zones**: Ensure all data is in local time for the study location
+- **Inconsistent time zones**: Ensure all data is in local standard time for the study location (see :ref:`met_forcing`)
 - **Sub-daily precipitation**: Aggregate appropriately while preserving intensity patterns
 - **Wind speed at different heights**: Apply logarithmic wind profile corrections if needed
 - **Pressure measurements**: Distinguish between station and sea-level pressure corrections

--- a/docs/source/inputs/yaml/index.rst
+++ b/docs/source/inputs/yaml/index.rst
@@ -182,7 +182,7 @@ The forcing file must be a text file with specific columns in the correct order.
 
 - Data must be continuous (no gaps)
 - Time stamps indicate the **end** of each period
-- Use local time (not UTC)
+- Use local standard time (fixed UTC offset, not civil time with daylight-saving shifts; see :doc:`/inputs/forcing-data` for details)
 - Use -999 for missing optional variables
 
 For detailed format specifications, column order, and optional variables, see :doc:`/inputs/forcing-data`.

--- a/docs/source/outputs/index.rst
+++ b/docs/source/outputs/index.rst
@@ -54,7 +54,7 @@ Temporal Information
 
 .. note::
 
-   Temporal information in output files (``iy``, ``id``, ``it``, ``imin``) are in **local time**
+   Temporal information in output files (``iy``, ``id``, ``it``, ``imin``) are in **local standard time**
    (consistent with :ref:`met_forcing`) and indicate the **ending timestamp** of each period.
 
    For example, for hourly data, ``2021-09-12 13:00`` indicates a record for the period

--- a/docs/source/outputs/legacy_text_columns.rst
+++ b/docs/source/outputs/legacy_text_columns.rst
@@ -113,7 +113,7 @@ SUEWS supports two output formats:
 
 The output format is configured in the YAML file. See :doc:`../inputs/yaml/index` for configuration details.
 
-.. note:: Temporal information in output files (i.e., ``iy``, ``id``, ``it`` and ``imin`` if existing) are in **local time** (i.e. consistent with :ref:`met_forcing`) and indicate the ending timestamp of corresponding periods: e.g. for hourly data, ``2021-09-12 13:00`` indicates a record for the period between ``2021-09-12 12:00`` (inclusive) and ``2021-09-12 13:00`` (exclusive).
+.. note:: Temporal information in output files (i.e., ``iy``, ``id``, ``it`` and ``imin`` if existing) are in **local standard time** (i.e. consistent with :ref:`met_forcing`) and indicate the ending timestamp of corresponding periods: e.g. for hourly data, ``2021-09-12 13:00`` indicates a record for the period between ``2021-09-12 12:00`` (inclusive) and ``2021-09-12 13:00`` (exclusive).
 
 
 Text Format Output Files

--- a/src/supy/data_model/core/site.py
+++ b/src/supy/data_model/core/site.py
@@ -2881,7 +2881,7 @@ class SiteProperties(BaseModel):
         default=40.0,
     )
     timezone: FlexibleRefValue(Union[TimezoneOffset, float]) = Field(
-        description="Time zone offset from UTC",
+        description="Fixed time zone offset from UTC in hours (e.g. 0 for UK/GMT, 1 for France/CET). This is a standard-time offset that does not change with daylight saving. Forcing data timestamps must use this same fixed offset year-round.",
         json_schema_extra={"unit": "h", "display_name": "Time zone (UTC offset)"},
         default=TimezoneOffset.UTC,
     )


### PR DESCRIPTION
## Summary

- Replace ambiguous "local time" with "local standard time" across all 7 docs pages that reference the forcing/output time convention
- Add a prominent admonition in the forcing-data page explaining the distinction with UK and France examples
- Enrich the `timezone` parameter description (Pydantic model + 2 legacy docs pages) to say "fixed offset that does not change with daylight saving"
- Cross-reference `timezone`, `startdls`/`enddls`, and the forcing data convention so users understand how the three work together

Partial fix for #1507 (points 1 and 8e: documentation clarity on what time convention is used). The broader code refactoring proposed in #1507 (UTC-internal calculations, profile alignment, output time options) is separate work.

Also motivated by a user email about DST handling for UK forcing data (converting to `Europe/London` introduced missing/duplicate rows) and [community forum thread #44](https://community.suews.io/t/question-on-utc-offset-in-suews-prepare-and-forcing-data-in-local-time/44) asking the same question for IST data.

## Test plan

- [x] Sphinx docs build succeeds with no new warnings
- [ ] Review the rendered admonition on the forcing-data page

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>