### PR TITLE
Fix build and validation for per land cover water use forcing

### DIFF
--- a/src/suews/src/suews_phys_waterdist.f95
+++ b/src/suews/src/suews_phys_waterdist.f95
@@ -1343,6 +1343,11 @@ CONTAINS
                ! Divide observed water use (in m3) by water use area to find water use (in mm)
                ! 2026-05-19, MP: Updated to only take per land cover forcing (incoming in mm)
                IF (WaterUseMethod == 1) THEN !If water use is observed
+                  ! Reset per-surface observed water use each timestep so a
+                  ! surface whose forcing column is missing (-999 sentinel)
+                  ! contributes zero rather than inheriting the previous
+                  ! timestep's value (wu_surf is persistent hydro state).
+                  wu_surf = 0.0D0
                   IF (Wu_mm_paved /= -999) THEN
                      wu_surf(1) = Wu_mm_paved
                   END IF
@@ -1365,7 +1370,7 @@ CONTAINS
                      wu_surf(7) = Wu_mm_water
                   END IF
                   wu = DOT_PRODUCT(wu_surf, sfr_surf)
-                  
+
                ! --------------------------------------------------------------------------------
                ! If water use is modelled, calculate at timestep of model resolution [mm]
                ELSEIF (WaterUseMethod == 0) THEN !If water use is modelled

--- a/src/suews_bridge/src/forcing.rs
+++ b/src/suews_bridge/src/forcing.rs
@@ -34,6 +34,14 @@ const LANDCOVER_SUFFIXES: &[&str] = &[
     "paved", "bldgs", "evetr", "dectr", "grass", "bsoil", "water",
 ];
 const LAI_LANDCOVER_SUFFIXES: &[&str] = &["evetr", "dectr", "grass"];
