### PR TITLE
Add autonomous issue-to-PR workflow (skills, sizing rules, contract)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -30,6 +30,7 @@ This directory contains all Claude Code-specific documentation, plans, and confi
 ├── skills/                # Action-oriented workflows (invoked via /skill-name)
 │   ├── audit-pr/          # PR review orchestrator
 │   ├── examine-issue/     # Issue analysis
+│   ├── fix-issue/         # Issue-to-PR workflow
 │   ├── lint-code/         # Code style (references rules/)
 │   ├── log-changes/       # CHANGELOG management
 │   ├── prep-release/      # Release preparation
@@ -38,7 +39,9 @@ This directory contains all Claude Code-specific documentation, plans, and confi
 │   ├── sync-docs/         # Doc-code consistency
 │   ├── republish-docs/    # Republish/revise released docs (clean anchor)
 │   ├── verify-build/      # Build config checks
-│   └── queue-pr/         # PR coordination and merge queue preflight
+│   ├── queue-pr/          # PR coordination and merge queue preflight
+│   ├── triage-issue/      # Issue governance (audit/rewrite/split)
+│   └── split-pr/          # Carve an oversized PR into a stacked series
 │
 ├── reference/             # Templates and static reference
 │   └── templates/         # Reusable templates
@@ -79,7 +82,10 @@ Skills perform specific workflows when invoked via `/skill-name`. Each skill has
 
 - `/start-work` - **Entry point** for all workflows (feature, bugfix, release, docs, refactoring, CI/build)
 - `/audit-pr <PR>` - Review a pull request comprehensively
+- `/split-pr <PR>` - Carve an oversized PR into a stacked series of small PRs
 - `/examine-issue <issue>` - Analyse a GitHub issue
+- `/triage-issue <issue>` - Audit, rewrite, or split an issue (governance)
+- `/fix-issue <issue>` - Triage and implement an issue to PR-ready status
 - `/lint-code` - Check code style
 - `/log-changes` - Update CHANGELOG
 - `/prep-release` - Prepare release
@@ -105,6 +111,11 @@ start-work ──────────┬── examine-issue (analysis)
    selector)          ├── prep-release (release workflow)
                       └── verify-build (CI/build workflow)
 
+fix-issue ────────────┬── triage-issue (readiness)
+  (issue to PR)       ├── lint-code / sync-docs / verify-build
+                      ├── log-changes
+                      └── audit-pr (PR readiness)
+
 prep-release ────────┬── verify-build (pre-flight)
                      ├── sync-docs (pre-flight)
                      ├── lint-code (pre-flight)
@@ -125,6 +136,7 @@ pre-commit hook ─────┬── ruff (Python)
 ## Quick Navigation
 
 - **"Start a new task"** -> `/start-work`
+- **"Fix a GitHub issue"** -> `/fix-issue <issue>`
 - **"How do I set up my environment?"** -> `/setup-dev`
 - **"Check my code style"** -> `/lint-code`
 - **"Update the CHANGELOG"** -> `/log-changes`

