### PR TITLE
Add strict legacy table normaliser

### DIFF
--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -84,6 +84,7 @@ py.install_sources(
             'util/converter/__init__.py',
             'util/converter/df_state.py',
             'util/converter/table/__init__.py',
+            'util/converter/table/legacy.py',
             'util/converter/table/table.py',
             'util/converter/table/reverse.py',
             'util/converter/table/table_writer.py',

--- a/src/supy/util/converter/table/legacy.py
+++ b/src/supy/util/converter/table/legacy.py
@@ -1,0 +1,191 @@
+"""Strict normalisation for legacy SUEWS text tables.
+
+Legacy SUEWS tables are whitespace-delimited files with two semantic header
+lines, inline comments, and ``-9`` end-of-data rows.  This module keeps the
+converter away from general-purpose CSV inference by exposing the small internal
+representation schema-edit operations need: column headers plus data rows.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+from chardet import detect
+
+
+class LegacyTableParseError(ValueError):
+    """Raised when a legacy table cannot be parsed without losing semantics."""
+
+    def __init__(self, source: str, message: str, line_number: int = 0):
+        self.source = source
+        self.line_number = line_number
+        prefix = f"{source}:{line_number}" if line_number else source
+        super().__init__(f"{prefix}: {message}")
+
+
+@dataclass
+class LegacyTable:
+    """Normalised legacy table contents."""
+
+    headers: list[str]
+    rows: list[list[str]]
+
+    @property
+    def codes(self) -> list[str]:
+        """Return row identifiers in on-disk order."""
+        return [row[0] for row in self.rows if row]
+
+    def to_text(self) -> str:
+        """Serialise using canonical whitespace and no legacy footer rows."""
+        index_line = " ".join(str(i + 1) for i in range(len(self.headers)))
+        lines = [index_line, " ".join(self.headers)]
+        lines.extend(" ".join(row) for row in self.rows)
+        return "\n".join(lines) + "\n"
+
+
+def _decode_legacy_text(path: Path) -> str:
+    """Read a legacy table, tolerating non-UTF-8 historical fixtures."""
+    raw = path.read_bytes()
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        encoding = (detect(raw) or {}).get("encoding") or "latin-1"
+        return raw.decode(encoding, errors="replace")
+
+
+def _tokens_from_line(raw_line: str) -> list[str]:
+    """Return semantic tokens after tab/comment normalisation."""
+    line = raw_line.replace("\r", "").replace("\t", " ")
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return []
+    if "!" in line:
+        line = line[: line.index("!")]
+    return line.split()
+
+
+def _is_legacy_footer(tokens: list[str]) -> bool:
+    """Return True for the legacy end-of-data sentinel row."""
+    return bool(tokens) and tokens[0] == "-9"
+
+
+def parse_legacy_table_text(
+    text: str,
+    *,
+    source: str = "<string>",
+    require_rows: bool = True,
+    allow_trailing_fields: bool = True,
+) -> LegacyTable:
+    """Parse legacy SUEWS table text into headers and rows.
+
+    Parameters
+    ----------
+    text : str
+        Raw table text.
+    source : str, optional
+        Label used in parse errors.
+    require_rows : bool, optional
+        If True, reject header-only tables. Converter edit paths use this to
+        avoid turning a failed parse into a plausible-looking rowless file.
+    allow_trailing_fields : bool, optional
+        If True, keep the fields a Fortran list-directed read would consume and
+        discard trailing tokens on the same record. Some historical tables used
+        those trailing tokens as annotation without a ``!`` comment marker.
+
+    Returns
+    -------
+    LegacyTable
+        Normalised headers and rows.
+    """
+    lines = text.splitlines()
+    header_records: list[tuple[int, list[str]]] = []
+    body_start = 0
+
+    for index, raw_line in enumerate(lines):
+        tokens = _tokens_from_line(raw_line)
+        if not tokens:
+            continue
+        header_records.append((index + 1, tokens))
+        if len(header_records) == 2:
+            body_start = index + 1
+            break
+
+    if len(header_records) < 2:
+        raise LegacyTableParseError(
+            source,
+            "expected two header lines before data rows",
+        )
+
+    _, index_tokens = header_records[0]
+    header_line, headers = header_records[1]
+    if not index_tokens:
+        raise LegacyTableParseError(source, "empty column-index header")
+    if not headers:
+        raise LegacyTableParseError(source, "empty column-name header", header_line)
+    if headers[0] not in {"Code", "Grid"}:
+        raise LegacyTableParseError(
+            source,
+            "first column must be 'Code' or 'Grid'",
+            header_line,
+        )
+    if len(set(headers)) != len(headers):
+        raise LegacyTableParseError(
+            source,
+            "duplicate column names are ambiguous",
+            header_line,
+        )
+
+    rows: list[list[str]] = []
+    expected_fields = len(headers)
+    for index, raw_line in enumerate(lines[body_start:], start=body_start + 1):
+        tokens = _tokens_from_line(raw_line)
+        if not tokens:
+            continue
+        if _is_legacy_footer(tokens):
+            break
+        if len(tokens) < expected_fields:
+            raise LegacyTableParseError(
+                source,
+                f"malformed data row: expected {expected_fields} fields, "
+                f"got {len(tokens)}",
+                index,
+            )
+        if len(tokens) > expected_fields:
+            if not allow_trailing_fields:
+                raise LegacyTableParseError(
+                    source,
+                    f"malformed data row: expected {expected_fields} fields, "
+                    f"got {len(tokens)}",
+                    index,
+                )
+            tokens = tokens[:expected_fields]
+        rows.append(tokens)
+
+    if require_rows and not rows:
+        raise LegacyTableParseError(
+            source,
+            "contains no data rows after normalisation",
+        )
+
+    return LegacyTable(headers=headers, rows=rows)
+
+
+def read_legacy_table(
+    path: Union[str, Path],
+    *,
+    require_rows: bool = True,
+    allow_trailing_fields: bool = True,
+) -> LegacyTable:
+    """Read and parse a legacy SUEWS table file."""
+    path_table = Path(path)
+    return parse_legacy_table_text(
+        _decode_legacy_text(path_table),
+        source=str(path_table),
+        require_rows=require_rows,
+        allow_trailing_fields=allow_trailing_fields,
+    )
+
+
+def write_legacy_table(path: Union[str, Path], table: LegacyTable) -> None:
+    """Write a normalised legacy table without ``-9`` footer rows."""
+    Path(path).write_text(table.to_text(), encoding="utf-8")

--- a/src/supy/util/converter/table/reverse.py
+++ b/src/supy/util/converter/table/reverse.py
@@ -34,10 +34,10 @@ from pathlib import Path
 from shutil import copyfile
 from typing import Optional
 
-from chardet import detect
 import f90nml
 
 from ...._env import logger_supy
+from .legacy import LegacyTable, read_legacy_table, write_legacy_table
 from .table import rules
 
 TARGET_VER = "2025a"
@@ -94,33 +94,6 @@ def _step_rules(from_ver: str, to_ver: str):
 # --------------------------------------------------------------------------- #
 # Tolerant table / namelist IO
 # --------------------------------------------------------------------------- #
-def _decode_text(path: Path) -> str:
-    """Read a legacy table as text, tolerating non-UTF-8 source encodings.
-
-    Legacy SUEWS tables predate the repo's UTF-8 mandate and carry stray
-    Latin-1 bytes (e.g. an accented author name). The forward converter
-    normalises these with ``convert_utf8`` before reading; capture reads the raw
-    source, so it detects the encoding (chardet, Latin-1 fallback) rather than
-    assuming UTF-8.
-
-    Parameters
-    ----------
-    path : Path
-        File to read.
-
-    Returns
-    -------
-    str
-        Decoded text.
-    """
-    raw = path.read_bytes()
-    try:
-        return raw.decode("utf-8")
-    except UnicodeDecodeError:
-        enc = (detect(raw) or {}).get("encoding") or "latin-1"
-        return raw.decode(enc, errors="replace")
-
-
 def _read_table(path: Path) -> tuple[list[str], list[list[str]]]:
     """Parse a SUEWS ``*.txt`` table into ``(header, rows)``.
 
@@ -139,17 +112,8 @@ def _read_table(path: Path) -> tuple[list[str], list[list[str]]]:
         ``(header, rows)`` where ``header`` is the list of column names and
         ``rows`` is a list of token lists (one per data row).
     """
-    lines = _decode_text(path).splitlines()
-    if len(lines) < 2:
-        return [], []
-    header = lines[1].split()
-    rows: list[list[str]] = []
-    for line in lines[2:]:
-        toks = line.split()
-        if not toks or toks[0].startswith("-9"):
-            break
-        rows.append(toks)
-    return header, rows
+    table = read_legacy_table(path)
+    return table.headers, table.rows
 
 
 def _write_table(path: Path, header: list[str], rows: list[list[str]]) -> None:
@@ -164,10 +128,7 @@ def _write_table(path: Path, header: list[str], rows: list[list[str]]) -> None:
     rows : list of list of str
         Data rows as token lists.
     """
-    index_line = " ".join(str(i + 1) for i in range(len(header)))
-    body = [index_line, " ".join(header)]
-    body.extend(" ".join(r) for r in rows)
-    path.write_text("\n".join(body) + "\n", encoding="utf-8")
+    write_legacy_table(path, LegacyTable(headers=list(header), rows=list(rows)))
 
 
 # --------------------------------------------------------------------------- #

--- a/src/supy/util/converter/table/table.py
+++ b/src/supy/util/converter/table/table.py
@@ -33,6 +33,7 @@ import pandas as pd
 
 from ...._env import logger_supy, trv_supy_module
 from ...._load import load_SUEWS_nml_simple
+from .legacy import LegacyTable, read_legacy_table, write_legacy_table
 from .profile_manager import ProfileManager
 
 warnings.filterwarnings("ignore")
@@ -600,26 +601,13 @@ def detect_table_version(input_dir):
 
 def _read_table_tokens(path):
     """Read a two-line-header SUEWS table without pandas inference."""
-    lines = Path(path).read_text(encoding="utf-8").splitlines()
-    if len(lines) < 2:
-        return [], []
-    headers = lines[1].split()
-    rows = []
-    for line in lines[2:]:
-        fields = line.split()
-        if not fields or fields[0].startswith("-9"):
-            break
-        rows.append(fields)
-    return headers, rows
+    table = read_legacy_table(path)
+    return table.headers, table.rows
 
 
 def _write_table_tokens(path, headers, rows):
     """Write a two-line-header SUEWS table without legacy footer rows."""
-    path = Path(path)
-    index_line = " ".join(str(i + 1) for i in range(len(headers)))
-    lines = [index_line, " ".join(headers)]
-    lines.extend(" ".join(row) for row in rows)
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_legacy_table(path, LegacyTable(headers=list(headers), rows=list(rows)))
 
 
 # rename:
@@ -703,71 +691,12 @@ def delete_var_nml(toFile, toVar, _toVal):
     nml.write(toFile, force=True)
 
 
-def _should_skip_line(line):
-    """Check if a line should be skipped during cleaning."""
-    stripped = line.strip()
-    # Skip empty lines and full-line comments
-    if not stripped or stripped.startswith("#"):
-        return True
-
-    # Detect whether this looks like a data line (starts with numeric code)
-    first_token = stripped.split()[0]
-    is_data_line = first_token.lstrip("-").isdigit()
-
-    # Skip lines that contain triple quotes or problematic quoted comments
-    if '"""' in line:
-        return True
-    if (
-        '"' in line
-        and not is_data_line
-        and ("Vegetation (average)" in line or "used for" in line)
-    ):
-        return True
-
-    # Skip lines starting with -9 (legacy footers)
-    return stripped.startswith("-9")
-
-
-def _process_line(line):
-    """Process a single line: remove comments and tabs."""
-    # Replace tabs with spaces
-    line = line.replace("\t", " ")
-
-    # Remove inline comments (everything after !)
-    if "!" in line:
-        line = line[: line.index("!")].rstrip()
-
-    return line
-
-
-def _ensure_consistent_columns(fields, header_col_count):
-    """Ensure field count matches header column count."""
-    if not header_col_count:
-        return fields
-
-    if len(fields) == header_col_count:
-        return fields
-
-    # Truncate extra fields or pad with -999
-    if len(fields) > header_col_count:
-        return fields[:header_col_count]
-    else:
-        while len(fields) < header_col_count:
-            fields.append("-999")
-        return fields
-
-
 def clean_legacy_table(file_path, output_path=None):
-    r"""
-    Clean legacy SUEWS table files for pandas compatibility.
+    r"""Normalise a legacy SUEWS table before schema conversion.
 
-    This function:
-    - Removes inline comments (text after ! character)
-    - Standardizes line endings (removes \r)
-    - Removes empty trailing columns
-    - Ensures consistent column counts
-    - Handles tab-separated values
-    - Removes ALL lines that start with -9 (legacy footers)
+    The normaliser follows the old Fortran table contract: whitespace-delimited
+    records, ``!`` inline comments, and ``-9`` end-of-data sentinels. It rejects
+    malformed rows instead of padding missing fields into plausible output.
 
     Args:
         file_path: Path to the input file
@@ -781,167 +710,23 @@ def clean_legacy_table(file_path, output_path=None):
         output_path = file_path
 
     logger_supy.debug(f"Cleaning legacy file: {file_path}")
-
-    # Track what was cleaned for reporting
-    cleaning_actions = []
-
-    with open(file_path, encoding="utf-8", errors="replace") as f:
-        lines = f.readlines()
-
-    if len(lines) < 2:
-        logger_supy.warning(
-            f"File {file_path} has less than 2 lines, skipping cleaning"
-        )
-        return file_path
-
-    header_lines = []  # Store header lines (first 2 lines)
-    data_lines = []  # Store data lines
-    header_col_count = None
-    line_count = 0  # Track non-empty lines
-
-    # Track cleaning statistics
-    comments_removed = 0
-    tabs_replaced = 0
-    footer_removed = False
-    columns_adjusted = 0
-
-    for i, raw_line in enumerate(lines):
-        # Remove carriage returns and trailing whitespace
-        line = raw_line.replace("\r", "").rstrip()
-
-        # Track tabs for reporting
-        if "\t" in line:
-            tabs_replaced += 1
-
-        # Check if line should be skipped
-        if _should_skip_line(line):
-            if line.strip().startswith("-9"):
-                footer_removed = True
-                logger_supy.debug(
-                    f"Removing legacy footer line {i + 1}: {line[:50]}... Stopping read after footer."
-                )
-                break  # Stop processing after footer
-            elif '"""' in line or (
-                '"' in line and ("Vegetation (average)" in line or "used for" in line)
-            ):
-                logger_supy.debug(
-                    f"Skipping line {i + 1} with problematic quoted comments: {line[:50]}..."
-                )
-                cleaning_actions.append(f"Removed metadata line {i + 1}")
-            continue
-
-        # Process the line (remove comments and tabs)
-        original_line = line
-        line = _process_line(line)
-        if "!" in original_line:
-            comments_removed += 1
-
-        # Split by spaces (tabs have been replaced with spaces)
-        fields = line.split()
-
-        # Skip empty lines after processing
-        if not fields:
-            continue
-
-        # For the header rows (first 2 non-empty lines), establish column count
-        if line_count < 2:
-            # Store header line
-            header_lines.append(" ".join(fields))
-            line_count += 1
-
-            # Set column count from the SECOND line (column names), not first
-            # First line may have trailing empty fields from tabs
-            if line_count == 2:
-                header_col_count = len(fields)
-                logger_supy.debug(
-                    f"Header column count set to {header_col_count} from column names line"
-                )
-                # Adjust first header line if needed
-                if len(header_lines[0].split()) != header_col_count:
-                    first_line_fields = header_lines[0].split()
-                    if len(first_line_fields) > header_col_count:
-                        header_lines[0] = " ".join(first_line_fields[:header_col_count])
-                        logger_supy.debug(
-                            f"Adjusted first header line from {len(first_line_fields)} to {header_col_count} fields"
-                        )
-            continue
-
-        # For data lines
-        line_count += 1
-
-        # Ensure consistent column count
-        original_field_count = len(fields)
-        fields = _ensure_consistent_columns(fields, header_col_count)
-        if len(fields) != original_field_count:
-            columns_adjusted += 1
-            if original_field_count > header_col_count:
-                logger_supy.debug(
-                    f"Line {i + 1}: Truncating from {original_field_count} to {header_col_count} fields"
-                )
-
-        # Store processed data line
-        data_lines.append(" ".join(fields))
-
-    # Combine header and data lines
-    cleaned_lines = header_lines + data_lines
-
-    # Note: We do NOT add footer lines - the -9 lines are removed entirely
-
-    # Write cleaned content
-    with open(output_path, "w", encoding="utf-8") as f:
-        f.write("\n".join(cleaned_lines))
-        if cleaned_lines and not cleaned_lines[-1].endswith("\n"):
-            f.write("\n")
-
-    # Report what was cleaned
-    if (
-        comments_removed > 0
-        or tabs_replaced > 0
-        or footer_removed
-        or columns_adjusted > 0
-    ):
-        clean_summary = []
-        if comments_removed > 0:
-            clean_summary.append(f"{comments_removed} inline comments")
-        if tabs_replaced > 0:
-            clean_summary.append(f"{tabs_replaced} tabs replaced")
-        if footer_removed:
-            clean_summary.append("legacy footer removed")
-        if columns_adjusted > 0:
-            clean_summary.append(
-                f"{columns_adjusted} lines adjusted for column consistency"
-            )
-        if cleaning_actions:
-            clean_summary.append(f"{len(cleaning_actions)} metadata lines removed")
-
-        logger_supy.info(
-            f"[OK] Cleaned {Path(file_path).name}: {', '.join(clean_summary)}"
-        )
-    else:
-        logger_supy.debug(f"File {Path(file_path).name} was already clean")
+    table = read_legacy_table(file_path)
+    write_legacy_table(output_path, table)
+    logger_supy.info(
+        f"[OK] Normalised {Path(file_path).name}: "
+        f"{len(table.headers)} columns, {len(table.rows)} rows"
+    )
 
     return output_path
 
 
-# Helper function to read SUEWS files robustly (kept for backward compatibility but simplified)
+# Helper function to read SUEWS files robustly
+# (kept for backward compatibility but simplified).
 def read_suews_table(toFile):
-    """Read SUEWS table file using numpy - simpler approach."""
+    """Read a SUEWS table file using the strict legacy parser."""
     try:
-        dataX = np.genfromtxt(
-            toFile,
-            dtype=str,
-            skip_header=1,
-            comments="!",
-            names=True,
-            invalid_raise=False,
-            encoding="UTF8",
-        )
-
-        # Convert to pandas DataFrame for compatibility
-        if dataX.size == 0:
-            return pd.DataFrame(columns=list(dataX.dtype.names))
-        else:
-            return pd.DataFrame(dataX.tolist(), columns=list(dataX.dtype.names))
+        table = read_legacy_table(toFile)
+        return pd.DataFrame(table.rows, columns=table.headers)
     except Exception as e:
         logger_supy.error(f"Failed to read {toFile}: {e!s}")
         raise

--- a/test/data_model/test_legacy_table_roundtrip.py
+++ b/test/data_model/test_legacy_table_roundtrip.py
@@ -26,8 +26,13 @@ import yaml
 pytest.importorskip("supy")
 from supy._load import load_InitialCond_grid_df  # noqa: PLC2701
 from supy.data_model.core.config import SUEWSConfig
+from supy.util.converter.table.legacy import (
+    LegacyTableParseError,
+    parse_legacy_table_text,
+)
 import supy.util.converter.table.reverse as R
 from supy.util.converter.table.table import (
+    add_var,
     clean_legacy_table,
     convert_table,
 )
@@ -135,6 +140,89 @@ def _compare_table(
 
 def _codes(rows: list[list[str]]) -> list[str]:
     return [row[0] for row in rows]
+
+
+def test_legacy_table_parser_normalises_fortran_style_tables():
+    """Parser follows the old Fortran table contract, not CSV inference."""
+    raw = (
+        "\t1\t2\t3\t! ordinal header for humans\n"
+        "Code\tA\tB\t! names\n"
+        "\n"
+        "10\t1\t2\t! inline comment\n"
+        "11   3   4\n"
+        "-9\n"
+        "12 5 6\n"
+    )
+
+    table = parse_legacy_table_text(raw, source="inline")
+
+    assert table.headers == ["Code", "A", "B"]
+    assert table.rows == [["10", "1", "2"], ["11", "3", "4"]]
+    assert table.codes == ["10", "11"]
+    assert table.to_text() == "1 2 3\nCode A B\n10 1 2\n11 3 4\n"
+
+
+@pytest.mark.parametrize(
+    ("row", "message", "allow_trailing_fields"),
+    [
+        ("10 1\n", "expected 3 fields, got 2", True),
+        ("10 1 2 3\n", "expected 3 fields, got 4", False),
+    ],
+)
+def test_legacy_table_parser_rejects_malformed_rows(
+    row, message, allow_trailing_fields
+):
+    """Rows that Fortran would not map positionally are rejected."""
+    raw = "1 2 3\nCode A B\n" + row
+
+    with pytest.raises(LegacyTableParseError, match=message):
+        parse_legacy_table_text(
+            raw,
+            source="bad-table",
+            allow_trailing_fields=allow_trailing_fields,
+        )
+
+
+def test_legacy_table_parser_ignores_fortran_trailing_annotations():
+    """Trailing tokens beyond the fixed read list are non-semantic."""
+    table = parse_legacy_table_text("1 2 3\nCode A B\n10 1 2 204.58\n")
+
+    assert table.rows == [["10", "1", "2"]]
+
+
+def test_legacy_table_parser_rejects_header_only_tables():
+    """A failed parse must not become a plausible header-only table."""
+    with pytest.raises(LegacyTableParseError, match="contains no data rows"):
+        parse_legacy_table_text("1 2\nCode A\n-9\n", source="rowless")
+
+
+def test_table_edit_rejects_malformed_rows_before_write(tmp_path):
+    """Schema edits fail before writing if the normaliser rejects the table."""
+    path = tmp_path / "SUEWS_Test.txt"
+    original = "1 2 3\nCode A B\n10 1\n"
+    path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(LegacyTableParseError, match="expected 3 fields, got 2"):
+        add_var(str(path), "C", "2", "9")
+
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_conversion_rejects_malformed_table_before_output(tmp_path):
+    """Malformed source tables fail before any rowless converted file is written."""
+    src = _extract_legacy_tables("2018b", tmp_path / "src")
+    malformed = src / "SUEWS_Irrigation.txt"
+    lines = malformed.read_text(encoding="utf-8").splitlines()
+    data, marker, comment = lines[2].partition("!")
+    fields = data.split()
+    lines[2] = " ".join(fields[:-1]) + f" {marker}{comment}"
+    malformed.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    out = tmp_path / "out"
+    with pytest.raises(LegacyTableParseError, match="malformed data row"):
+        convert_table(str(src), str(out), "2018b", "2025a", validate_profiles=False)
+
+    assert not any(out.rglob("SUEWS_Irrigation.txt"))
 
 
 def test_chained_forward_conversion_preserves_code_sets_when_table_reader_fails(
@@ -250,7 +338,11 @@ def test_runcontrol_roundtrip_preserves_keys(tmp_path):
         f"RunControl key set differs: "
         f"src_only={set(src_rc) - set(rev_rc)} rev_only={set(rev_rc) - set(src_rc)}"
     )
-    diffs = {k: (src_rc[k], rev_rc[k]) for k in src_rc if str(src_rc[k]) != str(rev_rc[k])}
+    diffs = {
+        k: (src_rc[k], rev_rc[k])
+        for k in src_rc
+        if str(src_rc[k]) != str(rev_rc[k])
+    }
     assert not diffs, f"RunControl value diffs: {diffs}"
 
 
@@ -267,7 +359,8 @@ def _forward_to_yaml(ver: str, src: Path, tmp: Path):
     convert_table(str(src), str(template), ver, "2025a", validate_profiles=False)
     df0 = load_InitialCond_grid_df(next(template.rglob("RunControl.nml")))
     cfg = SUEWSConfig.from_df_state(df0)
-    cfg.strict_initial_state_bounds = False  # legacy provenance (C3), as suews-convert does
+    # legacy provenance (C3), as suews-convert does
+    cfg.strict_initial_state_bounds = False
     cfg.to_yaml(tmp / "config.yml")
     df = SUEWSConfig(
         **yaml.safe_load((tmp / "config.yml").read_text(encoding="utf-8"))
@@ -572,7 +665,13 @@ def test_cross_version_chain_2016a_modern_2018b(tmp_path):
 
     src_b = _extract_legacy_tables("2018b", tmp_path / "srcB")
     template_b = tmp_path / "TB"
-    convert_table(str(src_b), str(template_b), "2018b", "2025a", validate_profiles=False)
+    convert_table(
+        str(src_b),
+        str(template_b),
+        "2018b",
+        "2025a",
+        validate_profiles=False,
+    )
     tmp_b = tmp_path / "legB"
     tmp_b.mkdir()
     rev_b = _reverse_via_writer(df, template_b, "2018b", src_b, tmp_b)


### PR DESCRIPTION
Fixes #1544

## Summary
- Add a dedicated parser/normaliser for legacy whitespace-delimited SUEWS tables.
- Route forward and reverse table IO through the normaliser so malformed inputs fail before schema edits write output.
- Preserve Fortran-style table semantics: positional whitespace fields, `!` comments, `-9` sentinels, and tolerated trailing annotation tokens.
- Add regression coverage for comments/tabs/footer handling, malformed rows, header-only tables, no-write failures, and round-trip conversion.

## Validation
- `make setup && source .venv/bin/activate && make dev`
- `source .venv/bin/activate && make test-smoke` -> 9 passed
- `source .venv/bin/activate && python -m pytest test/data_model/test_legacy_table_roundtrip.py -m "not slow"` -> 22 passed
- `source .venv/bin/activate && python -m ruff check src/supy/util/converter/table/legacy.py test/data_model/test_legacy_table_roundtrip.py --select I,F,E,W,UP`
- `source .venv/bin/activate && python -m ruff check src/supy/util/converter/table/table.py src/supy/util/converter/table/reverse.py --select I,F`
- `git diff --check`
- `source .venv/bin/activate && make test` -> 1617 passed, 6 skipped, 6 failed before installing the separate MCP dev package; the failures were limited to MCP protocol handshake imports. After `source .venv/bin/activate && uv pip install -e 'mcp[dev]'`, `source .venv/bin/activate && python -m pytest test/mcp/test_protocol_handshake.py -v --tb=short` passed (8 passed).
