### PR TITLE
Derive the wheel build matrix floor from requires-python

### DIFF
--- a/.claude/rules/ci/conventions.md
+++ b/.claude/rules/ci/conventions.md
@@ -279,6 +279,22 @@ Tier is user-selectable via the `test_tier` input. Matrix depends on `matrix_con
 - **ALL_PYTHON** (6): cp39, cp310, cp311, cp312, cp313, cp314
 - **BOOKEND_PYTHON** (2): cp39, cp314 (oldest + newest)
 
+These lists are the *candidate* CPython window. `determine-matrix.sh` clamps
+their lower edge to `pyproject.toml`'s `requires-python` (via
+`clamp_python_floor.py`), and the build matrix is the abi3 *floor* (lowest
+supported CPython). `requires-python` is the single source of truth for the
+floor, so raising it automatically drops the now-unsupported versions from
+both the build target and the test matrices -- the build matrix can no longer
+drift from the declared support floor (gh#1553).
+
+Because `determine_matrix` runs the matrix script from the **base** branch
+(trusted), it additionally sparse-checks the *built ref's* `pyproject.toml`
+(`github.sha`) as data only and passes it via `PR_PYPROJECT`. This is what
+lets a PR that raises `requires-python` build and test on its own corrected
+matrix; without it, the floor would always be read from base and a
+requires-python bump would fail CI with `cibuildwheel: No build identifiers
+selected`.
+
 ---
 
 ## Merge Queue Coverage Policy

--- a/.github/scripts/clamp_python_floor.py
+++ b/.github/scripts/clamp_python_floor.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Resolve the CPython build/test matrix from pyproject ``requires-python``.
+
+For an abi3 / limited-API wheel the build floor is the *lowest* supported
+CPython -- the lower bound of ``project.requires-python``. One wheel built
+there covers every newer CPython, so the floor is the only build target we
+need. Deriving the matrix from ``requires-python`` keeps ``pyproject.toml`` as
+the single source of truth and stops the CI build matrix drifting from the
+declared support floor.
+
+Background (gh#1553): raising ``requires-python`` to ``>=3.12`` while
+``determine-matrix.sh`` still hardcoded a ``cp39`` build target handed
+cibuildwheel ``cp39`` together with ``>=3.12``. The intersection was empty and
+the build aborted with ``cibuildwheel: No build identifiers selected``. This
+helper removes that second, drift-prone source of truth.
+
+This script reads the pyproject as DATA only -- nothing in it is executed --
+so it is safe to point at a pull-request's pyproject from a base-trusted
+caller.
+
+Modes (exactly one):
+  --floor-tag           print the floor build tag, e.g. ``cp312``
+  --clamp   '<json>'    print the cpXY JSON list with entries below the floor dropped
+  --bookend '<json>'    print ``["cp<floor>", "cp<newest-after-clamp>"]``
+
+All cpXY tags are assumed to be CPython 3.x (``cp3YY``); a non-3.x tag is a
+hard error rather than a silent guess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # tomllib is stdlib only on Python >= 3.11
+    tomllib = None
+
+
+def _die(msg: str) -> None:
+    # Emit a GitHub Actions error annotation and fail closed.
+    sys.exit(f"::error::clamp_python_floor: {msg}")
+
+
+def _read_requires_python(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        _die(f"cannot read {path}: {exc}")
+
+    # Prefer a real TOML parse; fall back to a line regex if tomllib is absent
+    # or the file is malformed (matches classify_pyproject.py's defensiveness).
+    if tomllib is not None:
+        try:
+            value = tomllib.loads(text).get("project", {}).get("requires-python")
+            if value:
+                return value
+        except (tomllib.TOMLDecodeError, AttributeError, TypeError):
+            pass
+
+    match = re.search(
+        r'^\s*requires-python\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE
+    )
+    if not match:
+        _die(f"no project.requires-python found in {path}")
+    return match.group(1)
+
+
+def _floor_minor(path: str) -> int:
+    requires_python = _read_requires_python(path)
+    match = re.search(r">=\s*3\.(\d+)", requires_python)
+    if not match:
+        _die(f"requires-python={requires_python!r} has no '>=3.Y' lower bound")
+    return int(match.group(1))
+
+
+def _tag_minor(tag: str) -> int:
+    match = re.fullmatch(r"cp3(\d+)", tag.strip())
+    if not match:
+        _die(f"not a CPython 3.x cpXY tag: {tag!r}")
+    return int(match.group(1))
+
+
+def _load_candidates(raw: str) -> list[str]:
+    try:
+        candidates = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _die(f"invalid cpXY JSON list {raw!r}: {exc}")
+    if not isinstance(candidates, list) or not all(
+        isinstance(item, str) for item in candidates
+    ):
+        _die(f"expected a JSON list of cpXY strings, got {raw!r}")
+    return candidates
+
+
+def main() -> None:
+    """Parse arguments and print the requested matrix value."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyproject", required=True, help="path to pyproject.toml")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--floor-tag", action="store_true", help="print cp<floor>")
+    mode.add_argument("--clamp", metavar="JSON", help="drop tags below the floor")
+    mode.add_argument(
+        "--bookend", metavar="JSON", help="print [floor, newest] after clamping"
+    )
+    args = parser.parse_args()
+
+    floor = _floor_minor(args.pyproject)
+
+    if args.floor_tag:
+        print(f"cp3{floor}")
+        return
+
+    raw = args.clamp if args.clamp is not None else args.bookend
+    candidates = _load_candidates(raw)
+    kept = [tag for tag in candidates if _tag_minor(tag) >= floor]
+    if not kept:
+        _die(f"no candidate CPython >= 3.{floor} in {candidates}")
+
+    if args.bookend is not None and len(kept) > 1:
+        kept = [kept[0], kept[-1]]
+
+    print(json.dumps(kept))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/determine-matrix.sh
+++ b/.github/scripts/determine-matrix.sh
@@ -4,9 +4,10 @@
 # Called from build-publish_to_pypi.yml determine_matrix job.
 # Writes buildplat, python, api_python, test_tier to GITHUB_OUTPUT.
 #
-# "python" is the cibuildwheel build matrix (always cp39 — emits one abi3
-# wheel per platform). Physics tests run during the build step on the
-# build Python only, since they're binary-determined (gh#1300).
+# "python" is the cibuildwheel build matrix (the abi3 floor derived from
+# pyproject's requires-python — emits one abi3 wheel per platform). Physics
+# tests run during the build step on the build Python only, since they're
+# binary-determined (gh#1300).
 # "api_python" is the cross-version matrix used by test-api-cross-python;
 # the api marker covers the Python wrapper surface (pandas/numpy/pydantic,
 # CLI, SUEWSSimulation) and needs full (platform x Python) coverage
@@ -28,6 +29,10 @@
 #   INPUT_PY39..PY314    -- inputs.py39..py314
 #   INPUT_TEST_TIER      -- inputs.test_tier (dispatch only)
 #   GITHUB_REF           -- github.ref (e.g. refs/tags/v2025a1)
+#   PR_PYPROJECT         -- path to the built ref's pyproject.toml (data only;
+#                           the requires-python floor source of truth). The
+#                           caller sparse-checks it from github.sha; defaults
+#                           to ./pyproject.toml.
 
 set -euo pipefail
 
@@ -42,16 +47,33 @@ FULL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-15-intel", "m
 PR_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-latest", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
 MINIMAL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"]]'
 
-# Python version presets
-BOOKEND_PYTHON='["cp39", "cp314"]'
-ALL_PYTHON='["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]'
+# Python version policy.
+#
+# The full candidate CPython window is authored here; its lower edge is then
+# clamped to pyproject's requires-python so the build/test matrix can never
+# drift from the declared support floor (gh#1553: a hardcoded cp39 build
+# target collided with requires-python>=3.12 and cibuildwheel aborted with
+# "No build identifiers selected"). requires-python is the single source of
+# truth for the floor; this list only sets the newest tested edge.
+PYTHON_CANDIDATES='["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]'
 
-# Build-side Python: always cp39 to emit cp39-abi3 wheels that cover all
-# supported CPython versions. The bridge is PyO3 abi3-py39 and meson-python
-# is configured with limited-api=true in pyproject.toml, so one wheel per
-# (OS, arch) covers cp39..cp3xx. BOOKEND_PYTHON / ALL_PYTHON are retained
-# for test-side matrices, not wheel builds.
-BUILD_PYTHON='["cp39"]'
+# Resolve the floor from the built ref's pyproject (data only; the logic lives
+# in this base-trusted script and its helper). PR_PYPROJECT points at a sparse
+# checkout of github.sha:pyproject.toml; fall back to the repo-root copy.
+PR_PYPROJECT="${PR_PYPROJECT:-pyproject.toml}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAMP="${SCRIPT_DIR}/clamp_python_floor.py"
+
+# Build-side Python: the abi3 floor (lowest supported CPython). One abi3 wheel
+# built there covers cp<floor>..cp3xx, since the bridge is PyO3 abi3 and
+# meson-python sets limited-api=true in pyproject.toml.
+BUILD_FLOOR="$(python3 "${CLAMP}" --pyproject "${PR_PYPROJECT}" --floor-tag)"
+BUILD_PYTHON="[\"${BUILD_FLOOR}\"]"
+
+# Test-side matrices: the candidate window clamped to the floor. BOOKEND is the
+# floor plus the newest still-supported edge; ALL is every supported version.
+BOOKEND_PYTHON="$(python3 "${CLAMP}" --pyproject "${PR_PYPROJECT}" --bookend "${PYTHON_CANDIDATES}")"
+ALL_PYTHON="$(python3 "${CLAMP}" --pyproject "${PR_PYPROJECT}" --clamp "${PYTHON_CANDIDATES}")"
 
 # Multiplatform needed when compiled extension might change
 NEEDS_MULTIPLATFORM=false

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -298,6 +298,20 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
+      # Data-only checkout of the BUILT ref's pyproject.toml (github.sha = the
+      # PR merge commit / pushed commit / dispatched branch tip). The matrix
+      # logic above stays base-trusted; only the requires-python value crosses
+      # the trust boundary, so it cannot execute PR-authored code. This is what
+      # lets the build floor track a PR's requires-python bump (gh#1553).
+      - name: Fetch built-ref pyproject (data only; requires-python floor)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: pyproject.toml
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+          path: _pr_meta
+
       - name: Set matrix based on trigger type
         id: set-matrix
         env:
@@ -321,6 +335,7 @@ jobs:
           INPUT_PY314: ${{ inputs.py314 }}
           INPUT_TEST_TIER: ${{ inputs.test_tier }}
           GITHUB_REF: ${{ github.ref }}
+          PR_PYPROJECT: _pr_meta/pyproject.toml
         run: bash .github/scripts/determine-matrix.sh
 
   post-ci-summary:


### PR DESCRIPTION
## Problem

`determine-matrix.sh` hardcoded the abi3 build target (`BUILD_PYTHON='["cp39"]'`)
as a second source of truth alongside `pyproject.toml`'s `requires-python`. Because
the `determine_matrix` job runs the script from the **base** branch (a deliberate
security choice — it does not execute PR-authored scripts), any PR that raises
`requires-python` keeps building the old floor: cibuildwheel is handed e.g. `cp39`
+ `>=3.12`, the intersection is empty, and the build aborts with
`cibuildwheel: No build identifiers selected` (seen on #1554).

## Fix

Make `requires-python` the single source of truth for the abi3 floor:

- New `clamp_python_floor.py` reads `requires-python` from a pyproject (data only)
  and emits the floor tag (`cp312`) / clamps a candidate cpXY list to it.
- `determine-matrix.sh` derives `BUILD_PYTHON` / `BOOKEND_PYTHON` / `ALL_PYTHON`
  from it instead of hardcoding them.
- `determine_matrix` additionally sparse-checks the **built ref's**
  `pyproject.toml` (`github.sha`) as data and passes it via `PR_PYPROJECT`. The
  matrix *logic* still runs from the trusted base; only the `requires-python`
  value crosses the trust boundary, so no PR-authored code is executed.

## Effect

- On `master` (`requires-python >=3.9`) the matrix is **unchanged**: floor cp39,
  bookend `[cp39, cp314]`, all six versions. This PR is a no-op for current builds
  — it only removes the drift.
- A future `requires-python` bump now flows through automatically: `>=3.12` ->
  build cp312, test `[cp312, cp314]` / `[cp312, cp313, cp314]`.

Unblocks #1554 (raise min Python to 3.12): after this lands, rebasing #1554 lets
it build and test cp312 on its own corrected matrix.

## Validation

Exercised `determine-matrix.sh` locally across `pull_request` / `merge_group` /
`schedule` / `workflow_dispatch` for both `>=3.9` and `>=3.12`; `master` output is
byte-identical to today. `clamp_python_floor.py` passes `ruff`; malformed
`requires-python` fails closed with a `::error::` annotation. The GitHub Actions
data-checkout plumbing is verified by a `workflow_dispatch` run on this branch.