--- a/.claude/rules/autonomous-workflow.md
+++ b/.claude/rules/autonomous-workflow.md
@@ -1,0 +1,137 @@
+# Autonomous Issue to PR to Merge Workflow Contract
+
+The contract that lets the SUEWS issue and PR skills compose into one autonomous
+pipeline, runnable in SOLO mode (one item at a time) or BATCH mode (a bounded set
+at once). It defines the stages, the machine-readable handoffs between them, the
+two execution modes, and the gating that keeps every irreversible or
+outward-facing action behind a human approval.
+
+This rule ties the pieces together; each stage's detail lives in its own skill.
+Read it alongside `work-sizing.md` (sizing and umbrella decomposition).
+
+---
+
+## Stages
+
+1. `triage-issue` -- issue governance. Emits a `[triage-issue] verdict` block.
+2. `fix-issue` -- one triaged issue to a PR-ready branch. Consumes the verdict
+   block; emits a `[fix-issue] PR-ready report`.
+3. `audit-pr` -- reviews the PR; runs a Size Gate first. Emits `Verdict`,
+   `Size gate`, and per-finding `[severity]` tags.
+4. `split-pr` -- carves an oversized PR into a stacked series. Emits a
+   `[split-pr] stack plan`. Invoked when audit-pr's Size Gate recommends a split.
+5. `queue-pr` -- orders ready PRs and (human-gated) enters the merge queue.
+
+`work-sizing.md` is the shared sizing authority for the four issue/PR skills
+(stages 1-4: triage-issue, fix-issue, audit-pr, split-pr). queue-pr orders ready
+PRs and does not itself apply the sizing criteria.
+
+---
+
+## Handoff vocabulary (machine-readable)
+
+Each stage ends with a parseable block so the next stage or orchestrator branches
+without reading prose:
+
+- triage-issue -> fix-issue: `Verdict: triaged|needs-discussion|skipped`,
+  `Readiness:`, `Applied:`, `Blocking question:`, `Next:`. fix-issue proceeds on
+  any `Verdict: triaged` (which triage-issue derives from `ready`, `needs-summary`,
+  or a `misframed` issue resolved to triaged via a gated rewrite); every
+  `needs-discussion` (which absorbs needs-repro / needs-scope / needs-acceptance /
+  superseded / duplicate) does NOT implement. `skipped` is a batch-coverage
+  accounting verdict, never handed to fix-issue as an implementation input.
+  `Applied:` drives the batch coverage split; `Blocking question:` / `Next:` carry
+  the needs-discussion reason fix-issue echoes.
+- needs-split -> umbrella decomposition (`work-sizing.md`), not implementation.
+  The five-stage pipeline terminates here at "umbrella proposed"; a human creates
+  the umbrella and sub-issues, and sweeping the resulting waves is outside this
+  contract (each child re-enters the pipeline as its own issue).
+- fix-issue -> audit-pr / merge: `[fix-issue] PR-ready report` with `Audit loop:`
+  and `Remaining:`. fix-issue terminates at PR-ready; it never merges.
+- audit-pr -> fix-issue / split-pr: `Verdict: clean|needs-attention`,
+  `Size gate: pass|split-recommended`, per-finding `[severity]`. fix-issue's audit
+  loop branches on these; `split-recommended` routes to split-pr.
+- split-pr -> queue-pr: `[split-pr] stack plan` with `Completeness:` and
+  `Concerns -> Children`.
+
+---
+
+## Execution modes
+
+### Solo
+
+One issue or PR at a time, a human typically present. A stage may pause for
+approval and resume. This is the default and the safe baseline.
+
+### Batch
+
+A bounded set processed unattended. Additional requirements over solo:
+
+- Bound the input explicitly and surface it. Every batch stage emits a `Scope:`
+  line (filter, returned/total, truncation flag) so a silent cap cannot read as
+  full coverage. Never rely on a tool's default limit.
+- Idempotency. triage-issue marks processed issues with `0-auto:audited`; batch
+  re-runs skip the redundant work for issues that carry it and have not been
+  updated since. An idempotency-skipped issue is still counted as triaged-noop in
+  the aggregate, never as `skipped`.
+- Coverage accounting. The batch aggregate partitions the returned set K and must
+  sum to it: triaged-applied + triaged-noop + needs-discussion + skipped = K. Full
+  backlog coverage holds only when `truncated: no`; otherwise the (total - K)
+  issues beyond the limit remain unswept.
+- No silent drop. An item that cannot be processed is recorded `skipped` with a
+  reason.
+- Bounded loops. Any review -> revise -> re-review loop follows
+  `.claude/rules/review-convergence.md`: a round cap, a signature-based
+  oscillation guard, and an explicit termination criterion so one item cannot
+  consume the batch. fix-issue's audit loop (cap 3) is the per-PR instance.
+
+---
+
+## Gating model
+
+Every stage partitions its actions into three tiers:
+
+- Auto-applicable: additive, reversible, read-only, or self-scoped. May run
+  unattended (e.g. triage-issue's maintainer-summary comment plus label; audit-pr's
+  read-only review and verdict computation -- drafting only, posting any comment is
+  human-gated per the always-human-gated list below; queue-pr's scan and ordering).
+- Confidence-gated: applied unattended only when stated gates hold, else escalate
+  (e.g. triage-issue's body-rewrite and retitle, which must preserve the original
+  report and raiser).
+- Human-gated: never auto-applied; the autonomous terminal is escalate-to-human.
+
+The following are ALWAYS human-gated, in every stage and both modes:
+
+- Merging or enqueuing a PR (`queue-pr --enqueue` / any `gh pr merge`).
+- Closing, superseding, or marking an issue duplicate.
+- Creating issues or parent/child links (umbrella decomposition).
+- Pushing to a branch the agent did not create this run (including any force-push
+  or rewrite), or editing the body/metadata of a PR you do not own.
+- Posting to a reporter or onto a PR you do not own.
+- Any structural schema/data-model migration.
+
+Privacy is a hard invariant on every outward write: no internal tracker IDs,
+absolute local paths, or private host names reach a public issue / PR / comment /
+commit. Scrub model-authored distilled text; force escalation on a hit inside
+preserved verbatim content.
+
+---
+
+## The merge gate
+
+The pipeline's terminal action -- merge -- is always a separate, explicitly
+approved step. fix-issue stops at PR-ready; split-pr hands a stack to queue-pr;
+queue-pr enters the merge queue only on explicit per-run approval. Handing work
+downstream never transfers merge authority. An autonomous batch run therefore
+converges to "PRs ready plus verdicts emitted", and a human authorises the merge.
+
+---
+
+## The 0-auto:audited label
+
+A repo label in the `0-` automation namespace marking that an autonomous pass has
+processed an issue. triage-issue applies it (if it exists) to every issue reaching
+a `triaged` or `needs-discussion` verdict; batch mode queries it to skip
+already-processed issues unless updated since. It is bookkeeping, so it is not
+counted as substantive work in the `Applied:` field. A maintainer creates the
+label once; the autonomous tier never creates labels.

--- a/.claude/rules/fortran/conventions.md
+++ b/.claude/rules/fortran/conventions.md
@@ -44,6 +44,22 @@ Conventions for SUEWS Fortran source files.
 
 ---
 
+## Code Size (heuristics, not gates)
+
+- **One module per file.** The `suews_<category>_<name>.f95` naming implies a
+  single primary module per file; do not accumulate unrelated modules in one file.
+- **Keep procedures focused.** Aim to keep a new subroutine/function to a single
+  calculation, roughly a few hundred lines at most; extract helpers rather than
+  growing one procedure. The legacy giants (e.g. the driver output packing) are
+  migration debt, not a template.
+- **Prefer derived types over long argument lists.** Bundle related state into a
+  `dts_*` type and pass that, instead of adding more positional arguments; flag
+  procedures with very many arguments for a derived-type refactor.
+- A change that only stays small by editing an oversized procedure is a signal to
+  split off a preparatory refactor first (see `.claude/rules/work-sizing.md`).
+
+---
+
 ## Examples
 
 ```fortran

--- a/.claude/rules/python/conventions.md
+++ b/.claude/rules/python/conventions.md
@@ -108,6 +108,23 @@ SUEWS-specific Python conventions. Complements ruff for standard linting.
 
 ---
 
+## Code Size (heuristics, not gates)
+
+- **Single-responsibility functions.** Keep functions focused and small (aim well
+  under ~75 lines); extract helpers rather than nesting deeply. ruff complexity
+  lints apply where configured.
+- **Cohesive modules.** Split a module that has grown to cover several unrelated
+  responsibilities; prefer several small modules over one catch-all.
+- **Modest argument counts.** Combined with the config-separation rule above,
+  prefer small, explicit signatures; pass plain values, not config objects.
+- **Exemptions.** Pydantic data-model classes with long field enumerations and
+  generated files (`_suews_driver.py`, `_version.py`) are exempt from the
+  function/module-length heuristics.
+- A fix that only stays small by editing an oversized function is a signal to
+  split off a preparatory refactor first (see `.claude/rules/work-sizing.md`).
+
+---
+
 ## Examples
 
 ```python

--- a/.claude/rules/review-convergence.md
+++ b/.claude/rules/review-convergence.md
@@ -1,0 +1,68 @@
+# Review-Revise Convergence Loop
+
+A reusable discipline for any iterative review -> revise -> re-review loop: PR
+audits, skill/rule authoring, documentation review, or revision against a feedback
+stream. It exists so the loop converges on a written criterion instead of running
+forever or stopping by feel. An iterative loop without a defined termination
+condition is a defect, not a process.
+
+This generalises `fix-issue`'s "Audit, Address, Re-Audit" loop; that step is one
+instance of the procedure below.
+
+---
+
+## The loop
+
+1. **Review** -- produce findings. The reviewer may be a single pass (a human, or
+   `audit-pr`) or an adversarial fan-out (several reviewers across dimensions, each
+   finding independently verified by a skeptic before it counts). Every confirmed
+   finding carries a severity (`blocking | major | minor | nit`) and a stable
+   signature (file + location + problem).
+2. **Triage and apply** -- apply confirmed blocking/major findings and cheap
+   minors. For any finding needing design, scientific, or human judgement, do NOT
+   guess: escalate and stop (see Escalation).
+3. **Re-review** -- run the next round over the revised artefact.
+4. **Test for convergence** (below). If converged, stop and report; otherwise go
+   to step 2.
+
+---
+
+## Convergence criterion (stop when ANY holds)
+
+- **Clean round**: a round yields zero confirmed blocking/major findings and
+  introduces no new finding class (only nits, or minors already judged
+  acceptable, remain).
+- **Diminishing returns**: confirmed findings strictly decrease round over round
+  and the remainder are all minors/nits explicitly judged acceptable.
+- **Round cap**: a hard cap (default 3-4 rounds). At the cap, stop and log every
+  remaining finding as accepted or deferred -- never silently.
+- **Escalation**: any round surfaces a finding needing human/design/scientific
+  judgement -> stop and hand it back.
+
+## Oscillation guard
+
+Track finding signatures across rounds. If a finding with the same signature
+reappears after a fix (the fix did not take, or each fix spawns the same class),
+stop and escalate rather than loop -- the same signature-based early exit
+`fix-issue` uses.
+
+## No silent termination
+
+At convergence, report: rounds run, the confirmed-per-round trend, what was
+applied, and what remains (accepted / deferred / escalated) with reasons. A loop
+that ends without stating the remainder reads as "all clean" when it may not be.
+
+---
+
+## Relation to other rules and skills
+
+- `fix-issue` step 5 is the per-PR instance: `audit-pr` is the reviewer, 3
+  iterations is the cap, signature recurrence is the early exit.
+- For multi-artefact or skill/rule authoring, the reviewer is typically an
+  adversarial fan-out (review -> independent verify -> confirmed) and the same
+  criterion applies.
+- In autonomous or batch mode the loop MUST be bounded by the cap and escalate
+  rather than spin, matching the "bounded loops" requirement in
+  `autonomous-workflow.md`.
+- Smaller units converge faster: keep the artefact under review right-sized
+  (`work-sizing.md`).

--- a/.claude/rules/rust/conventions.md
+++ b/.claude/rules/rust/conventions.md
@@ -105,6 +105,22 @@ The bridge marshals data between Fortran flat arrays and typed Rust structs:
 
 ---
 
+## Code Size (heuristics, not gates)
+
+- **One concern per module.** Follow the existing layout: each responsibility has
+  its own file (`ffi.rs`, `codec.rs`, `sim.rs`, ...), and each new state or
+  parameter type gets its own `<name>_state.rs` / `<name>_prm.rs` (see "Adding a
+  New State Type"). Do not accumulate unrelated types in one module.
+- **Small functions.** Keep functions focused. Run locally, `cargo clippy` warns
+  on `too_many_arguments` (>7 args) by default; cognitive-complexity is a
+  `nursery` lint you must opt into (`cargo clippy -- -W clippy::cognitive_complexity`
+  or a `[lints]` entry). Use these as informal signals -- nothing in CI or the
+  Makefile currently runs clippy, so it is not an automated gate.
+- A change that only stays small by editing an oversized module is a signal to
+  split off a preparatory refactor first (see `.claude/rules/work-sizing.md`).
+
+---
+
 ## Key Rules
 
 - **Never bypass the codec** -- all Fortran data access goes through `StateCodec` traits, not raw pointer arithmetic

--- a/.claude/rules/work-sizing.md
+++ b/.claude/rules/work-sizing.md
@@ -1,0 +1,146 @@
+# Right-Sizing Issues and Pull Requests
+
+Criteria for scoping a GitHub issue or pull request to a single, reviewable,
+revertible unit of work. Used by the issue and PR skills (`triage-issue`,
+`fix-issue`, `audit-pr`, `split-pr`) and applicable to any session that opens an
+issue or PR.
+
+This is guidance, not a mechanical gate. The goal is work that one person can
+understand, review, and revert in isolation. Prefer small and coherent over large
+and bundled.
+
+---
+
+## A right-sized issue
+
+A good issue is one actionable concern with a clear "done":
+
+- Describes a single problem or change, not a list of separable deliverables.
+- Has an acceptance criterion (or a small, coherent set) a PR author can test
+  against.
+- Points a contributor at the files, API, CLI, or docs area to inspect.
+- Can land as one focused PR, or as a short ordered series of independently
+  mergeable PRs.
+- Is self-contained: it does not require resolving unrelated decisions first.
+
+### Split it (readiness `needs-split`) when
+
+- It conflates multiple independent bugs, or a bug plus a feature.
+- Its acceptance criteria read as a checklist of deliverables that could ship
+  separately.
+- The framing is "and also / while we are here / epic / umbrella".
+- It spans several subsystems that could be fixed independently.
+- The resulting PR could not be reviewed in one sitting (see PR sizing below).
+- It is blocked on several unrelated decisions.
+
+On split: keep the original issue as the parent/umbrella, decompose into focused
+child issues, link them with GitHub native sub-issues (not body mentions), and
+preserve the original report and raiser attribution on the parent. Creating the
+children is a human-gated decision (see `triage-issue`).
+
+### Do not over-split
+
+- A trivial typo or one-line fix does not need its own tracking issue; just fix
+  it (batch related trivia).
+- Children must each be independently meaningful; do not slice one atomic change
+  into fragments that cannot stand alone.
+
+---
+
+## A right-sized PR
+
+A good PR is one logical change addressing one issue (or one coherent slice):
+
+- Explainable in a sentence or two; reviewable in a single pass.
+- Code, tests, and docs for that one change travel together.
+- No unrelated drive-by edits, reformatting, or opportunistic refactors.
+- Independently correct and revertible: it builds and passes CI on its own.
+- Minimal cross-subsystem blast radius.
+
+Soft heuristic: aim for a focused diff a reviewer can hold in their head (roughly
+a few hundred lines of meaningful change). Mechanical or generated diffs
+(formatting sweeps, regenerated artefacts, large fixture updates) do not count
+against this, but isolate them in their own commits or PRs so the semantic change
+stays small and reviewable.
+
+### Split it when
+
+- It mixes a refactor, a behaviour change, and formatting in one diff.
+- It bundles multiple unrelated fixes on one branch.
+- The description needs headed sections to explain unrelated parts.
+- A schema/data-model change is entangled with an unrelated feature (schema bumps
+  already warrant a dedicated change; see `python/schema-versioning.md` and the
+  "one PR per logical group" rule in `naming-convention.md`).
+- Review stalls because the reviewer cannot assess it as a whole.
+
+Prefer a stacked series of small PRs over one large branch: each PR independently
+mergeable, all tracked under the parent issue.
+
+### Do not over-split
+
+- Do not break one atomic change into PRs that fail to build or test on their
+  own. Each PR must leave the tree green.
+
+### Code granularity (language-specific)
+
+PR size is downstream of how the code is factored. A change lands small and
+reviewable when functions, files, and modules are themselves right-sized, and
+what "right-sized" means is language-specific. Apply the per-language size
+guidance, which loads with each language's conventions:
+
+- Fortran: `fortran/conventions.md` (one module per file, focused procedures,
+  derived types over long argument lists).
+- Python: `python/conventions.md` (single-responsibility functions, cohesive
+  modules).
+- Rust bridge: `rust/conventions.md` (one concern per module, small functions;
+  `cargo clippy`, run locally, warns on `too_many_arguments` by default -- clippy
+  is not wired into the Makefile or CI, so it is not an automated gate).
+
+If a fix only stays small by editing an oversized function or god-module, prefer a
+small preparatory refactor PR first, then the fix on top.
+
+---
+
+## Umbrella decomposition for large splits
+
+When a `needs-split` issue decomposes into several related children, structure it
+as a parent umbrella plus sub-issues so a human (or an automated runner that
+consumes this umbrella format) can sweep them in order. The SUEWS pipeline itself
+stops at "umbrella proposed"; creating the umbrella and running the waves is
+outside its five stages. Structure:
+
+- The parent issue carries the maintainer summary, the overall "done", and the
+  preserved original report and raiser attribution.
+- Each child is a focused, independently mergeable sub-issue, linked to the parent
+  with GitHub native sub-issues (not body mentions).
+- Record the children as a checklist on the parent (`- [ ] #N <task-id>: <title>`)
+  and group them into dependency-ordered waves: each wave is a set of children
+  with no unmet dependency on a later wave.
+- Label each child by work nature (for example a mechanical vs design-sensitive
+  distinction) and mark any child that must pause the sweep before its wave runs.
+- A status diagram (for example a mermaid graph with todo/wip/done/blocked
+  classes) on the parent is optional but helps track wave progress.
+
+Creating the umbrella and children is human-gated (see `triage-issue`); propose
+the structure and apply only after approval.
+
+---
+
+## Default relationships
+
+- One issue -> one PR is the default.
+- One large issue -> an ordered series of small PRs (stacked), each independently
+  mergeable, tracked under the parent.
+- Avoid many issues -> one PR; bundle only trivially related changes.
+
+## Where this is checked
+
+- `triage-issue`: assigns `needs-split` and proposes the decomposition at triage
+  time.
+- `fix-issue`: if a fix balloons mid-implementation, stop and propose a split
+  rather than growing the PR.
+- `audit-pr`: assesses PR size up front (Size Gate) and recommends a split before
+  reviewing an oversized or bundled PR.
+- `split-pr`: executes an approved PR split, carving a fat branch into a verified
+  stack of independently-green PRs (completeness-checked), then hands off to
+  `queue-pr`.

--- a/.claude/skills/audit-pr/SKILL.md
+++ b/.claude/skills/audit-pr/SKILL.md
@@ -14,9 +14,29 @@ gh pr view {pr} --json number,title,files,commits
 gh pr diff {pr} --name-only
 ```
 
+## Size Gate (run first)
+
+Before the detailed review, assess the review surface. If the PR is too large to
+review well in one pass, or bundles unrelated concerns, lead with a split
+recommendation instead of spending the review on an unreviewable diff:
+
+- Check diff scope: `gh pr diff {pr} --name-only` plus additions/deletions per
+  file. Watch for a large meaningful diff, many touched subsystems, or a mix of
+  refactor + behaviour change + formatting.
+- Apply `.claude/rules/work-sizing.md`. If the PR fails the right-sized-PR test,
+  recommend splitting it (a stacked series of small PRs, or carving out
+  mechanical/generated changes first) before review. PR size relates to
+  function/file/module granularity and the language conventions.
+- State the proposed split concretely: which files/concerns go in which PR, and
+  the suggested order. This is a recommendation; do not rewrite the branch.
+- A best-effort review may still follow if the author prefers, but the size
+  recommendation comes first.
+- To carry out the split, hand off to `split-pr`; audit-pr only recommends.
+
 ## Workflow
 
 - **Context**: Gather files, classify changes
+- **Size gate (first)**: see "Size Gate" above -- recommend a split before reviewing an oversized or bundled PR
 - **Code Style**: lint-code
 - **Scientific**: Physics validation (if applicable)
 - **Testing**: Coverage, FIRST principles
@@ -69,6 +89,8 @@ Details: `references/style-checks.md`
 
 === DRAFT SUMMARY ===
 **Status**: Needs attention / Ready
+Verdict: clean | needs-attention
+Size gate: pass | split-recommended
 
 | Category | Status |
 |----------|--------|
@@ -78,7 +100,10 @@ Details: `references/style-checks.md`
 | Docs | PASS/FAIL |
 
 ### Key Findings
-- [issues list]
+- [severity] finding (severity = blocking | major | minor | false-positive)
+
+The `Verdict`, `Size gate`, and per-finding `[severity]` tags are the fields a
+consuming skill (e.g. `fix-issue` step 5) branches on; keep them explicit.
 
 ### Suggested Reviewers
 @reviewer (module:name)
@@ -87,6 +112,34 @@ Details: `references/style-checks.md`
 ## Approval Options
 
 `approve` | `approve with edits` | `skip line comments` | `cancel`
+
+## Privacy scrub gate
+
+Before drafting any line comment or summary, scan the model-authored finding text
+(problem descriptions, summary, reviewer notes) for internal tracker IDs
+(`PER-\d+` and similar), absolute local/home paths (`/Users/...`,
+worktree/internal-tooling paths), and private host names (internal compute
+servers and the like). Redact these in distilled text. If a private token appears inside a
+verbatim quote pulled from the diff, CI log, or stack trace that must be preserved
+to make the finding actionable, replace it with neutral phrasing or escalate
+rather than post as-is. This operationalises the "Privacy is a hard invariant on
+every outward write" rule in `.claude/rules/autonomous-workflow.md`.
+
+## Autonomous Mode
+
+audit-pr is a read-only review stage in the issue -> PR -> merge pipeline. Under
+an autonomous orchestrator it NEVER posts to GitHub; its terminal output is the
+drafted review plus the machine-readable handoff block (`Verdict`, `Size gate`,
+per-finding `[severity]`).
+
+- Auto-applicable (read-only / self-scoped): gather context, run the Size Gate,
+  perform the review, and emit the verdict block. This review-and-emit tier is the
+  only one an opt-in standing approval can cover.
+- Human-gated, always escalate (never auto-applied, in any mode): posting any line
+  comment or review onto the PR. The "Wait for human confirmation" step is NOT
+  satisfied by a batch standing approval; there is no standing approval for
+  posting. The autonomous terminal is escalate-with-draft, the same shape as
+  `triage-issue`'s needs-discussion and `queue-pr`'s merge escalation.
 
 ## References
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: fix-issue
+description: Use whenever the user wants to fix a SUEWS GitHub issue into a validated, PR-ready branch. Trigger for requests like "fix issue #1534", "work this SUEWS bug into a PR", "take issue #1534 to PR-ready", "implement this issue", "turn this issue into a fix", or "drive this issue to a pull request". This skill starts from triage, implements the smallest scoped fix with tests, creates or updates the PR, runs an iterative audit-pr/address/re-audit loop until no valid audit issues remain, and stops at PR-ready status; it does not merge.
+---
+
+# Fix Issue
+
+Take one SUEWS GitHub issue from maintainer-ready understanding to a validated,
+PR-ready branch. Reuse the repo skills that already cover each stage.
+
+The terminal state is **PR-ready**, not merged. Do not report PR-ready while
+`audit-pr` still identifies unresolved valid issues.
+
+## Triggers
+
+- Use for: "fix issue #1534", "work this SUEWS bug into a PR", "take issue
+  #1534 to PR-ready", "implement this issue", or "turn this issue into a fix".
+- If the user only asks to audit, clarify, rewrite, or summarise an issue, use
+  `triage-issue` instead.
+
+## Capabilities
+
+- Fetch and triage SUEWS GitHub issue context.
+- Implement the smallest issue-scoped code/docs/test change.
+- Run SUEWS validation and targeted checks.
+- Commit only scoped files and create or update a PR.
+- Run `audit-pr`, address valid findings, and re-audit until clean.
+- Hand an oversized PR to `split-pr` rather than fixing an unreviewable diff.
+
+## Scripts
+
+No bundled scripts. Use `gh`, git, Makefile targets, and the relevant repo
+skills directly.
+
+## Safety Rules
+
+- Public GitHub issue edits, labels, comments, title changes, body rewrites, or
+  PR review comments require explicit approval for that exact action.
+- Reading, triaging, drafting, implementing, committing, pushing the branch, and
+  opening/updating the PR are allowed when clearly scoped -- but only when the
+  agent owns the branch head (fix-issue created it this run, or the operator
+  explicitly approved it; not merely that it is in-repo) and authored any existing
+  PR. If the head is a fork, a shared branch the agent did not create, or an
+  existing PR was opened by someone else, do not push to it or edit its
+  body/metadata: escalate with `Remaining` set to the ownership block.
+- Stop if the issue is not actionable, expected behaviour is unclear, or the fix
+  would require a broad redesign.
+- Stop if unrelated dirty worktree changes cannot be isolated. Never stage
+  unrelated files; always stage explicit paths.
+- If a structural data-model/schema migration is needed, surface a short plan
+  and ask before changing schema versions, upgrade handlers, or sample config.
+- Never let internal tracker IDs (e.g. Linear PER-XXX), absolute local paths
+  (e.g. `/Users/...`, worktree or internal-tooling paths), server/host names, or
+  other private-infrastructure references reach a PR body, commit message, or any
+  drafted comment. These surfaces are public; keep them public-safe.
+- Do not merge the PR. Handing the PR to `queue-pr` does not transfer merge
+  authority: enqueue/merge stays a separate, explicitly-approved step under
+  `queue-pr`'s own human gate.
+
+## Workflow
+
+### 1. Snapshot And Triage
+
+1. Confirm repository and worktree state:
+   ```bash
+   git status --porcelain=v1
+   git branch --show-current
+   gh repo view --json nameWithOwner,defaultBranchRef
+   ```
+   If the worktree has unrelated uncommitted changes that cannot be isolated,
+   stop (per Safety Rules). Do not branch on top of a dirty tree: `git checkout -b`
+   carries those edits onto the issue branch and into validation.
+2. Fetch the issue context:
+   ```bash
+   gh issue view <issue> --repo UMEP-dev/SUEWS \
+     --json number,title,body,labels,assignees,state,author,comments,url,createdAt,updatedAt
+   ```
+3. Entry from triage. When an orchestrator supplies a `[triage-issue] verdict`
+   block for this issue, treat it as the authoritative input; otherwise apply
+   `triage-issue` logic inline (classify readiness, preserve the reporter's
+   context, surface conclusions that live only in comments) and derive the same
+   verdict. Then branch on the verdict, matching `triage-issue`'s own decision
+   rule rather than enumerating every readiness value:
+   - `Verdict: triaged` with `Readiness: ready` (or `needs-summary`, which also
+     resolves to triaged): proceed to Scope And Implement.
+   - `Verdict: needs-discussion`: do not implement. Stop and hand back the
+     block's `Blocking question` / `Next` line. This one branch covers
+     needs-repro, needs-scope, needs-acceptance, superseded, and duplicate, which
+     `triage-issue` all collapses into needs-discussion.
+   - `needs-split` (surfaced as `needs-discussion` with the decomposition in
+     `Next:`): route to the umbrella/sub-issue decomposition in
+     `.claude/rules/work-sizing.md` rather than implementing or merely aborting.
+4. If a public issue update would help, draft it and wait for approval before
+   posting. If no public edit is needed, continue.
+5. This is the same gate as a `needs-discussion` verdict: stop with concrete
+   questions if the issue lacks expected behaviour, reproduction, affected
+   versions, or safe implementation scope. The verdict-driven abort in step 3 and
+   these prose questions are one gate, not two.
+
+### 2. Scope And Implement
+
+1. Map the issue to touched areas and read the relevant repo rules. If the fix
+   will touch `src/supy/data_model/`, read
+   `.claude/rules/python/schema-versioning.md` now and plan any
+   `CURRENT_SCHEMA_VERSION` bump, `SCHEMA_VERSIONS` entry, `yaml_upgrade.py`
+   handler, `sample_config.yml` resync, and docs churn into the same change set.
+   Do not defer these to the audit stage; the `schema-version-audit.yml` CI gate
+   and `audit-pr` will otherwise bounce the PR back.
+2. Select supporting skills as needed:
+   - `suews` for configuration, simulation, validation, or diagnostics.
+   - `lint-code` for style and file-type conventions.
+   - `sync-docs` when behaviour, config, outputs, APIs, or docs may drift.
+   - `verify-build` for source inclusion, packaging, schema, CI, or build metadata.
+   - `log-changes` when the fix is user-facing and should be recorded.
+3. Use the current branch only if it is already issue-scoped AND fix-issue created
+   it this run or the operator explicitly approved continuing on it; if it
+   pre-exists and carries commits the agent did not make this run, treat
+   continuation as human-gated and escalate. Otherwise, only after confirming the
+   worktree is clean (or its changes were isolated per step 1), create a short
+   issue branch from the target base using the user's configured branch prefix
+   when available. The clean-tree stop applies to branch creation, not to
+   continuing on an approved issue-scoped branch that legitimately carries the
+   in-progress fix.
+4. Reproduce or pin down the failure before editing when practical.
+5. Make the smallest issue-scoped change, kept to a single reviewable concern per
+   `.claude/rules/work-sizing.md`; if the fix grows beyond one right-sized PR,
+   stop and propose a split rather than growing the diff. Add or update a
+   regression test that
+   would have failed before the fix, unless the issue is docs-only or testing is
+   impractical; explain any exception.
+6. For SUEWS configs or simulation workflows, use structured SUEWS CLI/MCP
+   outputs. Do not scrape prose or invent parameter values.
+
+### 3. Validate
+
+Run validation appropriate to the touched files, with `make test-smoke` as the
+pre-commit baseline. Escalate to the full `make test` when the fix touches test
+files, core physics modules, or `src/supy/data_model/` (per
+`.claude/rules/00-project-essentials.md`). Add targeted checks as needed:
+`pytest`, `ruff check`, `fprettify --diff`, `sync-docs`, `verify-build`, or SUEWS
+validate/diagnose tools. If validation fails because of the fix, repair and
+rerun. If validation is blocked by environment setup, record a public-safe
+description of the blocker in the PR body, with any absolute local paths, host
+names, or internal references replaced by neutral phrasing (e.g. "the editable
+build step failed in the local toolchain").
+
+### 4. Commit And Open/Update PR
+
+1. Inspect `git diff --stat`, `git diff --cached --stat`, and untracked files;
+   ensure the final diff only contains issue-scoped paths.
+2. Stage explicit paths only.
+3. Commit with a human subject. When the commit is substantively assisted, add
+   the AI-collaboration trailer for the assistant that produced the change, never
+   the other one. The repo uses both, depending on which assistant drives the
+   work; pick the single matching line:
+   ```text
+   Co-authored-by: Codex <codex@openai.com>
+   Co-authored-by: Claude <noreply@anthropic.com>
+   ```
+4. Confirm ownership before writing. The head must be a branch in this repository
+   (not a fork); any existing PR for it must have been opened by the operating
+   account (`gh pr view <pr> --json author,headRepositoryOwner,headRepository,headRefName`;
+   compare `author.login` with `gh api user --jq .login`); AND the agent must own
+   the branch head -- confirm one of: fix-issue created the branch this run
+   (preferred), the remote head matches what the agent last pushed (push with
+   `--force-with-lease` so a foreign push since checkout is detected), or the
+   operator explicitly approved pushing to it. Commit authorship is only a weak
+   supplementary signal (trailers, cherry-picks, and a shared push identity make
+   it unreliable). If any check fails, stop and escalate -- never push to or edit a
+   branch/PR you do not own. Then push to `origin`.
+5. If the branch already has a PR you own, update the PR body when needed.
+   Otherwise create one with a concise title, issue link (`Fixes #<issue>` only
+   when the PR should close it; otherwise `Refs #<issue>`), fix summary,
+   validation status, and known limitations.
+
+### 5. Audit, Address, Re-Audit
+
+This loop is the per-PR instance of `.claude/rules/review-convergence.md`:
+`audit-pr` is the reviewer, the 3-iteration cap is the round cap, and the
+recurring-signature check is the oscillation guard.
+
+1. Once a PR exists, run `audit-pr` as a private PR-readiness audit. It may draft
+   comments, but do not post them without approval.
+2. Classify audit findings:
+   - valid blocking/major findings: fix them before PR-ready;
+   - broad or ambiguous findings: stop and ask for human judgement;
+   - minor or false-positive findings: record why they do not block;
+   - if `audit-pr`'s Size Gate recommends a split (the PR is oversized or
+     bundled): stop the address-and-re-audit loop and hand off to `split-pr`
+     rather than fixing findings against an unreviewable diff. This mirrors the
+     pre-implementation split guard in step 2.5.
+3. Address all valid blocking/major findings in the branch, run the relevant
+   validation again, commit scoped fixes, and push.
+4. Re-run `audit-pr` on the updated PR/head. Repeat this address-and-re-audit loop
+   until `audit-pr` returns `Verdict: clean`, to a maximum of 3 iterations. The
+   operative gate is whether any valid blocking/major finding remains, which the
+   per-finding `[severity]` field reports: a `needs-attention` verdict carrying
+   only minor/false-positive findings still resolves to PR-ready once each is
+   recorded per step 5.2. If valid findings remain after the 3rd iteration, stop
+   with `Remaining` set to the persisting findings and do not call the PR ready.
+5. Exit early when a finding with an identical signature (same file/location plus
+   same problem) recurs across two consecutive audits, or when a finding requires
+   design/scientific judgement; stop with `Remaining` set to that blocker. Do not
+   call the PR ready.
+
+## Output Format
+
+End with:
+
+```text
+[fix-issue] PR-ready report
+Issue: #<number> <title>
+Branch: <branch>
+PR: <url or not created: reason>
+Scope: <one-line summary>
+Validation: <commands and pass/blocked status>
+Audit loop: <clean after N iters | stopped after 3 iters: persisting | stopped on recurring finding: signature | split: handed to split-pr | not run: reason>
+Public GitHub edits: <none | drafted | approved and applied>
+Remaining: <none | explicit blocker>
+Next: ready for the normal review/merge workflow.
+```
+
+If the workflow stops early, use the same format and set `Remaining` to the
+specific question or blocker.

