### PR TITLE
Fix SUEWSSimulation initialisation from dict configs

### DIFF
--- a/.claude/rules/python/config-patterns.md
+++ b/.claude/rules/python/config-patterns.md
@@ -15,6 +15,39 @@ Separation of concerns between configuration parsing and implementation.
 
 ---
 
+## Validated Configuration Boundary
+
+Raw mappings are input data, not configuration objects. This includes
+YAML-loaded dictionaries, JSON-like payloads, and partial update dictionaries.
+
+- **DO**: Route full mapping inputs through the canonical Pydantic model path
+  (`SUEWSConfig` or another schema-owned constructor) so field renames,
+  readable physics names, `RefValue` wrappers, defaults, and conditional
+  validators all run.
+- **DO**: Keep equivalent public input forms semantically equivalent. A YAML
+  file, an in-memory mapping loaded from that YAML, and a `SUEWSConfig` object
+  should reach the same normalisation and validation path unless the API
+  documents a narrower contract.
+- **DO**: For partial updates, merge at the plain-data layer and revalidate the
+  resulting model. The merge function may prepare data; Pydantic remains the
+  validation boundary.
+- **DON'T**: Recursively `setattr` user mappings into existing Pydantic model
+  instances as the mechanism for parsing or validating configuration. That
+  bypasses field validators and breaks wrapped fields such as physics selectors.
+- **DON'T**: Infer special semantics from a Python container type alone. Lists
+  replace by default unless an API explicitly documents collection-specific
+  patch semantics.
+
+If collection-specific updates are needed, expose them as named API behaviour
+(for example, "update site by name/index") rather than guessing that every
+list-valued config field is that collection.
+
+Validation bypasses such as `model_construct`, `use_conditional_validation=False`,
+or backend-specific unchecked paths must be named, isolated, and covered by
+tests that state the bypass contract explicitly.
+
+---
+
 ## High-Level Classes (e.g., SUEWSSimulation)
 
 - **DO**: Parse and interpret configuration objects
@@ -101,3 +134,8 @@ When implementing a feature that uses configuration:
 - [ ] Convert types as needed (e.g., ensure integers)
 - [ ] Pass only primitive types or simple objects to low-level methods
 - [ ] Keep configuration parsing logic in one place
+- [ ] Route raw mapping inputs through the validated config model path
+- [ ] Revalidate after partial config merges; do not mutate Pydantic model
+      internals with recursive `setattr`
+- [ ] Define list update semantics explicitly; do not assume list-valued fields
+      are site collections

--- a/.claude/rules/tests/verification-methodology.md
+++ b/.claude/rules/tests/verification-methodology.md
@@ -11,6 +11,9 @@ Rules for numerical comparisons, test validation, and diagnostic investigations.
 2. **Run the existing test before writing custom scripts.** If a test exists for the comparison you need, run it (`pytest path::Class::method -v`). Only write custom code if no test covers the question.
 
 3. **Trace every public execution path before declaring a fix complete.** When a behavioural contract changes, verify the recommended API, deprecated APIs, and any unchecked/bypass mode separately. Shared validators are not enough unless every public path actually reaches them.
+   - For configuration behaviour, cover equivalent input forms explicitly: YAML path, in-memory mapping/dict, direct config object, and any documented update/patch API.
+   - If a public path accepts raw mappings, include at least one regression that exercises schema coercion/normalisation (for example renamed keys, readable physics names, `RefValue` fields, or defaults) and one ordinary collection field. This catches bypasses of Pydantic validators and list-specific special cases.
+   - When a path intentionally bypasses validation, assert the bypass semantics directly and name the bypass in the test.
 
 ## When results look unexpected
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,11 @@ EXAMPLES:
   - Unknown keys raise `ValueError` instead of being silently dropped (this previously masked no-op "updates" in two bundled tutorials, now corrected)
   - List values (including a plain `sites` list) replace the existing list; the `{index: patch}` / `{site_name: patch}` / single-site shorthand forms for `sites` are unchanged
   - A partial dict with no existing configuration raises an informative error instead of failing later with `No objects to concatenate`
