### PR TITLE
Fix empty CO2 RefValue YAML round-trip

### DIFF
--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -4217,10 +4217,11 @@ class SUEWSConfig(BaseModel):
         *,
         had_signature: bool = True,
     ) -> ValidationError:
-        """Transform Pydantic validation errors to use GRIDID instead of array indices.
+        """Transform Pydantic validation errors to label sites by GRIDID.
 
-        Uses structured error data to avoid string replacement collisions when
-        GRIDID values overlap with array indices (e.g., site 0 has GRIDID=1).
+        Uses structured error data to avoid string replacement collisions, and
+        formats locations as ``sites[gridiv=...]`` so a GRIDID such as 1 is not
+        mistaken for a second list item.
 
         `had_signature` carries whether the source YAML actually shipped a
         `schema_version` field. It is forwarded to `_drift_hint` so unsigned
@@ -4247,19 +4248,6 @@ class SUEWSConfig(BaseModel):
         modified_errors = []
         for err in error.errors():
             err_copy = err.copy()
-            loc_list = list(err_copy["loc"])
-
-            # Replace numeric site index with GRIDID in location tuple
-            if (
-                len(loc_list) >= 2
-                and loc_list[0] == "sites"
-                and isinstance(loc_list[1], int)
-            ):
-                site_idx = loc_list[1]
-                if site_idx in site_gridid_map:
-                    loc_list[1] = site_gridid_map[site_idx]
-
-            err_copy["loc"] = tuple(loc_list)
             modified_errors.append(err_copy)
 
         # Format into readable message
@@ -4268,7 +4256,7 @@ class SUEWSConfig(BaseModel):
         ]
 
         for err in modified_errors:
-            loc_str = ".".join(str(x) for x in err["loc"])
+            loc_str = cls._format_validation_loc(err["loc"], site_gridid_map)
             error_lines.append(loc_str)
             error_lines.append(
                 f"  {err['msg']} [type={err['type']}]"
@@ -4294,6 +4282,29 @@ class SUEWSConfig(BaseModel):
 
         error_msg = "\n".join(error_lines)
         raise ValueError(f"SUEWS Configuration Validation Error:\n{error_msg}")
+
+    @staticmethod
+    def _format_validation_loc(loc: tuple, site_gridid_map: dict) -> str:
+        """Format a Pydantic error location with explicit site GRIDID labels."""
+        parts = []
+        index = 0
+        while index < len(loc):
+            item = loc[index]
+            if (
+                item == "sites"
+                and index + 1 < len(loc)
+                and isinstance(loc[index + 1], int)
+            ):
+                site_idx = loc[index + 1]
+                if site_idx in site_gridid_map:
+                    parts.append(f"sites[gridiv={site_gridid_map[site_idx]}]")
+                else:
+                    parts.append(f"sites[{site_idx}]")
+                index += 2
+                continue
+            parts.append(str(item))
+            index += 1
+        return ".".join(parts)
 
     @classmethod
     def _drift_hint(

--- a/src/supy/data_model/core/type.py
+++ b/src/supy/data_model/core/type.py
@@ -5,7 +5,7 @@ from pydantic import (
     Field,
     field_validator,
     model_validator,
-    field_serializer,
+    model_serializer,
 )
 import numpy as np
 import pandas as pd
@@ -110,6 +110,17 @@ class RefValue(BaseModel, Generic[T]):
                 return self.value
         # For other modes, use default behavior
         return super().model_dump(**kwargs)
+
+    @model_serializer(mode="wrap")
+    def _serialize_with_value_key(self, handler, info):
+        """Keep ``value: null`` in nested dumps for schema-valid YAML."""
+        if info.mode == "json" and self.value is None:
+            data = {"value": None}
+            if self.ref is not None or not info.exclude_none:
+                data["ref"] = self.ref
+            return data
+
+        return handler(self)
 
     @classmethod
     def wrap(cls, value: Union[T, "RefValue[T]"]) -> "RefValue[T]":

--- a/test/data_model/test_data_model.py
+++ b/test/data_model/test_data_model.py
@@ -389,7 +389,7 @@ class TestLegacyDfStateStebbsDefaults(unittest.TestCase):
 
 
 class TestGrididErrorTransformation(unittest.TestCase):
-    """Test GRIDID transformation in validation error messages."""
+    """Test explicit GRIDID labels in validation error messages."""
 
     def setUp(self):
         """Set up test environment."""
@@ -408,7 +408,10 @@ class TestGrididErrorTransformation(unittest.TestCase):
         import yaml
 
         sites = [
-            {"gridiv": gid, "properties": {"lat": None if i == 0 else 51.5, "lng": 0.0}}
+            {
+                "gridiv": gid,
+                "properties": {"lat": None if i == 0 else 51.5, "lng": 0.0},
+            }
             for i, gid in enumerate(gridid_values)
         ]
         config_path = Path(self.temp_dir) / "config_test.yml"
@@ -421,8 +424,10 @@ class TestGrididErrorTransformation(unittest.TestCase):
 
         Tests the bug fix for string replacement collision:
         Site 0 with GRIDID=1, Site 1 with GRIDID=200.
-        Old approach would replace sites.0 -> sites.1, then sites.1 -> sites.200,
-        resulting in site 0's error showing as sites.200 incorrectly.
+        Old approach replaced sites.0 -> sites.1, then sites.1 -> sites.200,
+        resulting in site 0's error showing as sites.200 incorrectly. The
+        current output labels GRIDID explicitly so it cannot be read as an
+        array index.
         """
         config_path = self._create_invalid_config([1, 200])
 
@@ -430,11 +435,12 @@ class TestGrididErrorTransformation(unittest.TestCase):
             SUEWSConfig.from_yaml(config_path)
 
         error_msg = str(cm.exception)
-        # Only site 0 (GRIDID=1) has invalid data, so should see sites.1
-        self.assertIn("sites.1", error_msg)
+        # Only site 0 (GRIDID=1) has invalid data.
+        self.assertIn("sites[gridiv=1]", error_msg)
         # Should NOT see sites.200 (site 1 is valid)
         self.assertNotIn("sites.200", error_msg)
-        # Should NOT see sites.0 (array index should be replaced with GRIDID)
+        # Should NOT show an ambiguous dotted index/GRIDID location.
+        self.assertNotIn("sites.1", error_msg)
         self.assertNotIn("sites.0", error_msg)
 
     def test_gridid_substring_collision(self):
@@ -450,17 +456,20 @@ class TestGrididErrorTransformation(unittest.TestCase):
 
         error_msg = str(cm.exception)
         # Only site 0 (GRIDID=10) has invalid data
-        self.assertIn("sites.10", error_msg)
+        self.assertIn("sites[gridiv=10]", error_msg)
         # Should NOT see sites.100 (site 1 is valid)
         self.assertNotIn("sites.100", error_msg)
-        # Should NOT see sites.0 (array index should be replaced)
+        # Should NOT show an ambiguous dotted index/GRIDID location.
+        self.assertNotIn("sites.10", error_msg)
         self.assertNotIn("sites.0", error_msg)
 
     def test_gridid_refvalue_format(self):
         """Test GRIDID extraction from RefValue format."""
         import yaml
 
-        sites = [{"gridiv": {"value": 777}, "properties": {"lat": None, "lng": 0.0}}]
+        sites = [
+            {"gridiv": {"value": 777}, "properties": {"lat": None, "lng": 0.0}}
+        ]
         config_path = Path(self.temp_dir) / "config_refvalue.yml"
         with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump({"name": "Test", "sites": sites}, f)
@@ -468,7 +477,7 @@ class TestGrididErrorTransformation(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             SUEWSConfig.from_yaml(config_path)
 
-        self.assertIn("sites.777", str(cm.exception))
+        self.assertIn("sites[gridiv=777]", str(cm.exception))
 
 
 if __name__ == "__main__":

--- a/test/data_model/test_to_yaml_roundtrip.py
+++ b/test/data_model/test_to_yaml_roundtrip.py
@@ -11,6 +11,7 @@ import pytest
 import yaml
 from supy._env import trv_supy_module
 from supy.data_model.core.config import SUEWSConfig
+from supy.data_model.core.type import RefValue
 from supy.data_model.validation.pipeline.phase_a import find_extra_parameters
 
 pytestmark = pytest.mark.api
@@ -155,3 +156,60 @@ class TestToYamlRoundTrip:
         assert reloaded.sites[0].initial_states.qn_surfs == [1.0] * 7
 
         Path(tmp_path).unlink(missing_ok=True)
+
+    def test_refvalue_none_co2_fields_round_trip(self, sample_config, tmp_path):
+        """Unused CO2 RefValue fields should not serialise as empty mappings."""
+        # ARRANGE
+        co2 = sample_config.sites[0].properties.anthropogenic_emissions.co2
+        fields = [
+            "co2pointsource",
+            "ef_umolco2perj",
+            "enef_v_jkm",
+            "trafficunits",
+        ]
+        for field in fields:
+            setattr(co2, field, RefValue(None))
+
+        path_out = tmp_path / "roundtrip.yml"
+
+        # ACT
+        sample_config.to_yaml(path_out)
+        saved = yaml.safe_load(path_out.read_text(encoding="utf-8"))
+        reloaded = SUEWSConfig.from_yaml(path_out)
+
+        # ASSERT
+        saved_co2 = saved["sites"][0]["properties"]["anthropogenic_emissions"]["co2"]
+        reloaded_co2 = reloaded.sites[0].properties.anthropogenic_emissions.co2
+        for field in fields:
+            assert saved_co2[field] == {"value": None}
+            assert getattr(reloaded_co2, field).value is None
+
+    def test_refvalue_none_land_cover_co2_fields_round_trip(
+        self, sample_config, tmp_path
+    ):
+        """CO2-related vegetated land-cover fields should share the same contract."""
+        # ARRANGE
+        land_cover = sample_config.sites[0].properties.land_cover
+        surface_types = ["evetr", "dectr", "grass"]
+        for surface_type in surface_types:
+            surface = getattr(land_cover, surface_type)
+            surface.alpha_enh_bioco2 = RefValue(None)
+
+        path_out = tmp_path / "land-cover-roundtrip.yml"
+
+        # ACT
+        sample_config.to_yaml(path_out)
+        saved = yaml.safe_load(path_out.read_text(encoding="utf-8"))
+        reloaded = SUEWSConfig.from_yaml(path_out)
+
+        # ASSERT
+        saved_land_cover = saved["sites"][0]["properties"]["land_cover"]
+        reloaded_land_cover = reloaded.sites[0].properties.land_cover
+        for surface_type in surface_types:
+            assert saved_land_cover[surface_type]["alpha_enh_bioco2"] == {
+                "value": None
+            }
+            assert (
+                getattr(reloaded_land_cover, surface_type).alpha_enh_bioco2.value
+                is None
+            )


### PR DESCRIPTION
## Summary
- serialise nested `RefValue(None)` as `value: null` so `SUEWSConfig.to_yaml()` no longer writes schema-invalid empty mappings
- label validation paths with explicit `sites[gridiv=...]` locations to avoid confusing GRIDID with list index
- add regressions for anthropogenic CO2 fields and vegetated land-cover CO2 fields

Fixes #1532.

## Validation
- `uv run --extra dev --no-editable python -m pytest test/data_model/test_to_yaml_roundtrip.py -q`
- `uv run --extra dev --no-editable python -m pytest test/data_model/test_data_model.py::TestGrididErrorTransformation test/data_model/test_physics_orthogonal.py::test_model_physics_orthogonal_dumps_to_flat test/data_model/test_physics_orthogonal.py::test_model_physics_accepts_orthogonal_emissions_and_dumps_flat test/data_model/test_nested_physics.py -q`
- `PATH="/Users/tingsun/.codex/worktrees/21fc/suews/.venv/bin:$PATH" make test-smoke`