--- a/.claude/skills/queue-pr/SKILL.md
+++ b/.claude/skills/queue-pr/SKILL.md
@@ -10,6 +10,36 @@ GitHub merge queue. The aim is not to avoid all conflicts; it is to discover
 them before queue entry, choose a sensible ordering, and keep history updates
 intentional.
 
+## Safety Rules
+
+- `--enqueue` (any `gh pr merge`) is human-gated. It must never run in
+  autonomous, unattended, or batch mode. It requires explicit per-run user
+  approval naming the merge action ("put these in the merge queue"); the
+  conversational note in step 3 is not sufficient on its own. Never pass
+  `--admin`, never delete branches, and stop if GitHub rejects a PR rather than
+  forcing it through.
+- Posting `--comment` to PRs you do not author/own requires approval, because on
+  a collaboration repo it lands on third parties' PRs. The read-only dry-run scan
+  and comments on your own PRs may proceed when clearly scoped.
+- Do not force-push any PR branch you do not own without explicit approval for
+  that exact branch (matching `split-pr`). For your own coordinator branch,
+  `git push --force-with-lease` after a rebase is fine.
+- Do not auto-resolve scientific or schema conflicts to make Git clean; leave a
+  coordination comment and let the owner worktree decide.
+
+## Autonomous Mode
+
+queue-pr is the terminal merge boundary of the issue -> PR -> merge pipeline, so
+its consequential tiers stay human-gated even under an autonomous orchestrator:
+
+- Auto-applicable (read-only / self-scoped): the dry-run scan and the merge
+  ordering it proposes.
+- Human-gated, always escalate (never auto-applied in a batch): `--enqueue` /
+  any merge, and `--comment` onto PRs you do not own. The terminal outcome for
+  these is escalate-to-human, the same shape as `triage-issue`'s
+  `needs-discussion`. An opt-in standing approval covers only the read-only scan
+  and ordering tiers, never the merge or cross-author-comment tiers.
+
 ## Quick Start
 
 Scan ready-for-review PRs and propose a coordination order:
@@ -165,7 +195,9 @@ make test-smoke
 9. **Prepare queue entry**
    - Rebase or merge from latest `origin/master` only after confirming the
      intended history policy for the branch.
-   - Prefer `git push --force-with-lease` after a rebase.
+   - Prefer `git push --force-with-lease` after a rebase, and only on a branch you
+     own; force-pushing any other PR branch requires explicit per-branch approval
+     (see Safety Rules, Decision Rules, and Section 4).
    - Run `make test-smoke` before requesting merge queue entry.
    - Record the queue order and any known shared files in the PR comment or
      workspace note when coordinating several agents.
@@ -195,8 +227,9 @@ otherwise.
   `origin/master`; use a stacked PR until the dependency lands.
 - Do not run destructive commands such as `git reset --hard` or branch
   checkouts in another active worktree.
-- Do not force-push unless the user asked you to update that PR branch or the
-  branch is clearly yours to maintain.
+- Do not force-push any PR branch you do not own without explicit approval for
+  that exact branch (matching split-pr and Section 4's repair-wave gate). For
+  your own coordinator branch, prefer `git push --force-with-lease` after a rebase.
 - Do not auto-resolve scientific or schema conflicts just because Git can be
   made clean. Leave a coordination comment and let the owner worktree handle
   the domain decision.
@@ -236,6 +269,7 @@ When reporting a repo-wide queue scan, use this structure:
 === READY PR MERGE QUEUE PLAN ===
 Base: master
 Mode: dry-run | comment | enqueue
+Scope: base=<base>, ready-for-review filter; <K> fetched / <total> open; truncated: <yes|no>
 Candidates: N open PRs, M ready-for-review, K queueable
 
 Queue order:
@@ -255,3 +289,11 @@ Actions:
 Always include the PR numbers. The user needs to see exactly which PRs received
 coordination comments, which PRs are currently queueable, and which PRs were
 left alone because they are draft or blocked.
+
+The scanner is a batch stage, so it emits the contract `Scope:` line (see
+`.claude/rules/autonomous-workflow.md`): `<K>` fetched against an independently
+obtained `<total>` open count, with `truncated: yes` when `K < total` (the
+`--limit`, default 100, also corroborates). When `truncated: yes`, the candidate
+list is incomplete -- raise `--limit` (or paginate) before trusting the ordering,
+since merge-queue ordering relies on a complete candidate set. Never rely on the
+default limit for a backlog that may exceed it.

--- a/.claude/skills/queue-pr/scripts/queue-ready-prs.sh
+++ b/.claude/skills/queue-pr/scripts/queue-ready-prs.sh
@@ -232,6 +232,14 @@ done < "$order_tsv"
 open_count="$(wc -l < "$prs_tsv" | tr -d ' ')"
 ready_count="$(wc -l < "$ready_tsv" | tr -d ' ')"
 queueable_count="$(wc -l < "$order_tsv" | tr -d ' ')"
+total_open="$(gh api -X GET search/issues -f q="repo:$(gh repo view --json nameWithOwner --jq .nameWithOwner) is:pr is:open base:$base" --jq .total_count 2>/dev/null || echo "")"
+if [ -n "$total_open" ] && [ "$open_count" -lt "$total_open" ]; then
+    truncated="yes"
+elif [ "$open_count" -ge "$limit" ]; then
+    truncated="yes"
+else
+    truncated="no"
+fi
 scan_time="$(date -u '+%Y-%m-%d %H:%M UTC')"
 marker="<!-- suews-merge-queue-coordinator:v1 -->"
 
@@ -381,6 +389,7 @@ elif [ "$enqueue" -eq 1 ]; then
 else
     printf 'Mode: dry-run\n'
 fi
+printf 'Scope: base=%s, ready-for-review filter; %s fetched / %s open; truncated: %s\n' "$base" "$open_count" "${total_open:-unknown}" "$truncated"
 printf 'Candidates: %s open PRs, %s ready-for-review, %s queueable\n\n' "$open_count" "$ready_count" "$queueable_count"
 
 printf 'Queue order:\n'

--- a/.claude/skills/split-pr/SKILL.md
+++ b/.claude/skills/split-pr/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: split-pr
+description: Use whenever an oversized or bundled SUEWS pull request (or a fat local branch) needs to be carved into a stacked series of smaller, single-concern PRs that each build and pass tests on their own. Trigger for requests like "split this PR", "this PR is too big, break it up", "carve this branch into stacked PRs", "separate the refactor from the fix", "split off the formatting/generated changes", or when audit-pr's Size Gate recommends a split. This skill assesses the diff, proposes a split plan, creates per-child worktrees/branches, carves by concern or by commit while preserving authorship, verifies each child independently green, checks completeness (every change lands in exactly one child, nothing dropped), opens the stacked PRs for approval, and hands off to queue-pr. It does not merge and does not rewrite the original branch without explicit approval.
+---
+
+# Split PR
+
+Carve one oversized or bundled SUEWS pull request (or a fat local branch) into a
+stacked series of smaller, single-concern PRs. Each child must build and pass
+tests on its own, and the union of the children must equal the original diff with
+nothing dropped or duplicated.
+
+The terminal state is **a verified stack of PR-ready branches**, not merged. This
+skill does not review (`audit-pr`) and does not merge (`queue-pr` / merge queue).
+It preserves the original branch and PR untouched until the stack is verified.
+
+## Triggers
+
+- Use for: "split this PR", "this PR is too big", "carve this branch into stacked
+  PRs", "separate the refactor from the fix", "split off the formatting/generated
+  changes", or when `audit-pr`'s Size Gate recommends a split.
+- Size criteria live in `.claude/rules/work-sizing.md`. If the user only wants a
+  judgement on whether to split, use `audit-pr` (Size Gate) instead.
+
+## Safety Rules
+
+- Never rewrite or force-push the original branch/PR without explicit approval for
+  that exact branch. Carve into new branches; leave the original intact until the
+  stack is verified and the user approves retiring it.
+- Pushing the new branches and opening the child PRs requires approval. Local
+  carving, worktree creation, and verification are allowed when clearly scoped.
+- Every change in the original must land in exactly one child (see Completeness
+  check). Never silently drop or duplicate a hunk.
+- Each child must leave the tree green: it builds and passes `make test-smoke`
+  independently (a stacked child is verified on top of its parent).
+- Do not auto-resolve semantic, scientific, or schema conflicts that arise while
+  carving. Stop and report.
+- Preserve authorship via the by-commit/cherry-pick route, which keeps the
+  original author. The by-path route creates fresh commits authored by you; those
+  carry the AI-collaboration trailer for the assistant that made them (Codex or
+  Claude), never the wrong one. If single-author attribution must be retained for
+  a by-path child, prefer cherry-pick or pass `--author=`.
+- Never reuse or delete a pre-existing `split/<pr>-*` branch or worktree without
+  first reporting it and getting explicit approval; never delete the original
+  branch/PR.
+- Privacy on every outward write: never let internal tracker IDs (e.g. Linear
+  PER-XXX), absolute local/worktree paths (`/Users/...`, `../split-<pr>/...`),
+  internal branch names, or private host names reach a child PR body, commit
+  message, the stack/concern descriptions, or the retire recommendation. These
+  surfaces are public; scrub model-authored text (operationalises the privacy
+  invariant in `.claude/rules/autonomous-workflow.md`).
+- Stop if the diff cannot be cleanly separated into independent concerns, or if
+  splitting would require a broad redesign.
+
+## Scripts
+
+No bundled scripts. Use `git worktree`, `gh`, and the `queue-pr` scripts for the
+downstream coordination of the resulting stack.
+
+## Workflow
+
+### 1. Snapshot and assess
+
+1. Identify the source: a PR number or a local branch. Fetch and inspect:
+   ```bash
+   git fetch origin
+   gh pr view <pr> --json number,title,headRefName,headRefOid,baseRefName,author,files,url
+   gh pr diff <pr> --name-only
+   git diff --name-status origin/<base> <source-head>   # D = deletion, R = rename: special carve in step 3
+   ```
+2. Group the diff into separable concerns by file/subsystem and by commit
+   (`git log --oneline origin/<base>..<head>`). Watch for a mix of refactor +
+   behaviour change + formatting, bundled unrelated fixes, or generated/mechanical
+   changes that should be carved out first.
+3. Classify each child's base using `queue-pr`'s shape model, reduced to the two
+   shapes that apply when carving a fresh stack: a child is independent (off
+   `<base>`, no logical dependency) or stacked (off its parent child). Shared
+   build/schema/docs edits do not get their own shape term here; they become a
+   dedicated high-risk child (step 6 and "SUEWS high-risk files"), which is this
+   skill's form of `queue-pr`'s integration PR. `queue-pr`'s `serial` shape has no
+   analogue: a carved child's dependency is fixed by how it is carved.
+4. Propose the split plan: which files/commits go in which child, the order, and
+   independent-vs-stacked. Present it for approval before any surgery.
+
+### 2. Set up isolation
+
+1. Keep the original branch/PR untouched. Do not check out PR branches in an
+   active worktree.
+2. Pre-flight for leftovers from a prior interrupted run (never silent, never
+   auto-delete):
+   ```bash
+   git worktree list
+   git branch --list 'split/<pr>-*'
+   ```
+   If any `split/<pr>-*` branch or `../split-<pr>/*` worktree already exists, STOP
+   and report it. Then take one human-gated path: (a) resume, if the leftovers
+   match the approved plan; or (b) clean and re-carve, only on explicit approval:
+   ```bash
+   git worktree remove --force ../split-<pr>/<x>
+   git worktree prune
+   git branch -D split/<pr>-<x>          # branch persists after path removal
+   ```
+3. Create a coordinator area and per-child worktrees. Fresh carve (new branch off
+   the agreed base):
+   ```bash
+   mkdir -p ../split-<pr>
+   git worktree add -b split/<pr>-a ../split-<pr>/a origin/<base>
+   ```
+   For a stacked child, use `-b split/<pr>-<x>` off its parent child instead of
+   the base. The `-b` form fails with `fatal: a branch named '...' already exists`
+   (exit 255) if the branch is still present, so it must not be used on the resume
+   path. Resume instead re-attaches a worktree to an EXISTING leftover branch
+   (no `-b`):
+   ```bash
+   git worktree add ../split-<pr>/a split/<pr>-a
+   ```
+   After re-attaching, confirm the branch tip matches the approved plan before
+   continuing. Tear down the per-child worktrees after the stack is pushed
+   (`git worktree remove ../split-<pr>/<x>`), leaving the branches intact.
+
+### 3. Carve each child
+
+- **By path** (files group cleanly): in the child worktree, bring in only that
+  child's paths from the source head:
+  ```bash
+  git checkout <source-head> -- <path> [<path> ...]
+  git commit  # focused subject. NOTE: authored by you, not the original author --
+              # carving by path cannot preserve per-hunk authorship. Use the
+              # by-commit/cherry-pick route below to retain attribution, or pass
+              # --author="Name <email>". This fresh commit carries the
+              # AI-collaboration trailer for the assistant that made it.
+  ```
+  Caveat -- by-path carve cannot capture deletions or renames. `git checkout
+  <source-head> -- <path>` only copies files that exist at `<source-head>`, so a
+  path DELETED between base and head fails with `error: pathspec '<path>' did not
+  match any file(s) known to git` and the deletion is never staged. Carve a
+  deletion with `git rm <path>` in the child; for a rename, carve both sides
+  (`git rm <old-path>` and `git checkout <source-head> -- <new-path>`). The D/R
+  statuses from step 1's `git diff --name-status` tell you which paths need this.
+- **By commit** (the source has clean per-concern commits): cherry-pick the
+  commit group onto the child branch (cherry-pick preserves the original author).
+- Carve out mechanical/generated changes (formatting sweeps, regenerated
+  artefacts, large fixture updates) into their own child PR first so the semantic
+  children stay small and reviewable.
+
+### 4. Verify each child independently
+
+Run the green-tree check on each child on its own (a stacked child on top of its
+parent): build if needed, then `make test-smoke`, plus any targeted check the
+child's files warrant (`pytest`, `ruff check`, `fprettify --diff`). If a child is
+not green in isolation, the boundary is wrong; re-carve rather than papering over
+it.
+
+### 5. Completeness check (critical gate)
+
+Confirm the stack reproduces the original exactly, with nothing dropped or
+duplicated, using a single shape-general recombine that covers stacked,
+independent, and mixed shapes. Identify the LEAF branches that jointly cover every
+concern: every independent child, plus the TIP of each stacked sub-series (never a
+non-tip stacked child, whose commits its tip already contains). In a throwaway
+worktree off the base, octopus-merge exactly that leaf set, diff against the source
+head, then tear the worktree down:
+
+```bash
+git worktree add ../split-<pr>/_recombine origin/<base>
+git -C ../split-<pr>/_recombine merge --no-edit <leaf-1> <leaf-2> ...   # each independent child + each stacked sub-series TIP
+git -C ../split-<pr>/_recombine diff <source-head> HEAD                 # must be empty
+git worktree remove --force ../split-<pr>/_recombine
+```
+
+Fast path: for a PURELY stacked stack with no independent siblings, the single tip
+child already contains everything, so `git diff <source-head> <tip-child-branch>`
+suffices. Do not use the fast path in a mixed shape -- it false-flags the
+independent child's hunks as a phantom diff.
+
+If any recombine merge reports CONFLICT (non-zero exit, or `git status` shows
+`UU`), the children share an overlapping hunk -- the boundary is wrong. Run
+`git merge --abort` and re-carve; do NOT hand-resolve (that masks a bad split),
+and do not trust the subsequent `git diff`, which would run against a half-merged
+state. If the merge succeeds cleanly but the diff is non-empty, a change was lost
+or duplicated. Resolve before proceeding; never report a split complete while this
+diff is non-empty.
+
+### 6. Open the stack
+
+After approval, push the child branches and open the PRs:
+
+- Independent children: base each on `<base>`.
+- Stacked children: base each PR on its parent child branch; note the stacking in
+  the PR body so a reviewer reads them in order.
+- Link every child to the original (`Refs #<original>`), and list the stack in
+  each child body. Schema/sample-config/build/CHANGELOG changes should be their
+  own child (schema bumps already warrant a dedicated change per
+  `.claude/rules/python/schema-versioning.md`; see also the "one PR per logical
+  group" rule in `.claude/rules/naming-convention.md`).
+
+### 7. Retire the original and hand off
+
+- Recommend closing or converting the original PR to a tracking/umbrella issue
+  once the stack is up, preserving its discussion. This is human-gated; do not
+  auto-close.
+- Hand the stack to `queue-pr` for ordering and merge-queue entry. Handing off
+  does not transfer merge authority: enqueue/merge stays a separate,
+  explicitly-approved step under `queue-pr`'s own human gate.
+
+## SUEWS high-risk files
+
+Carve these into their own child PR rather than scattering them across children:
+schema/public API and sample configuration, `meson.build` / `src/supy/meson.build`,
+`.github/workflows/*`, `CHANGELOG.md`, dependency/lock files, generated docs
+indexes, and shared test fixtures/baselines. See the full list in `queue-pr`.
+
+## Decision Rules
+
+- Prefer carving by path when files group cleanly; carve by commit when the
+  history is already concern-clean.
+- Independent children become parallel PRs; dependent children become a stack.
+  Do not hide a dependency by basing a dependent child directly on the base.
+- A child that cannot be made green in isolation signals a wrong boundary, not a
+  reason to bundle.
+- Stop and report on any semantic/scientific/schema conflict; do not invent a
+  resolution to make Git clean.
+
+## Output Format
+
+End with:
+
+```text
+[split-pr] stack plan
+Source: #<pr> <title> (or branch)
+Shape: independent | stacked | mixed
+Concerns: <N identified in step 1> -> Children: <M created>   # must match or explain
+Children:
+  1. split/<pr>-a - <concern> - checks: test-smoke pass/blocked - PR <url|not pushed>
+  2. split/<pr>-b - <concern> - checks: ... - PR <url|not pushed>
+Completeness: empty-diff confirmed | MISMATCH: <what>
+Original: untouched | retire recommended (human) | closed (approved)
+Approvals: <none | push+open approved | retire approved>
+Remaining: <none | explicit blocker>
+Next: hand the stack to queue-pr for ordering and merge.
+```
+
+If the workflow stops early, use the same format and set `Remaining` to the
+specific blocker.

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -23,6 +23,9 @@ an issue body no longer reflects discoveries made in comments.
 - Summarise comments into maintainer-ready context.
 - Preserve the original report while drafting a clarified issue body.
 - Propose issue title, label, readiness, and follow-up changes.
+- Recommend splitting an oversized or multi-concern issue into focused child
+  issues under a parent, and propose that decomposition
+  (see `.claude/rules/work-sizing.md`).
 - Apply approved GitHub edits using `gh`.
 
 ## Scripts
@@ -38,11 +41,14 @@ gh issue view <number> --repo UMEP-dev/SUEWS \
   --json number,title,body,labels,assignees,state,author,comments,url,createdAt,updatedAt
 ```
 
-Audit a list:
+Audit a list (set an explicit `--limit`; gh defaults to 30 and silently
+truncates a larger backlog):
 
 ```bash
-gh issue list --repo UMEP-dev/SUEWS --state open \
+gh issue list --repo UMEP-dev/SUEWS --state open --limit 200 \
   --json number,title,labels,assignees,author,updatedAt,url
+# independent open total for the coverage check (do NOT derive it from the capped list):
+gh api -X GET search/issues -f q="repo:UMEP-dev/SUEWS is:issue is:open" --jq .total_count
 ```
 
 Apply an approved rewrite:
@@ -53,13 +59,19 @@ gh issue edit <number> --repo UMEP-dev/SUEWS --body-file <approved-body.md>
 
 ## Safety Rules
 
-- Do not edit an issue, labels, assignment, title, or comments unless the user
-  explicitly approves that exact action.
+- In interactive mode, do not edit an issue, labels, assignment, title, or
+  comments unless the user explicitly approves that exact action. In autonomous
+  mode, the opt-in contract in "Autonomous Mode" is the standing approval for the
+  auto-applicable and confidence-gated tiers only; the human-gated tier always
+  escalates to `needs-discussion`.
 - Preserve the original issue body in the proposed rewrite unless the user asks
   for a different archival strategy.
 - Treat comments as evidence, not as permission to overwrite the issue author's
   framing silently.
 - Acknowledge issue-author contributions when triage changes the framing.
+- Do not introduce internal tracker IDs (for example Linear references), private
+  infrastructure paths, or other non-public references into the rewritten body or
+  any posted comment. The issue surface is public; keep it public-safe.
 - Do not close unclear issues only because they are unclear. Either ask for the
   missing information, add a maintainer summary, or propose a clearer
   superseding issue.
@@ -84,18 +96,150 @@ output format before performing a rewrite or batch audit.
 
 ## Output Format
 
-Use the single-issue and batch formats in `references/methodology.md`.
+Use the single-issue and batch formats in `references/methodology.md`. In
+autonomous mode, end with the machine-readable verdict block defined there.
 
 ## Batch Audit Guidance
 
 - Start with recently updated open issues or a bounded label set unless the user
   explicitly asks for the whole backlog.
 - Do not attempt to rewrite many issues in one pass. First produce an audit
-  table and group follow-up actions.
+  list and group follow-up actions.
 - Prioritise issues that are in progress, high priority, linked to active PRs,
   or have long comment threads where the current body is stale.
 - Suggest follow-up categories: add reproduction, add maintainer summary,
-  clarify scope, supersede, close as duplicate, or leave as ready.
+  clarify scope, split into focused child issues, supersede, close as duplicate,
+  or leave as ready.
+- Whenever the input set is bounded (label filter, recency window, `--limit`, or
+  gh's default cap), emit a `Scope:` line stating the filter and the returned
+  count against an independently-obtained total open count (see Quick Start), and
+  flag truncation when the returned count K is less than that total (`K == --limit`
+  is a secondary corroborating signal only).
+- Skip the redundant GitHub writes and re-analysis for issues already carrying the
+  `0-auto:audited` label whose `updatedAt` has not advanced since; re-audit only
+  those updated since. Such an idempotency-skipped issue still emits a verdict
+  block (`Verdict: triaged`, `Applied: none`), counted as triaged-noop -- "skip"
+  means skip the redundant work, not drop the issue from output.
+
+## Autonomous Mode
+
+By default this skill is interactive: it drafts and waits for explicit approval
+before any GitHub edit. Autonomous mode is an opt-in contract for unattended
+orchestration (a scheduled backlog sweep, or an upstream skill that calls
+triage). It never asks a human mid-run. Every issue ends in exactly one of two
+terminal verdicts:
+
+- `triaged`: the issue is now maintainer-ready and only safe, additive,
+  reversible changes were applied.
+- `needs-discussion`: the next action needs human judgement or external input, so
+  nothing destructive is applied and the skill hands back the specific question.
+
+### Action tiers
+
+Auto-applicable (additive, reversible):
+
+- Before composing any text to post, run the Privacy scrub gate (below) over the
+  distilled content.
+- Post one maintainer-summary comment carrying the current framing distilled from
+  the discussion, tagged with the stable marker `<!-- triage-issue:summary -->`
+  for idempotency.
+- Apply a readiness label only if that exact label already exists in the repo.
+  Never create labels.
+- Mark the issue as processed: apply the `0-auto:audited` label if it exists in
+  the repo. It records that an autonomous pass handled the issue so batch re-runs
+  can skip it unless it is later updated. It is bookkeeping, not substantive work,
+  so it is not listed in the verdict `Applied:` field. Do not create the label.
+
+### Privacy scrub gate
+
+Before posting any comment or writing any rewritten body, scan the
+model-authored distilled text (Maintainer summary, Discussion summary) for:
+internal tracker IDs (`PER-\d+` and similar private references), absolute local
+paths (`/Users/...`, home-directory paths), and private host/infrastructure names
+(internal compute servers, worktree managers, and the like). On a hit in distilled
+text, redact the
+offending token. The verbatim "Original report" block must NOT be redacted (that
+would break the preservation gate): if the scan hits a private token inside the
+verbatim original body, force `needs-discussion` rather than post or rewrite.
+
+Confidence-gated (body rewrite and matching retitle, auto-applied only when every
+gate holds):
+
+- Replace the issue body with the maintainer-ready rewrite ONLY when all of:
+  - the new framing is already established in the thread (for example stated by a
+    maintainer), not a novel hypothesis the skill is introducing;
+  - the rewrite preserves every substantive claim from the original report; and
+  - the rewrite embeds the preserved "Original report" section below.
+
+  If any gate fails, do not rewrite -> `needs-discussion`.
+- A confidence-gated body rewrite MUST preserve the original body and its raiser.
+  Open the rewritten body with the marker `<!-- triage-issue:rewrite -->` and
+  include, verbatim, the "Original report" section from
+  `references/rewrite-template.md`, which carries the original body content, the
+  raiser's `@handle`, the creation date, and the original title. Never drop the
+  author attribution: GitHub keeps the issue's original author field, but the body
+  must still make provenance visible to a reader.
+- Retitle the issue when the confident reframe makes the current title
+  misleading, under the same gates: the new title must reflect framing already
+  established in the thread, and a retitle is applied only together with the body
+  rewrite (never standalone). The original title is preserved in the "Original
+  report" section and remains in GitHub's edit timeline.
+
+Human-gated (always force `needs-discussion`, never auto-applied):
+
+- Assignment.
+- Close, supersede, or mark duplicate.
+- Any reporter-facing request (for example "please add a reproduction").
+
+### Verdict decision rule (deterministic)
+
+Pre-condition (before the readiness mapping): if the issue cannot be fetched or
+processed, or is excluded by the scope bound, the verdict is `skipped` with the
+reason in `Blocking question`/`Next` and nothing applied; such issues never enter
+the readiness mapping (they have no rubric readiness). Otherwise map the audited
+rubric readiness status to a verdict:
+
+- `ready` -> `triaged` (apply label-if-exists, otherwise nothing).
+- `needs-summary` -> `triaged` (post the maintainer-summary comment; label-if-exists).
+- `needs-repro`, `needs-scope`, `needs-acceptance` -> `needs-discussion`
+  (state the precise missing item; do not ping the reporter).
+- `needs-split` -> `needs-discussion` (propose the decomposition into focused
+  child issues per `.claude/rules/work-sizing.md`; never auto-create issues or
+  parent/child links).
+- `misframed` -> `triaged` via a confidence-gated body rewrite (plus a matching
+  retitle when the current title is misleading) when every gate above holds;
+  otherwise `needs-discussion`.
+- `superseded`, `duplicate` -> `needs-discussion` (close/link needs approval).
+
+### Idempotency and re-runs
+
+- Before posting a summary comment, scan existing comments for
+  `<!-- triage-issue:summary -->`. If present and the thread has not materially
+  changed, verdict is `triaged` with nothing applied. If present but the framing
+  is stale, update that comment in place rather than posting a second one.
+- Before a body rewrite, check whether the body already starts with
+  `<!-- triage-issue:rewrite -->`. If present, the issue has already been
+  rewritten: update the maintainer-ready sections in place and never nest a second
+  "Original report" block. The preserved original body and `@handle` from the
+  first rewrite are authoritative and must survive every later rewrite untouched.
+
+### Batch in autonomous mode
+
+- Process the bounded input set, apply only auto-tier actions, and accumulate one
+  verdict per issue. Body rewrites, closes, and supersedes are recorded as
+  `needs-discussion`, never applied in bulk. Stop when the set is exhausted and
+  emit the scope line and partitioned aggregate defined in `methodology.md`.
+- Idempotency across runs uses the `0-auto:audited` label as the queryable marker
+  (complementing the in-body `<!-- triage-issue:* -->` markers): skip the
+  redundant work for issues that carry it and have not been updated since. Such an
+  idempotency-skipped issue still reports as triaged-noop (`Applied: none`), never
+  as the `skipped` verdict.
+- An issue that cannot be fetched/processed, or is excluded by the bound, gets the
+  `skipped` verdict (distinct from the idempotency skip above) with the reason,
+  never silently dropped.
+
+The Privacy scrub gate above applies in full to every autonomous post: never let
+internal tracker IDs or private paths reach a posted comment or body.
 
 ## References
 

--- a/.claude/skills/triage-issue/references/methodology.md
+++ b/.claude/skills/triage-issue/references/methodology.md
@@ -65,7 +65,7 @@ Use this format for one issue:
 ````text
 Issue: #<number> - <title>
 Type: <bug|feature|maintenance/refactor|documentation|meta/process>
-Readiness: <ready|needs-repro|needs-scope|needs-acceptance|needs-summary|misframed|superseded|duplicate>
+Readiness: <ready|needs-repro|needs-scope|needs-split|needs-acceptance|needs-summary|misframed|superseded|duplicate>
 
 Audit:
 - ...
@@ -87,19 +87,104 @@ Proposed body:
 
 ## Batch Output
 
-Use a compact table for a batch audit:
+Use a compact nested list for a batch audit, one entry per issue in the form
+`#<number> - <type> / <readiness> - <suggested action> (<notes>)`:
 
 ```text
-| Issue | Type | Readiness | Suggested action | Notes |
-|---|---|---|---|---|
-| #123 | bug | needs-repro | Ask for sample-data reproducer | Symptom clear, no actual/expected |
+- #123 - bug / needs-repro - ask for sample-data reproducer (symptom clear, no actual/expected)
+- #145 - feature / needs-scope - clarify non-goals before implementation (long thread, body stale)
 ```
 
-After the table, group follow-up actions as:
+After the list, group follow-up actions as:
 
 - add reproduction
 - add maintainer summary
 - clarify scope
+- split into focused child issues
 - supersede
 - close as duplicate
 - leave as ready
+
+## Proposing a Split
+
+When an issue bundles several independent concerns (multiple bugs, a bug plus a
+feature, or a broad ask that no single PR can close), recommend decomposing it
+rather than treating it as one unit. Its readiness is `needs-split`; size it
+against `.claude/rules/work-sizing.md`.
+
+Propose, do not create:
+
+- List each proposed child issue as a focused title plus a one-line scope, and its
+  issue type and acceptance criterion where known.
+- Keep the original issue as the parent/umbrella; its maintainer summary should
+  point to the children and state what "done" means for the whole.
+- Link children to the parent with GitHub native sub-issues, not body mentions.
+- Preserve the original report and raiser attribution on the parent exactly as a
+  rewrite would (see "Original report" in `rewrite-template.md`).
+- For a large split with several related children, structure it as a parent
+  umbrella plus native sub-issues grouped into dependency-ordered waves, per the
+  "Umbrella decomposition for large splits" section of
+  `.claude/rules/work-sizing.md`, so the children can be swept in order.
+- Creating the child issues and the parent/child links is human-gated: in
+  autonomous mode the verdict is always `needs-discussion` with the decomposition
+  in `Next:`; in interactive mode present the decomposition for approval before
+  creating anything.
+
+## Autonomous Verdict Output
+
+In autonomous mode (see `SKILL.md` "Autonomous Mode"), end each issue with a
+machine-readable verdict block so an orchestrator can branch without parsing
+prose:
+
+```text
+[triage-issue] verdict
+Issue: #<number> - <title>
+Type: <bug|feature|maintenance/refactor|documentation|meta/process>
+Readiness: <ready|needs-repro|needs-scope|needs-split|needs-acceptance|needs-summary|misframed|superseded|duplicate>
+Verdict: <triaged|needs-discussion|skipped>
+Applied: <none | comma-separated subset of: comment, label, body-rewrite, title>
+Blocking question: <none | the specific judgement or input required>
+Next: <ready for implementation/review | human decision required: ...>
+```
+
+The `0-auto:audited` processed-marker label is applied to every issue reaching a
+`triaged` or `needs-discussion` verdict; it is bookkeeping and is NOT listed in
+`Applied`, so it does not affect the triaged-applied vs triaged-noop split below.
+
+Invariants an orchestrator can rely on:
+
+- `Verdict: triaged` requires `Blocking question: none`. `Applied:` is `none` or
+  any combination of `comment`, `label`, `body-rewrite`, and `title`.
+- `body-rewrite` is valid only when the new body opens with
+  `<!-- triage-issue:rewrite -->` and embeds the preserved "Original report"
+  section carrying the original body verbatim, the raiser's `@handle`, and the
+  original title (see `rewrite-template.md`).
+- `title` may appear only together with `body-rewrite` (a retitle accompanies a
+  confident reframe and is never applied standalone).
+- `Verdict: needs-discussion` requires a non-empty `Blocking question`, and
+  `Applied:` is `none` (no destructive action is ever auto-applied).
+- `Verdict: skipped` is for an issue that could not be fetched/processed or was
+  excluded by the bound; it requires a reason in `Blocking question`/`Next` and
+  applies nothing.
+- Privacy: a scrub-gate hit in model-authored distilled text is redacted; a hit
+  in verbatim preserved content forces `needs-discussion` (never posted).
+- For a batch, emit one block per issue, then a scope line and a partitioned
+  aggregate that must sum to the returned count K:
+  `Scope: <filter>; <K> returned / <total> open; truncated: <yes|no>`
+  (truncated: yes when K < total -- the authoritative open count; K == `--limit`
+  is only a corroborating signal, used when total is unavailable), then
+  `Summary: <K> processed = <A> triaged-applied, <B> triaged-noop, <C> needs-discussion, <D> skipped`
+  where A = triaged with `Applied != none`; B = triaged with `Applied: none`
+  (this includes an idempotency-skipped issue -- already audited and unchanged, so
+  it reports as triaged-noop, never as `skipped`); C = needs-discussion;
+  D = skipped (unprocessable or out-of-bound). A+B+C+D MUST equal K, not the open
+  total. Full coverage of the open backlog is assertable only when
+  `truncated: no`; when `truncated: yes`, the Summary covers the returned window
+  of K issues only, and the (total - K) issues beyond the `--limit` remain
+  unswept -- re-run with a higher `--limit` (or paginate) to cover them.
+- Optional needs-discussion breakdown (additive; does not change A+B+C+D = K),
+  using rubric readiness values so each per-issue `Readiness` rolls up to exactly
+  one sub-bucket:
+  `Needs-discussion breakdown: <s> needs-split, <r> needs-repro, <c> needs-scope, <a> needs-acceptance, <m> misframed, <o> superseded/duplicate` where s+r+c+a+m+o = C.
+  The needs-split sub-count is the actionable one: those carry an approvable
+  umbrella decomposition in `Next:`, not a reporter-facing block.

--- a/.claude/skills/triage-issue/references/rewrite-template.md
+++ b/.claude/skills/triage-issue/references/rewrite-template.md
@@ -17,7 +17,19 @@ narrowed or broadened.]
 
 ## Original report
 
-> [Original issue body, preserved verbatim or clearly marked.]
+Reported by @<author-handle> on <created-date> under the title
+"<original-title>" (from `gh issue view --json author,createdAt,title`). Keep this
+attribution even when the body or title is rewritten: it makes the raiser and the
+original framing visible in the body itself, not only in GitHub's author field and
+edit timeline.
+
+<details>
+<summary>Original report (verbatim)</summary>
+
+[Original issue body, preserved verbatim. A collapsible block keeps code fences,
+lists, and YAML intact, which a blockquote would mangle.]
+
+</details>
 
 ## Discussion summary
 

--- a/.claude/skills/triage-issue/references/rubric.md
+++ b/.claude/skills/triage-issue/references/rubric.md
@@ -64,6 +64,8 @@ Look for:
 - `ready`: clear enough to implement or review.
 - `needs-repro`: bug report needs a minimal reproduction.
 - `needs-scope`: feature/refactor scope needs clarification.
+- `needs-split`: bundles several independent concerns that should be decomposed
+  into focused child issues under the original as a parent.
 - `needs-acceptance`: expected outcome is not yet testable.
 - `needs-summary`: useful context exists in comments but needs a maintainer summary.
 - `misframed`: title/body describe a downstream symptom after triage has
@@ -79,5 +81,7 @@ Ask:
 - Does the body distinguish symptom from root cause where known?
 - Would a contributor know what files, API, CLI command, or docs area to inspect?
 - Can a PR author derive tests or acceptance criteria from the issue?
+- Does the issue cover a single actionable concern, or several that should be
+  separate child issues? (see `.claude/rules/work-sizing.md`)
 - Are important discoveries currently buried only in comments?
 - If the framing changed, is the original issue author's contribution preserved?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,11 @@ Full setup: `/setup-dev` | Style check: `/lint-code` | Build check: `/verify-bui
 - `/setup-dev` - Environment setup
 - `/lint-code` - Check code style
 - `/sync-docs` - Doc-code consistency
+- `/fix-issue` - Triage and implement a GitHub issue to PR-ready status
 - `/republish-docs` - Republish/revise released docs (move tag to clean anchor)
 - `/verify-build` - Build configuration
 - `/audit-pr` - Review pull requests
+- `/split-pr` - Carve an oversized PR into a stacked series of small PRs
 - `/queue-pr` - Coordinate PRs before merge queue
 - `/log-changes` - Update CHANGELOG
 - `/prep-release` - Prepare releases


### PR DESCRIPTION
## Summary

Adds a composable, autonomy-ready **issue -> PR -> merge** pipeline to the `.claude`
workspace, runnable **solo** (one item) or **batch** (a bounded set). The stages
hand off via machine-readable verdict blocks, and the whole thing is governed by a
single contract with an explicit gating model.

## What's included

- **New skills**: `fix-issue` (triage -> implement -> validate -> PR-ready, stops
  before merge) and `split-pr` (carve an oversized PR into a stacked/independent/
  mixed series with a leaf-set completeness check).
- **triage-issue**: an autonomous mode with two terminal verdicts
  (`triaged` / `needs-discussion`), tiered actions (auto comment+label,
  confidence-gated body-rewrite+retitle that preserves the original report and
  raiser, human-gated close/supersede), a `needs-split` readiness, a privacy
  scrub gate, and a machine-readable verdict block.
- **audit-pr**: a **Size Gate** that runs first (recommends a split before
  reviewing an unreviewable diff), severity-tagged findings, and an Autonomous
  Mode (review-and-emit auto; posting always human-gated).
- **queue-pr**: Safety Rules + Autonomous Mode making the **merge step always
  human-gated**, plus a contract `Scope:`/truncation line on its batch scan.
- **New rules**: `work-sizing.md` (right-sized issues/PRs, language-specific code
  granularity, umbrella decomposition), `autonomous-workflow.md` (the end-to-end
  contract), and `review-convergence.md` (the review -> revise loop with an
  explicit termination criterion). Per-language **Code Size** sections added to
  the fortran/python/rust conventions.
- **`0-auto:audited`** label wired for batch idempotency and coverage accounting.

## Safety model

Every destructive or outward-facing action stays human-gated in both modes:
merging/enqueuing, closing/superseding, creating issues or parent/child links,
pushing to a branch the agent did not create this run, and reporter-facing posts.
A privacy invariant keeps internal tracker IDs, local paths, and host names off
public surfaces. An autonomous batch run converges to "PRs ready + verdicts
emitted"; a human authorises the merge.

## Scope and validation

- Documentation/tooling only — no `src/` or `test/` changes.
- Hardened via three adversarial multi-agent review passes (review -> independent
  verify -> revise) to convergence: no blocking or major findings remain.

## Note

`.claude/skills/curate-refs/SKILL.md` (pre-existing, untouched here) contains an
internal host name that should be scrubbed in a separate cleanup.