+  - Partial updates merge onto only the explicitly-set fields (`exclude_unset`), so conditional validators no longer mistake pydantic defaults for user-declared values on sparse configs
 - [change] Hardened configuration loading and mutation (#1530 follow-ups)
   - YAML configs are now parsed with `yaml.safe_load`; `yaml.FullLoader` could construct live Python objects from tags such as `!!python/name:os.system` embedded in a config file
   - Unknown top-level keys in a config (YAML or dict) raise `ValueError` instead of being silently retained as inert extras
+  - Site-completeness checks now apply to dict-loaded configs exactly as to YAML files (previously gated on the YAML file path, so the in-memory dict path skipped them)
   - `validate_assignment` enabled on `SUEWSConfig`, `Model`, `ModelControl`, `ModelPhysics`, and `Site`, so direct attribute assignment is validated and coerced instead of stored raw
 
 ### 5 Jun 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ EXAMPLES:
   - New `SUEWSConfig.from_dict()` classmethod is the single validated construction path; `from_yaml()` delegates to it
 - [change] Dict updates via `update_config()` are now strict and explicit (#1530)
   - Unknown keys raise `ValueError` instead of being silently dropped (this previously masked no-op "updates" in two bundled tutorials, now corrected)
-  - List values (including a plain `sites` list) replace the existing list; the `{index: patch}` / `{site_name: patch}` / single-site shorthand forms for `sites` are unchanged
+  - List values (including a plain `sites` list) replace the existing list; the `{index: patch}` / `{site_name: patch}` / single-site shorthand forms for `sites` are kept, but an unmatched site name now raises when multiple sites exist (previously a silent no-op); legacy field aliases (`stabilitymethod`, `output_file`, `forcing_file`, ...) are normalised in partial updates exactly as in full input
   - A partial dict with no existing configuration raises an informative error instead of failing later with `No objects to concatenate`
   - Partial updates merge onto only the explicitly-set fields (`exclude_unset`), so conditional validators no longer mistake pydantic defaults for user-declared values on sparse configs
 - [change] Hardened configuration loading and mutation (#1530 follow-ups)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ EXAMPLES:
 
 ## 2026
 
+### 11 Jun 2026
+
+- [bugfix] `SUEWSSimulation(config=dict)` and `update_config(dict)` now route through validated `SUEWSConfig` construction instead of mutating model internals by hand (#1530)
+  - Initialising from a full YAML-shaped dict previously failed with `<enum 'Enum'> cannot set attribute 'value'` or `'list' object has no attribute 'keys'`; it now behaves identically to loading the same data from a YAML file
+  - Partial update dicts are deep-merged onto the existing configuration and the result is re-validated, so enum coercion, RefValue wrapping, and range checks apply to dict input exactly as for YAML
+  - New `SUEWSConfig.from_dict()` classmethod is the single validated construction path; `from_yaml()` delegates to it
+- [change] Dict updates via `update_config()` are now strict and explicit (#1530)
+  - Unknown keys raise `ValueError` instead of being silently dropped (this previously masked no-op "updates" in two bundled tutorials, now corrected)
+  - List values (including a plain `sites` list) replace the existing list; the `{index: patch}` / `{site_name: patch}` / single-site shorthand forms for `sites` are unchanged
+  - A partial dict with no existing configuration raises an informative error instead of failing later with `No objects to concatenate`
+
 ### 5 Jun 2026
 
 - [change][experimental] File logging is now opt-in: importing or using `supy` no longer drops an (often empty) `SuPy.log` into the current working directory (#1516)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ EXAMPLES:
   - Unknown keys raise `ValueError` instead of being silently dropped (this previously masked no-op "updates" in two bundled tutorials, now corrected)
   - List values (including a plain `sites` list) replace the existing list; the `{index: patch}` / `{site_name: patch}` / single-site shorthand forms for `sites` are unchanged
   - A partial dict with no existing configuration raises an informative error instead of failing later with `No objects to concatenate`
+- [change] Hardened configuration loading and mutation (#1530 follow-ups)
+  - YAML configs are now parsed with `yaml.safe_load`; `yaml.FullLoader` could construct live Python objects from tags such as `!!python/name:os.system` embedded in a config file
+  - Unknown top-level keys in a config (YAML or dict) raise `ValueError` instead of being silently retained as inert extras
+  - `validate_assignment` enabled on `SUEWSConfig`, `Model`, `ModelControl`, `ModelPhysics`, and `Site`, so direct attribute assignment is validated and coerced instead of stored raw
 
 ### 5 Jun 2026
 

--- a/docs/source/sub-tutorials/suews-simulation-tutorial.rst
+++ b/docs/source/sub-tutorials/suews-simulation-tutorial.rst
@@ -148,11 +148,12 @@ Update configuration parameters without reloading:
     # Update timestep
     sim.update_config({'model': {'control': {'tstep': 600}}})
     
-    # Update multiple parameters
+    # Update multiple parameters (validated like YAML input;
+    # unknown keys raise ValueError)
     sim.update_config({
         'model': {
             'control': {'tstep': 300},
-            'physics': {'stabilitymethod': 2}
+            'physics': {'stability': 'CN98'}
         }
     })
     

--- a/docs/source/tutorials/tutorial_01_quick_start.py
+++ b/docs/source/tutorials/tutorial_01_quick_start.py
@@ -119,7 +119,18 @@ print("Original surface fractions:")
 print(sim.state_init.loc[:, "sfr_surf"])
 
 # Modify surface fractions using update_config
-sim.update_config({"initial_states": {"sfr_surf": [0.1, 0.1, 0.2, 0.3, 0.25, 0.05, 0]}})
+# (fractions must sum to 1.0; the update is validated like YAML input)
+sim.update_config({
+    "sites": {0: {"properties": {"land_cover": {
+        "paved": {"sfr": 0.1},
+        "bldgs": {"sfr": 0.1},
+        "evetr": {"sfr": 0.2},
+        "dectr": {"sfr": 0.3},
+        "grass": {"sfr": 0.25},
+        "bsoil": {"sfr": 0.05},
+        "water": {"sfr": 0.0},
+    }}}}
+})
 
 print("\nModified surface fractions:")
 print(sim.state_init.loc[:, "sfr_surf"])

--- a/docs/source/tutorials/tutorial_02_setup_own_site.py
+++ b/docs/source/tutorials/tutorial_02_setup_own_site.py
@@ -64,23 +64,22 @@ print("Location: lat=36.6, lng=-97.5")
 # Configure Land Cover Fractions
 # ------------------------------
 #
-# SUEWS divides the urban surface into 7 land cover types:
-#
-# - 0: Paved surfaces
-# - 1: Buildings
-# - 2: Evergreen trees
-# - 3: Deciduous trees
-# - 4: Grass
-# - 5: Bare soil
-# - 6: Water
+# SUEWS divides the urban surface into 7 land cover types: paved surfaces,
+# buildings, evergreen trees, deciduous trees, grass, bare soil, and water.
 #
 # Fractions must sum to 1.0. For this grassland site, we set 100% grass.
 
 sim.update_config({
     "sites": {0: {
-        "initial_states": {
-            "sfr_surf": [0, 0, 0, 0, 1.0, 0, 0],  # 100% grass (index 4)
-        }
+        "properties": {"land_cover": {
+            "paved": {"sfr": 0.0},
+            "bldgs": {"sfr": 0.0},
+            "evetr": {"sfr": 0.0},
+            "dectr": {"sfr": 0.0},
+            "grass": {"sfr": 1.0},
+            "bsoil": {"sfr": 0.0},
+            "water": {"sfr": 0.0},
+        }}
     }}
 })
 
@@ -99,9 +98,11 @@ sim.update_config({
         "properties": {
             # Measurement height (metres) - affects aerodynamic calculations
             "z": 40.0,
-            # Disable anthropogenic heat (rural site)
-            "popdensdaytime": 0,
-            "popdensnighttime": 0,
+            # Disable anthropogenic heat (rural site): zero population density
+            "anthropogenic_emissions": {"heat": {
+                "popdensdaytime": {"working_day": 0, "holiday": 0},
+                "popdensnighttime": 0,
+            }},
         }
     }}
 })

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -127,6 +127,20 @@ def _get_basemodel_type(annotation):
     return None
 
 
+def _assign_trusted(model_obj, field, value):
+    """Assign a field without triggering validate_assignment.
+
+    Named validation bypass for the legacy df_state -> config
+    reconstruction (``from_df_state``): that path predates validation and
+    must keep accepting raw values that cross-field validators would
+    reject (users mutate df_state directly in the deprecated DataFrame
+    workflow). Keeps ``model_fields_set`` accurate so ``exclude_unset``
+    dumps still include the assigned fields.
+    """
+    object.__setattr__(model_obj, field, value)
+    model_obj.__pydantic_fields_set__.add(field)
+
+
 def _strip_internal_fields(data, model_cls):
     """Recursively remove fields marked with internal_only=True from a model_dump dict.
 
@@ -4627,35 +4641,37 @@ class SUEWSConfig(BaseModel):
 
             # Set site properties
             site_properties = SiteProperties.from_df_state(df, grid_id)
-            site.properties = site_properties
+            _assign_trusted(site, "properties", site_properties)
 
             # Set initial states
             initial_states = InitialStates.from_df_state(df, grid_id)
-            site.initial_states = initial_states
+            _assign_trusted(site, "initial_states", initial_states)
 
             sites.append(site)
 
         # Update config with reconstructed data
-        config.sites = sites
+        _assign_trusted(config, "sites", sites)
 
         # Reconstruct model
-        config.model = Model.from_df_state(df, grid_ids[0])
+        _assign_trusted(config, "model", Model.from_df_state(df, grid_ids[0]))
 
         # Set name and description, using defaults if columns don't exist
         if ("config", "0") in df.columns:
-            config.name = df.loc[grid_ids[0], ("config", "0")]
+            _assign_trusted(config, "name", df.loc[grid_ids[0], ("config", "0")])
         elif "config" in df.columns:
-            config.name = df["config"].iloc[0]
+            _assign_trusted(config, "name", df["config"].iloc[0])
         else:
-            config.name = "Converted from legacy format"
+            _assign_trusted(config, "name", "Converted from legacy format")
 
         if ("description", "0") in df.columns:
-            config.description = df.loc[grid_ids[0], ("description", "0")]
+            _assign_trusted(config, "description", df.loc[grid_ids[0], ("description", "0")])
         elif "description" in df.columns:
-            config.description = df["description"].iloc[0]
+            _assign_trusted(config, "description", df["description"].iloc[0])
         else:
-            config.description = (
-                "Configuration converted from legacy SUEWS table format"
+            _assign_trusted(
+                config,
+                "description",
+                "Configuration converted from legacy SUEWS table format",
             )
 
         return config

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -2820,14 +2820,16 @@ class SUEWSConfig(BaseModel):
 
         Notes
         -----
-        Gated on ``self._yaml_path`` AND on raw-YAML presence in
-        ``self._yaml_raw``. The check fires only when:
+        Gated on raw-input presence in ``self._yaml_raw``. The check
+        fires only when:
 
-        1. The configuration was loaded from a YAML file (not a
-           programmatic ``SUEWSConfig(sites=[Site(...)])`` construction),
-           AND
+        1. The configuration was loaded from user-shaped input — a YAML
+           file via ``from_yaml`` or a dict via ``from_dict``, both of
+           which record the raw input (not a programmatic
+           ``SUEWSConfig(sites=[Site(...)])`` construction, which does
+           not), AND
         2. The site carries an explicit ``land_cover`` mapping in the raw
-           YAML. Within that block, both user-declared surface mappings
+           input. Within that block, both user-declared surface mappings
            and omitted surfaces that remain active through
            ``default_factory`` are checked. Sites that omit
            ``land_cover`` entirely are skipped.
@@ -2844,7 +2846,7 @@ class SUEWSConfig(BaseModel):
         """
         issues: List[Dict[str, str]] = []
 
-        if getattr(self, "_yaml_path", None) is None:
+        if getattr(self, "_yaml_raw", None) is None:
             return issues
 
         if not getattr(self, "sites", None):

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -498,7 +498,10 @@ class SUEWSConfig(BaseModel):
                     f"Output frequency must be positive, got {output_control.freq}s"
                 )
 
+            # tstep is FlexibleRefValue: unwrap a RefValue form before the
+            # modulo check (gh#1530 follow-up)
             tstep = self.model.control.tstep
+            tstep = getattr(tstep, "value", tstep)
             if output_control.freq % tstep != 0:
                 raise ValueError(
                     f"Output frequency ({output_control.freq}s) must be a multiple of timestep ({tstep}s)"

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -4337,14 +4337,51 @@ class SUEWSConfig(BaseModel):
         with open(path, "r", encoding="utf-8") as file:
             config_data = yaml.load(file, Loader=yaml.FullLoader)
 
-        # Snapshot the raw user YAML so site-level completeness checks can
+        return cls.from_dict(
+            config_data,
+            use_conditional_validation=use_conditional_validation,
+            strict=strict,
+            auto_generate_annotated=auto_generate_annotated,
+            yaml_path=path,
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        config_data: dict,
+        use_conditional_validation: bool = True,
+        strict: bool = True,
+        auto_generate_annotated: bool = False,
+        yaml_path: Optional[str] = None,
+    ) -> "SUEWSConfig":
+        """Initialize SUEWSConfig from a configuration dict with validation.
+
+        This is the single validated construction path for dict input
+        (gh#1530); ``from_yaml`` delegates here after reading the file.
+
+        Args:
+            config_data (dict): Configuration data, YAML-shaped.
+            use_conditional_validation (bool): Whether to use conditional validation
+            strict (bool): If True, raise errors on validation failure
+            auto_generate_annotated (bool): If True, automatically generate annotated YAML when validation issues found
+            yaml_path (str, optional): Source YAML path, when loaded from a file.
+
+        Returns:
+            SUEWSConfig: Validated instance of SUEWSConfig
+        """
+        # Work on a copy so the caller's dict is never mutated (validators
+        # such as the legacy output_file coercion pop keys in place).
+        config_data = deepcopy(config_data)
+
+        # Snapshot the raw user input so site-level completeness checks can
         # distinguish user-declared surfaces from pydantic-factory defaults
         # (gh#1333 follow-up). Deep-copied so later mutations of
         # ``config_data`` do not bleed into the validator's view.
         yaml_raw_snapshot = deepcopy(config_data)
 
-        # Store yaml path in config data for later use
-        config_data["_yaml_path"] = path
+        # Store source path (if any) in config data for later use
+        if yaml_path is not None:
+            config_data["_yaml_path"] = yaml_path
         config_data["_auto_generate_annotated"] = auto_generate_annotated
         config_data["_yaml_raw"] = yaml_raw_snapshot
 

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -172,7 +172,39 @@ def _strip_internal_fields(data, model_cls):
 class SUEWSConfig(BaseModel):
     """Main SUEWS configuration."""
 
-    model_config = ConfigDict(title="SUEWS Configuration", extra="allow")
+    # extra="allow" exists solely for the private bookkeeping keys below;
+    # user-facing unknown keys are rejected by _reject_unknown_top_level_keys.
+    model_config = ConfigDict(
+        title="SUEWS Configuration",
+        extra="allow",
+        validate_assignment=True,
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_unknown_top_level_keys(cls, values):
+        """Reject unknown top-level keys instead of silently retaining them.
+
+        gh#1530 follow-up: with ``extra="allow"`` a typo such as ``site:``
+        would be kept as an inert extra attribute and the user's data
+        silently ignored. Underscore-prefixed keys are the reserved internal
+        bookkeeping namespace (``_yaml_path``, ``_auto_generate_annotated``,
+        ``_yaml_raw``, ``_validation_summary``) and round-trip freely.
+        """
+        if isinstance(values, dict):
+            unknown = [
+                key
+                for key in values
+                if key not in cls.model_fields
+                and not str(key).startswith("_")
+            ]
+            if unknown:
+                valid = ", ".join(sorted(cls.model_fields))
+                raise ValueError(
+                    f"Unknown top-level configuration key(s): "
+                    f"{', '.join(map(repr, unknown))}. Valid keys: {valid}"
+                )
+        return values
 
     name: str = Field(
         default="sample config",
@@ -4335,7 +4367,7 @@ class SUEWSConfig(BaseModel):
             SUEWSConfig: Instance of SUEWSConfig initialized from YAML
         """
         with open(path, "r", encoding="utf-8") as file:
-            config_data = yaml.load(file, Loader=yaml.FullLoader)
+            config_data = yaml.safe_load(file)
 
         return cls.from_dict(
             config_data,

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -845,7 +845,7 @@ class ModelPhysics(BaseModel):
     Model physics configuration options.
     """
 
-    model_config = ConfigDict(title="Physics Methods")
+    model_config = ConfigDict(title="Physics Methods", validate_assignment=True)
 
     @model_validator(mode="before")
     @classmethod
@@ -1295,7 +1295,7 @@ class ForcingControl(BaseModel):
 
 
 class ModelControl(BaseModel):
-    model_config = ConfigDict(title="Model Control")
+    model_config = ConfigDict(title="Model Control", validate_assignment=True)
 
     @model_validator(mode="before")
     @classmethod
@@ -1493,7 +1493,7 @@ class ModelControl(BaseModel):
 
 
 class Model(BaseModel):
-    model_config = ConfigDict(title="Model Configuration")
+    model_config = ConfigDict(title="Model Configuration", validate_assignment=True)
 
     control: ModelControl = Field(
         default_factory=ModelControl,

--- a/src/supy/data_model/core/site.py
+++ b/src/supy/data_model/core/site.py
@@ -3170,7 +3170,7 @@ class Site(BaseModel):
     including all physical properties, initial states, and model parameters.
     """
 
-    model_config = ConfigDict(title="Site Configuration")
+    model_config = ConfigDict(title="Site Configuration", validate_assignment=True)
 
     name: str = Field(description="Name of the site", default="test site")
     gridiv: int = Field(

--- a/src/supy/data_model/validation/core/yaml_helpers.py
+++ b/src/supy/data_model/validation/core/yaml_helpers.py
@@ -1959,7 +1959,7 @@ def run_precheck(path: str) -> dict:
 
     # ---- Step 0: Load yaml from path into a dict ----
     with open(path, "r", encoding="utf-8") as file:
-        data = yaml.load(file, Loader=yaml.FullLoader)
+        data = yaml.safe_load(file)
 
     original_data = deepcopy(data)
     data = rename_keys_recursive(data, RAW_YAML_FIELD_RENAMES)

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -183,6 +183,10 @@ class SUEWSSimulation:
                 # Merge the partial update onto the existing config, then
                 # re-validate the whole configuration so enum coercion,
                 # RefValue wrapping, and range checks all apply (gh#1530).
+                # The merged dict is the user's effective input (original
+                # explicitly-set fields plus this update), so from_dict's
+                # default raw snapshot of it is the correct record for
+                # raw-gated completeness checks.
                 merged = self._merge_config_updates(self._config, config)
                 self._config = SUEWSConfig.from_dict(
                     merged,
@@ -219,11 +223,16 @@ class SUEWSSimulation:
           ``{index: patch}``, ``{site_name: patch}``, or a single-site
           shorthand patch
         """
+        # Dump only what the user explicitly set (exclude_unset): merging
+        # onto a full dump would materialise pydantic defaults as if the
+        # user had declared them, so conditional validators gated on
+        # model_fields_set or on the raw-input snapshot (e.g. RSL/faibldg,
+        # site completeness) would fire false errors on sparse configs.
         # Internal bookkeeping keys are re-stamped by from_dict; carrying
         # them through the merge would nest snapshots inside snapshots.
         base = {
             k: v
-            for k, v in config.model_dump(exclude_none=True, mode="json").items()
+            for k, v in config.model_dump(exclude_unset=True, mode="json").items()
             if not k.startswith("_")
         }
 

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -236,7 +236,33 @@ class SUEWSSimulation:
             if not k.startswith("_")
         }
 
+        def normalise_legacy_input(model_cls, upd):
+            """Run the model's mode='before' validators on an update dict.
+
+            The full from_dict/from_yaml path normalises legacy input
+            forms (field renames such as ``stabilitymethod`` ->
+            ``stability``, the ``output_file``/``forcing_file`` lifts)
+            through each model's before-validators. Partial updates must
+            accept the same forms, so the patch is run through the same
+            machinery before the unknown-key check (gh#1530 follow-up).
+            """
+            decorators = getattr(model_cls, "__pydantic_decorators__", None)
+            if decorators is None:
+                return upd
+            for name, decorator in decorators.model_validators.items():
+                if decorator.info.mode != "before":
+                    continue
+                validator = getattr(model_cls, name, None)
+                if validator is None:
+                    continue
+                result = validator(upd)
+                if isinstance(result, dict):
+                    upd = result
+            return upd
+
         def merge_node(node_obj, base_dict, upd, path):
+            if isinstance(node_obj, BaseModel) and not isinstance(node_obj, RefValue):
+                upd = normalise_legacy_input(type(node_obj), dict(upd))
             for key, value in upd.items():
                 key_path = f"{path}.{key}" if path else str(key)
                 if not path and key == "sites":
@@ -324,7 +350,9 @@ class SUEWSSimulation:
                         key,
                     )
 
-        merge_node(config, base, updates, "")
+        # Deep-copied so the legacy-input coercions (which restructure
+        # nested dicts in place) never mutate the caller's update dict.
+        merge_node(config, base, copy.deepcopy(updates), "")
         return base
 
     def update_forcing(

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -342,12 +342,20 @@ class SUEWSSimulation:
                         return
                     # Unmatched site name with a single site: patch that site
                     apply_site_patch(0, value)
-                else:
-                    # Ambiguous with multiple sites: skip rather than guess
+                elif hasattr(config.sites[0], key):
+                    # Single-site shorthand used with multiple sites is
+                    # ambiguous: skip rather than guess which site to patch
                     logger_supy.warning(
-                        "Skipping ambiguous sites update key '%s': no site "
-                        "with that name and multiple sites configured",
+                        "Skipping ambiguous sites update key '%s': "
+                        "single-site shorthand with multiple sites configured",
                         key,
+                    )
+                else:
+                    # Not a site field, so it can only be a (misspelled or
+                    # stale) site name: raise rather than silently no-op
+                    raise ValueError(
+                        f"Unknown site '{key}' in sites update. "
+                        f"Configured sites: {', '.join(map(repr, site_names))}"
                     )
 
         # Deep-copied so the legacy-input coercions (which restructure

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -6,6 +6,7 @@ Provides a user-friendly wrapper around the existing SuPy infrastructure.
 """
 
 import copy
+from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import Any, Optional, Union
 import warnings
@@ -179,6 +180,12 @@ class SUEWSSimulation:
                         "partial updates via update_config()."
                     )
                 self._config = candidate
+
+                # Parity with the YAML branch: auto-load forcing declared
+                # in the config. Relative paths resolve against the CWD
+                # here (no file anchor); failures warn rather than raise.
+                if auto_load_forcing:
+                    self._try_load_forcing_from_config()
             else:
                 # Merge the partial update onto the existing config, then
                 # re-validate the whole configuration so enum coercion,
@@ -293,12 +300,33 @@ class SUEWSSimulation:
                     if isinstance(base_val, dict):
                         base_val.update(patch)
                     else:
+                        if "value" not in patch:
+                            # Metadata-only patch with no dumped base entry
+                            # (field at its default): seed the current value
+                            # so re-validation does not see a value-less dict
+                            seed = attr.model_dump(exclude_none=True, mode="json")
+                            seed.update(patch)
+                            patch = seed
                         base_dict[key] = patch
                 elif isinstance(value, dict) and isinstance(attr, BaseModel):
                     base_val = base_dict.get(key)
                     if not isinstance(base_val, dict):
                         base_dict[key] = base_val = {}
                     merge_node(attr, base_val, value, key_path)
+                elif (
+                    isinstance(value, dict)
+                    and set(value) <= set(RefValue.model_fields)
+                    and "value" not in value
+                    and attr is not None
+                    and not isinstance(attr, (dict, list))
+                ):
+                    # Metadata-only RefValue-shaped patch on a bare-valued
+                    # field: seed the current value before re-validation
+                    current = attr.value if isinstance(attr, Enum) else attr
+                    base_dict[key] = {
+                        "value": copy.deepcopy(current),
+                        **copy.deepcopy(value),
+                    }
                 else:
                     # Scalars, enums, lists, and dict input for non-model
                     # nodes replace wholesale; validation coerces the result

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, Union
 import warnings
 
 import pandas as pd
+from pydantic import BaseModel
 
 from ._check import check_forcing
 from ._env import logger_supy
@@ -81,7 +82,8 @@ class SUEWSSimulation:
         config : str, Path, dict, or SUEWSConfig, optional
             Initial configuration source:
             - Path to YAML configuration file
-            - Dictionary with configuration parameters
+            - Dictionary with a full configuration (YAML-shaped, validated
+              through ``SUEWSConfig`` exactly like a YAML file)
             - SUEWSConfig object
             - None to create empty simulation
         """
@@ -112,7 +114,12 @@ class SUEWSSimulation:
         config : str, Path, dict, or SUEWSConfig
             Configuration source:
             - Path to YAML file
-            - Dictionary with parameters (can be partial)
+            - Dictionary with parameters: a full configuration dict when no
+              config is loaded yet, or a partial update merged onto the
+              existing config. Either way the result is re-validated through
+              ``SUEWSConfig``, so enum/RefValue coercion and range checks
+              apply exactly as for YAML input. Unknown keys raise
+              ``ValueError``; list values replace the existing list.
             - SUEWSConfig object
         auto_load_forcing : bool, optional
             If True (default), automatically load forcing data specified in the
@@ -158,12 +165,29 @@ class SUEWSSimulation:
                 self._try_load_forcing_from_config()
 
         elif isinstance(config, dict):
-            # Update existing config with dictionary
             if self._config is None:
-                self._config = SUEWSConfig()
-
-            # Deep update the configuration
-            self._update_config_from_dict(config)
+                # No existing config: treat the dict as a full configuration
+                # and build it through the validated SUEWSConfig path
+                # (gh#1530). Partial dicts are only meaningful as updates to
+                # an existing configuration.
+                candidate = SUEWSConfig.from_dict(config)
+                if not candidate.sites:
+                    raise ValueError(
+                        "Configuration dict defines no sites. Provide a full "
+                        "configuration dict (including 'sites'), or load a "
+                        "YAML file / SUEWSConfig first and then apply "
+                        "partial updates via update_config()."
+                    )
+                self._config = candidate
+            else:
+                # Merge the partial update onto the existing config, then
+                # re-validate the whole configuration so enum coercion,
+                # RefValue wrapping, and range checks all apply (gh#1530).
+                merged = self._merge_config_updates(self._config, config)
+                self._config = SUEWSConfig.from_dict(
+                    merged,
+                    yaml_path=str(self._config_path) if self._config_path else None,
+                )
 
             # Regenerate state DataFrame
             self._df_state_init = self._config.to_df_state()
@@ -175,50 +199,124 @@ class SUEWSSimulation:
 
         return self
 
-    def _update_config_from_dict(self, updates: dict):
-        """Apply dictionary updates to configuration."""
+    @staticmethod
+    def _merge_config_updates(config: SUEWSConfig, updates: dict) -> dict:
+        """Merge a partial update dict onto a validated config's dump.
 
-        def recursive_update(obj, upd):
+        Returns a plain dict ready for re-validation through
+        ``SUEWSConfig.from_dict``; the configuration is never mutated in
+        place, so enum coercion, RefValue wrapping, and range checks always
+        apply to the merged result (gh#1530).
+
+        Merge semantics:
+        - dicts merge recursively into model-backed nodes; unknown field
+          names raise ``ValueError`` instead of being silently dropped
+        - ``{"value": ...}`` dicts merge into RefValue leaves; any other
+          dict shape on a RefValue leaf replaces it wholesale (alternate
+          readable input forms are re-validated, not merged)
+        - lists replace wholesale
+        - ``sites`` additionally accepts the established mini-language:
+          ``{index: patch}``, ``{site_name: patch}``, or a single-site
+          shorthand patch
+        """
+        # Internal bookkeeping keys are re-stamped by from_dict; carrying
+        # them through the merge would nest snapshots inside snapshots.
+        base = {
+            k: v
+            for k, v in config.model_dump(exclude_none=True, mode="json").items()
+            if not k.startswith("_")
+        }
+
+        def merge_node(node_obj, base_dict, upd, path):
             for key, value in upd.items():
-                if hasattr(obj, key):
-                    attr = getattr(obj, key)
-                    if isinstance(value, dict) and hasattr(attr, "__dict__"):
-                        # Recursive to read nested dictionaries
-                        recursive_update(attr, value)
-                    # Check whether site index or site name is provided
-                    elif isinstance(attr, list):
-                        site_key = list(value.keys())[0]
-                        site_value = value[site_key]
-                        if isinstance(site_key, int):
-                            # Select site on index
-                            attr = attr[site_key]
-                            recursive_update(attr, site_value)
-                        elif isinstance(site_key, str):
-                            # Select site on name
-                            attr_site = next(
-                                (item for item in attr if item.name == site_key),
-                                None,
-                            )
-                            if attr_site:
-                                recursive_update(attr_site, site_value)
-                            elif len(attr) == 1:
-                                # Without name or index and only one site
-                                attr_site = attr[0]
-                                # Distinguish site name pattern from shorthand
-                                # If site_key is an attribute on the site object, it's shorthand
-                                if hasattr(attr_site, site_key):
-                                    # Shorthand pattern: {'name': 'test'} or {'properties': {...}}
-                                    recursive_update(attr_site, value)
-                                else:
-                                    # Site name pattern: {'NonExistent': {'gridiv': 99}}
-                                    recursive_update(attr_site, site_value)
-                            else:
-                                # Otherwise skip these parameters
-                                continue
+                key_path = f"{path}.{key}" if path else str(key)
+                if not path and key == "sites":
+                    merge_sites(base_dict, value)
+                    continue
+                if (
+                    isinstance(node_obj, BaseModel)
+                    and not isinstance(node_obj, RefValue)
+                    and key not in type(node_obj).model_fields
+                ):
+                    raise ValueError(f"Unknown configuration key: '{key_path}'")
+                attr = getattr(node_obj, key, None) if node_obj is not None else None
+                if isinstance(attr, RefValue):
+                    if isinstance(value, dict) and not (
+                        set(value) <= set(RefValue.model_fields)
+                    ):
+                        # Alternate readable input form; replace wholesale
+                        base_dict[key] = copy.deepcopy(value)
+                        continue
+                    # Scalars become {"value": ...} so the field keeps its
+                    # RefValue shape (and any ref metadata) across updates
+                    patch = (
+                        copy.deepcopy(value)
+                        if isinstance(value, dict)
+                        else {"value": copy.deepcopy(value)}
+                    )
+                    base_val = base_dict.get(key)
+                    if isinstance(base_val, dict):
+                        base_val.update(patch)
                     else:
-                        setattr(obj, key, value)
+                        base_dict[key] = patch
+                elif isinstance(value, dict) and isinstance(attr, BaseModel):
+                    base_val = base_dict.get(key)
+                    if not isinstance(base_val, dict):
+                        base_dict[key] = base_val = {}
+                    merge_node(attr, base_val, value, key_path)
+                else:
+                    # Scalars, enums, lists, and dict input for non-model
+                    # nodes replace wholesale; validation coerces the result
+                    base_dict[key] = copy.deepcopy(value)
 
-        recursive_update(self._config, updates)
+        def apply_site_patch(index, patch):
+            if not isinstance(patch, dict):
+                raise ValueError(
+                    f"Site update for sites[{index}] must be a dict, "
+                    f"got {type(patch).__name__}"
+                )
+            if not 0 <= index < len(config.sites):
+                raise ValueError(
+                    f"Site index {index} out of range "
+                    f"({len(config.sites)} site(s) configured)"
+                )
+            merge_node(
+                config.sites[index],
+                base["sites"][index],
+                patch,
+                f"sites[{index}]",
+            )
+
+        def merge_sites(base_dict, sites_value):
+            if isinstance(sites_value, list):
+                # Plain list replaces the sites list wholesale
+                base_dict["sites"] = copy.deepcopy(sites_value)
+                return
+            if not isinstance(sites_value, dict) or not sites_value:
+                raise ValueError("'sites' update must be a non-empty dict or a list")
+            site_names = [getattr(site, "name", None) for site in config.sites]
+            for key, value in sites_value.items():
+                if isinstance(key, int):
+                    apply_site_patch(key, value)
+                elif key in site_names:
+                    apply_site_patch(site_names.index(key), value)
+                elif len(config.sites) == 1:
+                    if hasattr(config.sites[0], key):
+                        # Single-site shorthand: the whole dict is one patch
+                        apply_site_patch(0, sites_value)
+                        return
+                    # Unmatched site name with a single site: patch that site
+                    apply_site_patch(0, value)
+                else:
+                    # Ambiguous with multiple sites: skip rather than guess
+                    logger_supy.warning(
+                        "Skipping ambiguous sites update key '%s': no site "
+                        "with that name and multiple sites configured",
+                        key,
+                    )
+
+        merge_node(config, base, updates, "")
+        return base
 
     def update_forcing(
         self, forcing_data: Union[str, Path, list, pd.DataFrame, SUEWSForcing]

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -581,6 +581,56 @@ class TestConfigFromDict:
         with pytest.raises(ValueError, match="TypoSite"):
             sim_from_yaml.update_config({"sites": {"TypoSite": {"gridiv": 9}}})
 
+    def test_init_from_full_dict_auto_loads_forcing(self, sample_config_dict):
+        """Full-dict init must auto-load resolvable forcing like YAML init.
+
+        gh#1530 review follow-up: the dict branch never called
+        _try_load_forcing_from_config, so a dict with an absolute (or
+        cwd-resolvable) forcing path left forcing empty while the same
+        data via a YAML file auto-loaded it.
+        """
+        forcing_abs = files("supy").joinpath("sample_data/Kc_2012_data_60.txt")
+        cfg = dict(sample_config_dict)
+        cfg["model"]["control"]["forcing"]["file"] = str(forcing_abs)
+
+        sim = SUEWSSimulation(cfg)
+
+        assert sim._df_forcing is not None
+        assert len(sim._df_forcing) > 0
+
+    def test_update_config_refvalue_ref_only_patch(self, tmp_path):
+        """A ref-only patch must keep the field's current value.
+
+        gh#1530 review follow-up: when the current form of a field is a
+        bare scalar (or the base dump lacks the key), a metadata-only
+        patch like {'ref': {...}} produced a value-less RefValue dict
+        and failed validation; the merge must seed the current value.
+        """
+        import yaml
+
+        sparse = {
+            "name": "sparse",
+            "model": {"control": {"tstep": 300}},
+            "sites": [
+                {
+                    "name": "s1",
+                    "gridiv": 1,
+                    "properties": {"lat": 51.5, "lng": 0.1},
+                }
+            ],
+        }
+        path = tmp_path / "sparse.yml"
+        path.write_text(yaml.safe_dump(sparse, sort_keys=False), encoding="utf-8")
+        sim = SUEWSSimulation(str(path))
+
+        sim.update_config({
+            "model": {"control": {"tstep": {"ref": {"desc": "site doc"}}}}
+        })
+
+        tstep = sim.config.model.control.tstep
+        assert int(tstep.value if hasattr(tstep, "value") else tstep) == 300
+        assert getattr(tstep, "ref", None) is not None
+
     def test_partial_dict_without_existing_config_raises_clearly(self):
         """A partial dict with no base config must raise an informative error.
 

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -406,7 +406,7 @@ class TestConfigFromDict:
         import yaml
 
         yaml_path = files("supy").joinpath("sample_data/sample_config.yml")
-        return yaml.safe_load(yaml_path.read_text())
+        return yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
 
     @pytest.fixture
     def sim_from_yaml(self):

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -257,18 +257,18 @@ class TestConfigSitesUpdate:
         assert sim_single_site.config.sites[0].properties.lng.value == -0.13
 
     def test_site_name_nonexistent_multi_sites(self, sim_multi_site):
-        """Test that non-matching site name is skipped gracefully when multiple sites exist."""
-        original_name1 = sim_multi_site.config.sites[0].name
-        original_name2 = sim_multi_site.config.sites[1].name
+        """Test that a non-matching site name raises when multiple sites exist.
 
-        # Update with non-existent site name should be skipped
-        sim_multi_site.update_config({
-            "sites": {"NonExistent": {"name": "ShouldNotApply"}}
-        })
-
-        # Both sites should remain unchanged
-        assert sim_multi_site.config.sites[0].name == original_name1
-        assert sim_multi_site.config.sites[1].name == original_name2
+        Changed in gh#1530: previously the unmatched name was silently
+        skipped, turning a misspelled site target into a no-op. Strict
+        dict updates now raise so the typo is caught. (Ambiguous
+        single-site shorthand keys remain a skip-with-warning - see
+        test_single_site_shorthand_fails_gracefully_multi_site.)
+        """
+        with pytest.raises(ValueError, match="NonExistent"):
+            sim_multi_site.update_config({
+                "sites": {"NonExistent": {"name": "ShouldNotApply"}}
+            })
 
     def test_site_name_multi_site_selective(self, sim_multi_site):
         """Test updating only one site by name when multiple sites exist."""
@@ -563,6 +563,23 @@ class TestConfigFromDict:
         f = sim_from_yaml.config.model.control.forcing.file
         inner = f.value if hasattr(f, "value") else f
         assert inner == "new_forcing.txt"
+
+    def test_update_config_unknown_site_name_multi_site_raises(self, sim_from_yaml):
+        """A typo'd site name must raise when multiple sites exist.
+
+        gh#1530 review follow-up: silently skipping an unmatched site name
+        makes a misspelled target a no-op exactly where selecting the
+        wrong site is most likely. (Ambiguous single-site shorthand with
+        multiple sites stays a skip-with-warning - pinned behaviour.)
+        """
+        import copy
+
+        site2 = copy.deepcopy(sim_from_yaml.config.sites[0])
+        site2.name = "Swindon"
+        sim_from_yaml.config.sites.append(site2)
+
+        with pytest.raises(ValueError, match="TypoSite"):
+            sim_from_yaml.update_config({"sites": {"TypoSite": {"gridiv": 9}}})
 
     def test_partial_dict_without_existing_config_raises_clearly(self):
         """A partial dict with no base config must raise an informative error.

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -532,6 +532,38 @@ class TestConfigFromDict:
         tstep = sim.config.model.control.tstep
         assert int(tstep.value if hasattr(tstep, "value") else tstep) == 600
 
+    def test_update_config_legacy_field_name_renamed(self, sim_from_yaml):
+        """Legacy field names must work in partial updates as in full input.
+
+        gh#1530 review follow-up: the full YAML/dict path normalises
+        deprecated names (e.g. ``stabilitymethod`` -> ``stability``) via
+        before-validators; partial updates must accept them identically.
+        """
+        sim_from_yaml.update_config({"model": {"physics": {"stabilitymethod": 3}}})
+
+        st = sim_from_yaml.config.model.physics.stability
+        inner = st.value if hasattr(st, "value") else st
+        assert int(inner) == 3
+
+    def test_update_config_legacy_output_file(self, sim_from_yaml):
+        """The deprecated output_file dict form must lift under output."""
+        sim_from_yaml.update_config({
+            "model": {"control": {"output_file": {"freq": 1800}}}
+        })
+
+        freq = sim_from_yaml.config.model.control.output.freq
+        assert int(freq.value if hasattr(freq, "value") else freq) == 1800
+
+    def test_update_config_legacy_forcing_file(self, sim_from_yaml):
+        """The deprecated forcing_file form must move under forcing.file."""
+        sim_from_yaml.update_config(
+            {"model": {"control": {"forcing_file": "new_forcing.txt"}}},
+        )
+
+        f = sim_from_yaml.config.model.control.forcing.file
+        inner = f.value if hasattr(f, "value") else f
+        assert inner == "new_forcing.txt"
+
     def test_partial_dict_without_existing_config_raises_clearly(self):
         """A partial dict with no base config must raise an informative error.
 

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -500,6 +500,38 @@ class TestConfigFromDict:
                 "model": {"physics": {"nonexistent_param": 1}}
             })
 
+    def test_partial_update_on_sparse_yaml_config(self, tmp_path):
+        """A trivial update on a sparse YAML config must not raise.
+
+        gh#1530 review follow-up: the merge path snapshotted the full
+        config dump (with materialised default land-cover surfaces) as
+        the raw-YAML record, so the site-completeness validator treated
+        pydantic defaults as user-declared and raised unrelated errors
+        for updates like a timestep change. The original raw YAML must
+        be preserved through merge-then-revalidate.
+        """
+        import yaml
+
+        sparse = {
+            "name": "sparse",
+            "model": {"control": {"tstep": 300}},
+            "sites": [
+                {
+                    "name": "s1",
+                    "gridiv": 1,
+                    "properties": {"lat": 51.5, "lng": 0.1},
+                }
+            ],
+        }
+        path = tmp_path / "sparse.yml"
+        path.write_text(yaml.safe_dump(sparse, sort_keys=False), encoding="utf-8")
+
+        sim = SUEWSSimulation(str(path))
+        sim.update_config({"model": {"control": {"tstep": 600}}})
+
+        tstep = sim.config.model.control.tstep
+        assert int(tstep.value if hasattr(tstep, "value") else tstep) == 600
+
     def test_partial_dict_without_existing_config_raises_clearly(self):
         """A partial dict with no base config must raise an informative error.
 

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -631,6 +631,22 @@ class TestConfigFromDict:
         assert int(tstep.value if hasattr(tstep, "value") else tstep) == 300
         assert getattr(tstep, "ref", None) is not None
 
+    def test_update_config_refvalue_tstep_with_output_freq(self, sim_from_yaml):
+        """RefValue-style tstep updates must work with output.freq set.
+
+        gh#1530 review follow-up: validate_model_output_config computed
+        ``freq % tstep`` without unwrapping a RefValue-wrapped tstep,
+        so a documented RefValue patch raised TypeError-as-schema-drift
+        whenever an output frequency was configured.
+        """
+        sim_from_yaml.update_config({"model": {"control": {"output": {"freq": 3600}}}})
+        sim_from_yaml.update_config({
+            "model": {"control": {"tstep": {"value": 300, "ref": {"desc": "doc"}}}}
+        })
+
+        tstep = sim_from_yaml.config.model.control.tstep
+        assert int(tstep.value if hasattr(tstep, "value") else tstep) == 300
+
     def test_partial_dict_without_existing_config_raises_clearly(self):
         """A partial dict with no base config must raise an informative error.
 

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -389,6 +389,129 @@ class TestConfigSitesUpdate:
         )
 
 
+class TestConfigFromDict:
+    """Regression tests for gh#1530: dict configs must use validated construction.
+
+    ``SUEWSSimulation(config=dict)`` and ``update_config(dict)`` must route
+    through the validated ``SUEWSConfig`` path rather than mutating model
+    internals by hand, so enum coercion, RefValue wrapping, and range checks
+    all apply to dict input exactly as they do to YAML files.
+    """
+
+    pytestmark = pytest.mark.cfg
+
+    @pytest.fixture
+    def sample_config_dict(self):
+        """Full configuration dict, as a user would get from yaml.safe_load."""
+        import yaml
+
+        yaml_path = files("supy").joinpath("sample_data/sample_config.yml")
+        return yaml.safe_load(yaml_path.read_text())
+
+    @pytest.fixture
+    def sim_from_yaml(self):
+        """Simulation loaded from the bundled sample YAML."""
+        yaml_path = files("supy").joinpath("sample_data/sample_config.yml")
+        return SUEWSSimulation(str(yaml_path))
+
+    def test_init_from_full_config_dict(self, sample_config_dict):
+        """Constructor must accept a full YAML-shaped dict (gh#1530)."""
+        sim = SUEWSSimulation(sample_config_dict)
+
+        assert sim.config is not None
+        assert sim._df_state_init is not None
+        assert len(sim.config.sites) == 1
+
+    def test_full_dict_equivalent_to_yaml(self, sample_config_dict, sim_from_yaml):
+        """Dict and YAML construction must produce the same initial state."""
+        sim_dict = SUEWSSimulation(sample_config_dict)
+
+        pd.testing.assert_frame_equal(
+            sim_dict._df_state_init,
+            sim_from_yaml._df_state_init,
+            check_dtype=False,
+        )
+
+    def test_update_config_full_dict_on_empty_sim(self, sample_config_dict):
+        """update_config with a full dict must work without a prior config."""
+        sim = SUEWSSimulation()
+        sim.update_config(sample_config_dict)
+
+        assert sim.config is not None
+        assert sim._df_state_init is not None
+
+    def test_update_config_int_enum_revalidated(self, sim_from_yaml):
+        """A raw int for an enum field must be coerced, not stored verbatim."""
+        from supy.data_model import RefValue
+        from supy.data_model.core.model import NetRadiationMethod
+
+        sim_from_yaml.update_config({"model": {"physics": {"net_radiation": 1}}})
+
+        nr = sim_from_yaml.config.model.physics.net_radiation
+        inner = nr.value if isinstance(nr, RefValue) else nr
+        assert isinstance(inner, NetRadiationMethod), (
+            f"Expected validated enum, got {type(inner).__name__}: {inner!r}"
+        )
+        assert int(inner) == 1
+        # State regeneration must still work after the update
+        assert sim_from_yaml._df_state_init is not None
+
+    def test_update_config_refvalue_enum_dict(self, sim_from_yaml):
+        """A RefValue-style {'value': N} enum update must coerce to the enum."""
+        from supy.data_model import RefValue
+        from supy.data_model.core.model import NetRadiationMethod
+
+        sim_from_yaml.update_config({
+            "model": {"physics": {"net_radiation": {"value": 3}}}
+        })
+
+        nr = sim_from_yaml.config.model.physics.net_radiation
+        inner = nr.value if isinstance(nr, RefValue) else nr
+        assert isinstance(inner, NetRadiationMethod), (
+            f"Expected validated enum, got {type(inner).__name__}: {inner!r}"
+        )
+        assert int(inner) == 3
+
+    def test_update_config_sites_as_list(self, sim_from_yaml):
+        """A plain list for sites must replace the sites list (gh#1530 comment)."""
+        site_dict = sim_from_yaml.config.sites[0].model_dump(
+            exclude_none=True, mode="json"
+        )
+        site_dict["name"] = "ReplacedSite"
+
+        sim_from_yaml.update_config({"sites": [site_dict]})
+
+        assert len(sim_from_yaml.config.sites) == 1
+        assert sim_from_yaml.config.sites[0].name == "ReplacedSite"
+
+    def test_update_config_plain_list_field(self, sim_from_yaml):
+        """List-valued fields other than sites must be updatable."""
+        sim_from_yaml.update_config({
+            "model": {"control": {"output": {"groups": ["SUEWS", "DailyState"]}}}
+        })
+
+        groups = sim_from_yaml.config.model.control.output.groups
+        assert list(groups) == ["SUEWS", "DailyState"]
+
+    def test_update_config_unknown_key_raises(self, sim_from_yaml):
+        """Unknown keys in an update dict must raise, not vanish silently."""
+        with pytest.raises((ValueError, KeyError)):
+            sim_from_yaml.update_config({
+                "model": {"physics": {"nonexistent_param": 1}}
+            })
+
+    def test_partial_dict_without_existing_config_raises_clearly(self):
+        """A partial dict with no base config must raise an informative error.
+
+        Previously this produced a cryptic downstream failure
+        (``No objects to concatenate``) from ``to_df_state`` on a site-less
+        default config (gh#1530 comment).
+        """
+        sim = SUEWSSimulation()
+        with pytest.raises(ValueError, match="site"):
+            sim.update_config({"model": {"control": {"tstep": 600}}})
+
+
 class TestForcing:
     """Test forcing data loading."""
 

--- a/test/data_model/test_from_yaml_errors.py
+++ b/test/data_model/test_from_yaml_errors.py
@@ -62,9 +62,7 @@ class TestFromYamlDriftHints:
         """
         # ARRANGE
         drifted = dict(sample_config_dict)
-        drifted["sites"][0]["properties"][
-            "removed_field_from_old_release"
-        ] = 42
+        drifted["sites"][0]["properties"]["removed_field_from_old_release"] = 42
         path = _write_yaml(tmp_path, drifted)
 
         # ACT / ASSERT
@@ -121,9 +119,7 @@ class TestFromYamlDriftHints:
         message = str(excinfo.value)
         assert "Detected schema version: 2025.12" in message
 
-    def test_unsigned_yaml_hint_requests_from_ver(
-        self, sample_config_dict, tmp_path
-    ):
+    def test_unsigned_yaml_hint_requests_from_ver(self, sample_config_dict, tmp_path):
         """Unsigned YAMLs must not be told to run the bare suews-convert command.
 
         The CLI rejects unsigned YAMLs unless `-f/--from` is supplied, so
@@ -145,3 +141,54 @@ class TestFromYamlDriftHints:
         assert "No schema_version field in YAML" in message
         assert "-f <release-tag>" in message
         assert f"Detected schema version: {CURRENT_SCHEMA_VERSION}" not in message
+
+
+class TestDictInputHardening:
+    """gh#1530 follow-ups: safe YAML loading and loud unknown-key handling."""
+
+    def test_from_yaml_rejects_python_object_tags(self, sample_config_dict, tmp_path):
+        """from_yaml must not construct arbitrary Python objects from tags.
+
+        yaml.FullLoader resolves ``!!python/name:os.system`` to the live
+        function; safe loading must reject the tag at parse time instead.
+        """
+        tagged = dict(sample_config_dict)
+        tagged["description"] = "PLACEHOLDER_FOR_TAG"
+        path = _write_yaml(tmp_path, tagged)
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace("PLACEHOLDER_FOR_TAG", "!!python/name:os.system"),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(yaml.YAMLError):
+            SUEWSConfig.from_yaml(str(path))
+
+    def test_unknown_top_level_key_raises(self, sample_config_dict):
+        """Unknown top-level keys must raise, not be silently retained."""
+        drifted = dict(sample_config_dict)
+        drifted["stray_key"] = 1
+
+        with pytest.raises(ValueError, match="stray_key"):
+            SUEWSConfig.from_dict(drifted)
+
+    def test_internal_bookkeeping_keys_accepted(self, sample_config_dict, tmp_path):
+        """The private _yaml_* keys must keep working through from_yaml."""
+        path = _write_yaml(tmp_path, sample_config_dict)
+        config = SUEWSConfig.from_yaml(str(path))
+        assert getattr(config, "_yaml_path", None) == str(path)
+
+    def test_assignment_is_validated(self, sample_config_dict):
+        """Direct attribute assignment must be validated, not stored raw."""
+        config = SUEWSConfig.from_dict(sample_config_dict)
+
+        with pytest.raises(ValueError):
+            config.model.physics.net_radiation = "not_a_method"
+
+        with pytest.raises(ValueError):
+            config.sites = "not a list"
+
+        # Valid assignments still coerce and succeed
+        config.model.control.tstep = 600
+        tstep = config.model.control.tstep
+        assert int(tstep.value if hasattr(tstep, "value") else tstep) == 600

--- a/test/data_model/test_from_yaml_errors.py
+++ b/test/data_model/test_from_yaml_errors.py
@@ -192,3 +192,24 @@ class TestDictInputHardening:
         config.model.control.tstep = 600
         tstep = config.model.control.tstep
         assert int(tstep.value if hasattr(tstep, "value") else tstep) == 600
+
+    def test_from_dict_runs_completeness_checks_like_yaml(
+        self, sample_config_dict, tmp_path
+    ):
+        """Dict input must hit the same site-completeness checks as YAML.
+
+        gh#1530 review follow-up: the completeness validator was gated on
+        ``_yaml_path``, so the in-memory dict path silently skipped checks
+        that the same data loaded from a file would fail.
+        """
+        from copy import deepcopy
+
+        broken = deepcopy(sample_config_dict)
+        broken["sites"][0]["properties"]["land_cover"]["grass"].pop("lai")
+
+        path = _write_yaml(tmp_path, broken)
+        with pytest.raises(ValueError):
+            SUEWSConfig.from_yaml(str(path))
+
+        with pytest.raises(ValueError):
+            SUEWSConfig.from_dict(broken)

--- a/test/data_model/test_timezone_enum.py
+++ b/test/data_model/test_timezone_enum.py
@@ -16,7 +16,6 @@ def test_timezone_enum_support():
 
     # Create a test config with float timezone value
     config_dict = {
-        "forcing": {"file": "test/benchmark1/forcing/Kc1_2011_data_5.txt"},
         "sites": [
             {
                 "name": "Test Site",
@@ -86,7 +85,6 @@ def test_timezone_enum_support():
 def test_timezone_boundary_values(tz_value):
     """Test timezone boundary values"""
     config_dict = {
-        "forcing": {"file": "test/benchmark1/forcing/Kc1_2011_data_5.txt"},
         "sites": [
             {
                 "name": f"Test Site TZ {tz_value}",
@@ -146,7 +144,6 @@ def test_timezone_boundary_values(tz_value):
 def test_timezone_validation_errors(tz_value):
     """Test that invalid timezone values still raise errors"""
     config_dict = {
-        "forcing": {"file": "test/benchmark1/forcing/Kc1_2011_data_5.txt"},
         "sites": [
             {
                 "name": "Test Site",

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -68,6 +68,17 @@ def registry():
 
 # Helper to construct a SUEWSConfig without running Pydantic on sites,
 # then inject the desired physics settings.
+def _force_set(model_obj, field, value):
+    """Named validation bypass for fixture mocks.
+
+    SUEWSConfig has ``validate_assignment=True`` (gh#1530 follow-up), so a
+    plain assignment would reject the SimpleNamespace stand-ins these
+    validator unit tests rely on. ``object.__setattr__`` skips pydantic's
+    assignment validation deliberately and only here.
+    """
+    object.__setattr__(model_obj, field, value)
+
+
 def make_cfg(**physics_kwargs):
     cfg = SUEWSConfig.model_construct()  # bypass validation
     # gh#1456: the STEBBS-scoped switches moved under a nested
@@ -100,7 +111,7 @@ def make_cfg(**physics_kwargs):
     phys = SimpleNamespace(**top_kwargs)
     if stebbs_members:
         phys.stebbs = SimpleNamespace(**stebbs_members)
-    cfg.model = SimpleNamespace(physics=phys)
+    _force_set(cfg, "model", SimpleNamespace(physics=phys))
     return cfg
 
 
@@ -2047,7 +2058,7 @@ def test_validate_spartacus_building_height_stebbs_off():
 
 def test_validate_spartacus_sfr_mismatch_bldgs_frac():
     cfg = SUEWSConfig.model_construct()
-    cfg.model = SimpleNamespace(physics=SimpleNamespace(net_radiation=1001))
+    _force_set(cfg, "model", SimpleNamespace(physics=SimpleNamespace(net_radiation=1001)))
     bldgs = SimpleNamespace(sfr=0.6)  
     lc = SimpleNamespace(bldgs=bldgs, evetr=None, dectr=None)
     vertical_layers = SimpleNamespace(
@@ -2066,7 +2077,7 @@ def test_validate_spartacus_sfr_mismatch_bldgs_frac():
 
 def test_validate_spartacus_sfr_consistent_values():
     cfg = SUEWSConfig.model_construct()
-    cfg.model = SimpleNamespace(physics=SimpleNamespace(net_radiation=1001))
+    _force_set(cfg, "model", SimpleNamespace(physics=SimpleNamespace(net_radiation=1001)))
     bldgs = SimpleNamespace(sfr=0.3)  
     evetr = SimpleNamespace(sfr=0.1)
     dectr = SimpleNamespace(sfr=0.2)
@@ -2083,7 +2094,7 @@ def test_validate_spartacus_sfr_consistent_values():
 def test_validate_spartacus_sfr_mismatch_veg_frac():
     """SPARTACUS SFR validation flags mismatch between evetr.sfr + dectr.sfr and veg_frac[0]."""
     cfg = SUEWSConfig.model_construct()
-    cfg.model = SimpleNamespace(physics=SimpleNamespace(net_radiation=1001))
+    _force_set(cfg, "model", SimpleNamespace(physics=SimpleNamespace(net_radiation=1001)))
 
     # land_cover vegetation: evetr + dectr = 0.4
     evetr = SimpleNamespace(sfr=0.1)
@@ -2170,7 +2181,7 @@ def test_validate_spartacus_veg_dimensions_missing_nlayer():
 def test_validate_spartacus_veg_dimensions_passing_case():
     """Passing case: dectreeh=12, height=[0, 5, 10, 15, 20], veg_frac=[0.3, 0.3, 0.2, 0, 0]"""
     cfg = SUEWSConfig.model_construct()
-    cfg.model = SimpleNamespace(physics=SimpleNamespace(net_radiation=1001))
+    _force_set(cfg, "model", SimpleNamespace(physics=SimpleNamespace(net_radiation=1001)))
     lc = SimpleNamespace(dectr=SimpleNamespace(height_deciduous_tree=12.0), evetr=None)
     vertical_layers = SimpleNamespace(
         height=[0, 5, 10, 15, 20],
@@ -2186,7 +2197,7 @@ def test_validate_spartacus_veg_dimensions_failing_case():
     Tree at 12 m falls in layer 10-15 m (layer_index=3), so veg_frac[3]=0.1 in the
     15-20 m layer should be flagged."""
     cfg = SUEWSConfig.model_construct()
-    cfg.model = SimpleNamespace(physics=SimpleNamespace(net_radiation=1001))
+    _force_set(cfg, "model", SimpleNamespace(physics=SimpleNamespace(net_radiation=1001)))
     lc = SimpleNamespace(dectr=SimpleNamespace(height_deciduous_tree=12.0), evetr=None)
     vertical_layers = SimpleNamespace(
         height=[0, 5, 10, 15, 20],
@@ -2201,7 +2212,7 @@ def test_validate_spartacus_veg_dimensions_failing_case():
 def test_validate_spartacus_veg_dimensions_boundary_case():
     """Boundary case: max_tree exactly on a layer boundary."""
     cfg = SUEWSConfig.model_construct()
-    cfg.model = SimpleNamespace(physics=SimpleNamespace(net_radiation=1001))
+    _force_set(cfg, "model", SimpleNamespace(physics=SimpleNamespace(net_radiation=1001)))
     lc = SimpleNamespace(dectr=SimpleNamespace(height_deciduous_tree=15.0), evetr=None)
     vertical_layers = SimpleNamespace(
         height=[0, 5, 10, 15, 20],
@@ -2215,7 +2226,7 @@ def test_validate_spartacus_veg_dimensions_boundary_case():
 def test_validate_spartacus_veg_dimensions_exceeds_all_case():
     """Exceeds-all case: max_tree=100 with height=[0, 5, 10] — should produce the 'exceeds' message."""
     cfg = SUEWSConfig.model_construct()
-    cfg.model = SimpleNamespace(physics=SimpleNamespace(net_radiation=1001))
+    _force_set(cfg, "model", SimpleNamespace(physics=SimpleNamespace(net_radiation=1001)))
     # Note: dectrh and evetrh are attributes of land_cover.dectr and land_cover.evetr, not land_cover itself
     dectr = SimpleNamespace(height_deciduous_tree=100.0)
     lc = SimpleNamespace(dectr=dectr, evetr=None)


### PR DESCRIPTION
## Summary

Closes #1530.

`SUEWSSimulation(config=dict)` failed with `<enum 'Enum'> cannot set attribute 'value'` (and `'list' object has no attribute "keys"` for list-shaped input) because `_update_config_from_dict` mutated validated pydantic model internals via recursive `setattr`, bypassing enum coercion, RefValue wrapping, and range checks. The dict path also assumed a complete config was already present and that the only list field was `sites`.

This PR makes validated `SUEWSConfig` construction the single path for all dict input.

## Core fix

- New `SUEWSConfig.from_dict()` classmethod, factored out of `from_yaml()` (which now delegates to it), so dict and YAML input share schema-version stamping, validation, and error transformation.
- `SUEWSSimulation(config=dict)` / `update_config(dict)` with no prior config construct a full validated config; partial updates deep-merge onto the existing config's `model_dump(exclude_unset=True)` and re-validate the whole result. The recursive-`setattr` machinery is removed.
- Merging onto only the explicitly-set fields keeps `model_fields_set`- and raw-snapshot-gated conditional validators honest: pydantic defaults are no longer mistaken for user-declared values on sparse configs.
- Full-dict construction honours `auto_load_forcing`, matching the YAML branch (relative paths resolve against the CWD; failures warn rather than raise).

## Update semantics (now strict and explicit)

- Unknown keys raise `ValueError` instead of being silently dropped (this previously masked no-op "updates" in two bundled tutorials, now corrected).
- Legacy schema aliases (`stabilitymethod`, `output_file`, `forcing_file`, ...) are accepted in partial updates exactly as in full input: update sub-dicts run through each model's own `mode="before"` validators, so there is no parallel alias registry to drift.
- Plain lists (including a `sites` list) replace the existing list; the `{index: patch}` / `{site_name: patch}` / single-site shorthand forms for `sites` are kept.
- An unmatched site name now raises when multiple sites exist (previously a silent no-op); ambiguous single-site shorthand with multiple sites keeps the established skip-with-warning behaviour.
- Scalar updates on RefValue fields keep the RefValue shape (and `ref` metadata); metadata-only `{'ref': ...}` patches seed the current value instead of failing re-validation.
- A partial dict with no existing config raises an informative error instead of failing later in `to_df_state`.

## Hardening (same root cause, folded in)

- Config YAML is parsed with `yaml.safe_load`; `yaml.FullLoader` resolved tags such as `!!python/name:os.system` into live Python objects at load time (second occurrence in `yaml_helpers.py` swapped as well).
- Unknown top-level config keys raise `ValueError` (underscore-prefixed keys remain the reserved internal bookkeeping namespace).
- `validate_assignment` enabled on `SUEWSConfig`, `Model`, `ModelControl`, `ModelPhysics`, and `Site`, closing the unvalidated direct-mutation hole that caused the original bug (`SiteProperties` already had it).
- Site-completeness checks now apply to dict-loaded configs exactly as to YAML files (previously gated on the YAML file path, so the in-memory dict path skipped them).

## Docs

- Tutorials 01/02 set surface fractions via a non-existent `initial_states.sfr_surf` key and population densities via non-existent `properties` fields - silent no-ops under the old code. Corrected to the real paths (`properties.land_cover.<surface>.sfr`, `properties.anthropogenic_emissions.heat.*`) and verified end-to-end; a stale `stabilitymethod` example in the simulation sub-tutorial updated to `stability`.

## Validation

- 21 new regression tests (16 in `test_suews_simulation.py::TestConfigFromDict`, 5 in `test_from_yaml_errors.py::TestDictInputHardening`), all written failing-first.
- Full `test/data_model` + `test_suews_simulation.py` suites pass (959 tests), `make test-smoke` passes, tutorials 01/02/07 run end-to-end.
- Four iterative review passes applied fixes for: raw-input gating parity, legacy-alias acceptance, strict multi-site names, and forcing auto-load / ref-only patch seeding.

## Note on the schema-audit label

`src/supy/data_model/` is touched, but the changes are additive/behavioural (new classmethod, validator gating, `validate_assignment`); no field, type, or YAML-surface change, so no schema version bump - hence `0-ci:schema-audit-ok`.
