### PR TITLE
Raise minimum supported Python to 3.12

### DIFF
--- a/.claude/rules/ci/conventions.md
+++ b/.claude/rules/ci/conventions.md
@@ -276,13 +276,15 @@ Tier is user-selectable via the `test_tier` input. Matrix depends on `matrix_con
 
 ### Python version presets
 
-- **ALL_PYTHON** (6): cp39, cp310, cp311, cp312, cp313, cp314
-- **BOOKEND_PYTHON** (2): cp39, cp314 (oldest + newest)
+- **PYTHON_CANDIDATES** (candidate window): cp39, cp310, cp311, cp312, cp313, cp314
+- **ALL_PYTHON** / **BOOKEND_PYTHON** are this window clamped to `requires-python`.
+  With the current `>=3.12` floor the effective sets are `ALL_PYTHON` = cp312,
+  cp313, cp314 and `BOOKEND_PYTHON` = cp312, cp314 (floor + newest); the abi3
+  build matrix is the floor alone (cp312).
 
-These lists are the *candidate* CPython window. `determine-matrix.sh` clamps
-their lower edge to `pyproject.toml`'s `requires-python` (via
-`clamp_python_floor.py`), and the build matrix is the abi3 *floor* (lowest
-supported CPython). `requires-python` is the single source of truth for the
+`determine-matrix.sh` clamps the candidate window's lower edge to
+`pyproject.toml`'s `requires-python` (via `clamp_python_floor.py`), and the
+build matrix is the abi3 *floor* (lowest supported CPython). `requires-python` is the single source of truth for the
 floor, so raising it automatically drops the now-unsupported versions from
 both the build target and the test matrices -- the build matrix can no longer
 drift from the declared support floor (gh#1553).
@@ -304,16 +306,16 @@ The merge queue deliberately uses a reduced matrix rather than the full matrix. 
 **What merge queue covers:**
 
 - 3 platforms: Linux x86_64, macOS ARM64, Windows AMD64
-- 2 Python versions: 3.9 (oldest supported), 3.14 (newest)
+- 2 Python versions: 3.12 (oldest supported), 3.14 (newest)
 - standard test tier: all tests except `slow`-marked
 
 **What merge queue omits:**
 
 - macOS Intel x86_64 (legacy platform, declining user base)
-- Python 3.10-3.13 (intermediate versions)
+- Python 3.13 (intermediate version)
 - `slow`-marked tests (>30s each)
 
-**Rationale:** Full matrix (4 platforms x 6 Python = 24 jobs) would make the merge queue too slow for its purpose as a fast gatekeeper before landing on master. The reduced matrix covers all three major OS families and version boundary extremes where compatibility issues most commonly surface.
+**Rationale:** Full matrix (4 platforms x 3 Python = 12 jobs) would make the merge queue too slow for its purpose as a fast gatekeeper before landing on master. The reduced matrix covers all three major OS families and version boundary extremes where compatibility issues most commonly surface.
 
 **Safety net:**
 

--- a/.claude/skills/prep-release/SKILL.md
+++ b/.claude/skills/prep-release/SKILL.md
@@ -191,7 +191,7 @@ git tag -d "$VERSION" && git push origin ":refs/tags/$VERSION"
 ## Single Wheel per Platform
 
 Each tag triggers one PyPI upload per platform via GitHub Actions:
-- `YYYY.M.D` - cp39-abi3 wheel (installs on cp39..cp3xx)
+- `YYYY.M.D` - cp312-abi3 wheel (installs on cp312..cp3xx)
 
 The runtime pin is `numpy>=1.22`, so the same wheel works in QGIS 3 LTR
 (NumPy 1.26.4), QGIS 4 (NumPy 2.x), and any modern Python environment.

--- a/.claude/skills/prep-release/references/release-steps.md
+++ b/.claude/skills/prep-release/references/release-steps.md
@@ -304,7 +304,7 @@ git push origin "$VERSION"
 
 **Monitor (~20 min):**
 - GitHub Actions: build_wheels, test_api_cross_python, publish
-- PyPI: supy `YYYY.M.D` appears (one cp39-abi3 wheel per platform)
+- PyPI: supy `YYYY.M.D` appears (one cp312-abi3 wheel per platform)
 - GitHub Release: created automatically after successful publish
 - Zenodo DOI appears on the dashboard
 - ReadTheDocs build succeeds

--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'Architecture (e.g., x86_64, arm64, AMD64)'
     required: true
   python:
-    description: 'Python version to build for (always cp39 — emits cp39-abi3 wheel)'
+    description: 'Python version to build for (always cp312 — emits cp312-abi3 wheel)'
     required: true
   test_tier:
     description: 'Test tier: smoke, core, cfg, standard, or all'
@@ -87,7 +87,7 @@ runs:
           --volume ${{ github.workspace }}/.rust-target-cache:/rust-target-cache
         # CIBW_ENABLE: ${{ inputs.python == 'cp314' && 'cp314' || '' }}
         CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
-        # Use manylinux_2_28 for Python 3.13+ (newer dependencies require it), manylinux2014 for 3.9-3.12 (older Linux compatibility)
+        # Use manylinux_2_28 for Python 3.13+ (newer dependencies require it), manylinux2014 for 3.12 (older Linux compatibility)
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ (inputs.python == 'cp313' || inputs.python == 'cp314') && 'manylinux_2_28' || 'manylinux2014' }}
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ (inputs.python == 'cp313' || inputs.python == 'cp314') && 'manylinux_2_28' || 'manylinux2014' }}
         # Configure pip and Rust cache — defaults for platforms without

--- a/.github/scripts/determine-matrix.sh
+++ b/.github/scripts/determine-matrix.sh
@@ -26,7 +26,7 @@
 #   INPUT_PLAT_MACOS_INTEL -- inputs.plat_macos_intel
 #   INPUT_PLAT_MACOS_ARM -- inputs.plat_macos_arm
 #   INPUT_PLAT_WINDOWS   -- inputs.plat_windows
-#   INPUT_PY39..PY314    -- inputs.py39..py314
+#   INPUT_PY312..PY314   -- inputs.py312..py314
 #   INPUT_TEST_TIER      -- inputs.test_tier (dispatch only)
 #   GITHUB_REF           -- github.ref (e.g. refs/tags/v2025a1)
 #   PR_PYPROJECT         -- path to the built ref's pyproject.toml (data only;
@@ -148,7 +148,7 @@ elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
       ;;
     custom)
       echo "Manual dispatch: custom platform matrix"
-      echo "  Build is always cp39-abi3; py3X toggles select the api cross-CPython matrix"
+      echo "  Build is always cp312-abi3; py3X toggles select the api cross-CPython matrix"
 
       PLATFORMS="["
       [[ "${INPUT_PLAT_LINUX}" == "true" ]] && PLATFORMS+='["ubuntu-latest", "manylinux", "x86_64"],'
@@ -164,9 +164,6 @@ elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
 
       # Build py3X test matrix from dispatch toggles
       TEST_PYS="["
-      [[ "${INPUT_PY39:-false}"  == "true" ]] && TEST_PYS+='"cp39",'
-      [[ "${INPUT_PY310:-false}" == "true" ]] && TEST_PYS+='"cp310",'
-      [[ "${INPUT_PY311:-false}" == "true" ]] && TEST_PYS+='"cp311",'
       [[ "${INPUT_PY312:-false}" == "true" ]] && TEST_PYS+='"cp312",'
       [[ "${INPUT_PY313:-false}" == "true" ]] && TEST_PYS+='"cp313",'
       [[ "${INPUT_PY314:-false}" == "true" ]] && TEST_PYS+='"cp314",'

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,7 +46,7 @@ Post-merge formatting workflow that:
 ### 3. Build and Publish (`build-publish_to_pypi.yml`)
 Automated build and publish workflow that:
 - Builds wheels for multiple platforms (Linux, macOS, Windows)
-- Supports Python 3.9-3.14
+- Supports Python 3.12-3.14
 - Runs tests on each platform
 - Publishes to TestPyPI on nightly/dev tag builds
 - Publishes to PyPI on tagged releases
@@ -57,13 +57,13 @@ Automated build and publish workflow that:
 When triggering via Actions tab → "Run workflow", you can configure:
 - **matrix_config**: Choose build matrix
   - `full` - All platforms, all Python versions (default)
-  - `pr` - Reduced: Linux + macOS ARM + Windows, Python 3.9 + 3.14
-  - `minimal` - Linux only, Python 3.9 + 3.14
+  - `pr` - Reduced: Linux + macOS ARM + Windows, Python 3.12 + 3.14
+  - `minimal` - Linux only, Python 3.12 + 3.14
   - `custom` - Use individual platform/Python toggles
 - **deploy_target**: `none` (validation) or `testpypi` (PyPI restricted to tags)
 - **test_tier**: `smoke`, `core`, `cfg`, `standard`, or `all`
 
-Every cp39-abi3 wheel also covers the current Windows QGIS 3 LTR and QGIS 4
+Every cp312-abi3 wheel also covers the current Windows QGIS 3 LTR and QGIS 4
 Python line. Both use Python 3.12 on Windows; the runtime pin is
 `numpy>=1.22` and the Rust bridge has no NumPy C-ABI dependency.
 

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -10,8 +10,8 @@ name: Build and Publish Python wheels to PyPI and TestPyPI
 #   dispatch  -- Manual with configurable matrix, deploy target, test tier
 #
 # Build strategy:
-#   One cp39-abi3 wheel per (OS, arch). The Rust bridge (PyO3 abi3-py39)
-#   makes the binary ABI-stable, so a single wheel installs on cp39..cp3xx.
+#   One cp312-abi3 wheel per (OS, arch). The Rust bridge (PyO3 abi3-py312)
+#   makes the binary ABI-stable, so a single wheel installs on cp312..cp3xx.
 #   Covers current Windows QGIS 3 LTR, QGIS 4, and general users — the runtime
 #   pin is numpy>=1.22 (Rust bridge has no NumPy C-ABI dependency; pure-Python
 #   code uses only NumPy 1.22-compatible APIs).
@@ -74,25 +74,13 @@ on:
         default: true
 
       # Python toggles drive the cross-CPython api-test matrix (gh#1300).
-      # The build is always cp39-abi3 (one wheel covers all supported CPythons),
+      # The build is always cp312-abi3 (one wheel covers all supported CPythons),
       # so these toggles only affect which interpreters install the wheel and
       # run `-m "api and <tier>"` in test_api_cross_python.
-      py39:
-        description: '[custom] Test on Python 3.9 (build is always cp39-abi3)'
+      py312:
+        description: '[custom] Test on Python 3.12 (build is always cp312-abi3)'
         type: boolean
         default: true
-      py310:
-        description: '[custom] Test on Python 3.10'
-        type: boolean
-        default: false
-      py311:
-        description: '[custom] Test on Python 3.11'
-        type: boolean
-        default: false
-      py312:
-        description: '[custom] Test on Python 3.12'
-        type: boolean
-        default: false
       py313:
         description: '[custom] Test on Python 3.13'
         type: boolean
@@ -327,9 +315,6 @@ jobs:
           INPUT_PLAT_MACOS_INTEL: ${{ inputs.plat_macos_intel }}
           INPUT_PLAT_MACOS_ARM: ${{ inputs.plat_macos_arm }}
           INPUT_PLAT_WINDOWS: ${{ inputs.plat_windows }}
-          INPUT_PY39: ${{ inputs.py39 }}
-          INPUT_PY310: ${{ inputs.py310 }}
-          INPUT_PY311: ${{ inputs.py311 }}
           INPUT_PY312: ${{ inputs.py312 }}
           INPUT_PY313: ${{ inputs.py313 }}
           INPUT_PY314: ${{ inputs.py314 }}
@@ -561,8 +546,8 @@ jobs:
       - create_nightly_tag
       - verify-release-tag
     # Production tags only: all platform wheels must succeed AND the
-    # cross-CPython api tests must pass (the only signal the cp39-abi3
-    # wheel imports on cp310..cp314 after the build matrix collapse).
+    # cross-CPython api tests must pass (the only signal the cp312-abi3
+    # wheel imports on cp312..cp314 after the build matrix collapse).
     if: |
       always() &&
       startsWith(github.ref, 'refs/tags') &&

--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -1,7 +1,7 @@
 # Reusable workflow: build SUEWS abi3 wheels with a matrix strategy.
 #
-# Called by build-publish_to_pypi.yml. One cp39-abi3 wheel per (OS, arch)
-# covers cp39..cp3xx. By isolating the matrix here, the caller job can use
+# Called by build-publish_to_pypi.yml. One cp312-abi3 wheel per (OS, arch)
+# covers cp312..cp3xx. By isolating the matrix here, the caller job can use
 # a static name that displays cleanly when skipped.
 
 name: Build wheels (reusable)
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       python_json:
-        description: 'JSON array of CPython tags used by cibuildwheel (always ["cp39"] — abi3)'
+        description: 'JSON array of CPython tags used by cibuildwheel (always ["cp312"] — abi3)'
         required: true
         type: string
       test_tier:

--- a/.github/workflows/cibuildwheel-debug.yml
+++ b/.github/workflows/cibuildwheel-debug.yml
@@ -15,7 +15,7 @@ name: Debug cibuildwheel with SSH
 # 1. Go to Actions tab → Select "Debug cibuildwheel with SSH"
 # 2. Click "Run workflow" and fill in parameters:
 #    - Platform-Arch: Choose from 4 valid combinations (Linux/macOS Intel/macOS ARM/Windows)
-#    - Python: cp39, cp310, cp311, cp312, cp313
+#    - Python: cp312, cp313, cp314
 #    - Debug mode: before-build, after-failure, always, disabled
 # 3. When SSH session starts, connect using the command shown in logs
 # 4. Use Claude Code for help: `claude -p "help me debug this cibuildwheel error"`
@@ -42,14 +42,12 @@ on:
       python_version:
         description: 'Python version'
         required: true
-        default: 'cp311'
+        default: 'cp312'
         type: choice
         options:
-          - cp39
-          - cp310
-          - cp311
           - cp312
           - cp313
+          - cp314
       debug_mode:
         description: 'Debug mode - when to provide SSH access'
         required: true
@@ -66,7 +64,7 @@ permissions:
 
 jobs:
   debug-cibuildwheel:
-    name: Debug ${{ inputs.python_version || 'cp311' }}-${{ inputs.platform_arch || 'macos-latest-arm64' }}
+    name: Debug ${{ inputs.python_version || 'cp312' }}-${{ inputs.platform_arch || 'macos-latest-arm64' }}
     runs-on: ${{
       (inputs.platform_arch || 'macos-latest-arm64') == 'ubuntu-latest-x86_64' && 'ubuntu-latest' ||
       (inputs.platform_arch || 'macos-latest-arm64') == 'macos-15-intel-x86_64' && 'macos-15-intel' ||
@@ -95,7 +93,7 @@ jobs:
         contains(inputs.platform_arch || 'macos-latest-arm64', 'windows') && 'win' }}
 
       # Core cibuildwheel configuration
-      CIBW_BUILD: ${{ inputs.python_version || 'cp311' }}-*
+      CIBW_BUILD: ${{ inputs.python_version || 'cp312' }}-*
       CIBW_ARCHS: ${{
         (inputs.platform_arch || 'macos-latest-arm64') == 'ubuntu-latest-x86_64' && 'x86_64' ||
         (inputs.platform_arch || 'macos-latest-arm64') == 'macos-15-intel-x86_64' && 'x86_64' ||
@@ -232,7 +230,7 @@ jobs:
           echo "Platform-Arch: ${{ inputs.platform_arch || 'macos-latest-arm64' }}"
           echo "Platform: ${DEBUG_PLATFORM}"
           echo "Architecture: ${DEBUG_ARCHITECTURE}"
-          echo "Python Version: ${{ inputs.python_version || 'cp311' }}"
+          echo "Python Version: ${{ inputs.python_version || 'cp312' }}"
           echo "Build Platform: ${DEBUG_BUILDPLAT}"
           echo "Debug Mode: ${DEBUG_MODE_VALUE}"
           echo "Actor: ${WORKFLOW_ACTOR}"
@@ -300,7 +298,7 @@ jobs:
           BUILD_OUTCOME: ${{ steps.build.outcome }}
           BUILD_EXIT_CODE: ${{ steps.build.outputs.exit_code }}
           DEBUG_PLATFORM_ARCH: ${{ inputs.platform_arch || 'macos-latest-arm64' }}
-          DEBUG_PYTHON_VERSION: ${{ inputs.python_version || 'cp311' }}
+          DEBUG_PYTHON_VERSION: ${{ inputs.python_version || 'cp312' }}
         run: |
           # Check if build failed
           if [ "${BUILD_OUTCOME}" == "failure" ] || [ "${BUILD_EXIT_CODE}" != "0" ]; then
@@ -452,7 +450,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: debug-${{ inputs.python_version || 'cp311' }}-${{ inputs.platform_arch || 'macos-latest-arm64' }}-${{ github.run_number }}
+          name: debug-${{ inputs.python_version || 'cp312' }}-${{ inputs.platform_arch || 'macos-latest-arm64' }}-${{ github.run_number }}
           path: debug-artifacts/
           retention-days: 7
 
@@ -460,7 +458,7 @@ jobs:
         if: steps.build.outcome == 'success'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: wheel-${{ inputs.python_version || 'cp311' }}-${{ inputs.platform_arch || 'macos-latest-arm64' }}
+          name: wheel-${{ inputs.python_version || 'cp312' }}-${{ inputs.platform_arch || 'macos-latest-arm64' }}
           path: ./wheelhouse/*.whl
 
       - name: Final status
@@ -468,7 +466,7 @@ jobs:
         shell: bash
         env:
           BUILD_OUTCOME: ${{ steps.build.outcome }}
-          DEBUG_PYTHON_VERSION: ${{ inputs.python_version || 'cp311' }}
+          DEBUG_PYTHON_VERSION: ${{ inputs.python_version || 'cp312' }}
           DEBUG_PLATFORM_ARCH: ${{ inputs.platform_arch || 'macos-latest-arm64' }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -184,7 +184,7 @@ jobs:
         if: steps.detect.outputs.docs_changed == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          # Documentation tooling requires Python 3.11+; runtime support remains 3.9+.
+          # Runtime and documentation tooling both require Python 3.12+.
           python-version: "3.13"
 
       - name: Install supy and build docs

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          # Documentation tooling requires Python 3.11+; runtime support remains 3.9+.
+          # Runtime and documentation tooling both require Python 3.12+.
           python-version: '3.13'
 
       - name: Install uv

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -1,4 +1,4 @@
-# Reusable workflow: install the cp39-abi3 wheel into each supported CPython
+# Reusable workflow: install the cp312-abi3 wheel into each supported CPython
 # version and run `pytest -m "api and <tier>"`. Normal tiers exclude the
 # QGIS/UMEP integration lane; `all` keeps it for scheduled/release/manual
 # validation where the Windows + Python 3.12 cell matches current QGIS 3 LTR
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       api_python_json:
-        description: 'JSON array of test-time CPython tags (e.g. ["cp39","cp314"])'
+        description: 'JSON array of test-time CPython tags (e.g. ["cp312","cp314"])'
         required: true
         type: string
       test_tier:
@@ -47,7 +47,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Resolve Python version (cp39 -> 3.9)
+      - name: Resolve Python version (cp312 -> 3.12)
         id: pyver
         shell: bash
         env:
@@ -62,7 +62,7 @@ jobs:
       - name: Download wheel for this platform
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: cp39-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
+          name: cp312-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
           path: wheelhouse/
 
       - name: Compose pytest marker expression for api tier

--- a/.github/workflows/test-detect-changes.yml
+++ b/.github/workflows/test-detect-changes.yml
@@ -182,7 +182,7 @@ jobs:
           if [[ "$DOCS" == "true" ]]; then echo "- docs build (pages-deploy.yml)"; TRIGGERED=true; fi
           if [[ "$SITE" == "true" ]]; then echo "- site deploy (pages-deploy.yml)"; TRIGGERED=true; fi
           if [[ "$NEEDS_BUILD" == "true" ]]; then
-            echo "- wheel build (build_wheels): cp39-abi3 wheel per platform"
+            echo "- wheel build (build_wheels): cp312-abi3 wheel per platform"
             TRIGGERED=true
           fi
           if [[ "$TRIGGERED" == "false" ]]; then echo "- nothing (all skipped)"; fi

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -5,8 +5,8 @@
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.9 (minimum supported version)
-target-version = "py39"
+# Assume Python 3.12 (minimum supported version)
+target-version = "py312"
 
 # Exclude common directories
 exclude = [
@@ -54,9 +54,6 @@ select = [
     "SIM",    # flake8-simplify
     "UP",     # pyupgrade
 
-    # Python version compatibility
-    "FA102",  # PEP 604 unions (X | None) need py3.10 at runtime; guard for py3.9
-
     # Documentation
     "D",      # pydocstyle
     
@@ -101,7 +98,6 @@ unfixable = [
     "B",      # Bugbear rules often need careful review
     "F841",   # Unused variables might be intentional
     "SIM",    # Simplifications might reduce clarity
-    "FA102",  # Autofix adds `from __future__ import annotations`, which breaks Pydantic
 ]
 
 # Allow unused variables when underscore-prefixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ EXAMPLES:
 
 ## 2026
 
+### 17 Jun 2026
+
+- [maintenance] Raised the minimum supported Python to 3.12, dropping 3.9/3.10/3.11 (#1553)
+  - The single abi3 wheel is now built as cp312-abi3 (PyO3 `abi3-py312`, cibuildwheel `cp312`) and still installs on cp312..cp3xx, covering current QGIS 3 LTR and QGIS 4 (Python 3.12 on Windows)
+  - CI build/test matrices, classifiers, ruff target, and the version-conditional dependency markers were trimmed accordingly
+
 ### 16 Jun 2026
 
 - [feature][experimental] Observed external water use can now be supplied per land cover in the forcing file via `wuh_paved`, `wuh_bldgs`, `wuh_evetr`, `wuh_dectr`, `wuh_grass`, `wuh_bsoil`, `wuh_water` (mm), replacing the single bulk `wuh`/`wu_m3` value when `WaterUseMethod=observed` (#1449)

--- a/dev-ref/RELEASE_MANUAL.md
+++ b/dev-ref/RELEASE_MANUAL.md
@@ -32,7 +32,7 @@ SUEWS adopts a **rolling release model** that reflects the continuous nature of 
    git push origin $VERSION
    ```
 4. **Wait ~20 min**: GitHub Actions builds **two versions** in parallel:
