### PR TITLE
Add triage-issue skill for issue governance

### DIFF
--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: triage-issue
+description: Use whenever auditing, clarifying, rewriting, or batch-reviewing SUEWS GitHub issue descriptions so they become maintainer-ready. Trigger for requests like "audit this issue", "make this issue agent-ready", "rewrite issue #123", "clean up open issues", "summarise comments into the issue body", "preserve the original report", or "triage SUEWS backlog". This skill preserves issue-author context, summarises discussion, drafts a clarified issue body, and requires explicit approval before editing GitHub.
+---
+
+# Triage Issue
+
+Turn workflow-originated SUEWS issues into maintainer-ready engineering work
+items without erasing the original issue author's contribution. Many good
+issues start from a real modelling/API workflow and only become technically
+clear after comments, reproductions, and maintainer discussion. Your job is to
+capture that transition.
+
+## Triggers
+
+Use this skill when the user asks to audit, clarify, rewrite, summarise,
+supersede, or batch-triage SUEWS GitHub issues. It is especially relevant when
+an issue body no longer reflects discoveries made in comments.
+
+## Capabilities
+
+- Audit an issue body against a type-specific rubric.
+- Summarise comments into maintainer-ready context.
+- Preserve the original report while drafting a clarified issue body.
+- Propose issue title, label, readiness, and follow-up changes.
+- Apply approved GitHub edits using `gh`.
+
+## Scripts
+
+No bundled script is required. Use the GitHub CLI commands below.
+
+## Quick Start
+
+Inspect one issue:
+
+```bash
+gh issue view <number> --repo UMEP-dev/SUEWS \
+  --json number,title,body,labels,assignees,state,author,comments,url,createdAt,updatedAt
+```
+
+Audit a list:
+
+```bash
+gh issue list --repo UMEP-dev/SUEWS --state open \
+  --json number,title,labels,assignees,author,updatedAt,url
+```
+
+Apply an approved rewrite:
+
+```bash
+gh issue edit <number> --repo UMEP-dev/SUEWS --body-file <approved-body.md>
+```
+
+## Safety Rules
+
+- Do not edit an issue, labels, assignment, title, or comments unless the user
+  explicitly approves that exact action.
+- Preserve the original issue body in the proposed rewrite unless the user asks
+  for a different archival strategy.
+- Treat comments as evidence, not as permission to overwrite the issue author's
+  framing silently.
+- Acknowledge issue-author contributions when triage changes the framing.
+- Do not close unclear issues only because they are unclear. Either ask for the
+  missing information, add a maintainer summary, or propose a clearer
+  superseding issue.
+- Reading or drafting is not permission to post.
+
+## Workflow
+
+1. Fetch the issue body, labels, assignees, state, comments, and linked PR
+   context needed to understand scope.
+2. Classify the issue type and readiness using `references/rubric.md`.
+3. Audit what is missing from the title/body and what has only been clarified
+   in comments.
+4. Preserve the original body, summarise the discussion, and draft a clearer
+   maintainer-ready body using `references/rewrite-template.md`.
+5. Present the audit, proposed title/body, label/status suggestions, and open
+   questions for approval.
+6. Apply approved edits with `gh issue edit --body-file`; optionally post an
+   approved explanatory comment.
+
+Read `references/methodology.md` for the full step-by-step procedure and
+output format before performing a rewrite or batch audit.
+
+## Output Format
+
+Use the single-issue and batch formats in `references/methodology.md`.
+
+## Batch Audit Guidance
+
+- Start with recently updated open issues or a bounded label set unless the user
+  explicitly asks for the whole backlog.
+- Do not attempt to rewrite many issues in one pass. First produce an audit
+  table and group follow-up actions.
+- Prioritise issues that are in progress, high priority, linked to active PRs,
+  or have long comment threads where the current body is stale.
+- Suggest follow-up categories: add reproduction, add maintainer summary,
+  clarify scope, supersede, close as duplicate, or leave as ready.
+
+## References
+
+- `references/rubric.md` - Issue type rubric and readiness statuses.
+- `references/rewrite-template.md` - Maintainer-ready body template.
+- `references/methodology.md` - Detailed audit workflow and output formats.

