### PR TITLE
Clarify storage capacity interception docs

### DIFF
--- a/src/supy/data_model/core/hydro.py
+++ b/src/supy/data_model/core/hydro.py
@@ -389,7 +389,16 @@ class StorageDrainParams(BaseModel):
     store_cap: Optional[FlexibleRefValue(float)] = Field(
         ge=0,
         default=None,
-        description="Current water storage capacity - the actual storage capacity available for surface water retention. This represents the depth of water that can be stored on or in the surface before drainage begins. For paved surfaces, this might represent depression storage; for vegetated surfaces, it includes canopy interception storage.",
+        description=(
+            "Current surface/interception water storage capacity - the actual "
+            "storage capacity available for surface water retention. This represents "
+            "the depth of water that can be stored on or in the surface before "
+            "drainage begins. For paved surfaces, this might represent depression "
+            "storage; for vegetated surfaces, it includes canopy interception "
+            "storage. See the SUEWS SiteInfo typical values page for examples of "
+            "storage-capacity values: "
+            "https://docs.suews.io/latest/inputs/tables/SUEWS_SiteInfo/Typical_Values.html."
+        ),
         json_schema_extra={"unit": "mm", "display_name": "Storage Capacity"},
     )
     drain_eq: FlexibleRefValue(int) = Field(


### PR DESCRIPTION
## Summary

- Clarifies `StorageDrainParams.store_cap` as surface/interception water storage capacity.
- Points users to the SUEWS SiteInfo typical values page for storage-capacity examples.

Closes #1556.

## Validation

- `uv run python docs/generate_datamodel_rst.py`
- `uv run python -m pytest test/docs/test_generate_datamodel_rst.py -q`
- `source .venv/bin/activate && make test-smoke`
- `git diff --check`

## Notes

- The generated `docs/source/inputs/yaml/config-reference/` files are ignored by git and are regenerated at docs-build time.
- `uv run ruff check --select E501 src/supy/data_model/core/hydro.py` still reports existing unrelated long lines in this file; the new description is split across adjacent string literals and `git diff --check` is clean.
