### PR TITLE
Stamp schema directive in Conductor settings and honour CONDUCTOR_PORT

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,3 +1,4 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [scripts]

--- a/scripts/conductor/run.sh
+++ b/scripts/conductor/run.sh
@@ -38,9 +38,19 @@ find_free_port() {
     echo "$port"
 }
 
-PORT_SITE=$(find_free_port 3000)
-PORT_DOCS=$(find_free_port 8000)
-PORT_DASH=$(find_free_port 4000)
+# Prefer the workspace's allocated port range (CONDUCTOR_PORT..+9) so
+# parallel workspaces get non-overlapping ports by construction; fall back
+# to the legacy fixed bases when running outside Conductor. The dashboard
+# takes CONDUCTOR_PORT itself so Conductor's "Open" button lands on it.
+if [ -n "$CONDUCTOR_PORT" ]; then
+    PORT_DASH=$(find_free_port "$CONDUCTOR_PORT")
+    PORT_SITE=$(find_free_port $((CONDUCTOR_PORT + 1)))
+    PORT_DOCS=$(find_free_port $((CONDUCTOR_PORT + 2)))
+else
+    PORT_SITE=$(find_free_port 3000)
+    PORT_DOCS=$(find_free_port 8000)
+    PORT_DASH=$(find_free_port 4000)
+fi
 echo "[run] Ports: site=$PORT_SITE docs=$PORT_DOCS dashboard=$PORT_DASH"
 
 # Track background PIDs so the trap can kill each whole process group.


### PR DESCRIPTION
## Summary

Two small improvements to the shared Conductor workspace config:

- Add the `#:schema https://conductor.build/schemas/settings.repo.schema.json` directive at the top of `.conductor/settings.toml` so TOML-aware editors validate the file against the repository settings schema.
- Make `scripts/conductor/run.sh` honour the workspace's allocated `CONDUCTOR_PORT` range: dashboard on `CONDUCTOR_PORT` (so Conductor's "Open" button lands on it), site preview on `+1`, live docs on `+2`. The legacy fixed bases (3000/8000/4000) remain as a fallback when running outside Conductor, and the free-port scan is retained as a guard.

## Validation

- `.conductor/settings.toml` parses cleanly with `tomllib`.
- `bash -n scripts/conductor/run.sh` passes.

No package code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)