--- a/.claude/skills/triage-issue/references/methodology.md
+++ b/.claude/skills/triage-issue/references/methodology.md
@@ -1,0 +1,105 @@
+# Issue Triage Methodology
+
+Use this file when auditing or rewriting a SUEWS GitHub issue. It expands the
+main workflow in `SKILL.md` and keeps the operational detail close to the
+rubric and rewrite template.
+
+## Detailed Workflow
+
+1. **Fetch context**
+   - Read the issue title, body, labels, assignees, author, state, comments,
+     linked PRs if relevant, and current URL.
+   - If a PR is linked or mentioned, inspect only enough PR context to
+     understand scope; avoid drifting into full PR review.
+
+2. **Classify**
+   - Choose one issue type: bug, feature, maintenance/refactor, documentation,
+     or meta/process.
+   - Assign an issue-readiness status from `rubric.md`.
+   - Note whether the title/body still match the current understanding.
+
+3. **Audit**
+   - Identify missing elements for the issue type.
+   - Separate observed symptom, affected workflow, suspected root cause,
+     expected behaviour, actual behaviour, evidence, and acceptance criteria.
+   - Mark discoveries that are currently present only in comments.
+
+4. **Summarise comments**
+   - Summarise the discussion in chronological order when useful.
+   - Preserve who contributed important information, especially reproductions,
+     diagnosis, scope changes, or suggested fixes.
+   - Be precise about maintainers who were also reporting from a user workflow:
+     describe the role they took in that moment without reducing their project
+     role to "user".
+   - Keep the summary concise: enough for a future maintainer to understand why
+     the framing changed without rereading the whole thread.
+
+5. **Draft maintainer-ready body**
+   - Use `rewrite-template.md`.
+   - Preserve the original body under an explicit "Original report" section.
+   - Add a "Maintainer summary" that states the current framing.
+   - Add current scope, discussion summary, expected/actual behaviour,
+     reproduction/evidence, and acceptance criteria where applicable.
+   - If the original framing remains good, propose adding only a concise
+     maintainer summary instead of rewriting the full body.
+
+6. **Present for approval**
+   - Show the current title and body.
+   - Show audit result and readiness status.
+   - Show a concise comment summary.
+   - Show the proposed title/body rewrite.
+   - Show suggested labels or status changes, if any.
+   - State uncertainties or information still needed.
+   - Ask for approval before editing.
+
+7. **Apply only after approval**
+   - Use a temporary file for multi-line bodies and `gh issue edit --body-file`.
+   - Optionally post a short comment explaining that the issue body was
+     clarified from the discussion, if the user approves.
+   - Report the issue URL and what changed.
+
+## Single-Issue Output
+
+Use this format for one issue:
+
+````text
+Issue: #<number> - <title>
+Type: <bug|feature|maintenance/refactor|documentation|meta/process>
+Readiness: <ready|needs-repro|needs-scope|needs-acceptance|needs-summary|misframed|superseded|duplicate>
+
+Audit:
+- ...
+
+Discussion summary:
+- ...
+
+Suggested action:
+- ...
+
+Proposed title:
+<title or "unchanged">
+
+Proposed body:
+```markdown
+...
+```
+````
+
+## Batch Output
+
+Use a compact table for a batch audit:
+
+```text
+| Issue | Type | Readiness | Suggested action | Notes |
+|---|---|---|---|---|
+| #123 | bug | needs-repro | Ask for sample-data reproducer | Symptom clear, no actual/expected |
+```
+
+After the table, group follow-up actions as:
+
+- add reproduction
+- add maintainer summary
+- clarify scope
+- supersede
+- close as duplicate
+- leave as ready