-   - `2025.10.14` (one cp39-abi3 wheel per platform, installs on cp39..cp3xx and any NumPy 1.22+/2.x)
+   - `2025.10.14` (one cp312-abi3 wheel per platform, installs on cp312..cp3xx and any NumPy 1.22+/2.x)
 
    Deployed to PyPI → GitHub Release → Zenodo DOI
 5. **Verify**: Check [Actions](https://github.com/UMEP-dev/SUEWS/actions), [PyPI](https://pypi.org/project/supy/), [Zenodo dashboard](https://zenodo.org/me/uploads)
@@ -44,9 +44,9 @@ SUEWS adopts a **rolling release model** that reflects the continuous nature of 
 
 ## Single Wheel Covers All Environments
 
-Every SUEWS release produces **one cp39-abi3 wheel per (OS, arch)** from a single git tag. That wheel installs and runs on:
+Every SUEWS release produces **one cp312-abi3 wheel per (OS, arch)** from a single git tag. That wheel installs and runs on:
 
-- CPython 3.9 through 3.14 (Rust bridge via PyO3 `abi3-py39`)
+- CPython 3.12 through 3.14 (Rust bridge via PyO3 `abi3-py312`)
 - NumPy 1.22+ (including QGIS 3 LTR's NumPy 1.26.4) through NumPy 2.x
 
 ### pip Install Behaviour
@@ -67,8 +67,8 @@ The UMEP (`rc1`) variant was retired in 2026-04 together with `.github/scripts/r
 From a single tag push:
 
 1. **Build** (`build_wheels` job)
-   - Builds one `cp39-abi3` wheel per (OS, arch) via cibuildwheel
-   - The Rust bridge uses PyO3 `abi3-py39`, so the wheel installs on cp39..cp3xx
+   - Builds one `cp312-abi3` wheel per (OS, arch) via cibuildwheel
+   - The Rust bridge uses PyO3 `abi3-py312`, so the wheel installs on cp312..cp3xx
    - Creates version `2024.10.7`
 
 2. **Cross-CPython API tests** (`test_api_cross_python` job)
@@ -619,7 +619,7 @@ This release focuses on [main theme: e.g., enhanced validation capabilities, mod
 pip install --upgrade supy
 ```
 
-The cp39-abi3 wheel installs on any CPython 3.9+ with NumPy 1.22+,
+The cp312-abi3 wheel installs on any CPython 3.12+ with NumPy 1.22+,
 covering QGIS 3 LTR (NumPy 1.26.4), QGIS 4, and standalone Python.
 
 ## Citation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ requires = [
 build-backend = 'mesonpy'
 
 [tool.meson-python]
-# Emit cp39-abi3 wheel tag when built under CPython 3.9.
-# The Rust bridge uses PyO3 with abi3-py39 (stable ABI), so one wheel
-# covers cp39..cp3xx. See src/suews_bridge/Cargo.toml.
+# Emit cp312-abi3 wheel tag when built under CPython 3.12.
+# The Rust bridge uses PyO3 with abi3-py312 (stable ABI), so one wheel
+# covers cp312..cp3xx. See src/suews_bridge/Cargo.toml.
 limited-api = true
 
 [tool.meson-python.args]
@@ -22,7 +22,7 @@ authors = [
     { name = "Dr Ting Sun", email = "ting.sun@ucl.ac.uk" },
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 license = { text = "GPL-V3.0" }
 readme = "README.md"
 
@@ -31,8 +31,8 @@ dependencies = [
     # Data processing
     "pandas",
     "numpy>=1.22",  # Covers current QGIS 3 LTR / QGIS 4 NumPy stacks; no ABI constraint (Rust bridge is NumPy-free)
-    "scipy<1.15; python_version >= '3.11' and python_version < '3.13' and platform_system == 'Linux'",  # manylinux2014 wheels
-    "scipy; python_version < '3.11' or python_version >= '3.13' or platform_system != 'Linux'",  # Others use latest
+    "scipy<1.15; python_version < '3.13' and platform_system == 'Linux'",  # 3.12 Linux: manylinux2014 wheels
+    "scipy; python_version >= '3.13' or platform_system != 'Linux'",  # Others use latest
     # xarray removed - only needed for gridded ERA5 (install separately)
     # dask removed - CLI uses stdlib multiprocessing.pool.ThreadPool
 
@@ -46,7 +46,7 @@ dependencies = [
     "seaborn",
     "chardet",
     "click",
-    "pyarrow>=20,<21; python_version < '3.14' and platform_system == 'Linux'",  # Linux needs manylinux2014 wheels on CPython 3.9-3.13
+    "pyarrow>=20,<21; python_version < '3.14' and platform_system == 'Linux'",  # Linux needs manylinux2014 wheels on CPython 3.12-3.13
     "pyarrow>=20; python_version < '3.14' and platform_system != 'Linux'",  # Non-Linux platforms may use newer pyarrow binaries
     "pyarrow>=22; python_version >= '3.14'",  # 22.x provides cp314 wheels on manylinux_2_28/macOS/Windows
 
@@ -74,9 +74,6 @@ dependencies = [
 
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -114,8 +111,8 @@ dev = [
 ]
 
 # Documentation tooling (isolated from the default dev environment).
-# Runtime support remains Python 3.9+; documentation builds require Python 3.11+
-# because current Sphinx extension versions, notably sphinx-design 0.7+, do.
+# Runtime support is Python 3.12+, which already satisfies the documentation
+# toolchain floor (current Sphinx extensions, notably sphinx-design 0.7+, need 3.11+).
 docs = [
     # Documentation - Essential only (based on conf.py usage)
     "sphinx>=7,<9",
@@ -124,7 +121,7 @@ docs = [
     "pybtex",                   # Bibliography processing
     "sphinxcontrib-bibtex>=2.6,<3", # Bibliography support (heavily customised)
     # Collapsible sections for YAML config docs (>=0.7 supports Sphinx 8)
-    "sphinx-design>=0.7.0; python_version >= '3.11'",
+    "sphinx-design>=0.7.0",
     "sphinx-last-updated-by-git", # Git info in docs
     "sphinx-click",             # CLI documentation
     "sphinx-gallery>=0.16.0",   # Gallery examples from Python scripts (GH-1029)
@@ -159,7 +156,7 @@ markers = [
     "api: Python wrapper correctness; run across (platform x Python) because pandas/numpy/pydantic surface varies",
     # Tier axis
     "smoke: Minimal wheel validation (~6 tests, ~60s)",
-    "smoke_bridge: Bridge-loading subset run across cp39..cp3xx after a single abi3 build",
+    "smoke_bridge: Bridge-loading subset run across cp312..cp3xx after a single abi3 build",
     "core: Core physics & logic tests (Fortran, driver)",
     "rust: Rust bridge backend tests (requires suews_bridge with physics feature)",
     "util: Utility function tests (non-critical)",
@@ -170,7 +167,7 @@ markers = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py312"
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/suews_bridge/Cargo.toml
+++ b/src/suews_bridge/Cargo.toml
@@ -39,7 +39,7 @@ features = ["ipc"]
 [dependencies.pyo3]
 version = "0.22"
 optional = true
-features = ["abi3-py39"]
+features = ["abi3-py312"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/test/data_model/test_yaml_upgrade.py
+++ b/test/data_model/test_yaml_upgrade.py
@@ -449,7 +449,7 @@ class TestSuewsConvertYamlPath:
         The `upgrade_yaml` helper writes progress lines to stderr via its
         `_log()` helper. We assert that stdout alone is a clean envelope —
         which is what real users see when piping `suews convert --format
-        json | jq`. Click <8.3 (used on cp39) defaults to mixing the two
+        json | jq`. Click <8.3 defaults to mixing the two
         streams in `CliRunner.invoke().stdout`; pass `mix_stderr=False`
         explicitly to get genuine separation, falling back gracefully on
         Click >=8.3 where the kwarg has been removed because the streams


### PR DESCRIPTION
## Summary

Raises the SUEWS/SuPy minimum supported Python to **3.12**, dropping 3.9, 3.10, and 3.11. Resolves #1553 (which proposed `>=3.11`); the floor was settled at 3.12 to match the Scientific Python baseline (SPEC 0) and the Python that current QGIS/UMEP ships, and to avoid a near-term repeat bump.

## Why the build pipeline moves too

The build is architected around a single **cp39-abi3** wheel (one stable-ABI wheel covering cp39..cp3xx). Raising `requires-python` to `>=3.12` is not a config-only change: cibuildwheel filters build targets by `requires-python`, so the existing `cp39` build selector would stop producing wheels. The wheel therefore moves to **cp312-abi3** (PyO3 `abi3-py312`, cibuildwheel `cp312`), and the wheel artifact name / cross-Python download were moved in lockstep.

## What changed

- `pyproject.toml`: `requires-python = ">=3.12"`; classifiers trimmed to 3.12-3.14; ruff `target-version = "py312"`; the now-redundant `python_version >= '3.11'` markers (scipy, sphinx-design) simplified.
- `.ruff.toml`: target `py312`; removed the `FA102` rule (it existed only to guard PEP 604 unions on 3.9).
- `src/suews_bridge/Cargo.toml`: PyO3 `abi3-py39` -> `abi3-py312`.
- CI: `determine-matrix.sh` (`BUILD_PYTHON` / `BOOKEND_PYTHON` / `ALL_PYTHON` -> cp312-based; dropped the py39/py310/py311 dispatch toggles); the wheel artifact name and the cross-Python download (`cp39-` -> `cp312-`); the debug workflow options; doc/comment text across the build/test workflows and README.
- Docs: `RELEASE_MANUAL.md`, prep-release skill notes, CI conventions, CHANGELOG.

## UMEP / QGIS

cp312-abi3 still covers current QGIS 3 LTR and QGIS 4 (both run Python 3.12 on Windows), so current UMEP is unaffected. A 3.12 floor drops only direct `pip` users on 3.9-3.11 and anyone on an older QGIS LTR bundling Python < 3.12.

**To confirm before merge:** the oldest QGIS LTR we intend to support and its bundled Python on Windows, so we know exactly who (if anyone) is dropped.

## Validation

- `pyproject.toml` / `.ruff.toml` / `Cargo.toml` parse; all PEP 508 dependency markers valid; `determine-matrix.sh` passes `bash -n`; all edited workflow YAML parses.
- PyO3 0.22.6 supports `abi3-py312`.
- The ruff `target-version` bump surfaces latent pyupgrade modernization suggestions but breaks no gate: CI runs no full `ruff check` or `ruff format --check` (only the `PLW1514` encoding audit, which is target-independent).
- The cp312-abi3 wheel build and cross-Python install tests run on CI here; they need a full toolchain build and cannot be reproduced locally.

Fixes #1553
