### PR TITLE
Normalise in-memory forcing in update_forcing (DataFrame/SUEWSForcing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ EXAMPLES:
 
 ## 2026
 
+### 15 Jun 2026
+
+- [bugfix] `SUEWSSimulation.update_forcing()` now normalises in-memory forcing (DataFrame or `SUEWSForcing`) the same way as file/path loading, instead of assigning it directly and bypassing preparation (#1537)
+  - The bypass meant an hourly DataFrame ran at its own timestep rather than the model timestep, so a 300 s model never reached the `23:55` daily-write point and `DailyState` silently stopped being saved
+  - In-memory forcing is now resampled to `model.control.tstep`, and the temporal columns (`iy`/`id`/`it`/`imin`/`isec`) are reasserted from the index so `isec` stays consistent
+  - In-memory inputs are validated as already being in the model-ready canonical form (canonical column names, a `DatetimeIndex`, pressure in hPa) and rejected with a clear error otherwise; pressure that looks like kPa is caught early rather than surfacing later as a generic out-of-range failure. No unit conversion or column renaming is applied to in-memory inputs -- build them via `supy.util.read_forcing` or `SUEWSForcing.from_file` to guarantee the contract
+
 ### 13 Jun 2026
 
 - [feature][experimental] Bidirectional legacy table conversion: regenerate any historical SUEWS table set (`2016a`-`2020a`) from a modern YAML config / `df_state`, complementing the existing forward (`suews-convert`) path, so a configuration can move between any `(version, representation)` pair in either direction (#1522)

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -27,7 +27,7 @@ from .data_model.core import SUEWSConfig
 from .suews_checkpoint import SUEWSCheckpoint
 from .suews_forcing import SUEWSForcing
 from .suews_output import SUEWSOutput
-from .util._io import read_forcing
+from .util._io import prepare_dataframe_forcing, read_forcing
 
 # Constants
 DEFAULT_OUTPUT_FREQ_SECONDS = 3600  # Default hourly output frequency
@@ -414,9 +414,17 @@ class SUEWSSimulation:
 
         Notes
         -----
-        When loading from file paths, forcing data is resampled to match the
-        model timestep from ``model.control.tstep`` in the configuration.
-        If no configuration is loaded, defaults to 300 seconds (5 minutes).
+        Regardless of input type, forcing data is resampled to match the
+        model timestep from ``model.control.tstep`` in the configuration
+        (defaulting to 300 seconds when no configuration is loaded). In-memory
+        inputs (DataFrame or :class:`~supy.SUEWSForcing`) are validated as
+        already being in the model-ready canonical form -- canonical column
+        names, a :class:`pandas.DatetimeIndex`, and pressure in hPa -- and
+        rejected with a clear error otherwise. Unlike file loading, no column
+        renaming or unit conversion is applied to in-memory inputs; build them
+        with :func:`supy.util.read_forcing` or
+        :meth:`supy.SUEWSForcing.from_file` to guarantee that contract
+        (gh#1537).
 
         Examples
         --------
@@ -443,9 +451,13 @@ class SUEWSSimulation:
         if isinstance(forcing_data, RefValue):
             forcing_data = forcing_data.value
         if isinstance(forcing_data, SUEWSForcing):
-            self._df_forcing = forcing_data.to_dataframe(include_extras=True)
+            self._df_forcing = prepare_dataframe_forcing(
+                forcing_data.to_dataframe(include_extras=True), tstep_mod=tstep_mod
+            )
         elif isinstance(forcing_data, pd.DataFrame):
-            self._df_forcing = forcing_data.copy()
+            self._df_forcing = prepare_dataframe_forcing(
+                forcing_data, tstep_mod=tstep_mod
+            )
         elif isinstance(forcing_data, list):
             # Handle list of files
             self._df_forcing = SUEWSSimulation._load_forcing_from_list(

--- a/src/supy/util/_io.py
+++ b/src/supy/util/_io.py
@@ -1,11 +1,26 @@
-import numpy as np
 from pathlib import Path
+
+import numpy as np
 import pandas as pd
+
+from .._env import logger_supy
 from .._load import (
+    BASELINE_DATETIME_FORCING_COLUMNS,
+    BASELINE_FORCING_COLUMNS,
+    FORCING_OPTIONAL_FILL,
     load_SUEWS_Forcing_met_df_pattern,
     resample_forcing_met,
     set_index_dt,
 )
+from ._missing import from_nan, to_nan
+
+# Surface air pressure is never below ~300 hPa (that altitude is well into
+# the free troposphere, not a surface site). A DataFrame whose median
+# pressure falls below this almost certainly carries kPa values that were
+# never converted to the hPa the model expects -- the conversion that file
+# loading applies but direct DataFrame assignment historically bypassed
+# (gh#1537).
+_PRESSURE_HPA_FLOOR = 300.0
 
 
 def read_suews(path_suews_file: str) -> pd.DataFrame:
@@ -61,20 +76,141 @@ def read_forcing(path_suews_file: str, tstep_mod=300) -> pd.DataFrame:
     str_pattern = path_suews_file.name
 
     df_forcing_raw = load_SUEWS_Forcing_met_df_pattern(path_input, str_pattern)
-    tstep_met_in = df_forcing_raw.index.to_series().diff().iloc[-1] / pd.Timedelta("1s")
+    return resample_forcing_df(df_forcing_raw, tstep_mod=tstep_mod)
+
+
+def resample_forcing_df(df_forcing_raw: pd.DataFrame, tstep_mod=300) -> pd.DataFrame:
+    """Align a datetime-indexed forcing DataFrame to the model timestep.
+
+    Shared by :func:`read_forcing` (file loading) and
+    :func:`prepare_dataframe_forcing` (in-memory DataFrame loading) so both
+    entry points infer the input timestep and resample identically. The
+    input timestep is read from the index spacing; resampling only happens
+    when the model timestep is finer than the input, matching the historical
+    file-loading behaviour.
+
+    Parameters
+    ----------
+    df_forcing_raw : pandas.DataFrame
+        Datetime-indexed forcing data with canonical column names.
+    tstep_mod : int or None, optional
+        Model timestep [s] to resample to, by default 300. If ``None``,
+        resampling is skipped (the frequency is still set on the index).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Forcing aligned to ``tstep_mod`` (or unchanged if no resampling was
+        required).
+    """
+    tstep_met_in = (
+        df_forcing_raw.index.to_series().diff().iloc[-1] / pd.Timedelta("1s")
+    )
     df_forcing_raw = df_forcing_raw.asfreq(f"{tstep_met_in:.0f}s")
 
     df_forcing = df_forcing_raw
 
     # resampling only when necessary
-    if tstep_mod is not None:
-        if tstep_mod < tstep_met_in:
-            from ._missing import to_nan, from_nan
+    if tstep_mod is not None and tstep_mod < tstep_met_in:
+        df_forcing = to_nan(df_forcing_raw)
+        df_forcing = resample_forcing_met(
+            df_forcing, tstep_met_in, tstep_mod, kdownzen=0
+        )
+        df_forcing = from_nan(df_forcing)
 
-            df_forcing = to_nan(df_forcing_raw)
-            df_forcing = resample_forcing_met(
-                df_forcing, tstep_met_in, tstep_mod, kdownzen=0
-            )
-            df_forcing = from_nan(df_forcing)
+    return df_forcing
 
+
+def prepare_dataframe_forcing(
+    df_forcing: pd.DataFrame, tstep_mod: int = 300
+) -> pd.DataFrame:
+    """Normalise an in-memory forcing DataFrame for SUEWS simulation.
+
+    Applies the same timestep alignment that file loading performs, after
+    validating that the DataFrame is already in the model-ready canonical
+    form. Unlike file loading, no column renaming or unit conversion is
+    applied: an in-memory DataFrame has no file convention to canonicalise
+    against, so it must already match the contract that
+    :func:`read_forcing`, :class:`supy.SUEWSForcing`, and
+    :attr:`supy.SUEWSSimulation.forcing` produce -- in particular, pressure
+    in hPa. Temporal columns (``iy``, ``id``, ``it``, ``imin``, ``isec``)
+    are reasserted from the index so they stay consistent after any
+    resampling (gh#1537).
+
+    Parameters
+    ----------
+    df_forcing : pandas.DataFrame
+        Datetime-indexed forcing data with canonical column names and
+        model-ready units.
+    tstep_mod : int, optional
+        Model timestep [s] to resample to, by default 300.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Forcing aligned to ``tstep_mod`` with consistent temporal columns.
+
+    Raises
+    ------
+    ValueError
+        If the DataFrame lacks a :class:`pandas.DatetimeIndex`, is missing
+        required meteorological columns, has fewer than two timestamps, or
+        carries pressure values that look like kPa rather than hPa.
+    """
+    if not isinstance(df_forcing.index, pd.DatetimeIndex):
+        raise ValueError(
+            "DataFrame forcing must have a pandas.DatetimeIndex; got "
+            f"{type(df_forcing.index).__name__}. Use supy.util.read_forcing "
+            "or supy.SUEWSForcing.from_file to build a model-ready DataFrame."
+        )
+
+    missing = [c for c in BASELINE_FORCING_COLUMNS if c not in df_forcing.columns]
+    if missing:
+        raise ValueError(
+            f"DataFrame forcing is missing required columns: {missing}. "
+            "Forcing is matched by column name; expected canonical names "
+            f"include {list(BASELINE_FORCING_COLUMNS)}."
+        )
+
+    if df_forcing.index.size < 2:
+        raise ValueError(
+            "DataFrame forcing must have at least two timestamps so the "
+            "input timestep can be inferred; "
+            f"got {df_forcing.index.size}."
+        )
+
+    # Pressure must be in hPa (the model unit). File loading converts kPa
+    # -> hPa; an in-memory DataFrame is taken as already converted. Catch
+    # the common "forgot to convert" mistake with a clear, early error
+    # rather than letting it surface later as a generic out-of-range check.
+    ser_pres = df_forcing["pres"]
+    ser_pres_valid = ser_pres[ser_pres > FORCING_OPTIONAL_FILL / 2]
+    if ser_pres_valid.size and ser_pres_valid.median() < _PRESSURE_HPA_FLOOR:
+        raise ValueError(
+            "DataFrame forcing pressure (`pres`) looks like kPa, not hPa "
+            f"(median {ser_pres_valid.median():.1f}). SUEWS expects surface "
+            "pressure in hPa; multiply by 10 if your data are in kPa, or use "
+            "supy.util.read_forcing, which applies the conversion."
+        )
+
+    df_forcing = resample_forcing_df(df_forcing.copy(), tstep_mod=tstep_mod)
+
+    # Reassert temporal columns from the (possibly resampled) index so they
+    # stay consistent with the data -- in particular `isec`, which a
+    # hand-built DataFrame may omit (gh#1537).
+    df_forcing["iy"] = df_forcing.index.year
+    df_forcing["id"] = df_forcing.index.dayofyear
+    df_forcing["it"] = df_forcing.index.hour
+    df_forcing["imin"] = df_forcing.index.minute
+    df_forcing["isec"] = df_forcing.index.second
+    complete_dt_columns = [*BASELINE_DATETIME_FORCING_COLUMNS, "isec"]
+    df_forcing[complete_dt_columns] = df_forcing[complete_dt_columns].astype(
+        np.int64
+    )
+
+    logger_supy.debug(
+        "Prepared DataFrame forcing: %d rows at tstep %ss",
+        len(df_forcing),
+        tstep_mod,
+    )
     return df_forcing

--- a/test/core/test_update_forcing_dataframe.py
+++ b/test/core/test_update_forcing_dataframe.py
@@ -1,0 +1,175 @@
+"""Regression tests for in-memory forcing normalisation (gh#1537).
+
+``SUEWSSimulation.update_forcing`` used to assign DataFrame / SUEWSForcing
+inputs directly to ``self._df_forcing``, bypassing the timestep resampling,
+temporal-column refresh, and unit contract that file loading applies. Hourly
+DataFrame forcing then ran at the input timestep instead of the model
+timestep, so a 300 s model never reached the ``23:55`` daily-write point and
+``DailyState`` stopped being saved. These tests pin the normalised behaviour.
+"""
+
+import pandas as pd
+import pytest
+
+try:
+    from importlib.resources import files
+except ImportError:  # pragma: no cover - Python < 3.9 fallback
+    from importlib_resources import files
+
+from supy.suews_sim import SUEWSSimulation
+from supy.util import read_forcing
+
+pytestmark = pytest.mark.api
+
+
+@pytest.fixture(scope="module")
+def sample_paths():
+    """Resolve the bundled sample config and hourly forcing file.
+
+    ``files(...)`` returns a meson-python editable traversable; ``str`` of a
+    file resolves to the real path, but the directory itself is not glob-able,
+    so each file is resolved individually.
+    """
+    return {
+        "config": str(files("supy").joinpath("sample_data/sample_config.yml")),
+        "forcing": str(files("supy").joinpath("sample_data/Kc_2012_data_60.txt")),
+    }
+
+
+@pytest.fixture(scope="module")
+def hourly_forcing(sample_paths):
+    """Canonical, hPa, NOT-yet-resampled hourly forcing DataFrame."""
+    return read_forcing(str(sample_paths["forcing"]), tstep_mod=None)
+
+
+class TestTimestepNormalisation:
+    """AC1/AC2: DataFrame forcing is resampled like path/file forcing."""
+
+    @pytest.mark.core
+    def test_dataframe_matches_path_loading(self, sample_paths, hourly_forcing):
+        """DataFrame and config/path loading yield the same forcing shape."""
+        # ARRANGE: config/path loading (the reference behaviour)
+        sim_path = SUEWSSimulation(str(sample_paths["config"]))
+
+        # ACT: DataFrame loading of the same data via the in-memory path
+        sim_df = SUEWSSimulation()
+        sim_df.update_config(str(sample_paths["config"]), auto_load_forcing=False)
+        sim_df.update_forcing(hourly_forcing)
+
+        # ASSERT: both resampled to the model timestep (5 min)
+        assert pd.infer_freq(sim_path._df_forcing.index) == "5min"
+        assert pd.infer_freq(sim_df._df_forcing.index) == "5min"
+        assert len(sim_df._df_forcing) == len(sim_path._df_forcing)
+        assert sim_df._df_forcing.index.equals(sim_path._df_forcing.index)
+
+    @pytest.mark.core
+    def test_hourly_input_is_upsampled(self, sample_paths, hourly_forcing):
+        """An hourly DataFrame is upsampled to the 300 s model timestep."""
+        assert pd.infer_freq(hourly_forcing.index) == "h"
+
+        sim = SUEWSSimulation()
+        sim.update_config(str(sample_paths["config"]), auto_load_forcing=False)
+        sim.update_forcing(hourly_forcing)
+
+        diffs = sim._df_forcing.index.to_series().diff().dropna()
+        assert (diffs == pd.Timedelta(seconds=300)).all()
+        # 8784 hourly rows -> 12 per hour after upsampling.
+        assert len(sim._df_forcing) == len(hourly_forcing) * 12
+
+    @pytest.mark.core
+    def test_dailystate_written_for_dataframe_forcing(
+        self, sample_paths, hourly_forcing
+    ):
+        """End-to-end: DailyState is saved once the forcing is resampled."""
+        sim = SUEWSSimulation()
+        sim.update_config(str(sample_paths["config"]), auto_load_forcing=False)
+        sim.update_forcing(hourly_forcing)
+
+        out = sim.run(
+            start_date="2012-01-01", end_date="2012-01-03 23:59:59", n_jobs=1
+        )
+        df_daily = out.df.xs("DailyState", level="group", axis=1)
+        # Three complete days -> three daily-state write points (the symptom
+        # in gh#1537 was zero rows here).
+        assert len(df_daily.dropna(how="all")) == 3
+
+
+class TestPressureUnitContract:
+    """AC3: pressure must be in hPa; kPa is rejected early and clearly."""
+
+    @pytest.mark.core
+    def test_kpa_pressure_rejected(self, hourly_forcing):
+        """A DataFrame with kPa pressure raises a clear ValueError."""
+        df_kpa = hourly_forcing.copy()
+        df_kpa["pres"] /= 10.0  # hPa -> kPa
+
+        sim = SUEWSSimulation()
+        with pytest.raises(ValueError, match="kPa"):
+            sim.update_forcing(df_kpa)
+
+    @pytest.mark.core
+    def test_hpa_pressure_accepted(self, sample_paths, hourly_forcing):
+        """Properly-converted hPa pressure passes the unit check."""
+        sim = SUEWSSimulation()
+        sim.update_config(str(sample_paths["config"]), auto_load_forcing=False)
+        sim.update_forcing(hourly_forcing)  # already hPa
+        assert sim._df_forcing["pres"].median() > 300
+
+
+class TestTemporalColumns:
+    """AC4: isec (and the other temporal columns) follow the index."""
+
+    @pytest.mark.core
+    def test_isec_derived_when_missing(self, sample_paths, hourly_forcing):
+        """A DataFrame without isec gains a correct isec column."""
+        df_no_isec = hourly_forcing.drop(columns=["isec"], errors="ignore")
+        assert "isec" not in df_no_isec.columns
+
+        sim = SUEWSSimulation()
+        sim.update_config(str(sample_paths["config"]), auto_load_forcing=False)
+        sim.update_forcing(df_no_isec)
+
+        assert "isec" in sim._df_forcing.columns
+        # 5-min boundaries have zero seconds.
+        assert (sim._df_forcing["isec"] == 0).all()
+
+    @pytest.mark.core
+    def test_temporal_columns_track_index(self, sample_paths, hourly_forcing):
+        """iy/id/it/imin/isec are reasserted from the resampled index."""
+        sim = SUEWSSimulation()
+        sim.update_config(str(sample_paths["config"]), auto_load_forcing=False)
+        sim.update_forcing(hourly_forcing)
+
+        idx = sim._df_forcing.index
+        assert (sim._df_forcing["iy"] == idx.year).all()
+        assert (sim._df_forcing["id"] == idx.dayofyear).all()
+        assert (sim._df_forcing["it"] == idx.hour).all()
+        assert (sim._df_forcing["imin"] == idx.minute).all()
+
+
+class TestValidationFailFast:
+    """Non-canonical DataFrames are rejected with actionable errors."""
+
+    @pytest.mark.core
+    def test_non_datetime_index_rejected(self, hourly_forcing):
+        """A DataFrame without a DatetimeIndex raises ValueError."""
+        df_bad = hourly_forcing.reset_index(drop=True)
+        sim = SUEWSSimulation()
+        with pytest.raises(ValueError, match="DatetimeIndex"):
+            sim.update_forcing(df_bad)
+
+    @pytest.mark.core
+    def test_missing_baseline_column_rejected(self, hourly_forcing):
+        """Dropping a required meteorological column raises ValueError."""
+        df_bad = hourly_forcing.drop(columns=["Tair"])
+        sim = SUEWSSimulation()
+        with pytest.raises(ValueError, match="missing required columns"):
+            sim.update_forcing(df_bad)
+
+    @pytest.mark.core
+    def test_single_row_rejected(self, hourly_forcing):
+        """A single-timestamp DataFrame cannot infer a timestep."""
+        df_bad = hourly_forcing.iloc[:1]
+        sim = SUEWSSimulation()
+        with pytest.raises(ValueError, match="at least two timestamps"):
+            sim.update_forcing(df_bad)


### PR DESCRIPTION
Fixes #1537.

## Problem

`SUEWSSimulation.update_forcing()` behaved differently depending on input type. Path/list inputs were read, canonicalised, unit-adjusted, and resampled to `model.control.tstep`; DataFrame and `SUEWSForcing` inputs were assigned straight to `self._df_forcing`, bypassing all of that.

The visible symptom: an hourly DataFrame ran at its own timestep rather than the model timestep, so a 300 s model never reached the `23:55` daily-write point and `DailyState` silently stopped being saved. Pressure unit handling also diverged (file loading converts kPa -> hPa; direct DataFrame assignment did not).

## Approach

In-memory forcing (DataFrame or `SUEWSForcing`) is now routed through a shared preparation step in `supy.util._io.prepare_dataframe_forcing`:

- **Resample** to `model.control.tstep`, reusing the same logic as file loading (extracted into `resample_forcing_df`, now shared with `read_forcing`). Idempotent: forcing already at the model timestep is unchanged.
- **Reassert** temporal columns (`iy`/`id`/`it`/`imin`/`isec`) from the index, so `isec` stays consistent even for hand-built DataFrames.
- **Validate** the input is already in model-ready canonical form (canonical column names, a `DatetimeIndex`, pressure in hPa) and fail fast with a clear error otherwise. Pressure that looks like kPa is caught early with an explicit message rather than surfacing later as a generic out-of-range failure.

No unit conversion or column renaming is applied to in-memory inputs: an in-memory DataFrame has no file convention to canonicalise against, so re-running the file canonicaliser would double-convert pressure (×10) for any DataFrame already produced by `read_forcing` / `sim.forcing`. The contract is therefore: build in-memory forcing via `supy.util.read_forcing` or `SUEWSForcing.from_file`.

## Acceptance criteria

- [x] `update_forcing(DataFrame)` no longer silently bypasses required forcing preparation
- [x] Hourly DataFrame forcing is resampled consistently with config/path loading (or rejected with a clear error)
- [x] Pressure/unit handling follows the same hPa contract as file loading
- [x] `isec` handling is covered for DataFrame forcing
- [x] Regression tests cover timestep consistency and pressure/unit handling using bundled sample data

## Validation

- New `test/core/test_update_forcing_dataframe.py` (10 tests) covering timestep normalisation, the DailyState symptom end-to-end, the kPa/hPa contract, isec derivation, and fail-fast validation.
- Existing forcing/simulation/checkpoint/IO suites re-run green (`test_suews_simulation`, `test_forcing_path_resolution`, `test_named_column_forcing`, `test_forcing_interpolation`, `test_supy`, `test_checkpoint`, `test_laimethod`, `test_irrigation_wiring`, `test_cli_conversion`).
- `make test-smoke` passes.

No `src/supy/data_model/` changes, so no schema-version bump is required.