--- a/.claude/skills/triage-issue/references/rewrite-template.md
+++ b/.claude/skills/triage-issue/references/rewrite-template.md
@@ -1,0 +1,74 @@
+# Maintainer-Ready Issue Template
+
+Use this template when proposing a rewritten SUEWS issue body. Include sections
+only when they are relevant; do not pad with empty prose. Keep the original
+issue body verbatim unless the user approves a different archival approach.
+
+```markdown
+## Maintainer summary
+
+[Clear current framing after triage. Explain the affected workflow/API and the
+root cause or current hypothesis, if known.]
+
+## Current scope
+
+[What this issue now covers. Include explicit non-goals if the discussion
+narrowed or broadened.]
+
+## Original report
+
+> [Original issue body, preserved verbatim or clearly marked.]
+
+## Discussion summary
+
+- [Comment author or role]: [relevant discovery, reproduction, clarification,
+  or scope change.]
+- [Maintainer]: [decision or proposed framing.]
+
+## Expected behaviour
+
+[What should happen.]
+
+## Actual behaviour
+
+[What happens now.]
+
+## Reproduction / evidence
+
+```bash
+# commands or minimal script, if available
+```
+
+[Observed output, linked logs, screenshots, or file references.]
+
+## Acceptance criteria
+
+- [ ] [Testable outcome.]
+- [ ] [Regression test or validation command.]
+- [ ] [Documentation or migration note, if needed.]
+```
+
+## Minimal Maintainer Summary
+
+If the original issue body is already accurate, propose a smaller edit:
+
+```markdown
+## Maintainer summary
+
+[One or two paragraphs clarifying current scope and next action.]
+
+---
+
+[Original issue body remains below.]
+```
+
+## Superseding Issue Note
+
+If the current issue should be replaced rather than rewritten, draft:
+
+```markdown
+This issue is being superseded by #NEW because the discussion clarified a
+different root-cause framing. The original report remains useful context,
+especially [specific contribution/reproduction/diagnosis]. Future work should
+continue in #NEW.
+```

--- a/.claude/skills/triage-issue/references/rubric.md
+++ b/.claude/skills/triage-issue/references/rubric.md
@@ -1,0 +1,83 @@
+# Issue Triage Rubric
+
+Use this rubric to evaluate whether a SUEWS GitHub issue is ready for
+implementation, review, or follow-up.
+
+## Issue Types
+
+### Bug
+
+Look for:
+
+- observed symptom
+- minimal reproduction, preferably with bundled sample data where possible
+- expected behaviour
+- actual behaviour
+- affected API, CLI command, config path, file format, or workflow
+- environment/version information when relevant
+- suspected root cause, if known
+- validation condition or regression test expectation
+
+### Feature
+
+Look for:
+
+- user need, scientific motivation, or workflow motivation
+- proposed behaviour
+- non-goals
+- affected API, config, CLI, documentation, or workflow surface
+- compatibility and migration considerations
+- acceptance criteria
+
+### Maintenance / Refactor
+
+Look for:
+
+- current pain point
+- behaviour that must be preserved
+- intended scope boundary
+- risks
+- validation plan
+
+### Documentation
+
+Look for:
+
+- target reader
+- current gap or confusion
+- affected documentation location
+- expected outcome
+
+### Meta / Process
+
+Look for:
+
+- process problem being solved
+- affected maintainers/contributors/workflow
+- proposed policy, tool, or skill
+- rollout plan
+- acceptance criteria
+- non-goals
+
+## Readiness Statuses
+
+- `ready`: clear enough to implement or review.
+- `needs-repro`: bug report needs a minimal reproduction.
+- `needs-scope`: feature/refactor scope needs clarification.
+- `needs-acceptance`: expected outcome is not yet testable.
+- `needs-summary`: useful context exists in comments but needs a maintainer summary.
+- `misframed`: title/body describe a downstream symptom after triage has
+  identified a clearer root cause.
+- `superseded`: should be replaced by a clearer issue.
+- `duplicate`: overlaps with an existing issue.
+
+## Framing Checks
+
+Ask:
+
+- Does the title describe the current understanding of the issue?
+- Does the body distinguish symptom from root cause where known?
+- Would a contributor know what files, API, CLI command, or docs area to inspect?
+- Can a PR author derive tests or acceptance criteria from the issue?
+- Are important discoveries currently buried only in comments?
+- If the framing changed, is the original issue author's contribution preserved?


### PR DESCRIPTION
## Summary

- Add a project-level `triage-issue` skill for auditing and clarifying SUEWS GitHub issues.
- Include a readiness/type rubric, detailed methodology, and maintainer-ready rewrite template.
- Preserve original issue reports, summarise comment discussion, and require approval before GitHub edits.

## Validation

- `python3 /Users/tingsun/.claude/skills/skill-creator/scripts/quick_validate.py .claude/skills/triage-issue`
- `source .venv/bin/activate && make dev && make test-smoke` — 9 passed, 1635 deselected, 4 warnings

Closes #1538