### PR TITLE
Fix DailyState-only output saving

### DIFF
--- a/src/supy/_save.py
+++ b/src/supy/_save.py
@@ -91,8 +91,10 @@ def gen_df_year(df_save, year, grid, group, output_level):
     df_grid_group = df_grid[group].copy()
     # get temporal index
     idx_dt = df_grid_group.index
-    freq = idx_dt.to_series().diff().iloc[-1]
-    df_grid_group = df_grid_group.asfreq(freq)
+    if len(idx_dt) > 1:
+        freq = idx_dt.to_series().diff().iloc[-1]
+        if pd.notna(freq):
+            df_grid_group = df_grid_group.asfreq(freq)
     # select output variables in `SUEWS` based on output level
     if group == "SUEWS":
         # Filter to only variables that exist in the dataframe
@@ -264,18 +266,24 @@ def save_df_output(
         df_save_no_daily = df_save
 
     # resample `df_output` at `freq_save` (excluding DailyState)
-    df_rsmp = resample_output(df_save_no_daily, freq_save, _internal=True)
+    if len(df_save_no_daily.columns) > 0:
+        df_rsmp = resample_output(df_save_no_daily, freq_save, _internal=True)
+    else:
+        df_rsmp = None
 
     # dataframes to save
     if save_tstep:
         # both original and resampled output dataframes
-        list_df_save = [df_save, df_rsmp]
+        list_df_save = [
+            df for df in [df_save, df_rsmp] if df is not None and len(df.columns) > 0
+        ]
     else:
         # combine resampled data with DailyState (if it exists)
         list_df_save = []
         if df_dailystate is not None:
             list_df_save.append(df_dailystate)
-        list_df_save.append(df_rsmp)
+        if df_rsmp is not None:
+            list_df_save.append(df_rsmp)
 
     # save output at the resampling frequency
     for i, df_save in enumerate(list_df_save):
@@ -390,12 +398,17 @@ def save_df_output(
 def save_df_ser(df_save, path_dir_save, site, output_level):
     list_grid = df_save.index.get_level_values("grid").unique()
     list_group = df_save.columns.get_level_values("group").unique()
-    list_year = df_save.index.get_level_values("datetime").year[:-1].unique()
+    is_dailystate_only = len(list_group) == 1 and list_group[0] == "DailyState"
+    idx_year = df_save.index.get_level_values("datetime").year
+    if is_dailystate_only:
+        list_year = idx_year.unique()
+    else:
+        # the last index value is dropped as supy uses starting timestamp of each year
+        # for naming files
+        list_year = idx_year[:-1].unique()
     list_path_save_df = []
     for grid in list_grid:
         for group in list_group:
-            # the last index value is dropped as supy uses starting timestamp of each year
-            # for naming files
             for year in list_year:
                 df_year = gen_df_year(df_save, year, grid, group, output_level)
                 if df_year.shape[0] > 0:

--- a/test/io_tests/test_dailystate_output.py
+++ b/test/io_tests/test_dailystate_output.py
@@ -9,6 +9,7 @@ import pytest
 
 import supy as sp
 from conftest import TIMESTEPS_PER_DAY
+from supy.data_model.core.model import OutputControl
 
 pytestmark = pytest.mark.physics
 
@@ -125,3 +126,32 @@ class TestDailyStateOutput:
                 # DailyState should not be affected by output frequency
                 df_ds = pd.read_csv(dailystate_files[0], sep="\t")
                 assert len(df_ds) > 0, f"DailyState should have data at freq={freq_s}"
+
+    def test_dailystate_only_output_config_saves_file(self):
+        """Test that requesting only DailyState writes a populated output file."""
+        df_state_init, df_forcing = sp.load_SampleData()
+        df_forcing_one_day = df_forcing.iloc[:TIMESTEPS_PER_DAY]
+
+        df_output, df_state_final = sp.run_supy(df_forcing_one_day, df_state_init)
+
+        with tempfile.TemporaryDirectory() as dir_temp:
+            list_files = sp.save_supy(
+                df_output,
+                df_state_final,
+                path_dir_save=dir_temp,
+                output_config=OutputControl(groups=["DailyState"]),
+            )
+
+            assert [f.name for f in list_files if "SUEWS" in f.name] == []
+            dailystate_files = [f for f in list_files if "DailyState" in f.name]
+            assert len(dailystate_files) == 1
+
+            df_saved = pd.read_csv(dailystate_files[0], sep="\t")
+            data_cols = [
+                c
+                for c in df_saved.columns
+                if c not in ["Year", "DOY", "Hour", "Min", "Dectime"]
+            ]
+
+            assert len(df_saved) == 1
+            assert (df_saved[data_cols] != -999).any().any()


### PR DESCRIPTION
## Summary
- avoid resampling an empty non-DailyState dataframe when only DailyState is requested
- keep single-row DailyState outputs savable by handling one-timestamp frequency inference and year selection
- add a regression test for OutputControl(groups=["DailyState"])

Closes #1534.

## Validation
- pytest -q test/io_tests/test_output_config.py test/io_tests/test_resample_output.py test/io_tests/test_dailystate_output.py
- make test-smoke