### PR TITLE
Add triage-pr skill: disposition router for draft and stalled PRs

### DIFF
--- a/.claude/rules/autonomous-workflow.md
+++ b/.claude/rules/autonomous-workflow.md
@@ -26,6 +26,17 @@ Read it alongside `work-sizing.md` (sizing and umbrella decomposition).
 (stages 1-4: triage-issue, fix-issue, audit-pr, split-pr). queue-pr orders ready
 PRs and does not itself apply the sizing criteria.
 
+`triage-pr` is the PR-axis sibling of triage-issue. Where triage-issue grooms the
+issue backlog for readiness, triage-pr grooms the draft and stalled PR backlog for
+disposition. It is a router, not a reviewer: it assigns each PR one of five verdicts
+(`advance`, `continue`, `defer`, `close`, `escalate`) and routes live PRs into the
+existing stages -- `advance` -> audit-pr / split-pr / queue-pr (and the user-level
+prep-pr where applicable); `continue` -> fix-issue / author. `defer` parks the PR
+with a named revisit trigger; `close` and `escalate` are always human-gated. It
+never merges and never closes (terminates at "disposition assigned plus live PRs
+handed off"). The always-human-gated list in the Gating model section already
+covers its close and escalate terminals.
+
 ---
 
 ## Handoff vocabulary (machine-readable)
@@ -53,6 +64,28 @@ without reading prose:
   loop branches on these; `split-recommended` routes to split-pr.
 - split-pr -> queue-pr: `[split-pr] stack plan` with `Completeness:` and
   `Concerns -> Children`.
+- triage-pr -> downstream skills: `[triage-pr] verdict` block per PR. Downstream
+  skills branch on `Verdict` and `Route`; they do not parse prose. The canonical
+  block (reproduce exactly):
+
+  ```
+  [triage-pr] verdict
+  PR: #<n>
+  Verdict: advance | continue | defer | close | escalate
+  Priority: P0 | P1 | P2 | -        (advance only)
+  Route: prep-pr | split-pr | queue-pr | fix-issue | -
+  Reason: <one line>
+  Revisit-by: YYYY-MM-DD | -        (defer only)
+  Blocked-on: #<n> | -             (defer only)
+  Applied: comment | label:<0-pr:...> | ready | none
+  Next: <downstream action / the human question>
+  ```
+
+  `Verdict: close` and `Verdict: escalate` are human terminals: labels
+  `0-pr:close-proposed` / `0-pr:escalate` are applied; no further automated
+  action. Downstream skills pick up `Verdict: advance` (via `Route:
+  prep-pr|split-pr|queue-pr`) and `Verdict: continue` (via `Route: fix-issue`)
+  without reading prose.
 
 ---
 
@@ -135,3 +168,29 @@ a `triaged` or `needs-discussion` verdict; batch mode queries it to skip
 already-processed issues unless updated since. It is bookkeeping, so it is not
 counted as substantive work in the `Applied:` field. A maintainer creates the
 label once; the autonomous tier never creates labels.
+
+## The 0-auto:pr-audited label and 0-pr:* disposition family
+
+`0-auto:pr-audited` is the PR-axis equivalent of `0-auto:audited`. triage-pr
+applies it (if it exists) to every PR that completes a triage run; batch mode
+queries it to skip PRs with no substantive activity since the previous audit. It
+is additive: applied once and left in place on re-runs. Not counted as substantive
+work in the `Applied:` field. A maintainer creates the label once; the autonomous
+tier never creates labels.
+
+The `0-pr:*` disposition family carries the current triage-pr verdict for a PR:
+
+| Verdict | Label |
+|---------|-------|
+| `advance` | `0-pr:advance` |
+| `continue` | `0-pr:continue` |
+| `defer` | `0-pr:deferred` |
+| `close` | `0-pr:close-proposed` |
+| `escalate` | `0-pr:escalate` |
+
+These labels are mutually exclusive: before applying any `0-pr:*` label, remove
+every other `0-pr:*` label already on the PR (state machine -- one label at a
+time). A maintainer creates all six labels once; triage-pr applies those that
+already exist and never creates labels. If a label is absent, the verdict is
+recorded in the marker comment and verdict block only, with a note that the label
+is missing.

--- a/.claude/skills/triage-pr/SKILL.md
+++ b/.claude/skills/triage-pr/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: triage-pr
+description: Use whenever auditing, prioritising, or batch-triaging SUEWS draft and stalled pull requests so each gets a clear disposition. Trigger for "triage PRs", "which draft PRs need attention", "what's the disposition of these PRs", "groom the PR backlog", "defer this PR with a reason", "which PRs are ready to advance to merge", or a scheduled PR-backlog sweep. Routes live PRs to prep-pr/split-pr/queue-pr; defers or escalates the rest; never merges or closes.
+---
+
+# Triage PR
+
+The PR-axis sibling of `triage-issue`. Where `triage-issue` grooms issue descriptions
+into maintainer-ready engineering work items, `triage-pr` grooms the draft and stalled
+PR backlog so every open PR has a clear, reasoned disposition.
+
+This skill is a **router**, not a reviewer. It decides *what happens next* for each PR;
+it does not re-review code, order the merge queue, or carve diffs. Those responsibilities
+stay with their owners:
+
+- Code review -> `audit-pr`
+- Merge queue ordering -> `queue-pr`
+- Oversized diff carving -> `split-pr`
+
+Verdict routes:
+
+- `advance` -> route to `prep-pr`, `split-pr`, or `queue-pr`
+- `continue` -> route to `fix-issue` or author
+- `defer` -> parked with a named revisit trigger
+- `close` -> **human-gated**: propose, never act
+- `escalate` -> **human-gated**: surface conflicting signals, never guess
+
+`triage-pr` never merges and never closes a PR.
+
+---
+
+## Triggers
+
+Use this skill when asked to:
+
+- Audit, prioritise, or groom the SUEWS draft/stalled PR backlog.
+- Assign a disposition to one or many draft or stale PRs.
+- Find which PRs are ready to advance, which should be deferred, and which need a
+  maintainer decision.
+- Run a scheduled PR-backlog sweep (autonomous batch mode).
+
+---
+
+## Capabilities
+
+- Scan the open PR backlog using the bundled read-only scanner.
+- Compute one of five verdicts (`advance`, `continue`, `defer`, `close`, `escalate`)
+  per PR using the signal-to-verdict rules in `references/rubric.md`.
+- Apply a `0-pr:*` disposition label (if it exists in the repo) and an idempotency
+  label (`0-auto:pr-audited`) to each processed PR.
+- Post (or upsert) a machine-readable marker comment containing the verdict block.
+- Record `defer` verdicts with a named revisit trigger (`revisit-by:` or `blocked-on:`).
+- Route `advance` PRs to the correct downstream skill (`prep-pr`, `split-pr`, or
+  `queue-pr`) based on CI, merge state, and size signals.
+- Escalate `close` and genuinely ambiguous `escalate` verdicts to a maintainer without
+  guessing or acting.
+
+---
+
+## Quick Start
+
+Run the read-only scanner to collect candidates:
+
+```
+bash .claude/skills/triage-pr/scripts/scan-prs.sh --stale-days 14
+```
+
+The scanner prints a `Scope:` line followed by one TSV row per candidate PR:
+
+```
+PR  STATE  CI  MERGE  REVIEW  AGE_D  CHURN  FILES  AUTHOR  TITLE
+```
+
+Then compute a verdict for each row using `references/rubric.md` and apply the
+procedure in `references/methodology.md`.
+
+For a different staleness threshold or a non-default repository:
+
+```
+bash .claude/skills/triage-pr/scripts/scan-prs.sh --repo UMEP-dev/SUEWS --stale-days 7
+```
+
+For JSON output (for scripting):
+
+```
+bash .claude/skills/triage-pr/scripts/scan-prs.sh --json 2>/dev/null | jq .
+```
+
+---
+
+## Safety Rules
+
+- Drafting or scanning is not permission to post, label, or flip PR state. In
+  interactive mode, present the verdict block for each PR and wait for explicit
+  approval before any write.
+- Reading a PR's signals is not permission to act on the PR.
+- Privacy is a hard invariant on every outward write. Apply the Privacy scrub gate
+  (below) before any comment or label rationale reaches GitHub.
+- `triage-pr` NEVER closes a PR, NEVER merges, and NEVER enqueues. These are
+  always human-gated.
+- Do not create labels. Apply labels only if they already exist in the repository.
+
+---
+
+## Label Model
+
+### Disposition labels (mutually exclusive, one per PR per run)
+
+| Verdict | Label |
+|---------|-------|
+| `advance` | `0-pr:advance` |
+| `continue` | `0-pr:continue` |
+| `defer` | `0-pr:defer` |
+| `close` | `0-pr:close-proposed` |
+| `escalate` | `0-pr:escalate` |
+
+These labels are mutually exclusive. Before applying any new `0-pr:*` label, remove
+every other `0-pr:*` label already on the PR (there should be at most one, but remove
+all if more than one is present). Never leave two `0-pr:*` labels on a PR simultaneously.
+
+### Bookkeeping label
+
+`0-auto:pr-audited` -- marks that an autonomous pass has processed this PR.
+It is additive: apply it once and leave it. Do not remove it on a re-run.
+It enables idempotency: batch re-runs skip PRs carrying this label whose
+last substantive activity predates the previous audit timestamp.
+
+### Priority
+
+Priority (P0/P1/P2) is **not** a label. It lives in the verdict block only.
+
+### Maintainer one-off setup
+
+Create these seven labels once in the repository:
+
+```
+0-auto:pr-audited
+0-pr:advance
+0-pr:continue
+0-pr:defer
+0-pr:close-proposed
+0-pr:escalate
+```
+
+`triage-pr` applies labels that already exist and NEVER creates them. If a label is
+absent, the verdict is recorded in the marker comment and handoff block only, with a
+note that the label is missing.
+
+---
+
+## Privacy Scrub Gate
+
+Before any outward write (marker comment, label rationale, or any text posted to
+GitHub), scan the model-authored distilled text for:
+
+- Internal tracker IDs (`PER-\d+` and similar private references).
+- Absolute local or home-directory paths (`/Users/...`, worktree paths).
+- Private host or infrastructure names (internal compute servers and the like).
+
+On a hit in distilled text, redact the offending token before posting.
+
+If a private token appears inside a verbatim quote (for example from the PR description
+or a commit message) that must be preserved to make the finding actionable, replace it
+with neutral phrasing or escalate to a maintainer rather than post as-is.
+
+This operationalises "Privacy is a hard invariant on every outward write" from
+`.claude/rules/autonomous-workflow.md`.
+
+---
+
+## Gating Model -- Three Tiers
+
+### Auto-applicable (additive, reversible, or self-scoped)
+
+May run without human approval:
+
+- Run the read-only scanner (`scan-prs.sh`).
+- Compute verdicts per `references/rubric.md`.
+- Post or upsert the marker comment on each PR (idempotent: replace an existing
+  `<!-- triage-pr:verdict ts=... -->` comment rather than duplicating it).
+- Apply the matching `0-pr:*` label using the mutual-exclusion swap described above,
+  if that label exists in the repo.
+- Apply the `0-auto:pr-audited` label if it exists in the repo.
+
+### Confidence-gated
+
+Applied without human approval only when all stated gates hold; escalated otherwise:
+
+- Flipping a draft PR to "ready for review" -- only when ALL advance gates in
+  `references/rubric.md` (Part A) hold AND the PR is one the agent created this run
+  (not a third-party PR).
+
+### Human-gated (always escalate; never auto-apply)
+
+- Closing or superseding a PR.
+- Any merge or queue-entry (`queue-pr --enqueue` or `gh pr merge`).
+- Posting to, marking ready, or force-pushing a PR the agent does not own.
+- Editing the body or metadata of a PR the agent does not own.
+
+### The verdict-vs-action split
+
+**A verdict is a disposition; enacting it is a separate tiered action.**
+
+An `advance` verdict on a third-party PR still gets the `0-pr:advance` label (auto)
+and the recommendation in the marker comment, but the ready-flip and downstream
+handoff are human-gated. The `Next:` field in the verdict block says "recommend
+marking ready / hand to `<route>`". The verdict is NOT downgraded to `escalate`
+because the enacting action is human-gated -- only the action waits; the verdict
+is recorded immediately.
+
+---
+
+## Workflow
+
+Read `references/methodology.md` for the full step-by-step procedure. The summary is:
+
+1. Run `scan-prs.sh` to collect the candidate set and the `Scope:` line.
+2. For each candidate PR, check idempotency (already audited with no new activity
+   and no fired revisit trigger -> record as `noop`, stop).
+3. Compute the verdict using `references/rubric.md`.
+4. Apply the auto-tier: upsert the marker comment; swap the `0-pr:*` label; apply
+   `0-auto:pr-audited`.
+5. State the route and next step in the verdict block:
+   - `advance` -> route to `prep-pr`, `split-pr`, or `queue-pr`; record priority.
+   - `continue` -> note live WIP; route is `fix-issue` or author notification.
+   - `defer` -> record `Revisit-by:` or `Blocked-on:` in the verdict block.
+   - `close` -> present `0-pr:close-proposed` for maintainer decision; no further
+     action.
+   - `escalate` -> state conflicting signals explicitly; present for maintainer
+     resolution.
+
+---
+
+## Autonomous Mode
+
+By default `triage-pr` is interactive: it drafts and waits for explicit approval
+before any write. Autonomous mode is an opt-in contract for unattended orchestration
+(a scheduled backlog sweep or an upstream orchestrator). It never asks a human
+mid-run.
+
+Opt-in standing approval covers ONLY the auto-applicable tier. The human-gated tier
+(close, merge/enqueue, third-party PR edits) always escalates in autonomous mode;
+there is no standing approval for those actions.
+
+In autonomous batch mode:
+
+- Bound the input set explicitly with `--limit`. Emit the scanner's `Scope:` line
+  verbatim so a silent cap is never read as full coverage.
+- Apply the idempotency check per PR before computing a verdict. A `noop` PR (already
+  audited, no new activity) is counted as `noop` in coverage, never as `skipped`.
+- Accumulate verdict counts across the batch and emit a `Summary:` line at the end.
+- A PR that cannot be fetched or processed is recorded as `skipped` with a reason in
+  the `Next:` field. Never silently drop a PR.
+- Coverage equation (must hold exactly):
+  `advance + continue + defer + close + escalate + noop + skipped = K`
+  where K is the fetched set size. Full coverage of the open backlog is assertable
+  only when `truncated: no`.
+
+Any review -> revise loop inside a batch run follows `.claude/rules/review-convergence.md`
+(round cap + oscillation guard). A single PR must not consume the batch; escalate and
+move on if it does not converge within the cap.
+
+---
+
+## Output Format
+
+Use the machine-readable handoff verdict block defined in `references/methodology.md`.
+The block is reproduced here for convenience; keep it identical to the canonical form
+in that file:
+
+```
+[triage-pr] verdict
+PR: #<n>
+Verdict: advance | continue | defer | close | escalate
+Priority: P0 | P1 | P2 | -        (advance only)
+Route: prep-pr | split-pr | queue-pr | fix-issue | -
+Reason: <one line>
+Revisit-by: YYYY-MM-DD | -        (defer only)
+Blocked-on: #<n> | -             (defer only)
+Applied: comment | label:<0-pr:...> | ready | none
+Next: <downstream action / the human question>
+```
+
+Downstream skills (`prep-pr`, `split-pr`, `queue-pr`, `fix-issue`) branch on `Verdict`
+and `Route`. They do NOT need to parse prose.
+
+---
+
+## References
+
+- `references/rubric.md` -- Signal-to-verdict decision rule (five verdicts, priority,
+  near-green CI definition).
+- `references/methodology.md` -- Step-by-step procedure, marker and idempotency
+  mechanics, machine-readable verdict block, batch coverage accounting.
+- `scripts/scan-prs.sh` -- Read-only PR signal scanner; emits TSV candidates for the
+  router.
+- `.claude/rules/autonomous-workflow.md` -- Pipeline contract: gating tiers, the
+  always-human-gated list, and the merge gate.
+- `.claude/rules/work-sizing.md` -- Right-sized-PR criteria; referenced by the `advance`
+  route decision (size gate -> `split-pr` vs `queue-pr` vs `prep-pr`).
+- `.claude/rules/review-convergence.md` -- Bounded loop discipline for any
+  review -> revise cycle inside a batch run.

--- a/.claude/skills/triage-pr/SKILL.md
+++ b/.claude/skills/triage-pr/SKILL.md
@@ -110,7 +110,7 @@ bash .claude/skills/triage-pr/scripts/scan-prs.sh --json 2>/dev/null | jq .
 |---------|-------|
 | `advance` | `0-pr:advance` |
 | `continue` | `0-pr:continue` |
-| `defer` | `0-pr:defer` |
+| `defer` | `0-pr:deferred` |
 | `close` | `0-pr:close-proposed` |
 | `escalate` | `0-pr:escalate` |
 
@@ -131,13 +131,13 @@ Priority (P0/P1/P2) is **not** a label. It lives in the verdict block only.
 
 ### Maintainer one-off setup
 
-Create these seven labels once in the repository:
+Create these six labels once in the repository:
 
 ```
 0-auto:pr-audited
 0-pr:advance
 0-pr:continue
-0-pr:defer
+0-pr:deferred
 0-pr:close-proposed
 0-pr:escalate
 ```

--- a/.claude/skills/triage-pr/references/methodology.md
+++ b/.claude/skills/triage-pr/references/methodology.md
@@ -50,7 +50,7 @@ live in `rubric.md`; this file covers the procedure for applying them.
      corresponding to the verdict:
      - `advance` -> `0-pr:advance`
      - `continue` -> `0-pr:continue`
-     - `defer` -> `0-pr:defer`
+     - `defer` -> `0-pr:deferred`
      - `close` -> `0-pr:close-proposed`
      - `escalate` -> `0-pr:escalate`
    - Apply the `0-auto:pr-audited` label if it does not already exist.
@@ -100,7 +100,7 @@ A PR carrying `0-pr:deferred` re-enters active triage when EITHER:
 - Its `blocked-on:#N` issue or PR has been closed/merged.
 
 When a trigger has fired, treat the PR as a fresh candidate: recompute the
-verdict from current scanner signals, swap the `0-pr:defer` label off, apply
+verdict from current scanner signals, swap the `0-pr:deferred` label off, apply
 the new label, and upsert the marker comment with the new verdict.
 
 If neither trigger has fired, the PR is a no-op for this run: count it as

--- a/.claude/skills/triage-pr/references/methodology.md
+++ b/.claude/skills/triage-pr/references/methodology.md
@@ -1,0 +1,276 @@
+# PR Triage Methodology
+
+Step-by-step procedure for the `triage-pr` skill. This file covers the
+execution workflow, marker and idempotency mechanics, the machine-readable
+handoff verdict block, and batch coverage accounting. Verdict decision rules
+live in `rubric.md`; this file covers the procedure for applying them.
+
+---
+
+## Step-by-step procedure
+
+### Solo mode (one PR at a time)
+
+1. **Run the scanner** for the target PR:
+
+   ```
+   bash .claude/skills/triage-pr/scripts/scan-prs.sh --repo UMEP-dev/SUEWS
+   ```
+
+   Or to scan a single PR directly by inspecting its open-PR entry in the
+   output. The scanner emits per-PR columns:
+
+   ```
+   PR  STATE  CI  MERGE  REVIEW  AGE_D  CHURN  FILES  AUTHOR  TITLE
+   ```
+
+   and a `Scope:` line (see Batch coverage accounting below).
+
+2. **Check idempotency** before computing a verdict:
+   - Does the PR carry the `0-auto:pr-audited` label?
+   - Is `last_substantive_activity <= marker_ts` (no new commits or human
+     comments since the previous audit)?
+   - If deferred, has the revisit trigger fired (i.e. `revisit-by:` date <=
+     today, or `blocked-on:#N` is now closed)?
+   - If ALL three conditions hold (and the revisit trigger has NOT fired for a
+     deferred PR), record this PR as a no-op and stop. Do not re-apply labels
+     or re-post a comment.
+
+3. **Compute the verdict** using `rubric.md`. Map the scanner signals to
+   exactly one of the five verdicts: `advance`, `continue`, `defer`,
+   `close`, or `escalate`.
+
+4. **Apply the auto-tier** (operations that run without human approval):
+   - **Upsert the marker comment** in place: find any existing
+     `<!-- triage-pr:verdict ts=... -->` comment on the PR and replace it;
+     if none exists, post a new one. The comment body contains the verdict
+     block (see below) with the updated timestamp.
+   - **Swap the `0-pr:*` label**: remove any existing `0-pr:*` label first
+     (these are mutually exclusive; never two at once), then apply the label
+     corresponding to the verdict:
+     - `advance` -> `0-pr:advance`
+     - `continue` -> `0-pr:continue`
+     - `defer` -> `0-pr:defer`
+     - `close` -> `0-pr:close-proposed`
+     - `escalate` -> `0-pr:escalate`
+   - Apply the `0-auto:pr-audited` label if it does not already exist.
+
+5. **State the route and next step**:
+   - `advance` -> state the route (`prep-pr`, `split-pr`, or `queue-pr`) and
+     priority (P0/P1/P2) in the verdict block; the downstream skill can act.
+   - `continue` -> note in the verdict block that the PR is live WIP; route
+     is `fix-issue` or direct author notification.
+   - `defer` -> record `Revisit-by:` or `Blocked-on:` in the verdict block;
+     no further action until the trigger fires.
+   - `close` -> **HUMAN-GATED**: post `0-pr:close-proposed` label and present
+     the verdict block for maintainer review. The skill never closes a PR.
+   - `escalate` -> **HUMAN-GATED**: post `0-pr:escalate` label and state the
+     conflicting signals in the verdict block. The skill never resolves
+     ambiguity by guessing.
+
+Solo mode may pause for human approval before any human-gated action and
+resume after confirmation.
+
+### Batch mode (bounded set, unattended)
+
+Batch mode runs the steps above for each PR in the candidate set without
+pausing mid-run.
+
+1. Run the scanner with an explicit `--limit` to bound the set. The scanner
+   prints the `Scope:` line before the rows. Never rely on the tool's
+   default limit as if it were full coverage.
+2. For each PR in the returned set:
+   - Apply the idempotency check (step 2 of solo mode). Idempotency-skipped
+     PRs are counted as `noop`; they are NOT counted as `skipped`.
+   - Compute verdict and apply auto-tier.
+   - Accumulate the verdict into the coverage buckets.
+3. Emit one verdict block per PR, then the `Scope:` line and a partitioned
+   `Summary:` (see Batch coverage accounting below).
+
+Any review -> revise loop inside the batch run follows
+`.claude/rules/review-convergence.md` (round cap + oscillation guard).
+A single item must not consume the batch; escalate and move on if it
+does not converge within the cap.
+
+### Deferred-PR re-surface check
+
+A PR carrying `0-pr:deferred` re-enters active triage when EITHER:
+
+- Its `revisit-by:YYYY-MM-DD` date is <= today, OR
+- Its `blocked-on:#N` issue or PR has been closed/merged.
+
+When a trigger has fired, treat the PR as a fresh candidate: recompute the
+verdict from current scanner signals, swap the `0-pr:defer` label off, apply
+the new label, and upsert the marker comment with the new verdict.
+
+If neither trigger has fired, the PR is a no-op for this run: count it as
+`noop` in the coverage accounting and do not re-apply labels or repost.
+
+---
+
+## Marker and idempotency mechanics
+
+### The marker comment
+
+Every PR that completes triage carries a marker comment with a machine-parseable
+header on the first line:
+
+```
+<!-- triage-pr:verdict ts=YYYY-MM-DDTHH:MM:SSZ -->
+```
+
+The rest of the comment is the verdict block (see below), including for
+`defer` verdicts the reason and revisit trigger(s).
+
+The timestamp `ts` is the UTC instant at which this run applied the verdict.
+On a re-run, the existing comment is **replaced in place** (upsert semantics),
+not duplicated. If no marker comment exists yet, a new comment is posted.
+
+### Idempotency skip condition
+
+A PR is a no-op for this run when ALL of the following hold:
+
+1. The PR carries the `0-auto:pr-audited` label.
+2. `last_substantive_activity <= marker_ts` -- no new commits or human
+   comments have arrived since the previous audit.
+3. If the PR is deferred: neither revisit trigger has fired.
+
+**Critical: `last_substantive_activity` definition.** Substantive activity is:
+
+```
+last_substantive_activity = max(last_commit_at, last_human_comment_at)
+```
+
+This is NEVER the raw `updatedAt` field from the GitHub API. The reason is a
+correctness trap: the triage skill's own label writes and comment upserts bump
+`updatedAt`. If `updatedAt` were used for staleness and idempotency, every
+triage run would reset the clock, making every PR appear "recently active" on
+the next run and defeating idempotency. The scanner already derives the correct
+substantive timestamp from commit data and filtered (non-bot) comment
+timestamps -- use the scanner's `AGE_D` column as the staleness signal, not the
+raw API field.
+
+### Label transition
+
+The `0-pr:*` labels are mutually exclusive. Before applying any new
+`0-pr:<verdict>` label:
+
+1. Query the PR's current labels.
+2. Remove any label whose name begins with `0-pr:` (there should be at most
+   one, but remove all if more than one is present).
+3. Apply the new `0-pr:<verdict>` label.
+
+This prevents a PR from ever carrying two `0-pr:*` labels simultaneously.
+
+The `0-auto:pr-audited` label is additive: apply it once and leave it; do not
+remove it on a re-run.
+
+---
+
+## Machine-readable handoff verdict block
+
+Every triage run ends with one verdict block per PR. This is the contract other
+skills and orchestrators branch on; reproduce it exactly.
+
+```
+[triage-pr] verdict
+PR: #<n>
+Verdict: advance | continue | defer | close | escalate
+Priority: P0 | P1 | P2 | -        (advance only)
+Route: prep-pr | split-pr | queue-pr | fix-issue | -
+Reason: <one line>
+Revisit-by: YYYY-MM-DD | -        (defer only)
+Blocked-on: #<n> | -             (defer only)
+Applied: comment | label:<0-pr:...> | ready | none
+Next: <downstream action / the human question>
+```
+
+Field rules:
+
+- `Verdict` is always one of the five values above; no other values are
+  permitted.
+- `Priority` is P0/P1/P2 only for `Verdict: advance`; use `-` for all
+  others.
+- `Route` names the downstream skill for `advance` (`prep-pr`, `split-pr`,
+  or `queue-pr`) and `fix-issue` for `continue`; use `-` for all other
+  verdicts.
+- `Revisit-by` and `Blocked-on` are populated only for `Verdict: defer`;
+  both are `-` for all other verdicts. A defer verdict must carry at least
+  one of them as a non-`-` value.
+- `Applied` is a comma-separated subset of the actions taken in this run:
+  `comment` (marker comment posted or upserted), `label:<0-pr:...>` (the
+  specific label applied), `ready` (draft PR marked ready -- only if
+  applicable). Use `none` for no-op runs or when nothing was written.
+- `Next` states the actionable next step, or for human-gated verdicts the
+  specific question the maintainer must answer.
+
+### Human terminals
+
+`Verdict: close` and `Verdict: escalate` are human terminals:
+
+- `close` -> label `0-pr:close-proposed`; no further automated action.
+  A maintainer reads the `Reason` and `Next` fields and decides whether
+  to close or reassign.
+- `escalate` -> label `0-pr:escalate`; `Reason` must name the conflicting
+  signals explicitly. A maintainer reads the block and resolves the
+  ambiguity.
+
+Downstream skills branch on `Verdict` (to pick a workflow) and on `Route`
+(to pick which skill handles the PR next). They do NOT need to parse prose.
+
+---
+
+## Batch coverage accounting
+
+### Scope line
+
+The scanner emits a `Scope:` line before the candidate rows. Emit it
+verbatim in any batch output:
+
+```
+Scope: repo=<OWNER/REPO>, drafts+stale-ready (stale>Nd); K fetched / T open; truncated: yes|no
+```
+
+where `K` is the number of PRs fetched and `T` is the independently-obtained
+total open PR count. When `truncated: yes`, the backlog is NOT fully covered;
+the `(T - K)` PRs beyond the `--limit` remain unswept and a re-run with a
+higher limit (or pagination) is required for full coverage.
+
+### Coverage equation
+
+The returned set K partitions exactly into seven buckets. The equation below
+must hold; any other sum is a bug:
+
+```
+advance + continue + defer + close + escalate + noop + skipped = K
+```
+
+where:
+
+- `advance` -- PRs assigned the `advance` verdict.
+- `continue` -- PRs assigned the `continue` verdict.
+- `defer` -- PRs assigned the `defer` verdict.
+- `close` -- PRs assigned the `close` verdict (label `0-pr:close-proposed`).
+- `escalate` -- PRs assigned the `escalate` verdict.
+- `noop` -- PRs that were idempotency-skipped (already audited, no new
+  activity, deferred trigger not fired). A `noop` PR is NOT a `skipped` PR.
+- `skipped` -- PRs that could not be processed (fetch failure, parse error,
+  or explicitly excluded by the bound). A reason must be recorded; never
+  silently drop a PR.
+
+### Summary line
+
+After the per-PR verdict blocks, emit:
+
+```
+Summary: K processed = <advance> advance, <continue> continue, <defer> defer,
+         <close> close-proposed, <escalate> escalate, <noop> noop, <skipped> skipped
+```
+
+The seven counts must sum to K, not to T. Full coverage of the open backlog
+is assertable only when `truncated: no`.
+
+### No silent drop
+
+A PR that cannot be processed is always recorded as `skipped` with a reason
+in the `Next` field of its verdict block. It is never omitted from the count.

--- a/.claude/skills/triage-pr/references/methodology.md
+++ b/.claude/skills/triage-pr/references/methodology.md
@@ -28,8 +28,9 @@ live in `rubric.md`; this file covers the procedure for applying them.
 
 2. **Check idempotency** before computing a verdict:
    - Does the PR carry the `0-auto:pr-audited` label?
-   - Is `last_substantive_activity <= marker_ts` (no new commits or human
-     comments since the previous audit)?
+   - Is the scanner's `last_activity_at` (the `--json` field carrying the UTC
+     instant of last substantive activity) `<= marker_ts` (no new commits or
+     human comments since the previous audit)?
    - If deferred, has the revisit trigger fired (i.e. `revisit-by:` date <=
      today, or `blocked-on:#N` is now closed)?
    - If ALL three conditions hold (and the revisit trigger has NOT fired for a
@@ -131,14 +132,17 @@ not duplicated. If no marker comment exists yet, a new comment is posted.
 A PR is a no-op for this run when ALL of the following hold:
 
 1. The PR carries the `0-auto:pr-audited` label.
-2. `last_substantive_activity <= marker_ts` -- no new commits or human
-   comments have arrived since the previous audit.
+2. `last_activity_at <= marker_ts` -- no new commits or human comments have
+   arrived since the previous audit. Both sides are absolute UTC instants:
+   `last_activity_at` is the scanner `--json` field; `marker_ts` is the `ts=`
+   value parsed from the marker comment header.
 3. If the PR is deferred: neither revisit trigger has fired.
 
-**Critical: `last_substantive_activity` definition.** Substantive activity is:
+**Critical: `last_activity_at` definition.** The scanner emits `last_activity_at`
+as the UTC instant of last substantive activity:
 
 ```
-last_substantive_activity = max(last_commit_at, last_human_comment_at)
+last_activity_at = max(last_commit_at, last_human_comment_at)
 ```
 
 This is NEVER the raw `updatedAt` field from the GitHub API. The reason is a
@@ -147,8 +151,10 @@ correctness trap: the triage skill's own label writes and comment upserts bump
 triage run would reset the clock, making every PR appear "recently active" on
 the next run and defeating idempotency. The scanner already derives the correct
 substantive timestamp from commit data and filtered (non-bot) comment
-timestamps -- use the scanner's `AGE_D` column as the staleness signal, not the
-raw API field.
+timestamps. Use the scanner's `last_activity_at` field for the absolute
+`<= marker_ts` comparison (it is null only when no commit, comment, or creation
+timestamp is available); the `AGE_D` column is the human-readable staleness
+signal in whole days and is NOT comparable to an absolute marker timestamp.
 
 ### Label transition
 

--- a/.claude/skills/triage-pr/references/rubric.md
+++ b/.claude/skills/triage-pr/references/rubric.md
@@ -1,0 +1,223 @@
+# PR Triage Rubric
+
+Signal-to-verdict decision rule for the `triage-pr` skill. The skill reads
+per-PR signals from the scanner (`scan-prs.sh`) and maps each PR to exactly
+one of five verdicts using the rules below.
+
+The scanner emits these columns per PR. All conditions in this rubric are
+expressed in these column names:
+
+    PR  STATE(draft|ready)  CI(passing|failing|pending|none)
+    MERGE(CLEAN|DIRTY|UNSTABLE|BLOCKED|BEHIND|UNKNOWN)
+    REVIEW(NONE|CHANGES_REQUESTED|APPROVED|REVIEW_REQUIRED)
+    AGE_D(int days)  CHURN(additions+deletions)  FILES(count)
+    AUTHOR(login)  TITLE
+
+Scope: this rubric assigns the verdict. Size assessment defers to
+`audit-pr`'s Size Gate (`.claude/rules/work-sizing.md`); merge ordering
+defers to `queue-pr`. Do not duplicate those rules here.
+
+---
+
+## TIE-BREAK RULE
+
+**Where signals genuinely conflict, the verdict is `escalate` -- never a
+guess.** If you can construct a reasonable argument for two different
+verdicts from the same signal set, choose `escalate` and state the
+conflicting signals in the reason field.
+
+---
+
+## Part A -- the five verdicts
+
+### advance
+
+A PR that is substantively complete and can move forward now.
+
+**All of the following must hold:**
+
+1. The diff is substantively complete: no TODO markers, no obviously missing
+   tests, no commented-out placeholder code in the body of the change.
+2. CI is near-green (see Part C). Failing required checks -> not `advance`.
+3. MERGE is CLEAN, or BEHIND with no conflicting changes (the only action
+   needed is a rebase, not a resolution). MERGE=DIRTY or MERGE=BLOCKED ->
+   not `advance`.
+4. The PR is tied to a live goal: there is a linked open issue, the
+   milestone is active, or the TITLE clearly maps to a current roadmap item.
+5. Size is within the right-sized-PR threshold. If audit-pr's Size Gate would
+   recommend a split, route to `split-pr` instead (this does not prevent an
+   `advance` verdict, but the route changes -- see below).
+
+**Route for `advance`:**
+
+- Size Gate would split -> route: `split-pr`.
+- CI passing, MERGE=CLEAN, REVIEW=APPROVED or REVIEW=NONE with low churn
+  -> route: `queue-pr`.
+- Otherwise (needs polish, review not yet requested, minor fixes outstanding)
+  -> route: `prep-pr`.
+
+**Priority** (Part B) is recorded in the verdict block for every `advance`.
+
+---
+
+### continue
+
+A PR with genuine live work-in-progress that is not yet ready to advance.
+
+**Signals that point to `continue`:**
+
+- STATE=draft, AND there is recent activity: AGE_D is low (roughly under
+  the stale threshold, typically 14 days), or a linked issue has an open
+  assignee actively progressing it.
+- CI=failing due to incomplete work: the failure is in a test or lint that
+  the author clearly has not addressed yet (e.g. a new test file is missing,
+  or the author's own commit message says "WIP").
+- REVIEW=CHANGES_REQUESTED and AGE_D is low: the author is expected to
+  iterate.
+- The diff contains TODO markers or commented-out code that is clearly
+  intentional scaffolding, not an oversight.
+
+**Route:** return to `fix-issue` workflow, or notify the author directly.
+
+**Boundary: continue vs defer.** `continue` means "keep going -- it is
+alive and someone is on it." `defer` means "valid work, intentionally
+paused, with a named trigger." If the PR has no recent activity and no open
+linked issue with an assignee, prefer `defer` over `continue`.
+
+---
+
+### defer
+
+Valid work that should not move forward right now, with a reason and a
+revisit trigger.
+
+**Signals that point to `defer`:**
+
+- MERGE=BLOCKED: the PR is explicitly blocked on another PR or upstream
+  change (and that blocker is not itself an `advance` candidate).
+- The PR targets a feature or fix that was deprioritised relative to the
+  current release wave (linked issue is backlogged, milestone is future).
+- REVIEW=CHANGES_REQUESTED and AGE_D is high: the author has not responded
+  and the work is otherwise sound -- valid but stalled without intent to
+  resume now.
+- The PR is waiting on a design or scope decision that is unresolved but
+  clearly recorded.
+
+**Every `defer` verdict must carry:**
+
+- `reason:` -- one sentence stating why it is not moving forward now.
+- At least one of:
+  - `revisit-by:YYYY-MM-DD` -- a calendar trigger.
+  - `blocked-on:#N` -- a specific PR or issue whose merge/close unblocks
+    this one.
+
+**Boundary: defer vs close.** `defer` is revivable via a named trigger;
+`close` is dead. If no plausible trigger exists, prefer `close` (with human
+gate).
+
+---
+
+### close
+
+A PR that is dead: superseded, obsolete, or abandoned with no prospect of
+revival.
+
+**Signals that point to `close`:**
+
+- The same change was merged in another PR (superseded).
+- The target feature, file, or subsystem was removed or substantially
+  refactored since the PR was opened, making the diff inapplicable.
+- STATE=ready or STATE=draft, AGE_D is very high (roughly 60+ days), no
+  linked open issue, no assignee, no recent comments, and REVIEW=NONE or
+  REVIEW=CHANGES_REQUESTED with no author response for weeks.
+- The PR is an experiment that was abandoned in favour of a different
+  approach, and the description or comments confirm this.
+
+**HUMAN-GATED.** `triage-pr` NEVER closes a PR. It proposes closure and
+states the reason. A maintainer takes the action.
+
+---
+
+### escalate
+
+Disposition genuinely unclear after applying the rules above.
+
+**Use `escalate` when:**
+
+- Signals conflict and no single verdict is clearly correct (tie-break rule
+  above).
+- The CI failure is in a required check but the cause is not apparent from
+  the diff or the check log (cannot tell whether it is a flaky check, a
+  real regression, or an infrastructure hiccup).
+- The PR is large and complex and the "substantively complete" question
+  cannot be answered without scientific or domain judgement.
+- The PR appears to overlap with another open PR or merged change, but the
+  relationship is not explicit.
+- MERGE=UNKNOWN and the reason is not obvious.
+
+**`escalate` is a human terminal.** The verdict block must state the
+conflicting or unclear signals so a maintainer can act without re-reading
+the entire PR.
+
+---
+
+## Part B -- advance priority rubric
+
+Priority applies only to `advance` verdicts. Record it in the verdict block.
+Do NOT apply it as a label.
+
+- **P0** -- the PR fixes a release blocker or a CI blocker, or its merge
+  directly unblocks one or more other `advance`-candidate PRs or open issues.
+- **P1** -- the PR is ready and right-sized; the author has merely stalled
+  (REVIEW=NONE or REVIEW=APPROVED, CI passing, AGE_D above stale threshold
+  but no blocker).
+- **P2** -- the PR is ready but lower impact: small doc fix, minor nit,
+  or an enhancement without an active milestone dependency.
+
+When priority is ambiguous between P0 and P1, prefer P0 only if there is a
+concrete blocking dependency (another PR, a failing release gate, an open
+issue explicitly citing this PR as a blocker). Otherwise default to P1.
+
+---
+
+## Part C -- "near-green" CI definition
+
+This is the single canonical definition for CI readiness used by `triage-pr`.
+
+### Green (CI=passing)
+
+CI=passing: all required checks pass. `advance` is permitted.
+
+### Near-green (advance permitted with note)
+
+CI=failing or CI=pending, but ONLY if ALL of the following hold:
+
+1. The failing checks are all NON-REQUIRED (optional checks, informational
+   jobs, or jobs flagged as `continue-on-error` in the workflow definition).
+2. OR the failing check is on the documented known-flaky list for this
+   repository (currently: none defined; add here when a flaky check is
+   formally identified and acknowledged by a maintainer).
+3. All REQUIRED checks either pass or have not yet run (CI=pending for
+   required checks -> route is `prep-pr`, not `queue-pr`, until they
+   resolve).
+
+When advancing a near-green PR, the verdict block must name the failing
+check(s) and state that they are non-required or known-flaky.
+
+### Not green (advance blocked)
+
+**A genuinely red REQUIRED check blocks `advance` unconditionally.**
+
+- If the red required check is due to incomplete or incorrect work in the
+  diff -> verdict is `continue`.
+- If the red required check is unexplained (no obvious cause in the diff or
+  the check log) -> verdict is `escalate`.
+
+NEVER advance a PR with a red required check. This rule has no exceptions.
+
+### CI=none
+
+CI=none means no checks have been registered. Treat as near-green for the
+purposes of the `advance` verdict, but note the absence in the verdict block.
+A CI=none PR should be routed to `prep-pr` so checks can be confirmed before
+`queue-pr`.

--- a/.claude/skills/triage-pr/references/rubric.md
+++ b/.claude/skills/triage-pr/references/rubric.md
@@ -84,6 +84,13 @@ alive and someone is on it." `defer` means "valid work, intentionally
 paused, with a named trigger." If the PR has no recent activity and no open
 linked issue with an assignee, prefer `defer` over `continue`.
 
+Note: the scanner does not emit the linked-issue / assignee signal. When the
+`AGE_D` and CI/MERGE signals alone leave the continue/defer choice genuinely
+balanced, look it up out-of-band (for example
+`gh pr view <n> --json closingIssuesReferences` and the linked issue's
+assignees) before deciding. If that lookup is not available or still
+ambiguous, apply the tie-break and `escalate` rather than guessing.
+
 ---
 
 ### defer

--- a/.claude/skills/triage-pr/scripts/scan-prs.sh
+++ b/.claude/skills/triage-pr/scripts/scan-prs.sh
@@ -213,19 +213,29 @@ ROWS="$(jq -r \
   | ( if $act == 0 then (.createdAt | to_epoch) else $act end ) as $act_floor
   | ( ($now - $act_floor) / 86400 | floor ) as $age_days
 
+  # ISO-8601 UTC instant of last substantive activity, for the router
+  # idempotency check (compare against the marker comment ts). Emitted in
+  # JSON only -- the table keeps its fixed 10 columns. Null if unknown.
+  | ( if $act_floor > 0 then ($act_floor | todateiso8601) else null end ) as $last_activity_at
+
   | ci_status(.statusCheckRollup // []) as $ci
 
+  # GitHub returns reviewDecision as an EMPTY STRING (not null) for PRs with
+  # no decision, so `// "NONE"` does NOT fire (the // operator only catches
+  # null/false and "" is truthy). Map empty/absent to "NONE" explicitly. Same
+  # guard on mergeStateStatus, which can also come back as "".
   | {
       pr:     .number,
       state:  (if .isDraft then "draft" else "ready" end),
       ci:     $ci,
-      merge:  (.mergeStateStatus // "UNKNOWN"),
-      review: (.reviewDecision   // "NONE"),
+      merge:  (if (.mergeStateStatus // "") == "" then "UNKNOWN" else .mergeStateStatus end),
+      review: (if (.reviewDecision   // "") == "" then "NONE"    else .reviewDecision   end),
       age_d:  $age_days,
       churn:  (.additions + .deletions),
       files:  (.files | length),
       author: .author.login,
-      title:  (.title | gsub("\t"; " "))
+      title:  (.title | gsub("\t"; " ")),
+      last_activity_at: $last_activity_at
     }
 ' <<<"$PRS_JSON")"
 

--- a/.claude/skills/triage-pr/scripts/scan-prs.sh
+++ b/.claude/skills/triage-pr/scripts/scan-prs.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# scan-prs.sh -- read-only PR signal scanner for the triage-pr skill.
+#
+# Fetches open pull requests from the target repository and emits a candidate
+# set (draft PRs and stale or changes-requested ready PRs) with cheap signals
+# for the triage-pr skill router to act upon.
+#
+# This script is READ-ONLY: it calls `gh` and `jq` only and never writes
+# labels, comments, or PR metadata.
+#
+# Usage:
+#   scan-prs.sh [--repo OWNER/REPO] [--stale-days N] [--limit N] [--json] [-h|--help]
+#
+# Options:
+#   --repo        GitHub repository in OWNER/REPO form (default: UMEP-dev/SUEWS)
+#   --stale-days  Number of days since last substantive activity before a
+#                 ready PR is considered stale (default: 14)
+#   --limit       Maximum number of PRs to fetch from the GitHub API (default: 200)
+#   --json        Emit candidates as a JSON array instead of a TSV table
+#   -h|--help     Print this help block and exit 0
+#
+# Output format (table mode):
+#   Scope: repo=..., fetched/open, truncated: yes|no
+#   PR  STATE  CI  MERGE  REVIEW  AGE_D  CHURN  FILES  AUTHOR  TITLE
+#   <one row per candidate>
+#
+# AGE_D (staleness in days) is derived from the most recent commit timestamp
+# or non-bot comment timestamp -- NEVER from `updatedAt`. Using `updatedAt`
+# would create a feedback loop: the triage skill's own label/comment writes
+# bump `updatedAt`, resetting the staleness clock and defeating idempotency.
+#
+# Two-phase fetch: the bulk query omits `commits` (which blows the GitHub
+# GraphQL node limit at high --limit values). Instead, the last commit date
+# for each PR is fetched individually via `gh pr view --json commits`. This
+# is slightly slower but avoids the 500,000-node cap on large repos.
+#
+# Candidate inclusion criteria:
+#   - state == draft  (always included regardless of age)
+#   - state == ready  AND  AGE_D > STALE_DAYS
+#   - state == ready  AND  reviewDecision == CHANGES_REQUESTED
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+
+REPO="UMEP-dev/SUEWS"
+STALE_DAYS=14
+LIMIT=200
+FORMAT="table"
+
+usage() {
+    # Print the header comment block (lines 2-37) and exit 0.
+    sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die() {
+    printf 'ERROR: %s\n' "$1" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo)
+            [ "$#" -ge 2 ] || die "--repo requires a value"
+            REPO="$2"
+            shift 2
+            ;;
+        --stale-days)
+            [ "$#" -ge 2 ] || die "--stale-days requires a value"
+            STALE_DAYS="$2"
+            shift 2
+            ;;
+        --limit)
+            [ "$#" -ge 2 ] || die "--limit requires a value"
+            LIMIT="$2"
+            shift 2
+            ;;
+        --json)
+            FORMAT="json"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+command -v gh  >/dev/null 2>&1 || die "gh CLI is required"
+command -v jq  >/dev/null 2>&1 || die "jq is required"
+gh auth status >/dev/null 2>&1 || die "gh is not authenticated (run: gh auth login)"
+
+# ---------------------------------------------------------------------------
+# Phase 1: bulk fetch -- all fields except commits to stay under the GitHub
+# GraphQL 500,000-node limit. Including `commits` in a 200-PR request with
+# multi-author commit histories routinely exceeds this cap.
+# ---------------------------------------------------------------------------
+
+PRS_JSON="$(gh pr list --repo "$REPO" --state open --limit "$LIMIT" \
+    --json number,title,isDraft,createdAt,updatedAt,labels,reviewDecision,\
+mergeable,mergeStateStatus,statusCheckRollup,headRefName,author,\
+additions,deletions,files,comments)"
+
+TOTAL_OPEN="$(gh api -X GET search/issues \
+    -f q="repo:${REPO} is:pr is:open" --jq .total_count)"
+
+FETCHED="$(jq 'length' <<<"$PRS_JSON")"
+TRUNCATED="no"
+[ "$FETCHED" -lt "$TOTAL_OPEN" ] && TRUNCATED="yes"
+
+# ---------------------------------------------------------------------------
+# Phase 2: per-PR last-commit date fetch.
+#
+# AGE_D derives from commit + non-bot comment timestamps, never from
+# `updatedAt`. Reason: triage-skill label/comment writes bump `updatedAt`,
+# which would reset the staleness clock and defeat idempotency across runs.
+#
+# The per-PR fetch avoids the GraphQL node-count cap that fires when
+# `commits` is included in a bulk request with a high --limit.
+# ---------------------------------------------------------------------------
+
+NUMBERS="$(jq -r '.[].number' <<<"$PRS_JSON")"
+
+# Build a JSON object: { "1234": "2026-05-01T10:00:00Z", ... }
+LAST_COMMIT_MAP="{}"
+while IFS= read -r pr_num; do
+    [ -n "$pr_num" ] || continue
+    last_commit="$(gh pr view "$pr_num" --repo "$REPO" --json commits \
+        --jq '[.commits[].committedDate] | if length == 0 then "" else max end' 2>/dev/null || echo "")"
+    LAST_COMMIT_MAP="$(jq --arg n "$pr_num" --arg d "$last_commit" \
+        '. + {($n): $d}' <<<"$LAST_COMMIT_MAP")"
+done <<<"$NUMBERS"
+
+# ---------------------------------------------------------------------------
+# Derive per-PR signals with jq.
+#
+# CI classification handles both `gh` check shapes:
+#   CheckRun:      has .status ("COMPLETED"|"IN_PROGRESS"...) and .conclusion
+#   StatusContext: has .state ("SUCCESS"|"FAILURE"|"ERROR"|"PENDING")
+# A missing or empty statusCheckRollup array -> "none" (no checks configured).
+# ---------------------------------------------------------------------------
+
+NOW_EPOCH="$(date -u +%s)"
+
+ROWS="$(jq -r \
+    --argjson now "$NOW_EPOCH" \
+    --argjson stale "$STALE_DAYS" \
+    --argjson commits_map "$LAST_COMMIT_MAP" '
+
+  def to_epoch:
+    (sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601);
+
+  # Detect bot accounts: login ending in [bot] or known list
+  def is_bot($login):
+    ($login | test("\\[bot\\]$"))
+    or (["github-actions","dependabot","codecov","pre-commit-ci","allcontributors"]
+        | index($login) != null);
+
+  # Robust CI classification over both CheckRun and StatusContext shapes.
+  # CheckRun:      .conclusion == "FAILURE"|"CANCELLED"; .status != "COMPLETED"
+  # StatusContext: .state      == "FAILURE"|"ERROR";     .state == "PENDING"
+  def ci_status($checks):
+    if ($checks | length) == 0 then "none"
+    elif ($checks | any(
+           (.conclusion? == "FAILURE" or .conclusion? == "CANCELLED") or
+           (.state?      == "FAILURE" or .state?      == "ERROR")
+         )) then "failing"
+    elif ($checks | any(
+           (.status? != null and .status? != "COMPLETED") or
+           (.state?  == "PENDING" or .state?  == "EXPECTED")
+         )) then "pending"
+    else "passing"
+    end;
+
+  .[]
+  | (.number | tostring) as $key
+
+  # Last commit date from the per-PR Phase 2 map (empty string -> epoch 0)
+  | ( $commits_map[$key] | if (. == null or . == "") then 0 else to_epoch end ) as $lastcommit
+
+  # Most recent non-bot comment timestamp
+  | ( [.comments[]? | select(is_bot(.author.login) | not) | .createdAt]
+      | map(to_epoch) | max // 0 ) as $lastcomment
+
+  # Substantive activity = latest of (last commit, last human comment).
+  # NEVER use .updatedAt: triage-skill writes bump it and would reset the
+  # staleness clock, defeating idempotency across repeated scan runs.
+  | ( [$lastcommit, $lastcomment] | max ) as $act
+
+  # Staleness in whole days; fall back to createdAt if $act == 0
+  | ( if $act == 0 then (.createdAt | to_epoch) else $act end ) as $act_floor
+  | ( ($now - $act_floor) / 86400 | floor ) as $age_days
+
+  | ci_status(.statusCheckRollup // []) as $ci
+
+  | {
+      pr:     .number,
+      state:  (if .isDraft then "draft" else "ready" end),
+      ci:     $ci,
+      merge:  (.mergeStateStatus // "UNKNOWN"),
+      review: (.reviewDecision   // "NONE"),
+      age_d:  $age_days,
+      churn:  (.additions + .deletions),
+      files:  (.files | length),
+      author: .author.login,
+      title:  (.title | gsub("\t"; " "))
+    }
+' <<<"$PRS_JSON")"
+
+# ---------------------------------------------------------------------------
+# Apply scope filter and emit output.
+#
+# A PR is a candidate if ANY of:
+#   - state == draft  (all drafts, regardless of age)
+#   - state == ready  AND  age_d > STALE_DAYS
+#   - state == ready  AND  reviewDecision == CHANGES_REQUESTED
+# ---------------------------------------------------------------------------
+
+SCOPE_LINE="Scope: repo=${REPO}, drafts+stale-ready (stale>${STALE_DAYS}d); ${FETCHED} fetched / ${TOTAL_OPEN} open; truncated: ${TRUNCATED}"
+
+if [ "$FORMAT" = "json" ]; then
+    echo "$SCOPE_LINE"
+    echo "$ROWS" | jq -s --argjson stale "$STALE_DAYS" '
+      [.[] | select(
+        .state == "draft" or
+        (.state == "ready" and .age_d > $stale) or
+        (.state == "ready" and .review == "CHANGES_REQUESTED")
+      )]'
+else
+    echo "$SCOPE_LINE"
+    printf 'PR\tSTATE\tCI\tMERGE\tREVIEW\tAGE_D\tCHURN\tFILES\tAUTHOR\tTITLE\n'
+    echo "$ROWS" | jq -r --argjson stale "$STALE_DAYS" '
+      select(
+        .state == "draft" or
+        (.state == "ready" and .age_d > $stale) or
+        (.state == "ready" and .review == "CHANGES_REQUESTED")
+      )
+      | [.pr, .state, .ci, .merge, .review, .age_d, .churn, .files, .author, .title]
+      | @tsv'
+fi

--- a/.claude/skills/triage-pr/scripts/scan-prs.sh
+++ b/.claude/skills/triage-pr/scripts/scan-prs.sh
@@ -51,8 +51,9 @@ LIMIT=200
 FORMAT="table"
 
 usage() {
-    # Print the header comment block (lines 2-37) and exit 0.
-    sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'
+    # Print the header comment block (lines 2-40, through the inclusion
+    # criteria bullets) and exit 0.
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 die() {
@@ -69,11 +70,13 @@ while [ "$#" -gt 0 ]; do
             ;;
         --stale-days)
             [ "$#" -ge 2 ] || die "--stale-days requires a value"
+            [[ "$2" =~ ^[0-9]+$ ]] || die "--stale-days must be a non-negative integer, got: $2"
             STALE_DAYS="$2"
             shift 2
             ;;
         --limit)
             [ "$#" -ge 2 ] || die "--limit requires a value"
+            [[ "$2" =~ ^[0-9]+$ ]] || die "--limit must be a non-negative integer, got: $2"
             LIMIT="$2"
             shift 2
             ;;
@@ -103,6 +106,13 @@ gh auth status >/dev/null 2>&1 || die "gh is not authenticated (run: gh auth log
 # Phase 1: bulk fetch -- all fields except commits to stay under the GitHub
 # GraphQL 500,000-node limit. Including `commits` in a 200-PR request with
 # multi-author commit histories routinely exceeds this cap.
+#
+# Note: `labels`, `updatedAt`, and `headRefName` are fetched but NOT emitted
+# by this scanner. They are reserved for the triage-pr skill router (labels
+# -> check `0-pr:*` state and exclude actively-queued PRs; headRefName ->
+# worktree creation; updatedAt -> fetched but deliberately NOT used for
+# staleness, see the AGE_D note above). Keep them so a future cleanup does
+# not strip fields the router depends on.
 # ---------------------------------------------------------------------------
 
 PRS_JSON="$(gh pr list --repo "$REPO" --state open --limit "$LIMIT" \
@@ -159,9 +169,11 @@ ROWS="$(jq -r \
   def to_epoch:
     (sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601);
 
-  # Detect bot accounts: login ending in [bot] or known list
+  # Detect bot accounts: login ending in [bot] or known list.
+  # Guard against a null login (deleted GitHub accounts produce
+  # .author == null; `null | test(...)` throws and aborts the whole jq).
   def is_bot($login):
-    ($login | test("\\[bot\\]$"))
+    ($login != null and ($login | test("\\[bot\\]$")))
     or (["github-actions","dependabot","codecov","pre-commit-ci","allcontributors"]
         | index($login) != null);
 
@@ -187,8 +199,9 @@ ROWS="$(jq -r \
   # Last commit date from the per-PR Phase 2 map (empty string -> epoch 0)
   | ( $commits_map[$key] | if (. == null or . == "") then 0 else to_epoch end ) as $lastcommit
 
-  # Most recent non-bot comment timestamp
-  | ( [.comments[]? | select(is_bot(.author.login) | not) | .createdAt]
+  # Most recent non-bot comment timestamp. Use .author?.login so a missing
+  # .author key (deleted account) is tolerated rather than aborting.
+  | ( [.comments[]? | select(is_bot(.author?.login) | not) | .createdAt]
       | map(to_epoch) | max // 0 ) as $lastcomment
 
   # Substantive activity = latest of (last commit, last human comment).
@@ -228,7 +241,8 @@ ROWS="$(jq -r \
 SCOPE_LINE="Scope: repo=${REPO}, drafts+stale-ready (stale>${STALE_DAYS}d); ${FETCHED} fetched / ${TOTAL_OPEN} open; truncated: ${TRUNCATED}"
 
 if [ "$FORMAT" = "json" ]; then
-    echo "$SCOPE_LINE"
+    # Scope line goes to stderr so stdout is pure JSON (parsable by `jq .`).
+    echo "$SCOPE_LINE" >&2
     echo "$ROWS" | jq -s --argjson stale "$STALE_DAYS" '
       [.[] | select(
         .state == "draft" or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Full setup: `/setup-dev` | Style check: `/lint-code` | Build check: `/verify-bui
 - `/fix-issue` - Triage and implement a GitHub issue to PR-ready status
 - `/republish-docs` - Republish/revise released docs (move tag to clean anchor)
 - `/verify-build` - Build configuration
+- `/triage-pr` - Triage draft and stalled PRs into a disposition (advance/continue/defer/close/escalate)
 - `/audit-pr` - Review pull requests
 - `/split-pr` - Carve an oversized PR into a stacked series of small PRs
 - `/queue-pr` - Coordinate PRs before merge queue


### PR DESCRIPTION
## Summary

`triage-pr` is a new skill that grooms the **draft and stalled pull-request backlog**. It is the PR-axis sibling of `triage-issue`: where `triage-issue` grooms the issue backlog for readiness, `triage-pr` grooms the PR backlog for disposition. It is a router, not a reviewer -- it assigns each draft or stalled PR exactly one of five verdicts and routes the live ones into the existing skills, without re-reviewing code (`audit-pr`), ordering the queue (`queue-pr`), or carving diffs (`split-pr`).

Verdicts and routes:

- `advance` -- substantively ready; routes to `audit-pr` / `split-pr` / `queue-pr`, carrying a P0/P1/P2 merge-urgency note
- `continue` -- live work-in-progress; hands back to the author / `fix-issue`
- `defer` -- valid but parked, with a recorded reason and a revisit trigger (`revisit-by:` date and/or `blocked-on:#N`) so it re-surfaces instead of rotting silently
- `close` -- superseded/obsolete/abandoned (proposed only; human-gated)
- `escalate` -- disposition genuinely unclear (human-gated)

Scope: every draft PR, plus ready PRs that have gone quiet (default threshold 14 days) or are stalled with changes requested. Actively-moving PRs and those already in the merge queue are excluded.

## What's included

- `.claude/skills/triage-pr/scripts/scan-prs.sh` -- read-only `gh`/`jq` signal scanner (emits a `Scope:` line plus per-PR signals; staleness is derived from commit/comment timestamps, never `updatedAt`, to avoid a self-reset feedback loop)
- `.claude/skills/triage-pr/references/rubric.md` -- the signal-to-verdict decision rule, the advance priority rubric, and an explicit "near-green" CI definition
- `.claude/skills/triage-pr/references/methodology.md` -- workflow, marker/idempotency mechanics, the machine-readable handoff block, and batch coverage accounting
- `.claude/skills/triage-pr/SKILL.md` -- entry point: triggers, gating tiers, privacy scrub gate, autonomous mode, output format
- `.claude/rules/autonomous-workflow.md` -- registers triage-pr as the PR-backlog governance stage, adds its handoff vocabulary, and documents the new label namespace (additive only; existing five-stage pipeline untouched)
- `CLAUDE.md` -- adds `/triage-pr` to the skills list

## Labels (full verdict mirror)

The skill applies labels that already exist and never creates them. A maintainer seeds these six labels once:

- `0-auto:pr-audited` -- processed / idempotency marker
- `0-pr:advance`, `0-pr:continue`, `0-pr:deferred`, `0-pr:close-proposed`, `0-pr:escalate` -- mutually-exclusive disposition state, relabelled each run (the skill removes any prior `0-pr:*` label before applying the new one)

If a label is absent, the verdict is recorded in the marker comment and handoff block only, with a note that the label is missing.

## Validation

- Scanner dry-run against the current open PRs: correct `Scope:` line, scope filter behaves as specified, `REVIEW=NONE` fallback works, `last_activity_at` emitted for the idempotency comparison, `--json` output parses.
- Reviewed for spec compliance, code quality, and adversarial holistic correctness; two scanner bugs were found and fixed (empty-string `reviewDecision` not falling back to `NONE`; the idempotency check needing an absolute `last_activity_at` timestamp the scanner now emits).
- ASCII-only throughout; the scanner is strictly read-only; no model (Fortran/Python) code touched.

## Gating

Merging, closing, and enqueuing remain human-gated. The skill terminates at "disposition assigned plus live PRs handed off"; it never merges and never closes.
