### PR TITLE
Fix release-docs-anchor: precise banner grep + full clean rebuild

### DIFF
--- a/.claude/rules/docs/release-docs-sanity.md
+++ b/.claude/rules/docs/release-docs-sanity.md
@@ -37,11 +37,14 @@ creates an off-master anchor commit, and force-moves the tag onto it. Do **not**
 point a release tag at the `rtd` branch HEAD directly — its HTML carries the
 dev banner.
 
-**Manual check** (after RTD rebuilds the moved tag):
+**Manual check** (after RTD rebuilds the moved tag). Grep the banner-specific
+sentence, not the bare phrase "Development Version" -- the latter legitimately
+appears in `installation.rst` (TestPyPI dev builds) and `searchindex.js`:
 
 ```bash
-# Should print nothing for the stable/release build
-curl -fsSL https://docs.suews.io/stable/inputs/forcing-data.html | grep -c "Development Version"
+# Should print 0 for the stable/release build
+curl -fsSL https://docs.suews.io/stable/inputs/forcing-data.html \
+  | grep -c "built from a development version"
 ```
 
 ### 2. No `.dev` in user-facing schema labels

--- a/.github/workflows/release-docs-anchor.yml
+++ b/.github/workflows/release-docs-anchor.yml
@@ -139,8 +139,16 @@ jobs:
           python3 scripts/security/remove_legacy_namespace_pth.py
           cd docs
           make generate-rst
+          # Force a FULL clean rebuild. The rtd branch ships pre-built
+          # docs/build/html that docs-sync built with a .dev version, so it
+          # carries the "Development Version" banner on every page. An
+          # incremental sphinx-build only re-renders pages whose source
+          # changed; unchanged pages would keep the stale dev banner. The
+          # version flip (.dev -> clean) is a theme-level change that does not
+          # invalidate per-page doctrees, so we must rebuild from scratch.
+          rm -rf build
           echo "Building docs version from tag ${RELEASE_TAG}"
-          SUEWS_DOCS_VERSION_REF="${RELEASE_TAG}" sphinx-build -M html source build
+          SUEWS_DOCS_VERSION_REF="${RELEASE_TAG}" sphinx-build -M html source build -E -a
 
       # ----------------------------------------------------------------
       # 6. Sanity gate: the built HTML must NOT carry the dev banner

--- a/.github/workflows/release-docs-anchor.yml
+++ b/.github/workflows/release-docs-anchor.yml
@@ -149,12 +149,18 @@ jobs:
       - name: Assert no Development Version banner in built HTML
         run: |
           set -euo pipefail
-          if grep -rl "Development Version" docs/build/html >/dev/null 2>&1; then
-            echo "::error::Built HTML still contains a 'Development Version' banner. The version ref did not resolve clean."
-            grep -rl "Development Version" docs/build/html | head -5
+          # Match the banner-specific sentence from docs/source/conf.py's
+          # announcement HTML ("This documentation was built from a development
+          # version"). Do NOT grep the bare phrase "Development Version" -- it
+          # legitimately appears in installation.rst (TestPyPI dev builds) and
+          # the aggregated searchindex.js, which would be false positives.
+          BANNER_PHRASE="built from a development version"
+          if grep -rl "${BANNER_PHRASE}" docs/build/html >/dev/null 2>&1; then
+            echo "::error::Built HTML still contains the dev-version banner. The version ref did not resolve clean."
+            grep -rl "${BANNER_PHRASE}" docs/build/html | head -5
             exit 1
           fi
-          echo "OK: no Development Version banner in built HTML"
+          echo "OK: no dev-version banner in built HTML"
 
       # ----------------------------------------------------------------
       # 7. Create the off-master anchor commit (child of the source branch)


### PR DESCRIPTION
## Summary

Two fixes to `release-docs-anchor.yml` (added in #1526), found on its first real runs:

1. **Precise banner grep.** The sanity gate grepped the bare phrase `Development Version`, which legitimately appears in `installation.rst` (TestPyPI dev-build instructions) and `searchindex.js`. Now greps the banner-specific sentence `built from a development version` (emitted only by `conf.py`'s announcement HTML; 0 hits in installation prose).
2. **Full clean rebuild.** The `rtd` branch ships pre-built `docs/build/html` that `docs-sync` built with a `.dev` version, so every page carries the banner. An incremental `sphinx-build` only re-renders changed pages, leaving unchanged pages (e.g. `outputconfig.html`) with the stale banner. The version flip (`.dev` -> clean) is a theme-level change that doesn't invalidate per-page doctrees, so the workflow now `rm -rf build` and passes `-E -a` to re-render the whole site clean.

## Context

First runs of the workflow (27329844843, 27330215157) failed at the banner gate for these two reasons. Re-dispatched from this branch to publish the banner-free `2026.6.5` stable docs; this PR lands the fixes on master.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>