+// External water use (wuh) is accepted on every surface, so its suffix
+// whitelist mirrors the full LANDCOVER_SUFFIXES set. Kept as a separate
+// named const (referenced by the WUH var below) so the gh#1372
+// cross-language parity guard can assert it against
+// supy._load.WUH_LANDCOVER_SUFFIXES.
+const WU_LANDCOVER_SUFFIXES: &[&str] = &[
+    "paved", "bldgs", "evetr", "dectr", "grass", "bsoil", "water",
+];
 
 pub struct PerLandcoverVar {
     pub prefix: &'static str,

--- a/src/suews_bridge/src/forcing_io.rs
+++ b/src/suews_bridge/src/forcing_io.rs
@@ -716,7 +716,7 @@ mod tests {
         assert_eq!(row_val(&forcing, 0, SuewsField::lai_evetr.index()), forcing.extras["lai_evetr"][0]);
         assert_eq!(row_val(&forcing, 0, SuewsField::lai_dectr.index()), forcing.extras["lai_dectr"][0]);
         assert_eq!(row_val(&forcing, 0, SuewsField::lai_grass.index()), forcing.extras["lai_grass"][0]);
-        assert_ne!(row_val(&forcing, 0, SuewsField::wu_m3.index()), forcing.extras["wuh_paved"][0]);
+        assert_eq!(row_val(&forcing, 0, SuewsField::wu_mm_paved.index()), forcing.extras["wuh_paved"][0]);
         // Canonical block unchanged in shape.
         assert_eq!(forcing.block.len(), forcing.len_sim * FORCING_BLOCK_STRIDE);
     }

--- a/src/supy/_run_rust.py
+++ b/src/supy/_run_rust.py
@@ -221,7 +221,7 @@ def _prepare_forcing_block(df_forcing: pd.DataFrame) -> np.ndarray:
             block[:, target_idx] = df_forcing[source_col].values
         else:
             block[:, target_idx] = -999.0
-    
+
     bulk_wuh_col = columns_by_lower.get("wuh")
     for target_idx, wuh_col in enumerate(WUH_KERNEL_COLUMNS, start=23):
         source_col = columns_by_lower.get(wuh_col, bulk_wuh_col)

--- a/src/supy/data_model/core/forcing_validation.py
+++ b/src/supy/data_model/core/forcing_validation.py
@@ -44,9 +44,13 @@ _PHYSICS_REQUIRED_FORCING: dict[tuple[str, int], frozenset[str]] = {
 }
 
 LAI_VEG_COLUMNS = ("lai_evetr", "lai_dectr", "lai_grass")
+# Per-land-cover external water-use forcing columns, named with the same
+# `wuh_<suffix>` convention users write in their forcing files (see
+# supy._load.WUH_LANDCOVER_SUFFIXES). Each falls back to the bulk `wuh`
+# column when its per-surface column is absent, mirroring LAI_VEG_COLUMNS.
 WUH_SURF_COLUMNS = (
-    "wu_mm_paved", "wu_mm_bldgs", "wu_mm_evetr",
-    "wu_mm_evetr", "wu_mm_grass", "wu_mm_bsoil", "wu_mm_water`"
+    "wuh_paved", "wuh_bldgs", "wuh_evetr", "wuh_dectr",
+    "wuh_grass", "wuh_bsoil", "wuh_water",
 )
 
 
@@ -187,6 +191,8 @@ def validate_forcing_columns_against_physics(
                     missing.append((field_name, value, col, reason))
             elif col.lower() == "wuh":
                 reason = _wuh_validity_issue(forcing_columns)
+                if reason is not None:
+                    missing.append((field_name, value, col, reason))
             elif col.lower() not in available:
                 missing.append((field_name, value, col, "missing"))
             elif not _column_has_valid_data(forcing_columns, col.lower()):

--- a/test/core/test_run_rust.py
+++ b/test/core/test_run_rust.py
@@ -112,3 +112,35 @@ def test_prepare_forcing_block_prefers_per_vegetation_lai():
     np.testing.assert_allclose(block[:, 20], df_forcing["lai_evetr"])
     np.testing.assert_allclose(block[:, 21], df_forcing["lai_dectr"])
     np.testing.assert_allclose(block[:, 22], df_forcing["lai_grass"])
+
+
+def test_prepare_forcing_block_broadcasts_bulk_wuh_to_seven_kernel_columns():
+    df_forcing = _minimal_forcing_frame()
+    df_forcing["Wuh"] = [0.4, 0.5]
+
+    block = _run_rust._prepare_forcing_block(df_forcing)
+
+    assert block.shape == (len(df_forcing), 30)
+    for col in range(23, 30):
+        np.testing.assert_allclose(block[:, col], df_forcing["Wuh"])
+
+
+def test_prepare_forcing_block_prefers_per_surface_wuh():
+    df_forcing = _minimal_forcing_frame()
+    per_surface = {
+        "wuh_paved": [0.11, 0.12],
+        "wuh_bldgs": [0.21, 0.22],
+        "wuh_evetr": [0.31, 0.32],
+        "wuh_dectr": [0.41, 0.42],
+        "wuh_grass": [0.51, 0.52],
+        "wuh_bsoil": [0.61, 0.62],
+        "wuh_water": [0.71, 0.72],
+    }
+    for name, values in per_surface.items():
+        df_forcing[name] = values
+
+    block = _run_rust._prepare_forcing_block(df_forcing)
+
+    assert block.shape == (len(df_forcing), 30)
+    for offset, name in enumerate(per_surface):
+        np.testing.assert_allclose(block[:, 23 + offset], df_forcing[name])

--- a/test/data_model/test_forcing_validation.py
+++ b/test/data_model/test_forcing_validation.py
@@ -208,6 +208,106 @@ def test_validate_forcing_columns_rejects_partial_lai_with_invalid_fallback():
         validate_forcing_columns_against_physics(df, physics)
 
 
+def test_validate_forcing_columns_accepts_full_per_surface_wuh_with_bulk_missing():
+    """water_use=observed can use full per-surface wuh even when bulk wuh is sentinel."""
+    import pandas as pd
+    from types import SimpleNamespace
+
+    from supy.data_model.core.forcing_validation import (
+        validate_forcing_columns_against_physics,
+    )
+
+    physics = SimpleNamespace(water_use=1)
+    df = pd.DataFrame(
+        {
+            "wuh": [-999.0, -999.0],
+            "wuh_paved": [0.1, 0.2],
+            "wuh_bldgs": [0.1, 0.2],
+            "wuh_evetr": [0.1, 0.2],
+            "wuh_dectr": [0.1, 0.2],
+            "wuh_grass": [0.1, 0.2],
+            "wuh_bsoil": [0.1, 0.2],
+            "wuh_water": [0.1, 0.2],
+        }
+    )
+
+    validate_forcing_columns_against_physics(df, physics)
+
+
+def test_validate_forcing_columns_accepts_bulk_wuh_fallback():
+    """water_use=observed accepts a bulk wuh column shared across all surfaces."""
+    import pandas as pd
+    from types import SimpleNamespace
+
+    from supy.data_model.core.forcing_validation import (
+        validate_forcing_columns_against_physics,
+    )
+
+    physics = SimpleNamespace(water_use=1)
+    df = pd.DataFrame({"wuh": [0.5, 0.3]})
+
+    validate_forcing_columns_against_physics(df, physics)
+
+
+def test_validate_forcing_columns_rejects_missing_wuh():
+    """water_use=observed requires a wuh column; none present must fail."""
+    import pandas as pd
+    from types import SimpleNamespace
+
+    from supy.data_model.core.forcing_validation import (
+        validate_forcing_columns_against_physics,
+    )
+
+    physics = SimpleNamespace(water_use=1)
+    df = pd.DataFrame({"kdown": [100.0, 120.0]})
+
+    with pytest.raises(ValueError, match=r"wuh.*required.*water_use=1"):
+        validate_forcing_columns_against_physics(df, physics)
+
+
+def test_validate_forcing_columns_rejects_all_sentinel_wuh():
+    """A bulk wuh of all -999 (and no per-surface) must fail under water_use=observed."""
+    import pandas as pd
+    from types import SimpleNamespace
+
+    from supy.data_model.core.forcing_validation import (
+        validate_forcing_columns_against_physics,
+    )
+
+    physics = SimpleNamespace(water_use=1)
+    df = pd.DataFrame({"wuh": [-999.0, -999.0]})
+
+    with pytest.raises(ValueError, match=r"wuh.*valid data.*water_use=1"):
+        validate_forcing_columns_against_physics(df, physics)
+
+
+def test_validate_forcing_columns_rejects_invalid_per_surface_wuh():
+    """Any invalid per-surface wuh source must fail under water_use=observed."""
+    import pandas as pd
+    from types import SimpleNamespace
+
+    from supy.data_model.core.forcing_validation import (
+        validate_forcing_columns_against_physics,
+    )
+
+    physics = SimpleNamespace(water_use=1)
+    df = pd.DataFrame(
+        {
+            "wuh": [0.5, 0.5],
+            "wuh_paved": [0.1, -999.0],
+            "wuh_bldgs": [0.1, 0.2],
+            "wuh_evetr": [0.1, 0.2],
+            "wuh_dectr": [0.1, 0.2],
+            "wuh_grass": [0.1, 0.2],
+            "wuh_bsoil": [0.1, 0.2],
+            "wuh_water": [0.1, 0.2],
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"wuh.*valid data.*water_use=1"):
+        validate_forcing_columns_against_physics(df, physics)
+
+
 def test_python_rust_whitelist_parity():
     """gh#1372 cross-language guard: Python and Rust must agree on the
     per-landcover whitelist, surface short codes, baseline-required set,


### PR DESCRIPTION
Small fixes on top of @MatthewPaskin's per-land-cover water-use forcing work (#1449), targeted at `mp/per-pc-wu-forcing` so they merge straight into that branch — nothing here rewrites the branch history.

What this fixes:

- **forcing.rs** — defines the missing `WU_LANDCOVER_SUFFIXES` const referenced by the `WUH` per-landcover var and the cross-language parity guard (was failing `cargo clippy` and the cp39 wheel builds).
- **forcing_io.rs** — the per-landcover load test referenced the removed `SuewsField::wu_m3`; it now asserts the canonical `wu_mm_paved` column equals the loaded `wuh_paved` extra, mirroring the LAI checks.
- **forcing_validation.py** — corrects `WUH_SURF_COLUMNS` (it dropped `dectr`, duplicated `evetr`, and carried a stray backtick) and renames to the `wuh_<suffix>` forcing-column convention; wires the validity reason into `missing` so `WaterUseMethod=observed` fails fast on a missing/all-sentinel `wuh` column instead of silently running on `-999`.
- **waterdist.f95** — resets `wu_surf` each timestep so a surface whose forcing is missing (`-999`) contributes zero rather than inheriting the previous step's value.

Verified against the same change rebased on master: `make dev`, `make test-smoke` (9 passed), forcing Python tests (19 passed incl. the cross-language parity guard), `cargo clippy` clean, and a targeted check of the observed-water-use validation gate.

The `0-ci:schema-audit-ok` label is applied because the only `data_model/` touch is forcing-column validation, not a YAML config-schema change — no `CURRENT_SCHEMA_VERSION` bump is needed.
