### PR TITLE
Fix EHC layer dimensions for SPARTACUS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 77 | 83 | 30 | 81 | 40 | 312 |
+| 2026 | 77 | 84 | 30 | 81 | 40 | 313 |
 | 2025 | 60 | 68 | 22 | 71 | 36 | 256 |
 | 2024 | 12 | 17 | 1 | 12 | 1 | 43 |
 | 2023 | 11 | 14 | 3 | 9 | 1 | 38 |
@@ -53,6 +53,12 @@ EXAMPLES:
 | 2017 | 9 | 0 | 3 | 2 | 0 | 14 |
 
 ## 2026
+
+### 20 Jun 2026
+
+- [bugfix] Corrected EHC heat-storage parameter packing so roof/wall thermal arrays follow SPARTACUS vertical layers while standard surface arrays follow the seven SUEWS surface classes (#1565)
+  - The EHC bridge schema version is now bumped for the changed packed layout, and the lumped-slab EHC path skips invalid surface-class thermal layers instead of zeroing the whole grid-cell storage response
+  - Added smoke regressions for EHC surface heat-capacity sensitivity and invalid-surface handling so these failures are caught earlier without running the full benchmark suite
 
 ### 17 Jun 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,8 @@ EXAMPLES:
 ### 20 Jun 2026
 
 - [bugfix] Corrected EHC heat-storage parameter packing so roof/wall thermal arrays follow SPARTACUS vertical layers while standard surface arrays follow the seven SUEWS surface classes (#1565)
-  - The EHC bridge schema version is now bumped for the changed packed layout, and the lumped-slab EHC path skips invalid surface-class thermal layers instead of zeroing the whole grid-cell storage response
-  - Added smoke regressions for EHC surface heat-capacity sensitivity and invalid-surface handling so these failures are caught earlier without running the full benchmark suite
+  - The EHC bridge schema version is now bumped for the changed packed layout, the zero-layer YAML/bridge/Fortran layout keeps the established empty-payload contract, and the lumped-slab EHC path skips invalid surface-class thermal layers instead of zeroing the whole grid-cell storage response
+  - Added smoke regressions for EHC surface heat-capacity sensitivity, SPARTACUS facet heat-capacity sensitivity, and invalid-surface handling so these failures are caught earlier without running the full benchmark suite
 
 ### 17 Jun 2026
 

--- a/src/suews/src/suews_ctrl_driver.f95
+++ b/src/suews/src/suews_ctrl_driver.f95
@@ -2147,7 +2147,7 @@ CONTAINS
                   ! END ASSOCIATE
                   CALL EHC( &
                      tstep, & !input
-                     nlayer, &
+                     nlayer, config%NetRadiationMethod <= 1000, &
                      ! QG_surf, qg_roof, qg_wall, &
                      tsfc_roof, tin_roof, temp_in_roof, k_roof, cp_roof, dz_roof, sfr_roof, & !input
                      tsfc_wall, tin_wall, temp_in_wall, k_wall, cp_wall, dz_wall, sfr_wall, & !input
@@ -2789,6 +2789,7 @@ CONTAINS
       REAL(KIND(1D0)) :: qe_building !aggregated qe of building facets[W m-2]
       REAL(KIND(1D0)), DIMENSION(nsurf) :: drain
       REAL(KIND(1D0)), DIMENSION(7) :: capStore_surf ! current storage capacity [mm]
+      LOGICAL :: use_building_facets_for_ehc
 
       ! CALL hydroState_next%allocHydro(nlayer)
       ! ALLOCATE (hydroState%soil_store_roof(nlayer))
@@ -2798,6 +2799,7 @@ CONTAINS
 
       ! load dim constants
       nlayer = siteInfo%nlayer
+      use_building_facets_for_ehc = config%StorageHeatMethod == 5 .AND. config%NetRadiationMethod > 1000
 
       ALLOCATE (rss_roof(nlayer))
       ALLOCATE (runoff_roof(nlayer))
@@ -2967,7 +2969,7 @@ CONTAINS
                   rss_surf, ev0_surf, qe0_surf) !output
 
                ! MP: Use EHC
-               IF (storageheatmethod == 5) THEN
+               IF (storageheatmethod == 5 .AND. use_building_facets_for_ehc) THEN
                   ! --- roofs ---
                   ! net available energy for evaporation
                   qn_e_roof = qn_roof + qf - qs_roof ! qn1 changed to qn1_snowfree, lj in May 2013
@@ -3027,7 +3029,7 @@ CONTAINS
                qe_surf = tlv*ev_surf
 
                ! --- update building related ---
-               IF (storageheatmethod == 5) THEN
+               IF (storageheatmethod == 5 .AND. use_building_facets_for_ehc) THEN
                   ! update building specific values
                   qe_surf(BldgSurf) = qe_building
                   state_surf(BldgSurf) = state_building

--- a/src/suews/src/suews_phys_ehc.f95
+++ b/src/suews/src/suews_phys_ehc.f95
@@ -30,88 +30,127 @@ CONTAINS
       REAL(KIND(1D0)), INTENT(inout) :: T(:)
       REAL(KIND(1D0)), INTENT(in) :: dx(:), dt, k(:), rhocp(:), bc(2)
       REAL(KIND(1D0)), INTENT(out) :: Qs
-      ! REAL(KIND(1D0)), INTENT(out) :: Tsfc
-      LOGICAL :: bctype(2) ! if true, use surrogate flux as boundary condition
-      ! LOGICAL, INTENT(in) :: debug
       INTEGER :: i, n
-      REAL(KIND(1D0)), ALLOCATABLE :: w(:), a(:), T_temp(:), cfl(:)
-
-      ! REAL(KIND(1D0)) :: cfl_max
+      REAL(KIND(1D0)), ALLOCATABLE :: g_itf(:), T_in(:), T_temp(:), dt_limit(:)
       REAL(KIND(1D0)) :: dt_remain
       REAL(KIND(1D0)) :: dt_step
       REAL(KIND(1D0)) :: dt_step_cfl
+      REAL(KIND(1D0)) :: g_up, g_down, g_left, g_right
+      REAL(KIND(1D0)) :: denom
 
-      REAL(KIND(1D0)), ALLOCATABLE :: T_in(:), T_out(:)
-      ! REAL(KIND(1D0)) :: dt_x ! for recursion
-      ! INTEGER :: n_div ! for recursion
       n = SIZE(T)
-      ALLOCATE (w(0:n), a(n), T_temp(n), cfl(n), T_in(n), T_out(n))
+      Qs = 0.0D0
+      IF (n <= 0 .OR. dt <= 0.0D0) RETURN
+      IF (ANY(dx <= 0.0D0) .OR. ANY(k <= 0.0D0) .OR. ANY(rhocp <= 0.0D0)) RETURN
 
-      ! save initial temperatures
+      ALLOCATE (g_itf(MAX(1, n - 1)), T_in(n), T_temp(n), dt_limit(n))
       T_in = T
-      ! w = interface temperature
-      w(1:n) = T
-      w(0) = bc(1); w(n) = bc(2)
-      !convert from flux to equivalent temperature, not exact
-      ! F = k dT/dX => dx*F/k + T(i+1) = T(i)
-      bctype = .FALSE. ! force to use T as boundary condition, TS 09 Aug 2023
-      IF (bctype(1)) w(0) = bc(1)*0.5*dx(1)/k(1) + w(1)
-      IF (bctype(2)) w(n) = bc(2)*0.5*dx(n)/k(n) + w(n)
-      ! print *, 'bc(1)=', bc(1), 'bc(2)=',bc(2)
-      ! print *, 'w(0)=', w(0), 'w(n)=', w(n)
-      ! print *, 'k=', k, 'dx=', dx
-      a = k/dx
+
+      g_up = 2.0D0*k(1)/dx(1)
+      g_down = 2.0D0*k(n)/dx(n)
       DO i = 1, n - 1
-         w(i) = (T(i + 1)*a(i + 1) + T(i)*a(i))/(a(i) + a(i + 1))
+         denom = k(i + 1)*dx(i) + k(i)*dx(i + 1)
+         g_itf(i) = 2.0D0*k(i)*k(i + 1)/denom
       END DO
 
-      ! fix convergece issue with recursion
+      DO i = 1, n
+         IF (i == 1) THEN
+            g_left = g_up
+         ELSE
+            g_left = g_itf(i - 1)
+         END IF
+         IF (i == n) THEN
+            g_right = g_down
+         ELSE
+            g_right = g_itf(i)
+         END IF
+         dt_limit(i) = rhocp(i)*dx(i)/(g_left + g_right)
+      END DO
+
+      ! Explicit finite-volume update with Dirichlet boundary temperatures.
+      ! Qs is the material heat-content tendency, matching DeltaQS storage.
       dt_remain = dt
-      dt_step_cfl = 0.05*MINVAL(dx**2/(k/rhocp))
-      DO WHILE (dt_remain > 1E-10)
+      dt_step_cfl = 0.45D0*MINVAL(dt_limit)
+      DO WHILE (dt_remain > 1.0D-10)
          dt_step = MIN(dt_step_cfl, dt_remain)
-         !PRINT *, 'dt_remain: ', dt_remain
-         !PRINT *, 'dt_step_cfl: ', dt_step_cfl
-         !PRINT *, '***** dt_step: ', dt_step
-          !!FO!!
-         ! PRINT *, 'w: ', w
-         ! PRINT *, 'rhocp: ', rhocp
-         ! PRINT *, 'dt: ', dt
-         ! PRINT *, 'dx: ', dx
-         ! PRINT *, 'a: ', a
          DO i = 1, n
-            ! PRINT *, 'i: ', i
-            ! PRINT *, 'i: ', (dt/rhocp(i))
-            ! PRINT *, 'i: ', (w(i - 1) - 2*T(i) + w(i))
-            ! PRINT *, 'i: ', 2*a(i)/dx(i)
-            T_temp(i) = &
-               (dt_step/rhocp(i)) &
-               *(w(i - 1) - 2*T(i) + w(i)) &
-               *a(i)/dx(i) &
-               + T(i)
+            IF (i == 1) THEN
+               g_left = g_up*(bc(1) - T(i))
+            ELSE
+               g_left = g_itf(i - 1)*(T(i - 1) - T(i))
+            END IF
+            IF (i == n) THEN
+               g_right = g_down*(bc(2) - T(i))
+            ELSE
+               g_right = g_itf(i)*(T(i + 1) - T(i))
+            END IF
+            T_temp(i) = T(i) + dt_step*(g_left + g_right)/(rhocp(i)*dx(i))
          END DO
          T = T_temp
-         DO i = 1, n - 1
-            w(i) = (T(i + 1)*a(i + 1) + T(i)*a(i))/(a(i) + a(i + 1))
-         END DO
          dt_remain = dt_remain - dt_step
       END DO
-       !!FO!!
-      ! PRINT *, 'T1: ', T1
-      !for storage the internal distribution of heat should not be important
-       !!FO!! k*d(dT/dx)/dx = rhoCp*(dT/dt) => rhoCp*(dT/dt)*dx = dQs => dQs = k*d(dT/dx)
-      ! Qs = (w(0) - T(1))*2*a(1) + (w(n) - T(n))*2*a(n)
-      ! Qs=sum((T1-T)*rhocp*dx)/dt!
-
-      ! Tsfc = w(0)
-      ! save output temperatures
-      T_out = T_temp
-      ! new way for calcualating heat storage
-      Qs = SUM( &
-           (([bc(1), T_out(1:n - 1)] + T_out)/2. & ! updated temperature
-            -([bc(1), T_in(1:n - 1)] + T_in)/2) & ! initial temperature
-           *rhocp*dx/dt)
+      Qs = SUM((T - T_in)*rhocp*dx)/dt
    END SUBROUTINE heatcond1d_vstep
+
+   SUBROUTINE heatcond1d_gstep(T, Qs, heat_cap, g_face, dt, bc, q_top, q_bottom)
+      REAL(KIND(1D0)), INTENT(inout) :: T(:)
+      REAL(KIND(1D0)), INTENT(in) :: heat_cap(:), g_face(:), dt, bc(2)
+      REAL(KIND(1D0)), INTENT(out) :: Qs
+      REAL(KIND(1D0)), INTENT(out), OPTIONAL :: q_top, q_bottom
+      INTEGER :: i, n
+      REAL(KIND(1D0)), ALLOCATABLE :: T_in(:), T_temp(:), dt_limit(:)
+      REAL(KIND(1D0)) :: dt_remain
+      REAL(KIND(1D0)) :: dt_step
+      REAL(KIND(1D0)) :: dt_step_cfl
+      REAL(KIND(1D0)) :: flux_left, flux_right
+      REAL(KIND(1D0)) :: q_top_acc, q_bottom_acc
+
+      n = SIZE(T)
+      Qs = 0.0D0
+      IF (PRESENT(q_top)) q_top = 0.0D0
+      IF (PRESENT(q_bottom)) q_bottom = 0.0D0
+      IF (n <= 0 .OR. dt <= 0.0D0) RETURN
+      IF (SIZE(heat_cap) /= n .OR. SIZE(g_face) /= n + 1) RETURN
+      IF (ANY(heat_cap <= 0.0D0) .OR. ANY(g_face < 0.0D0)) RETURN
+
+      ALLOCATE (T_in(n), T_temp(n), dt_limit(n))
+      T_in = T
+
+      DO i = 1, n
+         IF (g_face(i) + g_face(i + 1) <= 0.0D0) RETURN
+         dt_limit(i) = heat_cap(i)/(g_face(i) + g_face(i + 1))
+      END DO
+
+      ! Explicit finite-volume update for a lumped slab with pre-aggregated
+      ! plan-area heat capacities and interface conductances.
+      dt_remain = dt
+      dt_step_cfl = 0.45D0*MINVAL(dt_limit)
+      q_top_acc = 0.0D0
+      q_bottom_acc = 0.0D0
+      DO WHILE (dt_remain > 1.0D-10)
+         dt_step = MIN(dt_step_cfl, dt_remain)
+         q_top_acc = q_top_acc + dt_step*g_face(1)*(bc(1) - T(1))
+         q_bottom_acc = q_bottom_acc + dt_step*g_face(n + 1)*(T(n) - bc(2))
+         DO i = 1, n
+            IF (i == 1) THEN
+               flux_left = g_face(i)*(bc(1) - T(i))
+            ELSE
+               flux_left = g_face(i)*(T(i - 1) - T(i))
+            END IF
+            IF (i == n) THEN
+               flux_right = g_face(i + 1)*(bc(2) - T(i))
+            ELSE
+               flux_right = g_face(i + 1)*(T(i + 1) - T(i))
+            END IF
+            T_temp(i) = T(i) + dt_step*(flux_left + flux_right)/heat_cap(i)
+         END DO
+         T = T_temp
+         dt_remain = dt_remain - dt_step
+      END DO
+      Qs = SUM((T - T_in)*heat_cap)/dt
+      IF (PRESENT(q_top)) q_top = q_top_acc/dt
+      IF (PRESENT(q_bottom)) q_bottom = q_bottom_acc/dt
+   END SUBROUTINE heatcond1d_gstep
 
    RECURSIVE SUBROUTINE heatcond1d_CN(T, Qs, dx, dt, k, rhocp, bc)
       REAL(KIND(1D0)), INTENT(inout) :: T(:)
@@ -220,7 +259,9 @@ CONTAINS
       ! ---Here we use the outermost surface temperatures to calculate
       ! ------the heat flux from the surface as the change of Qs for SEB
       ! ------considering there might be fluxes going out from the lower boundary
-      Qs = (T_up - T_out(1))*k(1)/(dx(1)*0.5) - (T_out(n) - T_lw)*k(n)/(dx(n)*0.5)
+      Qs = SUM( &
+           (T_out - T_in) &
+           *rhocp*dx/dt)
       ! Qs = (T_out(1) - T_out(2)) * k(1) / dx(1)
       ! Qs = Qs_acc / dt
    END SUBROUTINE heatcond1d_CN
@@ -322,7 +363,7 @@ CONTAINS
          END DO
 
          ! solve the tridiagonal matrix using Thomas algorithm
-         CALL thomas_triMat(vec_lw, vec_diag, vec_up, vec_rhs, n, T_tmp)
+         CALL thomas_triMat(vec_lw, vec_diag, vec_up, vec_rhs, n_tmp, T_tmp)
          dt_remain = dt_remain - dt_step
          Qs_acc = Qs_acc + (T_up - T_tmp(1))*k_tmp(1)/(dx_tmp(1)*0.5)*dt_step
       END DO
@@ -376,12 +417,11 @@ CONTAINS
    ! ===============================================================================================
    ! extended ESTM, TS 20 Jan 2022
    ! renamed to EHC (explicit heat conduction) to avoid confusion with ESTM
-   ! ESTM_ehc accoutns for
-   ! 1. heterogeneous building facets (roofs, walls) at different vertical levels
-   ! 2. all standard ground-level surfaces (dectr, evetr, grass, bsoil and water)
+   ! EHC can calculate storage heat flux as either a coarse plan-area slab
+   ! for OHM-like benchmarks or as facet-resolved roof/wall/surface conduction.
    SUBROUTINE EHC( &
       tstep, & !input
-      nlayer, &
+      nlayer, use_lumped_slab, &
       tsfc_roof, tin_roof, temp_in_roof, k_roof, cp_roof, dz_roof, sfr_roof, & !input
       tsfc_wall, tin_wall, temp_in_wall, k_wall, cp_wall, dz_wall, sfr_wall, & !input
       tsfc_surf, tin_surf, temp_in_surf, k_surf, cp_surf, dz_surf, sfr_surf, & !input
@@ -392,11 +432,12 @@ CONTAINS
       USE module_ctrl_const_allocate, ONLY: &
          nsurf, ndepth, &
          PavSurf, BldgSurf, ConifSurf, DecidSurf, GrassSurf, BSoilSurf, WaterSurf
-      USE module_phys_ehc_heatflux, ONLY: heatcond1d_vstep, heatcond1d_CN, heatcond1d_CN_dense
+      USE module_phys_ehc_heatflux, ONLY: heatcond1d_vstep, heatcond1d_gstep, heatcond1d_CN, heatcond1d_CN_dense
 
       IMPLICIT NONE
       INTEGER, INTENT(in) :: tstep
       INTEGER, INTENT(in) :: nlayer ! number of vertical levels in urban canopy
+      LOGICAL, INTENT(in) :: use_lumped_slab
 
       ! REAL(KIND(1D0)), DIMENSION(nsurf), INTENT(in) :: QG_surf ! ground heat flux
       ! extended for ESTM_ehc
@@ -476,20 +517,118 @@ CONTAINS
 
       ! use finite depth heat conduction solver
       LOGICAL :: use_heatcond1d, use_heatcond1d_water
+      LOGICAL, PARAMETER :: use_zero_flux_bottom = .FALSE.
+      REAL(KIND(1D0)), DIMENSION(ndepth) :: temp_lumped, cap_lumped
+      REAL(KIND(1D0)), DIMENSION(ndepth + 1) :: g_lumped
+      REAL(KIND(1D0)) :: tsfc_lumped, tin_lumped, qs_lumped, qs_per_surface
+      REAL(KIND(1D0)) :: q_top_lumped, q_bottom_lumped
+      REAL(KIND(1D0)) :: surface_weight, layer_cap, layer_temp_cap, face_resistance
+      LOGICAL :: valid_lumped
 
-      ! normalised surface fractions
-      REAL(KIND(1D0)), DIMENSION(nlayer) :: sfr_roof_n
-      REAL(KIND(1D0)), DIMENSION(nlayer) :: sfr_wall_n
+      QS = 0.0D0
+      QS_surf = 0.0D0
+      QS_roof = 0.0D0
+      QS_wall = 0.0D0
+      temp_out_surf = temp_in_surf
+      temp_out_roof = temp_in_roof
+      temp_out_wall = temp_in_wall
+
+      IF (use_lumped_slab) THEN
+         ! Coarse plan-area slab: aggregate only the standard SUEWS surface fractions.
+         ! This keeps EHC comparable to OHM before adding facet-resolved complexity.
+         surface_weight = 0.0D0
+         tsfc_lumped = 0.0D0
+         tin_lumped = 0.0D0
+         g_lumped = 0.0D0
+         cap_lumped = 0.0D0
+         temp_lumped = 0.0D0
+         valid_lumped = .TRUE.
+         DO i_facet = 1, nsurf
+            IF (sfr_surf(i_facet) > 0.0D0) THEN
+               surface_weight = surface_weight + sfr_surf(i_facet)
+               DO i_depth = 1, ndepth
+                  IF (dz_surf(i_facet, i_depth) <= 0.0D0 &
+                      .OR. k_surf(i_facet, i_depth) <= 0.0D0 &
+                      .OR. cp_surf(i_facet, i_depth) <= 0.0D0) valid_lumped = .FALSE.
+               END DO
+            END IF
+         END DO
+         IF (surface_weight <= 1.0D-12) RETURN
+         IF (.NOT. valid_lumped) RETURN
+
+         DO i_depth = 1, ndepth
+            layer_cap = 0.0D0
+            layer_temp_cap = 0.0D0
+            DO i_facet = 1, nsurf
+               IF (sfr_surf(i_facet) > 0.0D0) THEN
+                  layer_cap = layer_cap + sfr_surf(i_facet)*cp_surf(i_facet, i_depth)*dz_surf(i_facet, i_depth)
+                  layer_temp_cap = layer_temp_cap + sfr_surf(i_facet)*cp_surf(i_facet, i_depth) &
+                                   *dz_surf(i_facet, i_depth)*temp_in_surf(i_facet, i_depth)
+               END IF
+            END DO
+            IF (layer_cap <= 1.0D-12) THEN
+               valid_lumped = .FALSE.
+            ELSE
+               cap_lumped(i_depth) = layer_cap
+               temp_lumped(i_depth) = layer_temp_cap/layer_cap
+            END IF
+         END DO
+         IF (.NOT. valid_lumped) RETURN
+
+         DO i_facet = 1, nsurf
+            IF (sfr_surf(i_facet) > 0.0D0) THEN
+               face_resistance = 0.5D0*dz_surf(i_facet, 1)/k_surf(i_facet, 1)
+               g_lumped(1) = g_lumped(1) + sfr_surf(i_facet)/face_resistance
+               tsfc_lumped = tsfc_lumped + sfr_surf(i_facet)*tsfc_surf(i_facet)/face_resistance
+
+               IF (.NOT. use_zero_flux_bottom) THEN
+                  face_resistance = 0.5D0*dz_surf(i_facet, ndepth)/k_surf(i_facet, ndepth)
+                  g_lumped(ndepth + 1) = g_lumped(ndepth + 1) + sfr_surf(i_facet)/face_resistance
+                  tin_lumped = tin_lumped + sfr_surf(i_facet)*tin_surf(i_facet)/face_resistance
+               END IF
+
+               DO i_depth = 1, ndepth - 1
+                  face_resistance = 0.5D0*dz_surf(i_facet, i_depth)/k_surf(i_facet, i_depth) &
+                                    + 0.5D0*dz_surf(i_facet, i_depth + 1)/k_surf(i_facet, i_depth + 1)
+                  g_lumped(i_depth + 1) = g_lumped(i_depth + 1) + sfr_surf(i_facet)/face_resistance
+               END DO
+            END IF
+         END DO
+         IF (ANY(g_lumped(1:ndepth) <= 1.0D-12)) RETURN
+         IF ((.NOT. use_zero_flux_bottom) .AND. g_lumped(ndepth + 1) <= 1.0D-12) RETURN
+
+         tsfc_lumped = tsfc_lumped/g_lumped(1)
+         IF (.NOT. use_zero_flux_bottom) THEN
+            tin_lumped = tin_lumped/g_lumped(ndepth + 1)
+         END IF
+
+         bc(1) = tsfc_lumped
+         bc(2) = tin_lumped
+         CALL heatcond1d_gstep(temp_lumped, qs_lumped, cap_lumped, g_lumped, tstep*1.0D0, bc, &
+                               q_top_lumped, q_bottom_lumped)
+
+         ! With a finite lower boundary, SUEWS needs the outdoor-surface storage
+         ! flux; the material heat-content tendency also includes lower exchange.
+         IF (use_zero_flux_bottom) THEN
+            QS = qs_lumped
+         ELSE
+            QS = q_top_lumped
+         END IF
+         qs_per_surface = QS/surface_weight
+         QS_surf = qs_per_surface
+         QS_roof = 0.0D0
+         QS_wall = 0.0D0
+         DO i_facet = 1, nsurf
+            temp_out_surf(i_facet, :) = temp_lumped
+         END DO
+         RETURN
+      END IF
 
       ! initialise solver flags
       use_heatcond1d = .TRUE.
       use_heatcond1d_water = .FALSE.
       debug = .FALSE.
 
-      ! normalised surface fractions
-      ! NB: the sum of sfr_roof (sfr_wall) is NOT unity; so need to be normalised by the sum
-      sfr_roof_n = sfr_roof/SUM(sfr_roof)
-      sfr_wall_n = sfr_wall/SUM(sfr_wall)
       ! sub-facets of buildings: e.g. walls, roofs, etc.
       DO i_group = 1, 3
 
@@ -505,10 +644,11 @@ CONTAINS
             nfacet = nsurf
          END IF
          ! PRINT *, 'nfacet here: ', nfacet
-         ALLOCATE (tsfc_cal(nfacet))
-         ALLOCATE (tin_cal(nfacet))
-         ALLOCATE (qs_cal(nfacet))
-         ALLOCATE (temp_cal(nfacet, ndepth))
+	         ALLOCATE (tsfc_cal(nfacet))
+	         ALLOCATE (tin_cal(nfacet))
+	         ALLOCATE (qs_cal(nfacet))
+	         qs_cal = 0.0D0
+	         ALLOCATE (temp_cal(nfacet, ndepth))
          ALLOCATE (k_cal(nfacet, ndepth))
          ALLOCATE (cp_cal(nfacet, ndepth))
          ALLOCATE (dz_cal(nfacet, ndepth))

--- a/src/suews/src/suews_phys_ehc.f95
+++ b/src/suews/src/suews_phys_ehc.f95
@@ -432,6 +432,7 @@ CONTAINS
       USE module_ctrl_const_allocate, ONLY: &
          nsurf, ndepth, &
          PavSurf, BldgSurf, ConifSurf, DecidSurf, GrassSurf, BSoilSurf, WaterSurf
+      USE module_ctrl_error_state, ONLY: add_supy_warning
       USE module_phys_ehc_heatflux, ONLY: heatcond1d_vstep, heatcond1d_gstep, heatcond1d_CN, heatcond1d_CN_dense
 
       IMPLICIT NONE
@@ -556,7 +557,10 @@ CONTAINS
                IF (valid_lumped_surf(i_facet)) surface_weight = surface_weight + sfr_surf(i_facet)
             END IF
          END DO
-         IF (surface_weight <= 1.0D-12) RETURN
+         IF (surface_weight <= 1.0D-12) THEN
+            CALL add_supy_warning('EHC lumped slab: no valid positive-fraction surface thermal layers; QS remains zero')
+            RETURN
+         END IF
 
          DO i_depth = 1, ndepth
             layer_cap = 0.0D0
@@ -575,7 +579,10 @@ CONTAINS
                temp_lumped(i_depth) = layer_temp_cap/layer_cap
             END IF
          END DO
-         IF (.NOT. valid_lumped) RETURN
+         IF (.NOT. valid_lumped) THEN
+            CALL add_supy_warning('EHC lumped slab: invalid aggregated heat capacity; QS remains zero')
+            RETURN
+         END IF
 
          DO i_facet = 1, nsurf
             IF (valid_lumped_surf(i_facet)) THEN
@@ -596,8 +603,14 @@ CONTAINS
                END DO
             END IF
          END DO
-         IF (ANY(g_lumped(1:ndepth) <= 1.0D-12)) RETURN
-         IF ((.NOT. use_zero_flux_bottom) .AND. g_lumped(ndepth + 1) <= 1.0D-12) RETURN
+         IF (ANY(g_lumped(1:ndepth) <= 1.0D-12)) THEN
+            CALL add_supy_warning('EHC lumped slab: invalid aggregated internal conductance; QS remains zero')
+            RETURN
+         END IF
+         IF ((.NOT. use_zero_flux_bottom) .AND. g_lumped(ndepth + 1) <= 1.0D-12) THEN
+            CALL add_supy_warning('EHC lumped slab: invalid aggregated lower-boundary conductance; QS remains zero')
+            RETURN
+         END IF
 
          tsfc_lumped = tsfc_lumped/g_lumped(1)
          IF (.NOT. use_zero_flux_bottom) THEN

--- a/src/suews/src/suews_phys_ehc.f95
+++ b/src/suews/src/suews_phys_ehc.f95
@@ -524,6 +524,7 @@ CONTAINS
       REAL(KIND(1D0)) :: q_top_lumped, q_bottom_lumped
       REAL(KIND(1D0)) :: surface_weight, layer_cap, layer_temp_cap, face_resistance
       LOGICAL :: valid_lumped
+      LOGICAL, DIMENSION(nsurf) :: valid_lumped_surf
 
       QS = 0.0D0
       QS_surf = 0.0D0
@@ -543,24 +544,25 @@ CONTAINS
          cap_lumped = 0.0D0
          temp_lumped = 0.0D0
          valid_lumped = .TRUE.
+         valid_lumped_surf = .FALSE.
          DO i_facet = 1, nsurf
             IF (sfr_surf(i_facet) > 0.0D0) THEN
-               surface_weight = surface_weight + sfr_surf(i_facet)
+               valid_lumped_surf(i_facet) = .TRUE.
                DO i_depth = 1, ndepth
                   IF (dz_surf(i_facet, i_depth) <= 0.0D0 &
                       .OR. k_surf(i_facet, i_depth) <= 0.0D0 &
-                      .OR. cp_surf(i_facet, i_depth) <= 0.0D0) valid_lumped = .FALSE.
+                      .OR. cp_surf(i_facet, i_depth) <= 0.0D0) valid_lumped_surf(i_facet) = .FALSE.
                END DO
+               IF (valid_lumped_surf(i_facet)) surface_weight = surface_weight + sfr_surf(i_facet)
             END IF
          END DO
          IF (surface_weight <= 1.0D-12) RETURN
-         IF (.NOT. valid_lumped) RETURN
 
          DO i_depth = 1, ndepth
             layer_cap = 0.0D0
             layer_temp_cap = 0.0D0
             DO i_facet = 1, nsurf
-               IF (sfr_surf(i_facet) > 0.0D0) THEN
+               IF (valid_lumped_surf(i_facet)) THEN
                   layer_cap = layer_cap + sfr_surf(i_facet)*cp_surf(i_facet, i_depth)*dz_surf(i_facet, i_depth)
                   layer_temp_cap = layer_temp_cap + sfr_surf(i_facet)*cp_surf(i_facet, i_depth) &
                                    *dz_surf(i_facet, i_depth)*temp_in_surf(i_facet, i_depth)
@@ -576,7 +578,7 @@ CONTAINS
          IF (.NOT. valid_lumped) RETURN
 
          DO i_facet = 1, nsurf
-            IF (sfr_surf(i_facet) > 0.0D0) THEN
+            IF (valid_lumped_surf(i_facet)) THEN
                face_resistance = 0.5D0*dz_surf(i_facet, 1)/k_surf(i_facet, 1)
                g_lumped(1) = g_lumped(1) + sfr_surf(i_facet)/face_resistance
                tsfc_lumped = tsfc_lumped + sfr_surf(i_facet)*tsfc_surf(i_facet)/face_resistance
@@ -615,11 +617,13 @@ CONTAINS
             QS = q_top_lumped
          END IF
          qs_per_surface = QS/surface_weight
-         QS_surf = qs_per_surface
          QS_roof = 0.0D0
          QS_wall = 0.0D0
          DO i_facet = 1, nsurf
-            temp_out_surf(i_facet, :) = temp_lumped
+            IF (valid_lumped_surf(i_facet)) THEN
+               QS_surf(i_facet) = qs_per_surface
+               temp_out_surf(i_facet, :) = temp_lumped
+            END IF
          END DO
          RETURN
       END IF
@@ -644,11 +648,11 @@ CONTAINS
             nfacet = nsurf
          END IF
          ! PRINT *, 'nfacet here: ', nfacet
-	         ALLOCATE (tsfc_cal(nfacet))
-	         ALLOCATE (tin_cal(nfacet))
-	         ALLOCATE (qs_cal(nfacet))
-	         qs_cal = 0.0D0
-	         ALLOCATE (temp_cal(nfacet, ndepth))
+            ALLOCATE (tsfc_cal(nfacet))
+            ALLOCATE (tin_cal(nfacet))
+            ALLOCATE (qs_cal(nfacet))
+            qs_cal = 0.0D0
+            ALLOCATE (temp_cal(nfacet, ndepth))
          ALLOCATE (k_cal(nfacet, ndepth))
          ALLOCATE (cp_cal(nfacet, ndepth))
          ALLOCATE (dz_cal(nfacet, ndepth))

--- a/src/suews/src/suews_type_ehc.f95
+++ b/src/suews/src/suews_type_ehc.f95
@@ -1,5 +1,7 @@
 module module_type_ehc
 
+   USE module_ctrl_const_allocate, ONLY: nsurf
+
    implicit none
 
    TYPE, PUBLIC :: EHC_PRM
@@ -28,32 +30,38 @@ module module_type_ehc
 
 CONTAINS
 
-   SUBROUTINE allocate_ehc_prm_c(self, nlayer, ndepth)
-      CLASS(EHC_PRM), INTENT(INOUT) :: self
-      INTEGER, INTENT(IN) :: nlayer, ndepth
+	   SUBROUTINE allocate_ehc_prm_c(self, nlayer, ndepth)
+	      CLASS(EHC_PRM), INTENT(INOUT) :: self
+	      INTEGER, INTENT(IN) :: nlayer, ndepth
+	      INTEGER :: nsurf_alloc
 
-      ! CALL allocate_ehc_prm(self, nlayer, ndepth)
-      CALL self%DEALLOCATE()
-      ALLOCATE (self%soil_store_capacity_roof(nlayer))
-      ALLOCATE (self%soil_store_capacity_wall(nlayer))
-      ALLOCATE (self%state_limit_roof(nlayer))
-      ALLOCATE (self%state_limit_wall(nlayer))
-      ALLOCATE (self%wet_thresh_roof(nlayer))
-      ALLOCATE (self%wet_thresh_wall(nlayer))
-      ALLOCATE (self%tin_roof(nlayer))
-      ALLOCATE (self%tin_wall(nlayer))
-      ALLOCATE (self%tin_surf(nlayer))
-      ALLOCATE (self%k_roof(nlayer, ndepth))
-      ALLOCATE (self%k_wall(nlayer, ndepth))
-      ALLOCATE (self%k_surf(nlayer, ndepth))
-      ALLOCATE (self%cp_roof(nlayer, ndepth))
-      ALLOCATE (self%cp_wall(nlayer, ndepth))
-      ALLOCATE (self%cp_surf(nlayer, ndepth))
-      ALLOCATE (self%dz_roof(nlayer, ndepth))
-      ALLOCATE (self%dz_wall(nlayer, ndepth))
-      ALLOCATE (self%dz_surf(nlayer, ndepth))
+	      ! CALL allocate_ehc_prm(self, nlayer, ndepth)
+	      CALL self%DEALLOCATE()
+	      IF (nlayer > 0) THEN
+	         nsurf_alloc = nsurf
+	      ELSE
+	         nsurf_alloc = 0
+	      END IF
+	      ALLOCATE (self%soil_store_capacity_roof(nlayer))
+	      ALLOCATE (self%soil_store_capacity_wall(nlayer))
+	      ALLOCATE (self%state_limit_roof(nlayer))
+	      ALLOCATE (self%state_limit_wall(nlayer))
+	      ALLOCATE (self%wet_thresh_roof(nlayer))
+	      ALLOCATE (self%wet_thresh_wall(nlayer))
+	      ALLOCATE (self%tin_roof(nlayer))
+	      ALLOCATE (self%tin_wall(nlayer))
+	      ALLOCATE (self%tin_surf(nsurf_alloc))
+	      ALLOCATE (self%k_roof(nlayer, ndepth))
+	      ALLOCATE (self%k_wall(nlayer, ndepth))
+	      ALLOCATE (self%k_surf(nsurf_alloc, ndepth))
+	      ALLOCATE (self%cp_roof(nlayer, ndepth))
+	      ALLOCATE (self%cp_wall(nlayer, ndepth))
+	      ALLOCATE (self%cp_surf(nsurf_alloc, ndepth))
+	      ALLOCATE (self%dz_roof(nlayer, ndepth))
+	      ALLOCATE (self%dz_wall(nlayer, ndepth))
+	      ALLOCATE (self%dz_surf(nsurf_alloc, ndepth))
 
-   END SUBROUTINE allocate_ehc_prm_c
+	   END SUBROUTINE allocate_ehc_prm_c
 
    SUBROUTINE deallocate_ehc_prm_c(self)
       CLASS(EHC_PRM), INTENT(INOUT) :: self

--- a/src/suews/src/suews_type_ehc.f95
+++ b/src/suews/src/suews_type_ehc.f95
@@ -30,38 +30,38 @@ module module_type_ehc
 
 CONTAINS
 
-	   SUBROUTINE allocate_ehc_prm_c(self, nlayer, ndepth)
-	      CLASS(EHC_PRM), INTENT(INOUT) :: self
-	      INTEGER, INTENT(IN) :: nlayer, ndepth
-	      INTEGER :: nsurf_alloc
+   SUBROUTINE allocate_ehc_prm_c(self, nlayer, ndepth)
+      CLASS(EHC_PRM), INTENT(INOUT) :: self
+      INTEGER, INTENT(IN) :: nlayer, ndepth
+      INTEGER :: nsurf_alloc
 
-	      ! CALL allocate_ehc_prm(self, nlayer, ndepth)
-	      CALL self%DEALLOCATE()
-	      IF (nlayer > 0) THEN
-	         nsurf_alloc = nsurf
-	      ELSE
-	         nsurf_alloc = 0
-	      END IF
-	      ALLOCATE (self%soil_store_capacity_roof(nlayer))
-	      ALLOCATE (self%soil_store_capacity_wall(nlayer))
-	      ALLOCATE (self%state_limit_roof(nlayer))
-	      ALLOCATE (self%state_limit_wall(nlayer))
-	      ALLOCATE (self%wet_thresh_roof(nlayer))
-	      ALLOCATE (self%wet_thresh_wall(nlayer))
-	      ALLOCATE (self%tin_roof(nlayer))
-	      ALLOCATE (self%tin_wall(nlayer))
-	      ALLOCATE (self%tin_surf(nsurf_alloc))
-	      ALLOCATE (self%k_roof(nlayer, ndepth))
-	      ALLOCATE (self%k_wall(nlayer, ndepth))
-	      ALLOCATE (self%k_surf(nsurf_alloc, ndepth))
-	      ALLOCATE (self%cp_roof(nlayer, ndepth))
-	      ALLOCATE (self%cp_wall(nlayer, ndepth))
-	      ALLOCATE (self%cp_surf(nsurf_alloc, ndepth))
-	      ALLOCATE (self%dz_roof(nlayer, ndepth))
-	      ALLOCATE (self%dz_wall(nlayer, ndepth))
-	      ALLOCATE (self%dz_surf(nsurf_alloc, ndepth))
+      ! CALL allocate_ehc_prm(self, nlayer, ndepth)
+      CALL self%DEALLOCATE()
+      IF (nlayer > 0) THEN
+         nsurf_alloc = nsurf
+      ELSE
+         nsurf_alloc = 0
+      END IF
+      ALLOCATE (self%soil_store_capacity_roof(nlayer))
+      ALLOCATE (self%soil_store_capacity_wall(nlayer))
+      ALLOCATE (self%state_limit_roof(nlayer))
+      ALLOCATE (self%state_limit_wall(nlayer))
+      ALLOCATE (self%wet_thresh_roof(nlayer))
+      ALLOCATE (self%wet_thresh_wall(nlayer))
+      ALLOCATE (self%tin_roof(nlayer))
+      ALLOCATE (self%tin_wall(nlayer))
+      ALLOCATE (self%tin_surf(nsurf_alloc))
+      ALLOCATE (self%k_roof(nlayer, ndepth))
+      ALLOCATE (self%k_wall(nlayer, ndepth))
+      ALLOCATE (self%k_surf(nsurf_alloc, ndepth))
+      ALLOCATE (self%cp_roof(nlayer, ndepth))
+      ALLOCATE (self%cp_wall(nlayer, ndepth))
+      ALLOCATE (self%cp_surf(nsurf_alloc, ndepth))
+      ALLOCATE (self%dz_roof(nlayer, ndepth))
+      ALLOCATE (self%dz_wall(nlayer, ndepth))
+      ALLOCATE (self%dz_surf(nsurf_alloc, ndepth))
 
-	   END SUBROUTINE allocate_ehc_prm_c
+   END SUBROUTINE allocate_ehc_prm_c
 
    SUBROUTINE deallocate_ehc_prm_c(self)
       CLASS(EHC_PRM), INTENT(INOUT) :: self

--- a/src/suews_bridge/c_api/driver.f95
+++ b/src/suews_bridge/c_api/driver.f95
@@ -476,9 +476,9 @@ subroutine initialise_site_state( &
 
    integer :: ib
 
-	   call site%allocate(nlayer)
-	   site%nlayer = nlayer
-	   call site%ehc%allocate(nlayer, ndepth)
+   call site%allocate(nlayer)
+   site%nlayer = nlayer
+   call site%ehc%allocate(nlayer, ndepth)
    call site%spartacus_layer%allocate(nlayer)
    call site%spartacus%allocate(nlayer)
 
@@ -556,13 +556,13 @@ subroutine unpack_site_members( &
       err = local_err
       return
    end if
-	   required_len = 8_c_int * int(nlayer, c_int) + int(nsurf, c_int) + &
-	                  6_c_int * int(nlayer * ndepth, c_int) + 3_c_int * int(nsurf * ndepth, c_int)
-	   if (member_len>=required_len) then
-	      call ehc_prm_unpack(site_flat(int(member_offset) + 1), member_len, &
-	                          int(nlayer, c_int), int(ndepth, c_int), site%ehc, local_err)
-	      if (local_err/=SUEWS_CAPI_OK) then
-	         err = local_err
+   required_len = 8_c_int * int(nlayer, c_int) + int(nsurf, c_int) + &
+                  6_c_int * int(nlayer * ndepth, c_int) + 3_c_int * int(nsurf * ndepth, c_int)
+   if (member_len>=required_len) then
+      call ehc_prm_unpack(site_flat(int(member_offset) + 1), member_len, &
+                          int(nlayer, c_int), int(ndepth, c_int), site%ehc, local_err)
+      if (local_err/=SUEWS_CAPI_OK) then
+         err = local_err
          return
       end if
    end if

--- a/src/suews_bridge/c_api/driver.f95
+++ b/src/suews_bridge/c_api/driver.f95
@@ -22,7 +22,7 @@ use module_ctrl_type, only: SUEWS_TIMER, SUEWS_CONFIG, SUEWS_SITE, SUEWS_STATE, 
 use module_ctrl_error_state, only: reset_supy_error
 use module_c_api_spartacus_prm, only: spartacus_prm_unpack
 use module_c_api_lumps, only: lumps_prm_unpack
-use module_c_api_ehc_prm, only: ehc_prm_unpack
+use module_c_api_ehc_prm, only: ehc_prm_unpack, ehc_surface_len
 use module_c_api_spartacus_layer_prm, only: spartacus_layer_prm_unpack
 use module_c_api_surf_store, only: surf_store_prm_unpack
 use module_c_api_irrigation_prm, only: irrigation_prm_unpack
@@ -522,6 +522,7 @@ subroutine unpack_site_members( &
    integer(c_int) :: member_len
    integer(c_int) :: local_err
    integer(c_int) :: required_len
+   integer(c_int) :: n_surf_ehc
 
    call member_span_from_toc(site_flat_len, site_toc, site_toc_len, site_member_count, &
                              SUEWS_CAPI_SITE_MEMBER_SPARTACUS, member_offset, member_len, local_err)
@@ -556,8 +557,9 @@ subroutine unpack_site_members( &
       err = local_err
       return
    end if
-   required_len = 8_c_int * int(nlayer, c_int) + int(nsurf, c_int) + &
-                  6_c_int * int(nlayer * ndepth, c_int) + 3_c_int * int(nsurf * ndepth, c_int)
+   n_surf_ehc = ehc_surface_len(int(nlayer, c_int))
+   required_len = 8_c_int * int(nlayer, c_int) + n_surf_ehc + &
+                  6_c_int * int(nlayer * ndepth, c_int) + 3_c_int * n_surf_ehc * int(ndepth, c_int)
    if (member_len>=required_len) then
       call ehc_prm_unpack(site_flat(int(member_offset) + 1), member_len, &
                           int(nlayer, c_int), int(ndepth, c_int), site%ehc, local_err)

--- a/src/suews_bridge/c_api/driver.f95
+++ b/src/suews_bridge/c_api/driver.f95
@@ -476,9 +476,9 @@ subroutine initialise_site_state( &
 
    integer :: ib
 
-   call site%allocate(nlayer)
-   site%nlayer = nlayer
-   call site%ehc%allocate(7, ndepth)
+	   call site%allocate(nlayer)
+	   site%nlayer = nlayer
+	   call site%ehc%allocate(nlayer, ndepth)
    call site%spartacus_layer%allocate(nlayer)
    call site%spartacus%allocate(nlayer)
 
@@ -556,11 +556,13 @@ subroutine unpack_site_members( &
       err = local_err
       return
    end if
-   required_len = 9_c_int * int(nsurf, c_int) + 9_c_int * int(nsurf * ndepth, c_int)
-   if (member_len>=required_len) then
-      call ehc_prm_unpack(site_flat(int(member_offset) + 1), member_len, int(nsurf, c_int), int(ndepth, c_int), site%ehc, local_err)
-      if (local_err/=SUEWS_CAPI_OK) then
-         err = local_err
+	   required_len = 8_c_int * int(nlayer, c_int) + int(nsurf, c_int) + &
+	                  6_c_int * int(nlayer * ndepth, c_int) + 3_c_int * int(nsurf * ndepth, c_int)
+	   if (member_len>=required_len) then
+	      call ehc_prm_unpack(site_flat(int(member_offset) + 1), member_len, &
+	                          int(nlayer, c_int), int(ndepth, c_int), site%ehc, local_err)
+	      if (local_err/=SUEWS_CAPI_OK) then
+	         err = local_err
          return
       end if
    end if

--- a/src/suews_bridge/c_api/ehc_prm.f95
+++ b/src/suews_bridge/c_api/ehc_prm.f95
@@ -45,6 +45,7 @@ public :: suews_ehc_prm_schema_version
 public :: suews_ehc_prm_default
 public :: suews_ehc_prm_error_message
 public :: ehc_prm_unpack
+public :: ehc_surface_len
 
 contains
 

--- a/src/suews_bridge/c_api/ehc_prm.f95
+++ b/src/suews_bridge/c_api/ehc_prm.f95
@@ -17,7 +17,7 @@ public :: SUEWS_CAPI_OK
 public :: SUEWS_CAPI_BAD_BUFFER
 public :: SUEWS_CAPI_BAD_STATE
 
-integer(c_int), parameter, public :: SUEWS_CAPI_EHC_PRM_SCHEMA_VERSION = 1_c_int
+integer(c_int), parameter, public :: SUEWS_CAPI_EHC_PRM_SCHEMA_VERSION = 2_c_int
 
 type :: ehc_prm_shadow
    real(c_double), dimension(:), allocatable :: soil_store_capacity_roof
@@ -51,10 +51,10 @@ contains
 subroutine suews_ehc_prm_len(n_flat, nlayer, ndepth, err) bind(C, name='suews_ehc_prm_len')
    implicit none
 
-	   integer(c_int), intent(out) :: n_flat
-	   integer(c_int), intent(out) :: nlayer
-	   integer(c_int), intent(out) :: ndepth
-	   integer(c_int), intent(out) :: err
+      integer(c_int), intent(out) :: n_flat
+      integer(c_int), intent(out) :: nlayer
+      integer(c_int), intent(out) :: ndepth
+      integer(c_int), intent(out) :: err
 
    type(ehc_prm_shadow) :: state
 
@@ -78,10 +78,10 @@ subroutine suews_ehc_prm_default(flat, n_flat, nlayer, ndepth, err) bind(C, name
 
    real(c_double), intent(out) :: flat(*)
    integer(c_int), value, intent(in) :: n_flat
-	   integer(c_int), intent(out) :: nlayer
-	   integer(c_int), intent(out) :: ndepth
-	   integer(c_int), intent(out) :: err
-	   integer(c_int) :: n_surf_ehc
+      integer(c_int), intent(out) :: nlayer
+      integer(c_int), intent(out) :: ndepth
+      integer(c_int), intent(out) :: err
+      integer(c_int) :: n_surf_ehc
 
    type(ehc_prm_shadow) :: state
 
@@ -277,12 +277,12 @@ subroutine ehc_prm_layout(state, n_flat, nlayer, ndepth, err)
 
    type(ehc_prm_shadow), intent(in) :: state
    integer(c_int), intent(out) :: n_flat
-	   integer(c_int), intent(out) :: nlayer
-	   integer(c_int), intent(out) :: ndepth
-	   integer(c_int), intent(out) :: err
-	   integer(c_int) :: n_surf_ehc
+      integer(c_int), intent(out) :: nlayer
+      integer(c_int), intent(out) :: ndepth
+      integer(c_int), intent(out) :: err
+      integer(c_int) :: n_surf_ehc
 
-	   nlayer = 0_c_int
+      nlayer = 0_c_int
    ndepth = 0_c_int
    err = SUEWS_CAPI_OK
 
@@ -291,39 +291,39 @@ subroutine ehc_prm_layout(state, n_flat, nlayer, ndepth, err)
    call update_len_from_vec(state%state_limit_roof, nlayer, err)
    call update_len_from_vec(state%state_limit_wall, nlayer, err)
    call update_len_from_vec(state%wet_thresh_roof, nlayer, err)
-	   call update_len_from_vec(state%wet_thresh_wall, nlayer, err)
-	   call update_len_from_vec(state%tin_roof, nlayer, err)
-	   call update_len_from_vec(state%tin_wall, nlayer, err)
+      call update_len_from_vec(state%wet_thresh_wall, nlayer, err)
+      call update_len_from_vec(state%tin_roof, nlayer, err)
+      call update_len_from_vec(state%tin_wall, nlayer, err)
 
-	   call update_len_from_mat(state%k_roof, nlayer, ndepth, err)
-	   call update_len_from_mat(state%k_wall, nlayer, ndepth, err)
-	   call update_len_from_mat(state%cp_roof, nlayer, ndepth, err)
-	   call update_len_from_mat(state%cp_wall, nlayer, ndepth, err)
-	   call update_len_from_mat(state%dz_roof, nlayer, ndepth, err)
-	   call update_len_from_mat(state%dz_wall, nlayer, ndepth, err)
-	   call update_depth_from_surf_mat(state%k_surf, ndepth, err)
-	   call update_depth_from_surf_mat(state%cp_surf, ndepth, err)
-	   call update_depth_from_surf_mat(state%dz_surf, ndepth, err)
+      call update_len_from_mat(state%k_roof, nlayer, ndepth, err)
+      call update_len_from_mat(state%k_wall, nlayer, ndepth, err)
+      call update_len_from_mat(state%cp_roof, nlayer, ndepth, err)
+      call update_len_from_mat(state%cp_wall, nlayer, ndepth, err)
+      call update_len_from_mat(state%dz_roof, nlayer, ndepth, err)
+      call update_len_from_mat(state%dz_wall, nlayer, ndepth, err)
+      call update_depth_from_surf_mat(state%k_surf, ndepth, err)
+      call update_depth_from_surf_mat(state%cp_surf, ndepth, err)
+      call update_depth_from_surf_mat(state%dz_surf, ndepth, err)
 
    call require_vec_layout(state%soil_store_capacity_roof, nlayer, err)
    call require_vec_layout(state%soil_store_capacity_wall, nlayer, err)
    call require_vec_layout(state%state_limit_roof, nlayer, err)
    call require_vec_layout(state%state_limit_wall, nlayer, err)
    call require_vec_layout(state%wet_thresh_roof, nlayer, err)
-	   call require_vec_layout(state%wet_thresh_wall, nlayer, err)
-	   call require_vec_layout(state%tin_roof, nlayer, err)
-	   call require_vec_layout(state%tin_wall, nlayer, err)
-	   call require_surf_vec_layout(state%tin_surf, nlayer, err)
+      call require_vec_layout(state%wet_thresh_wall, nlayer, err)
+      call require_vec_layout(state%tin_roof, nlayer, err)
+      call require_vec_layout(state%tin_wall, nlayer, err)
+      call require_surf_vec_layout(state%tin_surf, nlayer, err)
 
-	   call require_mat_layout(state%k_roof, nlayer, ndepth, err)
-	   call require_mat_layout(state%k_wall, nlayer, ndepth, err)
-	   call require_mat_layout(state%cp_roof, nlayer, ndepth, err)
-	   call require_mat_layout(state%cp_wall, nlayer, ndepth, err)
-	   call require_mat_layout(state%dz_roof, nlayer, ndepth, err)
-	   call require_mat_layout(state%dz_wall, nlayer, ndepth, err)
-	   call require_surf_mat_layout(state%k_surf, nlayer, ndepth, err)
-	   call require_surf_mat_layout(state%cp_surf, nlayer, ndepth, err)
-	   call require_surf_mat_layout(state%dz_surf, nlayer, ndepth, err)
+      call require_mat_layout(state%k_roof, nlayer, ndepth, err)
+      call require_mat_layout(state%k_wall, nlayer, ndepth, err)
+      call require_mat_layout(state%cp_roof, nlayer, ndepth, err)
+      call require_mat_layout(state%cp_wall, nlayer, ndepth, err)
+      call require_mat_layout(state%dz_roof, nlayer, ndepth, err)
+      call require_mat_layout(state%dz_wall, nlayer, ndepth, err)
+      call require_surf_mat_layout(state%k_surf, nlayer, ndepth, err)
+      call require_surf_mat_layout(state%cp_surf, nlayer, ndepth, err)
+      call require_surf_mat_layout(state%dz_surf, nlayer, ndepth, err)
 
    if (err/=SUEWS_CAPI_OK) then
       n_flat = 0_c_int
@@ -332,10 +332,10 @@ subroutine ehc_prm_layout(state, n_flat, nlayer, ndepth, err)
 
    if (nlayer==0_c_int) ndepth = 0_c_int
 
-	   n_surf_ehc = ehc_surface_len(nlayer)
-	   n_flat = 8_c_int * nlayer + n_surf_ehc + &
-	            6_c_int * nlayer * ndepth + 3_c_int * n_surf_ehc * ndepth
-	   err = SUEWS_CAPI_OK
+      n_surf_ehc = ehc_surface_len(nlayer)
+      n_flat = 8_c_int * nlayer + n_surf_ehc + &
+               6_c_int * nlayer * ndepth + 3_c_int * n_surf_ehc * ndepth
+      err = SUEWS_CAPI_OK
 
 end subroutine ehc_prm_layout
 
@@ -475,40 +475,40 @@ subroutine ehc_prm_pack(state, flat, n_flat, nlayer, ndepth, err)
    integer(c_int), intent(in) :: n_flat
    integer(c_int), intent(out) :: nlayer
    integer(c_int), intent(out) :: ndepth
-	   integer(c_int), intent(out) :: err
-	   integer(c_int) :: n_expected
-	   integer(c_int) :: idx
-	   integer(c_int) :: n_surf_ehc
+      integer(c_int), intent(out) :: err
+      integer(c_int) :: n_expected
+      integer(c_int) :: idx
+      integer(c_int) :: n_surf_ehc
 
-	   call ehc_prm_layout(state, n_expected, nlayer, ndepth, err)
-	   if (err/=SUEWS_CAPI_OK) return
+      call ehc_prm_layout(state, n_expected, nlayer, ndepth, err)
+      if (err/=SUEWS_CAPI_OK) return
 
    if (n_flat<n_expected) then
       err = SUEWS_CAPI_BAD_BUFFER
       return
    end if
 
-	   n_surf_ehc = ehc_surface_len(nlayer)
-	   idx = 1_c_int
-	   call pack_vec(state%soil_store_capacity_roof, flat, idx, nlayer)
+      n_surf_ehc = ehc_surface_len(nlayer)
+      idx = 1_c_int
+      call pack_vec(state%soil_store_capacity_roof, flat, idx, nlayer)
    call pack_vec(state%soil_store_capacity_wall, flat, idx, nlayer)
    call pack_vec(state%state_limit_roof, flat, idx, nlayer)
    call pack_vec(state%state_limit_wall, flat, idx, nlayer)
    call pack_vec(state%wet_thresh_roof, flat, idx, nlayer)
-	   call pack_vec(state%wet_thresh_wall, flat, idx, nlayer)
-	   call pack_vec(state%tin_roof, flat, idx, nlayer)
-	   call pack_vec(state%tin_wall, flat, idx, nlayer)
-	   call pack_vec(state%tin_surf, flat, idx, n_surf_ehc)
+      call pack_vec(state%wet_thresh_wall, flat, idx, nlayer)
+      call pack_vec(state%tin_roof, flat, idx, nlayer)
+      call pack_vec(state%tin_wall, flat, idx, nlayer)
+      call pack_vec(state%tin_surf, flat, idx, n_surf_ehc)
 
-	   call pack_mat(state%k_roof, flat, idx, nlayer, ndepth)
-	   call pack_mat(state%k_wall, flat, idx, nlayer, ndepth)
-	   call pack_mat(state%k_surf, flat, idx, n_surf_ehc, ndepth)
-	   call pack_mat(state%cp_roof, flat, idx, nlayer, ndepth)
-	   call pack_mat(state%cp_wall, flat, idx, nlayer, ndepth)
-	   call pack_mat(state%cp_surf, flat, idx, n_surf_ehc, ndepth)
-	   call pack_mat(state%dz_roof, flat, idx, nlayer, ndepth)
-	   call pack_mat(state%dz_wall, flat, idx, nlayer, ndepth)
-	   call pack_mat(state%dz_surf, flat, idx, n_surf_ehc, ndepth)
+      call pack_mat(state%k_roof, flat, idx, nlayer, ndepth)
+      call pack_mat(state%k_wall, flat, idx, nlayer, ndepth)
+      call pack_mat(state%k_surf, flat, idx, n_surf_ehc, ndepth)
+      call pack_mat(state%cp_roof, flat, idx, nlayer, ndepth)
+      call pack_mat(state%cp_wall, flat, idx, nlayer, ndepth)
+      call pack_mat(state%cp_surf, flat, idx, n_surf_ehc, ndepth)
+      call pack_mat(state%dz_roof, flat, idx, nlayer, ndepth)
+      call pack_mat(state%dz_wall, flat, idx, nlayer, ndepth)
+      call pack_mat(state%dz_surf, flat, idx, n_surf_ehc, ndepth)
 
    err = SUEWS_CAPI_OK
 
@@ -522,23 +522,23 @@ subroutine ehc_prm_unpack(flat, n_flat, nlayer, ndepth, state, err)
    integer(c_int), intent(in) :: nlayer
    integer(c_int), intent(in) :: ndepth
    type(EHC_PRM), intent(inout) :: state
-	   integer(c_int), intent(out) :: err
+      integer(c_int), intent(out) :: err
 
-	   integer(c_int) :: n_expected
-	   integer(c_int) :: idx
-	   integer(c_int) :: n_surf_ehc
+      integer(c_int) :: n_expected
+      integer(c_int) :: idx
+      integer(c_int) :: n_surf_ehc
 
    if (nlayer<0_c_int .or. ndepth<0_c_int) then
       err = SUEWS_CAPI_BAD_BUFFER
       return
    end if
 
-	   n_surf_ehc = ehc_surface_len(nlayer)
-	   n_expected = 8_c_int * nlayer + n_surf_ehc + &
-	                6_c_int * nlayer * ndepth + 3_c_int * n_surf_ehc * ndepth
-	   if (n_flat<n_expected) then
-	      err = SUEWS_CAPI_BAD_BUFFER
-	      return
+      n_surf_ehc = ehc_surface_len(nlayer)
+      n_expected = 8_c_int * nlayer + n_surf_ehc + &
+                   6_c_int * nlayer * ndepth + 3_c_int * n_surf_ehc * ndepth
+      if (n_flat<n_expected) then
+         err = SUEWS_CAPI_BAD_BUFFER
+         return
    end if
 
    err = SUEWS_CAPI_OK
@@ -547,20 +547,20 @@ subroutine ehc_prm_unpack(flat, n_flat, nlayer, ndepth, state, err)
    call ensure_vec_alloc(state%state_limit_roof, nlayer, err)
    call ensure_vec_alloc(state%state_limit_wall, nlayer, err)
    call ensure_vec_alloc(state%wet_thresh_roof, nlayer, err)
-	   call ensure_vec_alloc(state%wet_thresh_wall, nlayer, err)
-	   call ensure_vec_alloc(state%tin_roof, nlayer, err)
-	   call ensure_vec_alloc(state%tin_wall, nlayer, err)
-	   call ensure_vec_alloc(state%tin_surf, n_surf_ehc, err)
+      call ensure_vec_alloc(state%wet_thresh_wall, nlayer, err)
+      call ensure_vec_alloc(state%tin_roof, nlayer, err)
+      call ensure_vec_alloc(state%tin_wall, nlayer, err)
+      call ensure_vec_alloc(state%tin_surf, n_surf_ehc, err)
 
-	   call ensure_mat_alloc(state%k_roof, nlayer, ndepth, err)
-	   call ensure_mat_alloc(state%k_wall, nlayer, ndepth, err)
-	   call ensure_mat_alloc(state%k_surf, n_surf_ehc, ndepth, err)
-	   call ensure_mat_alloc(state%cp_roof, nlayer, ndepth, err)
-	   call ensure_mat_alloc(state%cp_wall, nlayer, ndepth, err)
-	   call ensure_mat_alloc(state%cp_surf, n_surf_ehc, ndepth, err)
-	   call ensure_mat_alloc(state%dz_roof, nlayer, ndepth, err)
-	   call ensure_mat_alloc(state%dz_wall, nlayer, ndepth, err)
-	   call ensure_mat_alloc(state%dz_surf, n_surf_ehc, ndepth, err)
+      call ensure_mat_alloc(state%k_roof, nlayer, ndepth, err)
+      call ensure_mat_alloc(state%k_wall, nlayer, ndepth, err)
+      call ensure_mat_alloc(state%k_surf, n_surf_ehc, ndepth, err)
+      call ensure_mat_alloc(state%cp_roof, nlayer, ndepth, err)
+      call ensure_mat_alloc(state%cp_wall, nlayer, ndepth, err)
+      call ensure_mat_alloc(state%cp_surf, n_surf_ehc, ndepth, err)
+      call ensure_mat_alloc(state%dz_roof, nlayer, ndepth, err)
+      call ensure_mat_alloc(state%dz_wall, nlayer, ndepth, err)
+      call ensure_mat_alloc(state%dz_surf, n_surf_ehc, ndepth, err)
    if (err/=SUEWS_CAPI_OK) return
 
    idx = 1_c_int
@@ -569,20 +569,20 @@ subroutine ehc_prm_unpack(flat, n_flat, nlayer, ndepth, state, err)
    call unpack_vec(flat, idx, state%state_limit_roof, nlayer)
    call unpack_vec(flat, idx, state%state_limit_wall, nlayer)
    call unpack_vec(flat, idx, state%wet_thresh_roof, nlayer)
-	   call unpack_vec(flat, idx, state%wet_thresh_wall, nlayer)
-	   call unpack_vec(flat, idx, state%tin_roof, nlayer)
-	   call unpack_vec(flat, idx, state%tin_wall, nlayer)
-	   call unpack_vec(flat, idx, state%tin_surf, n_surf_ehc)
+      call unpack_vec(flat, idx, state%wet_thresh_wall, nlayer)
+      call unpack_vec(flat, idx, state%tin_roof, nlayer)
+      call unpack_vec(flat, idx, state%tin_wall, nlayer)
+      call unpack_vec(flat, idx, state%tin_surf, n_surf_ehc)
 
-	   call unpack_mat(flat, idx, state%k_roof, nlayer, ndepth)
-	   call unpack_mat(flat, idx, state%k_wall, nlayer, ndepth)
-	   call unpack_mat(flat, idx, state%k_surf, n_surf_ehc, ndepth)
-	   call unpack_mat(flat, idx, state%cp_roof, nlayer, ndepth)
-	   call unpack_mat(flat, idx, state%cp_wall, nlayer, ndepth)
-	   call unpack_mat(flat, idx, state%cp_surf, n_surf_ehc, ndepth)
-	   call unpack_mat(flat, idx, state%dz_roof, nlayer, ndepth)
-	   call unpack_mat(flat, idx, state%dz_wall, nlayer, ndepth)
-	   call unpack_mat(flat, idx, state%dz_surf, n_surf_ehc, ndepth)
+      call unpack_mat(flat, idx, state%k_roof, nlayer, ndepth)
+      call unpack_mat(flat, idx, state%k_wall, nlayer, ndepth)
+      call unpack_mat(flat, idx, state%k_surf, n_surf_ehc, ndepth)
+      call unpack_mat(flat, idx, state%cp_roof, nlayer, ndepth)
+      call unpack_mat(flat, idx, state%cp_wall, nlayer, ndepth)
+      call unpack_mat(flat, idx, state%cp_surf, n_surf_ehc, ndepth)
+      call unpack_mat(flat, idx, state%dz_roof, nlayer, ndepth)
+      call unpack_mat(flat, idx, state%dz_wall, nlayer, ndepth)
+      call unpack_mat(flat, idx, state%dz_surf, n_surf_ehc, ndepth)
 
    err = SUEWS_CAPI_OK
 

--- a/src/suews_bridge/c_api/ehc_prm.f95
+++ b/src/suews_bridge/c_api/ehc_prm.f95
@@ -6,6 +6,7 @@ use, intrinsic :: iso_c_binding, only: c_int, c_double, c_char
 use module_c_api_common, only: &
    SUEWS_CAPI_OK, SUEWS_CAPI_BAD_BUFFER, SUEWS_CAPI_BAD_STATE, &
    copy_to_c_buffer, suews_capi_error_text
+use module_ctrl_const_allocate, only: nsurf
 use module_type_ehc, only: EHC_PRM
 
 implicit none
@@ -50,10 +51,10 @@ contains
 subroutine suews_ehc_prm_len(n_flat, nlayer, ndepth, err) bind(C, name='suews_ehc_prm_len')
    implicit none
 
-   integer(c_int), intent(out) :: n_flat
-   integer(c_int), intent(out) :: nlayer
-   integer(c_int), intent(out) :: ndepth
-   integer(c_int), intent(out) :: err
+	   integer(c_int), intent(out) :: n_flat
+	   integer(c_int), intent(out) :: nlayer
+	   integer(c_int), intent(out) :: ndepth
+	   integer(c_int), intent(out) :: err
 
    type(ehc_prm_shadow) :: state
 
@@ -77,15 +78,29 @@ subroutine suews_ehc_prm_default(flat, n_flat, nlayer, ndepth, err) bind(C, name
 
    real(c_double), intent(out) :: flat(*)
    integer(c_int), value, intent(in) :: n_flat
-   integer(c_int), intent(out) :: nlayer
-   integer(c_int), intent(out) :: ndepth
-   integer(c_int), intent(out) :: err
+	   integer(c_int), intent(out) :: nlayer
+	   integer(c_int), intent(out) :: ndepth
+	   integer(c_int), intent(out) :: err
+	   integer(c_int) :: n_surf_ehc
 
    type(ehc_prm_shadow) :: state
 
    call ehc_prm_pack(state, flat, n_flat, nlayer, ndepth, err)
 
 end subroutine suews_ehc_prm_default
+
+integer(c_int) function ehc_surface_len(nlayer) result(n)
+   implicit none
+
+   integer(c_int), intent(in) :: nlayer
+
+   if (nlayer>0_c_int) then
+      n = int(nsurf, c_int)
+   else
+      n = 0_c_int
+   end if
+
+end function ehc_surface_len
 
 subroutine update_len_from_vec(field, nlayer, err)
    implicit none
@@ -138,6 +153,33 @@ subroutine update_len_from_mat(field, nlayer, ndepth, err)
 
 end subroutine update_len_from_mat
 
+subroutine update_depth_from_surf_mat(field, ndepth, err)
+   implicit none
+
+   real(c_double), dimension(:, :), allocatable, intent(in) :: field
+   integer(c_int), intent(inout) :: ndepth
+   integer(c_int), intent(inout) :: err
+   integer(c_int) :: surf_here
+   integer(c_int) :: depth_here
+
+   if (err/=SUEWS_CAPI_OK) return
+   if (.not. allocated(field)) return
+
+   surf_here = int(size(field, 1), c_int)
+   depth_here = int(size(field, 2), c_int)
+   if (surf_here/=int(nsurf, c_int)) then
+      err = SUEWS_CAPI_BAD_STATE
+      return
+   end if
+
+   if (ndepth==0_c_int) then
+      ndepth = depth_here
+   elseif (ndepth/=depth_here) then
+      err = SUEWS_CAPI_BAD_STATE
+   end if
+
+end subroutine update_depth_from_surf_mat
+
 subroutine require_vec_layout(field, nlayer, err)
    implicit none
 
@@ -182,16 +224,65 @@ subroutine require_mat_layout(field, nlayer, ndepth, err)
 
 end subroutine require_mat_layout
 
+subroutine require_surf_vec_layout(field, nlayer, err)
+   implicit none
+
+   real(c_double), dimension(:), allocatable, intent(in) :: field
+   integer(c_int), intent(in) :: nlayer
+   integer(c_int), intent(inout) :: err
+   integer(c_int) :: n_expected
+
+   if (err/=SUEWS_CAPI_OK) return
+   n_expected = ehc_surface_len(nlayer)
+
+   if (n_expected==0_c_int) then
+      if (allocated(field)) err = SUEWS_CAPI_BAD_STATE
+   else
+      if (.not. allocated(field)) then
+         err = SUEWS_CAPI_BAD_STATE
+      elseif (int(size(field), c_int)/=n_expected) then
+         err = SUEWS_CAPI_BAD_STATE
+      end if
+   end if
+
+end subroutine require_surf_vec_layout
+
+subroutine require_surf_mat_layout(field, nlayer, ndepth, err)
+   implicit none
+
+   real(c_double), dimension(:, :), allocatable, intent(in) :: field
+   integer(c_int), intent(in) :: nlayer
+   integer(c_int), intent(in) :: ndepth
+   integer(c_int), intent(inout) :: err
+   integer(c_int) :: n_expected
+
+   if (err/=SUEWS_CAPI_OK) return
+   n_expected = ehc_surface_len(nlayer)
+
+   if (n_expected==0_c_int .or. ndepth==0_c_int) then
+      if (allocated(field)) err = SUEWS_CAPI_BAD_STATE
+   else
+      if (.not. allocated(field)) then
+         err = SUEWS_CAPI_BAD_STATE
+      elseif (int(size(field, 1), c_int)/=n_expected .or. &
+              int(size(field, 2), c_int)/=ndepth) then
+         err = SUEWS_CAPI_BAD_STATE
+      end if
+   end if
+
+end subroutine require_surf_mat_layout
+
 subroutine ehc_prm_layout(state, n_flat, nlayer, ndepth, err)
    implicit none
 
    type(ehc_prm_shadow), intent(in) :: state
    integer(c_int), intent(out) :: n_flat
-   integer(c_int), intent(out) :: nlayer
-   integer(c_int), intent(out) :: ndepth
-   integer(c_int), intent(out) :: err
+	   integer(c_int), intent(out) :: nlayer
+	   integer(c_int), intent(out) :: ndepth
+	   integer(c_int), intent(out) :: err
+	   integer(c_int) :: n_surf_ehc
 
-   nlayer = 0_c_int
+	   nlayer = 0_c_int
    ndepth = 0_c_int
    err = SUEWS_CAPI_OK
 
@@ -200,40 +291,39 @@ subroutine ehc_prm_layout(state, n_flat, nlayer, ndepth, err)
    call update_len_from_vec(state%state_limit_roof, nlayer, err)
    call update_len_from_vec(state%state_limit_wall, nlayer, err)
    call update_len_from_vec(state%wet_thresh_roof, nlayer, err)
-   call update_len_from_vec(state%wet_thresh_wall, nlayer, err)
-   call update_len_from_vec(state%tin_roof, nlayer, err)
-   call update_len_from_vec(state%tin_wall, nlayer, err)
-   call update_len_from_vec(state%tin_surf, nlayer, err)
+	   call update_len_from_vec(state%wet_thresh_wall, nlayer, err)
+	   call update_len_from_vec(state%tin_roof, nlayer, err)
+	   call update_len_from_vec(state%tin_wall, nlayer, err)
 
-   call update_len_from_mat(state%k_roof, nlayer, ndepth, err)
-   call update_len_from_mat(state%k_wall, nlayer, ndepth, err)
-   call update_len_from_mat(state%k_surf, nlayer, ndepth, err)
-   call update_len_from_mat(state%cp_roof, nlayer, ndepth, err)
-   call update_len_from_mat(state%cp_wall, nlayer, ndepth, err)
-   call update_len_from_mat(state%cp_surf, nlayer, ndepth, err)
-   call update_len_from_mat(state%dz_roof, nlayer, ndepth, err)
-   call update_len_from_mat(state%dz_wall, nlayer, ndepth, err)
-   call update_len_from_mat(state%dz_surf, nlayer, ndepth, err)
+	   call update_len_from_mat(state%k_roof, nlayer, ndepth, err)
+	   call update_len_from_mat(state%k_wall, nlayer, ndepth, err)
+	   call update_len_from_mat(state%cp_roof, nlayer, ndepth, err)
+	   call update_len_from_mat(state%cp_wall, nlayer, ndepth, err)
+	   call update_len_from_mat(state%dz_roof, nlayer, ndepth, err)
+	   call update_len_from_mat(state%dz_wall, nlayer, ndepth, err)
+	   call update_depth_from_surf_mat(state%k_surf, ndepth, err)
+	   call update_depth_from_surf_mat(state%cp_surf, ndepth, err)
+	   call update_depth_from_surf_mat(state%dz_surf, ndepth, err)
 
    call require_vec_layout(state%soil_store_capacity_roof, nlayer, err)
    call require_vec_layout(state%soil_store_capacity_wall, nlayer, err)
    call require_vec_layout(state%state_limit_roof, nlayer, err)
    call require_vec_layout(state%state_limit_wall, nlayer, err)
    call require_vec_layout(state%wet_thresh_roof, nlayer, err)
-   call require_vec_layout(state%wet_thresh_wall, nlayer, err)
-   call require_vec_layout(state%tin_roof, nlayer, err)
-   call require_vec_layout(state%tin_wall, nlayer, err)
-   call require_vec_layout(state%tin_surf, nlayer, err)
+	   call require_vec_layout(state%wet_thresh_wall, nlayer, err)
+	   call require_vec_layout(state%tin_roof, nlayer, err)
+	   call require_vec_layout(state%tin_wall, nlayer, err)
+	   call require_surf_vec_layout(state%tin_surf, nlayer, err)
 
-   call require_mat_layout(state%k_roof, nlayer, ndepth, err)
-   call require_mat_layout(state%k_wall, nlayer, ndepth, err)
-   call require_mat_layout(state%k_surf, nlayer, ndepth, err)
-   call require_mat_layout(state%cp_roof, nlayer, ndepth, err)
-   call require_mat_layout(state%cp_wall, nlayer, ndepth, err)
-   call require_mat_layout(state%cp_surf, nlayer, ndepth, err)
-   call require_mat_layout(state%dz_roof, nlayer, ndepth, err)
-   call require_mat_layout(state%dz_wall, nlayer, ndepth, err)
-   call require_mat_layout(state%dz_surf, nlayer, ndepth, err)
+	   call require_mat_layout(state%k_roof, nlayer, ndepth, err)
+	   call require_mat_layout(state%k_wall, nlayer, ndepth, err)
+	   call require_mat_layout(state%cp_roof, nlayer, ndepth, err)
+	   call require_mat_layout(state%cp_wall, nlayer, ndepth, err)
+	   call require_mat_layout(state%dz_roof, nlayer, ndepth, err)
+	   call require_mat_layout(state%dz_wall, nlayer, ndepth, err)
+	   call require_surf_mat_layout(state%k_surf, nlayer, ndepth, err)
+	   call require_surf_mat_layout(state%cp_surf, nlayer, ndepth, err)
+	   call require_surf_mat_layout(state%dz_surf, nlayer, ndepth, err)
 
    if (err/=SUEWS_CAPI_OK) then
       n_flat = 0_c_int
@@ -242,8 +332,10 @@ subroutine ehc_prm_layout(state, n_flat, nlayer, ndepth, err)
 
    if (nlayer==0_c_int) ndepth = 0_c_int
 
-   n_flat = 9_c_int * nlayer + 9_c_int * nlayer * ndepth
-   err = SUEWS_CAPI_OK
+	   n_surf_ehc = ehc_surface_len(nlayer)
+	   n_flat = 8_c_int * nlayer + n_surf_ehc + &
+	            6_c_int * nlayer * ndepth + 3_c_int * n_surf_ehc * ndepth
+	   err = SUEWS_CAPI_OK
 
 end subroutine ehc_prm_layout
 
@@ -383,38 +475,40 @@ subroutine ehc_prm_pack(state, flat, n_flat, nlayer, ndepth, err)
    integer(c_int), intent(in) :: n_flat
    integer(c_int), intent(out) :: nlayer
    integer(c_int), intent(out) :: ndepth
-   integer(c_int), intent(out) :: err
-   integer(c_int) :: n_expected
-   integer(c_int) :: idx
+	   integer(c_int), intent(out) :: err
+	   integer(c_int) :: n_expected
+	   integer(c_int) :: idx
+	   integer(c_int) :: n_surf_ehc
 
-   call ehc_prm_layout(state, n_expected, nlayer, ndepth, err)
-   if (err/=SUEWS_CAPI_OK) return
+	   call ehc_prm_layout(state, n_expected, nlayer, ndepth, err)
+	   if (err/=SUEWS_CAPI_OK) return
 
    if (n_flat<n_expected) then
       err = SUEWS_CAPI_BAD_BUFFER
       return
    end if
 
-   idx = 1_c_int
-   call pack_vec(state%soil_store_capacity_roof, flat, idx, nlayer)
+	   n_surf_ehc = ehc_surface_len(nlayer)
+	   idx = 1_c_int
+	   call pack_vec(state%soil_store_capacity_roof, flat, idx, nlayer)
    call pack_vec(state%soil_store_capacity_wall, flat, idx, nlayer)
    call pack_vec(state%state_limit_roof, flat, idx, nlayer)
    call pack_vec(state%state_limit_wall, flat, idx, nlayer)
    call pack_vec(state%wet_thresh_roof, flat, idx, nlayer)
-   call pack_vec(state%wet_thresh_wall, flat, idx, nlayer)
-   call pack_vec(state%tin_roof, flat, idx, nlayer)
-   call pack_vec(state%tin_wall, flat, idx, nlayer)
-   call pack_vec(state%tin_surf, flat, idx, nlayer)
+	   call pack_vec(state%wet_thresh_wall, flat, idx, nlayer)
+	   call pack_vec(state%tin_roof, flat, idx, nlayer)
+	   call pack_vec(state%tin_wall, flat, idx, nlayer)
+	   call pack_vec(state%tin_surf, flat, idx, n_surf_ehc)
 
-   call pack_mat(state%k_roof, flat, idx, nlayer, ndepth)
-   call pack_mat(state%k_wall, flat, idx, nlayer, ndepth)
-   call pack_mat(state%k_surf, flat, idx, nlayer, ndepth)
-   call pack_mat(state%cp_roof, flat, idx, nlayer, ndepth)
-   call pack_mat(state%cp_wall, flat, idx, nlayer, ndepth)
-   call pack_mat(state%cp_surf, flat, idx, nlayer, ndepth)
-   call pack_mat(state%dz_roof, flat, idx, nlayer, ndepth)
-   call pack_mat(state%dz_wall, flat, idx, nlayer, ndepth)
-   call pack_mat(state%dz_surf, flat, idx, nlayer, ndepth)
+	   call pack_mat(state%k_roof, flat, idx, nlayer, ndepth)
+	   call pack_mat(state%k_wall, flat, idx, nlayer, ndepth)
+	   call pack_mat(state%k_surf, flat, idx, n_surf_ehc, ndepth)
+	   call pack_mat(state%cp_roof, flat, idx, nlayer, ndepth)
+	   call pack_mat(state%cp_wall, flat, idx, nlayer, ndepth)
+	   call pack_mat(state%cp_surf, flat, idx, n_surf_ehc, ndepth)
+	   call pack_mat(state%dz_roof, flat, idx, nlayer, ndepth)
+	   call pack_mat(state%dz_wall, flat, idx, nlayer, ndepth)
+	   call pack_mat(state%dz_surf, flat, idx, n_surf_ehc, ndepth)
 
    err = SUEWS_CAPI_OK
 
@@ -428,20 +522,23 @@ subroutine ehc_prm_unpack(flat, n_flat, nlayer, ndepth, state, err)
    integer(c_int), intent(in) :: nlayer
    integer(c_int), intent(in) :: ndepth
    type(EHC_PRM), intent(inout) :: state
-   integer(c_int), intent(out) :: err
+	   integer(c_int), intent(out) :: err
 
-   integer(c_int) :: n_expected
-   integer(c_int) :: idx
+	   integer(c_int) :: n_expected
+	   integer(c_int) :: idx
+	   integer(c_int) :: n_surf_ehc
 
    if (nlayer<0_c_int .or. ndepth<0_c_int) then
       err = SUEWS_CAPI_BAD_BUFFER
       return
    end if
 
-   n_expected = 9_c_int * nlayer + 9_c_int * nlayer * ndepth
-   if (n_flat<n_expected) then
-      err = SUEWS_CAPI_BAD_BUFFER
-      return
+	   n_surf_ehc = ehc_surface_len(nlayer)
+	   n_expected = 8_c_int * nlayer + n_surf_ehc + &
+	                6_c_int * nlayer * ndepth + 3_c_int * n_surf_ehc * ndepth
+	   if (n_flat<n_expected) then
+	      err = SUEWS_CAPI_BAD_BUFFER
+	      return
    end if
 
    err = SUEWS_CAPI_OK
@@ -450,20 +547,20 @@ subroutine ehc_prm_unpack(flat, n_flat, nlayer, ndepth, state, err)
    call ensure_vec_alloc(state%state_limit_roof, nlayer, err)
    call ensure_vec_alloc(state%state_limit_wall, nlayer, err)
    call ensure_vec_alloc(state%wet_thresh_roof, nlayer, err)
-   call ensure_vec_alloc(state%wet_thresh_wall, nlayer, err)
-   call ensure_vec_alloc(state%tin_roof, nlayer, err)
-   call ensure_vec_alloc(state%tin_wall, nlayer, err)
-   call ensure_vec_alloc(state%tin_surf, nlayer, err)
+	   call ensure_vec_alloc(state%wet_thresh_wall, nlayer, err)
+	   call ensure_vec_alloc(state%tin_roof, nlayer, err)
+	   call ensure_vec_alloc(state%tin_wall, nlayer, err)
+	   call ensure_vec_alloc(state%tin_surf, n_surf_ehc, err)
 
-   call ensure_mat_alloc(state%k_roof, nlayer, ndepth, err)
-   call ensure_mat_alloc(state%k_wall, nlayer, ndepth, err)
-   call ensure_mat_alloc(state%k_surf, nlayer, ndepth, err)
-   call ensure_mat_alloc(state%cp_roof, nlayer, ndepth, err)
-   call ensure_mat_alloc(state%cp_wall, nlayer, ndepth, err)
-   call ensure_mat_alloc(state%cp_surf, nlayer, ndepth, err)
-   call ensure_mat_alloc(state%dz_roof, nlayer, ndepth, err)
-   call ensure_mat_alloc(state%dz_wall, nlayer, ndepth, err)
-   call ensure_mat_alloc(state%dz_surf, nlayer, ndepth, err)
+	   call ensure_mat_alloc(state%k_roof, nlayer, ndepth, err)
+	   call ensure_mat_alloc(state%k_wall, nlayer, ndepth, err)
+	   call ensure_mat_alloc(state%k_surf, n_surf_ehc, ndepth, err)
+	   call ensure_mat_alloc(state%cp_roof, nlayer, ndepth, err)
+	   call ensure_mat_alloc(state%cp_wall, nlayer, ndepth, err)
+	   call ensure_mat_alloc(state%cp_surf, n_surf_ehc, ndepth, err)
+	   call ensure_mat_alloc(state%dz_roof, nlayer, ndepth, err)
+	   call ensure_mat_alloc(state%dz_wall, nlayer, ndepth, err)
+	   call ensure_mat_alloc(state%dz_surf, n_surf_ehc, ndepth, err)
    if (err/=SUEWS_CAPI_OK) return
 
    idx = 1_c_int
@@ -472,20 +569,20 @@ subroutine ehc_prm_unpack(flat, n_flat, nlayer, ndepth, state, err)
    call unpack_vec(flat, idx, state%state_limit_roof, nlayer)
    call unpack_vec(flat, idx, state%state_limit_wall, nlayer)
    call unpack_vec(flat, idx, state%wet_thresh_roof, nlayer)
-   call unpack_vec(flat, idx, state%wet_thresh_wall, nlayer)
-   call unpack_vec(flat, idx, state%tin_roof, nlayer)
-   call unpack_vec(flat, idx, state%tin_wall, nlayer)
-   call unpack_vec(flat, idx, state%tin_surf, nlayer)
+	   call unpack_vec(flat, idx, state%wet_thresh_wall, nlayer)
+	   call unpack_vec(flat, idx, state%tin_roof, nlayer)
+	   call unpack_vec(flat, idx, state%tin_wall, nlayer)
+	   call unpack_vec(flat, idx, state%tin_surf, n_surf_ehc)
 
-   call unpack_mat(flat, idx, state%k_roof, nlayer, ndepth)
-   call unpack_mat(flat, idx, state%k_wall, nlayer, ndepth)
-   call unpack_mat(flat, idx, state%k_surf, nlayer, ndepth)
-   call unpack_mat(flat, idx, state%cp_roof, nlayer, ndepth)
-   call unpack_mat(flat, idx, state%cp_wall, nlayer, ndepth)
-   call unpack_mat(flat, idx, state%cp_surf, nlayer, ndepth)
-   call unpack_mat(flat, idx, state%dz_roof, nlayer, ndepth)
-   call unpack_mat(flat, idx, state%dz_wall, nlayer, ndepth)
-   call unpack_mat(flat, idx, state%dz_surf, nlayer, ndepth)
+	   call unpack_mat(flat, idx, state%k_roof, nlayer, ndepth)
+	   call unpack_mat(flat, idx, state%k_wall, nlayer, ndepth)
+	   call unpack_mat(flat, idx, state%k_surf, n_surf_ehc, ndepth)
+	   call unpack_mat(flat, idx, state%cp_roof, nlayer, ndepth)
+	   call unpack_mat(flat, idx, state%cp_wall, nlayer, ndepth)
+	   call unpack_mat(flat, idx, state%cp_surf, n_surf_ehc, ndepth)
+	   call unpack_mat(flat, idx, state%dz_roof, nlayer, ndepth)
+	   call unpack_mat(flat, idx, state%dz_wall, nlayer, ndepth)
+	   call unpack_mat(flat, idx, state%dz_surf, n_surf_ehc, ndepth)
 
    err = SUEWS_CAPI_OK
 

--- a/src/suews_bridge/src/ehc_prm.rs
+++ b/src/suews_bridge/src/ehc_prm.rs
@@ -602,4 +602,59 @@ mod tests {
         let err = ehc_prm_from_values_payload(&payload).expect_err("missing dims should fail");
         assert_eq!(err, BridgeError::BadState);
     }
+
+    #[test]
+    fn mixed_layer_surface_layout_uses_nlayer_and_nsurf() {
+        let nlayer = 3;
+        let ndepth = 2;
+        let expected = 8 * nlayer + NSURF + 6 * nlayer * ndepth + 3 * NSURF * ndepth;
+        assert_eq!(
+            ehc_prm_expected_flat_len(nlayer, ndepth).expect("layout length should fit"),
+            expected
+        );
+
+        let flat: Vec<f64> = (0..expected).map(|i| i as f64).collect();
+        let state = EhcPrm::from_flat_with_dims(&flat, nlayer, ndepth)
+            .expect("mixed EHC layout should decode");
+
+        assert_eq!(state.nlayer, nlayer);
+        assert_eq!(state.ndepth, ndepth);
+        assert_eq!(state.tin_roof.len(), nlayer);
+        assert_eq!(state.tin_wall.len(), nlayer);
+        assert_eq!(state.tin_surf.len(), NSURF);
+        assert_eq!(state.cp_roof.len(), nlayer * ndepth);
+        assert_eq!(state.cp_wall.len(), nlayer * ndepth);
+        assert_eq!(state.cp_surf.len(), NSURF * ndepth);
+
+        let names = ehc_prm_field_names_with_dims(nlayer, ndepth);
+        assert_eq!(names.len(), expected);
+        assert!(names.contains(&"cp_roof_03_02".to_string()));
+        assert!(names.contains(&"cp_wall_03_02".to_string()));
+        assert!(names.contains(&"cp_surf_07_02".to_string()));
+        assert!(!names.contains(&"cp_roof_07_01".to_string()));
+    }
+
+    #[test]
+    fn values_payload_rejects_surface_arrays_sized_like_nlayer() {
+        let nlayer = 3;
+        let ndepth = 2;
+        let bad_surface_len = nlayer;
+        let mut dims = ehc_prm_dims_map(nlayer, ndepth);
+        dims.insert("tin_surf".to_string(), vec![bad_surface_len]);
+        dims.insert("k_surf".to_string(), vec![bad_surface_len, ndepth]);
+        dims.insert("cp_surf".to_string(), vec![bad_surface_len, ndepth]);
+        dims.insert("dz_surf".to_string(), vec![bad_surface_len, ndepth]);
+
+        let bad_len =
+            8 * nlayer + bad_surface_len + 6 * nlayer * ndepth + 3 * bad_surface_len * ndepth;
+        let payload = EhcPrmValuesPayload {
+            schema_version: EHC_PRM_SCHEMA_VERSION,
+            values: vec![0.0; bad_len],
+            dims,
+        };
+
+        let err = ehc_prm_from_values_payload(&payload)
+            .expect_err("surface-class arrays must not be sized like vertical layers");
+        assert_eq!(err, BridgeError::BadState);
+    }
 }

--- a/src/suews_bridge/src/ehc_prm.rs
+++ b/src/suews_bridge/src/ehc_prm.rs
@@ -479,9 +479,6 @@ fn ehc_prm_dims_from_payload(payload: &EhcPrmValuesPayload) -> Result<(usize, us
     let nlayer = nlayer.unwrap_or(0);
     let ndepth = ndepth.unwrap_or(0);
     let surf_len = surf_len.unwrap_or(0);
-    if nlayer == 0 && ndepth != 0 {
-        return Err(BridgeError::BadState);
-    }
     if surf_len != surface_len(nlayer) {
         return Err(BridgeError::BadState);
     }
@@ -656,5 +653,26 @@ mod tests {
         let err = ehc_prm_from_values_payload(&payload)
             .expect_err("surface-class arrays must not be sized like vertical layers");
         assert_eq!(err, BridgeError::BadState);
+    }
+
+    #[test]
+    fn zero_layer_layout_keeps_empty_surface_contract() {
+        let nlayer = 0;
+        let ndepth = 5;
+
+        assert_eq!(
+            ehc_prm_expected_flat_len(nlayer, ndepth).expect("zero-layer layout should fit"),
+            0
+        );
+
+        let state = EhcPrm::from_flat_with_dims(&[], nlayer, ndepth)
+            .expect("zero-layer EHC layout should decode as the empty/default contract");
+        assert_eq!(state.tin_surf.len(), 0);
+        assert_eq!(state.cp_surf.len(), 0);
+
+        let payload = ehc_prm_to_values_payload(&state);
+        let recovered =
+            ehc_prm_from_values_payload(&payload).expect("zero-layer EHC payload should roundtrip");
+        assert_eq!(recovered, state);
     }
 }

--- a/src/suews_bridge/src/ehc_prm.rs
+++ b/src/suews_bridge/src/ehc_prm.rs
@@ -2,13 +2,14 @@ use crate::codec::{
     dims_element_count, field_index, require_field_dims, validate_flat_len, PayloadDims,
     ValuesPayloadWithDims,
 };
+use crate::core::NSURF;
 use crate::error::BridgeError;
 use crate::ffi;
 use std::collections::BTreeMap;
 
 pub const EHC_PRM_SCHEMA_VERSION: u32 = 1;
 
-const EHC_VEC_FIELDS: [&str; 9] = [
+const EHC_LAYER_VEC_FIELDS: [&str; 8] = [
     "soil_storecap_roof",
     "soil_storecap_wall",
     "state_limit_roof",
@@ -17,12 +18,28 @@ const EHC_VEC_FIELDS: [&str; 9] = [
     "wet_thresh_wall",
     "tin_roof",
     "tin_wall",
-    "tin_surf",
 ];
 
-const EHC_MAT_FIELDS: [&str; 9] = [
-    "k_roof", "k_wall", "k_surf", "cp_roof", "cp_wall", "cp_surf", "dz_roof", "dz_wall", "dz_surf",
+const EHC_SURF_VEC_FIELDS: [&str; 1] = ["tin_surf"];
+
+const EHC_LAYER_MAT_FIELDS: [&str; 6] = [
+    "k_roof", "k_wall", "cp_roof", "cp_wall", "dz_roof", "dz_wall",
 ];
+
+const EHC_SURF_MAT_FIELDS: [&str; 3] = ["k_surf", "cp_surf", "dz_surf"];
+
+const EHC_FIELD_COUNT: usize = EHC_LAYER_VEC_FIELDS.len()
+    + EHC_SURF_VEC_FIELDS.len()
+    + EHC_LAYER_MAT_FIELDS.len()
+    + EHC_SURF_MAT_FIELDS.len();
+
+const EHC_LAYER_MAT_GROUPS: [[&str; 2]; 3] = [
+    ["k_roof", "k_wall"],
+    ["cp_roof", "cp_wall"],
+    ["dz_roof", "dz_wall"],
+];
+
+const EHC_SURF_MAT_BY_GROUP: [&str; 3] = ["k_surf", "cp_surf", "dz_surf"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EhcPrmSchema {
@@ -36,8 +53,7 @@ pub struct EhcPrmSchema {
 
 pub type EhcPrmValuesPayload = ValuesPayloadWithDims;
 
-#[derive(Debug, Clone, PartialEq)]
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EhcPrm {
     pub nlayer: usize,
     pub ndepth: usize,
@@ -61,47 +77,86 @@ pub struct EhcPrm {
     pub dz_surf: Vec<f64>,
 }
 
-
 fn matrix_len(nlayer: usize, ndepth: usize) -> Result<usize, BridgeError> {
     nlayer.checked_mul(ndepth).ok_or(BridgeError::BadState)
 }
 
+fn surface_len(nlayer: usize) -> usize {
+    if nlayer == 0 {
+        0
+    } else {
+        NSURF
+    }
+}
+
 pub fn ehc_prm_expected_flat_len(nlayer: usize, ndepth: usize) -> Result<usize, BridgeError> {
-    let vec_len = EHC_VEC_FIELDS
+    let surf_len = surface_len(nlayer);
+    let layer_vec_len = EHC_LAYER_VEC_FIELDS
         .len()
         .checked_mul(nlayer)
         .ok_or(BridgeError::BadState)?;
-    let mat_len = EHC_MAT_FIELDS
+    let layer_mat_len = EHC_LAYER_MAT_FIELDS
         .len()
         .checked_mul(matrix_len(nlayer, ndepth)?)
         .ok_or(BridgeError::BadState)?;
-    vec_len.checked_add(mat_len).ok_or(BridgeError::BadState)
+    let surf_mat_len = EHC_SURF_MAT_FIELDS
+        .len()
+        .checked_mul(matrix_len(surf_len, ndepth)?)
+        .ok_or(BridgeError::BadState)?;
+    layer_vec_len
+        .checked_add(surf_len)
+        .and_then(|v| v.checked_add(layer_mat_len))
+        .and_then(|v| v.checked_add(surf_mat_len))
+        .ok_or(BridgeError::BadState)
 }
 
 fn ehc_prm_dims_map(nlayer: usize, ndepth: usize) -> PayloadDims {
     let mut dims = PayloadDims::new();
-    for field in EHC_VEC_FIELDS {
+    let surf_len = surface_len(nlayer);
+    for field in EHC_LAYER_VEC_FIELDS {
         dims.insert(field.to_string(), vec![nlayer]);
     }
-    for field in EHC_MAT_FIELDS {
+    for field in EHC_SURF_VEC_FIELDS {
+        dims.insert(field.to_string(), vec![surf_len]);
+    }
+    for field in EHC_LAYER_MAT_FIELDS {
         dims.insert(field.to_string(), vec![nlayer, ndepth]);
+    }
+    for field in EHC_SURF_MAT_FIELDS {
+        dims.insert(field.to_string(), vec![surf_len, ndepth]);
     }
     dims
 }
 
 pub fn ehc_prm_field_names_with_dims(nlayer: usize, ndepth: usize) -> Vec<String> {
     let mut names = Vec::new();
+    let surf_len = surface_len(nlayer);
 
-    for field in EHC_VEC_FIELDS {
+    for field in EHC_LAYER_VEC_FIELDS {
         for layer in 0..nlayer {
             names.push(format!("{field}_{:02}", layer + 1));
         }
     }
+    for field in EHC_SURF_VEC_FIELDS {
+        for surf in 0..surf_len {
+            names.push(format!("{field}_{:02}", surf + 1));
+        }
+    }
 
-    for field in EHC_MAT_FIELDS {
-        for layer in 0..nlayer {
+    for (layer_fields, surf_field) in EHC_LAYER_MAT_GROUPS
+        .iter()
+        .zip(EHC_SURF_MAT_BY_GROUP.iter())
+    {
+        for field in layer_fields {
+            for layer in 0..nlayer {
+                for depth in 0..ndepth {
+                    names.push(format!("{field}_{:02}_{:02}", layer + 1, depth + 1));
+                }
+            }
+        }
+        for surf in 0..surf_len {
             for depth in 0..ndepth {
-                names.push(format!("{field}_{:02}_{:02}", layer + 1, depth + 1));
+                names.push(format!("{surf_field}_{:02}_{:02}", surf + 1, depth + 1));
             }
         }
     }
@@ -113,9 +168,11 @@ impl EhcPrm {
     fn validate_layout(&self) -> Result<(), BridgeError> {
         let nlayer = self.nlayer;
         let ndepth = self.ndepth;
-        let nmat = matrix_len(nlayer, ndepth)?;
+        let nsurf_ehc = surface_len(nlayer);
+        let layer_mat_len = matrix_len(nlayer, ndepth)?;
+        let surf_mat_len = matrix_len(nsurf_ehc, ndepth)?;
 
-        let vec_fields = [
+        let layer_vec_fields = [
             &self.soil_storecap_roof,
             &self.soil_storecap_wall,
             &self.state_limit_roof,
@@ -124,27 +181,31 @@ impl EhcPrm {
             &self.wet_thresh_wall,
             &self.tin_roof,
             &self.tin_wall,
-            &self.tin_surf,
         ];
-        for field in vec_fields {
+        for field in layer_vec_fields {
             if field.len() != nlayer {
                 return Err(BridgeError::BadState);
             }
         }
+        if self.tin_surf.len() != nsurf_ehc {
+            return Err(BridgeError::BadState);
+        }
 
-        let mat_fields = [
+        let layer_mat_fields = [
             &self.k_roof,
             &self.k_wall,
-            &self.k_surf,
             &self.cp_roof,
             &self.cp_wall,
-            &self.cp_surf,
             &self.dz_roof,
             &self.dz_wall,
-            &self.dz_surf,
         ];
-        for field in mat_fields {
-            if field.len() != nmat {
+        for field in layer_mat_fields {
+            if field.len() != layer_mat_len {
+                return Err(BridgeError::BadState);
+            }
+        }
+        for field in [&self.k_surf, &self.cp_surf, &self.dz_surf] {
+            if field.len() != surf_mat_len {
                 return Err(BridgeError::BadState);
             }
         }
@@ -160,8 +221,10 @@ impl EhcPrm {
         let expected_len = ehc_prm_expected_flat_len(nlayer, ndepth)?;
         validate_flat_len(flat, expected_len)?;
 
-        let vec_len = nlayer;
-        let mat_len = matrix_len(nlayer, ndepth)?;
+        let layer_vec_len = nlayer;
+        let surf_vec_len = surface_len(nlayer);
+        let layer_mat_len = matrix_len(nlayer, ndepth)?;
+        let surf_mat_len = matrix_len(surf_vec_len, ndepth)?;
         let mut idx = 0_usize;
         let mut take = |count: usize| {
             let out = flat[idx..idx + count].to_vec();
@@ -172,24 +235,24 @@ impl EhcPrm {
         let state = Self {
             nlayer,
             ndepth,
-            soil_storecap_roof: take(vec_len),
-            soil_storecap_wall: take(vec_len),
-            state_limit_roof: take(vec_len),
-            state_limit_wall: take(vec_len),
-            wet_thresh_roof: take(vec_len),
-            wet_thresh_wall: take(vec_len),
-            tin_roof: take(vec_len),
-            tin_wall: take(vec_len),
-            tin_surf: take(vec_len),
-            k_roof: take(mat_len),
-            k_wall: take(mat_len),
-            k_surf: take(mat_len),
-            cp_roof: take(mat_len),
-            cp_wall: take(mat_len),
-            cp_surf: take(mat_len),
-            dz_roof: take(mat_len),
-            dz_wall: take(mat_len),
-            dz_surf: take(mat_len),
+            soil_storecap_roof: take(layer_vec_len),
+            soil_storecap_wall: take(layer_vec_len),
+            state_limit_roof: take(layer_vec_len),
+            state_limit_wall: take(layer_vec_len),
+            wet_thresh_roof: take(layer_vec_len),
+            wet_thresh_wall: take(layer_vec_len),
+            tin_roof: take(layer_vec_len),
+            tin_wall: take(layer_vec_len),
+            tin_surf: take(surf_vec_len),
+            k_roof: take(layer_mat_len),
+            k_wall: take(layer_mat_len),
+            k_surf: take(surf_mat_len),
+            cp_roof: take(layer_mat_len),
+            cp_wall: take(layer_mat_len),
+            cp_surf: take(surf_mat_len),
+            dz_roof: take(layer_mat_len),
+            dz_wall: take(layer_mat_len),
+            dz_surf: take(surf_mat_len),
         };
 
         state.validate_layout()?;
@@ -325,14 +388,15 @@ pub fn ehc_prm_from_ordered_values(values: &[f64]) -> Result<EhcPrm, BridgeError
 }
 
 fn ehc_prm_dims_from_payload(payload: &EhcPrmValuesPayload) -> Result<(usize, usize), BridgeError> {
-    if payload.dims.len() != EHC_VEC_FIELDS.len() + EHC_MAT_FIELDS.len() {
+    if payload.dims.len() != EHC_FIELD_COUNT {
         return Err(BridgeError::BadState);
     }
 
     let mut nlayer: Option<usize> = None;
     let mut ndepth: Option<usize> = None;
+    let mut surf_len: Option<usize> = None;
 
-    for field in EHC_VEC_FIELDS {
+    for field in EHC_LAYER_VEC_FIELDS {
         let dims = require_field_dims(&payload.dims, field, 1)?;
         let layer_here = dims_element_count(&dims)?;
         if let Some(expected) = nlayer {
@@ -344,7 +408,19 @@ fn ehc_prm_dims_from_payload(payload: &EhcPrmValuesPayload) -> Result<(usize, us
         }
     }
 
-    for field in EHC_MAT_FIELDS {
+    for field in EHC_SURF_VEC_FIELDS {
+        let dims = require_field_dims(&payload.dims, field, 1)?;
+        let surf_here = dims_element_count(&dims)?;
+        if let Some(expected) = surf_len {
+            if surf_here != expected {
+                return Err(BridgeError::BadState);
+            }
+        } else {
+            surf_len = Some(surf_here);
+        }
+    }
+
+    for field in EHC_LAYER_MAT_FIELDS {
         let dims = require_field_dims(&payload.dims, field, 2)?;
         let layer_here = dims[0];
         let depth_here = dims[1];
@@ -372,9 +448,41 @@ fn ehc_prm_dims_from_payload(payload: &EhcPrmValuesPayload) -> Result<(usize, us
         }
     }
 
+    for field in EHC_SURF_MAT_FIELDS {
+        let dims = require_field_dims(&payload.dims, field, 2)?;
+        let surf_here = dims[0];
+        let depth_here = dims[1];
+        let mat_len = dims_element_count(&dims)?;
+
+        if let Some(expected) = surf_len {
+            if surf_here != expected {
+                return Err(BridgeError::BadState);
+            }
+        } else {
+            surf_len = Some(surf_here);
+        }
+
+        if let Some(expected) = ndepth {
+            if depth_here != expected {
+                return Err(BridgeError::BadState);
+            }
+        } else {
+            ndepth = Some(depth_here);
+        }
+
+        let expected_mat_len = matrix_len(surf_here, depth_here)?;
+        if mat_len != expected_mat_len {
+            return Err(BridgeError::BadState);
+        }
+    }
+
     let nlayer = nlayer.unwrap_or(0);
     let ndepth = ndepth.unwrap_or(0);
+    let surf_len = surf_len.unwrap_or(0);
     if nlayer == 0 && ndepth != 0 {
+        return Err(BridgeError::BadState);
+    }
+    if surf_len != surface_len(nlayer) {
         return Err(BridgeError::BadState);
     }
     Ok((nlayer, ndepth))

--- a/src/suews_bridge/src/ehc_prm.rs
+++ b/src/suews_bridge/src/ehc_prm.rs
@@ -7,7 +7,7 @@ use crate::error::BridgeError;
 use crate::ffi;
 use std::collections::BTreeMap;
 
-pub const EHC_PRM_SCHEMA_VERSION: u32 = 1;
+pub const EHC_PRM_SCHEMA_VERSION: u32 = 2;
 
 const EHC_LAYER_VEC_FIELDS: [&str; 8] = [
     "soil_storecap_roof",

--- a/src/suews_bridge/src/sim.rs
+++ b/src/suews_bridge/src/sim.rs
@@ -415,7 +415,7 @@ fn validate_site_codec(
     let ehc = if ehc_slice.is_empty() {
         ehc_prm_from_ordered_values(ehc_slice)?
     } else {
-        EhcPrm::from_flat_with_dims(ehc_slice, NSURF, ndepth as usize)?
+        EhcPrm::from_flat_with_dims(ehc_slice, nlayer_usize, ndepth as usize)?
     };
     let spartacus_layer_slice = member_slice(site_flat, site_toc, SITE_MEMBER_SPARTACUS_LAYER)?;
     let spartacus_layer = if spartacus_layer_slice.is_empty() {
@@ -883,7 +883,12 @@ pub fn run_simulation(input: SimulationInput) -> Result<SimulationOutput, Bridge
         return Err(BridgeError::BadState);
     }
 
-    validate_site_codec(&site_members.flat, &site_members.toc, input.nlayer, input.ndepth)?;
+    validate_site_codec(
+        &site_members.flat,
+        &site_members.toc,
+        input.nlayer,
+        input.ndepth,
+    )?;
 
     let mut timer_out = vec![0.0_f64; SUEWS_TIMER_FLAT_LEN];
     let mut state_out = vec![0.0_f64; state_members.flat.len()];
@@ -1014,11 +1019,7 @@ mod tests {
         let mut err = -1_i32;
 
         unsafe {
-            ffi::suews_output_group_ncolumns(
-                ncols_arr.as_mut_ptr(),
-                &mut n_groups,
-                &mut err,
-            );
+            ffi::suews_output_group_ncolumns(ncols_arr.as_mut_ptr(), &mut n_groups, &mut err);
         }
 
         assert_eq!(

--- a/src/suews_bridge/src/yaml_config.rs
+++ b/src/suews_bridge/src/yaml_config.rs
@@ -1508,7 +1508,8 @@ fn apply_config_overrides(config: &mut SuewsConfig, root: &Value) {
 
 fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, nlayer: usize, ndepth: usize) {
     let layer_mat_len = nlayer * ndepth;
-    let surf_mat_len = NSURF * ndepth;
+    let surf_len = if nlayer == 0 { 0 } else { NSURF };
+    let surf_mat_len = surf_len * ndepth;
 
     site.ehc.nlayer = nlayer;
     site.ehc.ndepth = ndepth;
@@ -1523,7 +1524,7 @@ fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, nlayer: usize, n
     site.ehc.wet_thresh_wall.resize(nlayer, 0.0);
     site.ehc.tin_roof.resize(nlayer, 5.0);
     site.ehc.tin_wall.resize(nlayer, 5.0);
-    site.ehc.tin_surf.resize(NSURF, 2.0);
+    site.ehc.tin_surf.resize(surf_len, 2.0);
     site.ehc.k_roof.resize(layer_mat_len, 0.0);
     site.ehc.k_wall.resize(layer_mat_len, 0.0);
     site.ehc.k_surf.resize(surf_mat_len, 0.0);
@@ -1534,49 +1535,54 @@ fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, nlayer: usize, n
     site.ehc.dz_wall.resize(layer_mat_len, 0.0);
     site.ehc.dz_surf.resize(surf_mat_len, 0.0);
 
-    // Populate k_surf, cp_surf, dz_surf from each surface type's thermal_layers.
-    // Row-major layout: element [surf_idx * ndepth + depth_idx].
-    for &(surface_name, surface_idx) in &SURFACE_YAML_ORDER {
-        let tl_path = ["properties", "land_cover", surface_name, "thermal_layers"];
-        if let Some(k_vals) = read_numeric_sequence(
-            site_root,
-            &[tl_path[0], tl_path[1], tl_path[2], tl_path[3], "k"],
-        ) {
-            for (j, &v) in k_vals.iter().take(ndepth).enumerate() {
-                site.ehc.k_surf[surface_idx * ndepth + j] = v;
-            }
-        }
-        if let Some(cp_vals) = read_numeric_sequence(
-            site_root,
-            &[tl_path[0], tl_path[1], tl_path[2], tl_path[3], "rho_cp"],
-        )
-        .or_else(|| {
-            read_numeric_sequence(
+    if surf_len > 0 {
+        // Populate k_surf, cp_surf, dz_surf from each surface type's thermal_layers.
+        // Row-major layout: element [surf_idx * ndepth + depth_idx].
+        for &(surface_name, surface_idx) in &SURFACE_YAML_ORDER {
+            let tl_path = ["properties", "land_cover", surface_name, "thermal_layers"];
+            if let Some(k_vals) = read_numeric_sequence(
                 site_root,
-                &[tl_path[0], tl_path[1], tl_path[2], tl_path[3], "cp"],
+                &[tl_path[0], tl_path[1], tl_path[2], tl_path[3], "k"],
+            ) {
+                for (j, &v) in k_vals.iter().take(ndepth).enumerate() {
+                    site.ehc.k_surf[surface_idx * ndepth + j] = v;
+                }
+            }
+            if let Some(cp_vals) = read_numeric_sequence(
+                site_root,
+                &[tl_path[0], tl_path[1], tl_path[2], tl_path[3], "rho_cp"],
             )
-        }) {
-            for (j, &v) in cp_vals.iter().take(ndepth).enumerate() {
-                site.ehc.cp_surf[surface_idx * ndepth + j] = v;
+            .or_else(|| {
+                read_numeric_sequence(
+                    site_root,
+                    &[tl_path[0], tl_path[1], tl_path[2], tl_path[3], "cp"],
+                )
+            }) {
+                for (j, &v) in cp_vals.iter().take(ndepth).enumerate() {
+                    site.ehc.cp_surf[surface_idx * ndepth + j] = v;
+                }
             }
-        }
-        if let Some(dz_vals) = read_numeric_sequence(
-            site_root,
-            &[tl_path[0], tl_path[1], tl_path[2], tl_path[3], "dz"],
-        ) {
-            for (j, &v) in dz_vals.iter().take(ndepth).enumerate() {
-                site.ehc.dz_surf[surface_idx * ndepth + j] = v;
+            if let Some(dz_vals) = read_numeric_sequence(
+                site_root,
+                &[tl_path[0], tl_path[1], tl_path[2], tl_path[3], "dz"],
+            ) {
+                for (j, &v) in dz_vals.iter().take(ndepth).enumerate() {
+                    site.ehc.dz_surf[surface_idx * ndepth + j] = v;
+                }
             }
-        }
 
-        // tin_surf from initial_states.<surface>.tin, fallback to temperature[0].
-        if let Some(v) =
-            read_numeric(site_root, &["initial_states", surface_name, "tin"]).or_else(|| {
-                read_numeric_sequence(site_root, &["initial_states", surface_name, "temperature"])
+            // tin_surf from initial_states.<surface>.tin, fallback to temperature[0].
+            if let Some(v) = read_numeric(site_root, &["initial_states", surface_name, "tin"])
+                .or_else(|| {
+                    read_numeric_sequence(
+                        site_root,
+                        &["initial_states", surface_name, "temperature"],
+                    )
                     .and_then(|vals| vals.first().copied())
-            })
-        {
-            site.ehc.tin_surf[surface_idx] = v;
+                })
+            {
+                site.ehc.tin_surf[surface_idx] = v;
+            }
         }
     }
 
@@ -2446,6 +2452,25 @@ mod tests {
         assert!((run_cfg.site.ehc.tin_surf[0] - 17.540002822875977).abs() < 1.0e-12);
         assert!((run_cfg.site.ehc.tin_roof[0] - 17.540002822875977).abs() < 1.0e-12);
         assert!((run_cfg.site.ehc.tin_wall[0] - 17.540002822875977).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn zero_layer_ehc_yaml_layout_keeps_empty_surface_contract() {
+        let yaml_str =
+            include_str!("../../../test/fixtures/data_test/stebbs_test/sample_config.yml");
+        let mut root: Value = serde_yaml::from_str(yaml_str).expect("fixture YAML should parse");
+        let site = first_site_mut(&mut root).expect("fixture should contain a first site");
+        *get_path_mut(site, &["properties", "vertical_layers", "nlayer", "value"])
+            .expect("fixture should define nlayer") = serde_yaml::to_value(0).unwrap();
+
+        let run_cfg = load_run_config_from_value(&mut root).expect("run config should parse");
+
+        assert_eq!(run_cfg.site.ehc.nlayer, 0);
+        assert_eq!(run_cfg.site.ehc.ndepth, run_cfg.ndepth as usize);
+        assert_eq!(run_cfg.site.ehc.tin_surf.len(), 0);
+        assert_eq!(run_cfg.site.ehc.k_surf.len(), 0);
+        assert_eq!(run_cfg.site.ehc.cp_surf.len(), 0);
+        assert_eq!(run_cfg.site.ehc.dz_surf.len(), 0);
     }
 
     #[test]

--- a/src/suews_bridge/src/yaml_config.rs
+++ b/src/suews_bridge/src/yaml_config.rs
@@ -601,9 +601,7 @@ fn apply_vertical_layers_overrides(site: &mut SuewsSite, site_root: &Value) {
         // Both former branches (lengths match, or height non-empty) did the
         // same prefix-assign, so they collapse to one condition. Behaviour is
         // unchanged; the duplicated else-if may have been intended to differ.
-        if site.spartacus.height.len() == height_values.len()
-            || !site.spartacus.height.is_empty()
-        {
+        if site.spartacus.height.len() == height_values.len() || !site.spartacus.height.is_empty() {
             assign_prefix(
                 site.spartacus.height.as_mut_slice(),
                 height_values.as_slice(),
@@ -835,8 +833,10 @@ fn apply_irrigation_overrides(site: &mut SuewsSite, site_root: &Value) {
     if let Some(v) = read_i32(site_root, &["properties", "irrigation", "ie_end"]) {
         site.irrigation.ie_end = v;
     }
-    if let Some(v) = read_numeric(site_root, &["properties", "irrigation", "internalwateruse_h"])
-    {
+    if let Some(v) = read_numeric(
+        site_root,
+        &["properties", "irrigation", "internalwateruse_h"],
+    ) {
         site.irrigation.internalwateruse_h = v;
     }
 
@@ -1506,35 +1506,33 @@ fn apply_config_overrides(config: &mut SuewsConfig, root: &Value) {
     }
 }
 
-fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, ndepth: usize) {
-    // EHC arrays use NSURF (7) as the first dimension to match the physics loop
-    // which iterates i_surf=1..nsurf. The Fortran C API driver now uses nsurf
-    // (not SPARTACUS nlayer) for EHC buffer sizing and unpacking.
-    let nlayer_ehc = NSURF;
-    let mat_len = nlayer_ehc * ndepth;
+fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, nlayer: usize, ndepth: usize) {
+    let layer_mat_len = nlayer * ndepth;
+    let surf_mat_len = NSURF * ndepth;
 
-    site.ehc.nlayer = nlayer_ehc;
+    site.ehc.nlayer = nlayer;
     site.ehc.ndepth = ndepth;
 
-    // Resize all EHC arrays to correct dimensions (zero-filled by default).
-    site.ehc.soil_storecap_roof.resize(nlayer_ehc, 0.0);
-    site.ehc.soil_storecap_wall.resize(nlayer_ehc, 0.0);
-    site.ehc.state_limit_roof.resize(nlayer_ehc, 0.0);
-    site.ehc.state_limit_wall.resize(nlayer_ehc, 0.0);
-    site.ehc.wet_thresh_roof.resize(nlayer_ehc, 0.0);
-    site.ehc.wet_thresh_wall.resize(nlayer_ehc, 0.0);
-    site.ehc.tin_roof.resize(nlayer_ehc, 5.0);
-    site.ehc.tin_wall.resize(nlayer_ehc, 5.0);
-    site.ehc.tin_surf.resize(nlayer_ehc, 2.0);
-    site.ehc.k_roof.resize(mat_len, 0.0);
-    site.ehc.k_wall.resize(mat_len, 0.0);
-    site.ehc.k_surf.resize(mat_len, 0.0);
-    site.ehc.cp_roof.resize(mat_len, 0.0);
-    site.ehc.cp_wall.resize(mat_len, 0.0);
-    site.ehc.cp_surf.resize(mat_len, 0.0);
-    site.ehc.dz_roof.resize(mat_len, 0.0);
-    site.ehc.dz_wall.resize(mat_len, 0.0);
-    site.ehc.dz_surf.resize(mat_len, 0.0);
+    // Roof and wall arrays follow SPARTACUS vertical layers; standard
+    // surface arrays follow SUEWS surface classes.
+    site.ehc.soil_storecap_roof.resize(nlayer, 0.0);
+    site.ehc.soil_storecap_wall.resize(nlayer, 0.0);
+    site.ehc.state_limit_roof.resize(nlayer, 0.0);
+    site.ehc.state_limit_wall.resize(nlayer, 0.0);
+    site.ehc.wet_thresh_roof.resize(nlayer, 0.0);
+    site.ehc.wet_thresh_wall.resize(nlayer, 0.0);
+    site.ehc.tin_roof.resize(nlayer, 5.0);
+    site.ehc.tin_wall.resize(nlayer, 5.0);
+    site.ehc.tin_surf.resize(NSURF, 2.0);
+    site.ehc.k_roof.resize(layer_mat_len, 0.0);
+    site.ehc.k_wall.resize(layer_mat_len, 0.0);
+    site.ehc.k_surf.resize(surf_mat_len, 0.0);
+    site.ehc.cp_roof.resize(layer_mat_len, 0.0);
+    site.ehc.cp_wall.resize(layer_mat_len, 0.0);
+    site.ehc.cp_surf.resize(surf_mat_len, 0.0);
+    site.ehc.dz_roof.resize(layer_mat_len, 0.0);
+    site.ehc.dz_wall.resize(layer_mat_len, 0.0);
+    site.ehc.dz_surf.resize(surf_mat_len, 0.0);
 
     // Populate k_surf, cp_surf, dz_surf from each surface type's thermal_layers.
     // Row-major layout: element [surf_idx * ndepth + depth_idx].
@@ -1583,7 +1581,7 @@ fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, ndepth: usize) {
     }
 
     if let Some(roofs) = read_sequence(site_root, &["properties", "vertical_layers", "roofs"]) {
-        for (layer_idx, roof_root) in roofs.iter().take(nlayer_ehc).enumerate() {
+        for (layer_idx, roof_root) in roofs.iter().take(nlayer).enumerate() {
             if let Some(v) = read_numeric(roof_root, &["soilstorecap"]) {
                 site.ehc.soil_storecap_roof[layer_idx] = v;
             }
@@ -1615,7 +1613,7 @@ fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, ndepth: usize) {
     }
 
     if let Some(walls) = read_sequence(site_root, &["properties", "vertical_layers", "walls"]) {
-        for (layer_idx, wall_root) in walls.iter().take(nlayer_ehc).enumerate() {
+        for (layer_idx, wall_root) in walls.iter().take(nlayer).enumerate() {
             if let Some(v) = read_numeric(wall_root, &["soilstorecap"]) {
                 site.ehc.soil_storecap_wall[layer_idx] = v;
             }
@@ -1647,7 +1645,7 @@ fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, ndepth: usize) {
     }
 
     if let Some(roofs) = read_sequence(site_root, &["initial_states", "roofs"]) {
-        for (layer_idx, roof_root) in roofs.iter().take(nlayer_ehc).enumerate() {
+        for (layer_idx, roof_root) in roofs.iter().take(nlayer).enumerate() {
             if let Some(v) = read_numeric(roof_root, &["tin"]).or_else(|| {
                 read_numeric_sequence(roof_root, &["temperature"])
                     .and_then(|vals| vals.first().copied())
@@ -1658,7 +1656,7 @@ fn apply_ehc_overrides(site: &mut SuewsSite, site_root: &Value, ndepth: usize) {
     }
 
     if let Some(walls) = read_sequence(site_root, &["initial_states", "walls"]) {
-        for (layer_idx, wall_root) in walls.iter().take(nlayer_ehc).enumerate() {
+        for (layer_idx, wall_root) in walls.iter().take(nlayer).enumerate() {
             if let Some(v) = read_numeric(wall_root, &["tin"]).or_else(|| {
                 read_numeric_sequence(wall_root, &["temperature"])
                     .and_then(|vals| vals.first().copied())
@@ -1811,7 +1809,7 @@ fn apply_site_overrides(
     apply_anthro_emis_overrides(site, site_root);
     apply_building_archetype_overrides(site, site_root)?;
     apply_stebbs_overrides(site, site_root)?;
-    apply_ehc_overrides(site, site_root, ndepth);
+    apply_ehc_overrides(site, site_root, nlayer, ndepth);
     Ok(())
 }
 
@@ -2420,6 +2418,13 @@ mod tests {
 
         let ndepth = run_cfg.ndepth as usize;
         assert!(ndepth > 0);
+        assert_eq!(run_cfg.site.ehc.nlayer, run_cfg.nlayer as usize);
+        assert_eq!(run_cfg.site.ehc.tin_surf.len(), NSURF);
+        assert_eq!(run_cfg.site.ehc.k_surf.len(), NSURF * ndepth);
+        assert_eq!(
+            run_cfg.site.ehc.k_roof.len(),
+            run_cfg.site.ehc.nlayer * ndepth
+        );
 
         assert!((run_cfg.site.ehc.dz_roof[0] - 0.03).abs() < 1.0e-12);
         assert!((run_cfg.site.ehc.k_roof[0] - 0.106).abs() < 1.0e-12);
@@ -2700,8 +2705,7 @@ mod tests {
         map.insert(Value::String("same_emissivity_wall".into()), flat(0));
         map.insert(Value::String("same_emissivity_roof".into()), flat(0));
 
-        let cfg_nested =
-            load_run_config_from_value(&mut root_nested).expect("parse nested STEBBS");
+        let cfg_nested = load_run_config_from_value(&mut root_nested).expect("parse nested STEBBS");
         let cfg_flat = load_run_config_from_value(&mut root_flat).expect("parse flat STEBBS");
 
         // flat(19)/flat(20)/flat(21) — the only STEBBS switches in the c_api
@@ -2709,7 +2713,10 @@ mod tests {
         assert_eq!(cfg_nested.config.stebbs_method, 1);
         assert_eq!(cfg_nested.config.rc_method, 2);
         assert_eq!(cfg_nested.config.setpoint_method, 0);
-        assert_eq!(cfg_nested.config.stebbs_method, cfg_flat.config.stebbs_method);
+        assert_eq!(
+            cfg_nested.config.stebbs_method,
+            cfg_flat.config.stebbs_method
+        );
         assert_eq!(cfg_nested.config.rc_method, cfg_flat.config.rc_method);
         assert_eq!(
             cfg_nested.config.setpoint_method,

--- a/test/core/test_ehc_regression.py
+++ b/test/core/test_ehc_regression.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+import supy as sp
+
+
+pytestmark = [
+    pytest.mark.physics,
+    pytest.mark.core,
+    pytest.mark.rust,
+    pytest.mark.smoke,
+]
+
+
+SURFACE_NAMES = ("paved", "bldgs", "evetr", "dectr", "grass", "bsoil", "water")
+
+
+def _run_short_ehc_with_surface_cp(rho_cp):
+    sim = sp.SUEWSSimulation.from_sample_data()
+    layer_values = [rho_cp] * 5
+    surface_updates = {
+        name: {"thermal_layers": {"rho_cp": {"value": layer_values}}}
+        for name in SURFACE_NAMES
+    }
+    sim.update_config(
+        {
+            "model": {
+                "physics": {
+                    "net_radiation": {"value": 3},
+                    "storage_heat": {"value": 5},
+                }
+            },
+            "sites": {
+                "properties": {
+                    "land_cover": surface_updates,
+                }
+            },
+        }
+    )
+
+    output = sim.run(end_date=sim._df_forcing.index[11])
+    return output.df[("SUEWS", "QS")].to_numpy()
+
+
+def test_ehc_lumped_storage_is_sensitive_to_surface_rho_cp():
+    low_cp_qs = _run_short_ehc_with_surface_cp(1.0e6)
+    high_cp_qs = _run_short_ehc_with_surface_cp(4.0e6)
+
+    assert low_cp_qs.shape == high_cp_qs.shape
+    assert np.max(np.abs(high_cp_qs - low_cp_qs)) > 1.0

--- a/test/core/test_ehc_regression.py
+++ b/test/core/test_ehc_regression.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 import pytest
 
@@ -46,6 +48,45 @@ def _run_short_ehc_with_surface_cp(rho_cp, surface_rho_cp=None):
     return output.df[("SUEWS", "QS")].to_numpy()
 
 
+def _with_vertical_layer_cp(layers, rho_cp):
+    updates = []
+    for layer in layers:
+        layer_update = copy.deepcopy(layer)
+        thermal_layers = layer_update.setdefault("thermal_layers", {})
+        existing_cp = thermal_layers.get("rho_cp", {})
+        if isinstance(existing_cp, dict):
+            ndepth = len(existing_cp.get("value", [])) or 5
+        else:
+            ndepth = 5
+        thermal_layers["rho_cp"] = {"value": [rho_cp] * ndepth}
+        updates.append(layer_update)
+    return updates
+
+
+def _run_short_spartacus_ehc_with_building_cp(rho_cp):
+    sim = sp.SUEWSSimulation.from_sample_data()
+    cfg = sim._config.model_dump(exclude_none=True, mode="json")
+    land_cover = cfg["sites"][0]["properties"]["land_cover"]
+    vertical_layers = cfg["sites"][0]["properties"]["vertical_layers"]
+    vertical_layers["roofs"] = _with_vertical_layer_cp(vertical_layers["roofs"], rho_cp)
+    vertical_layers["walls"] = _with_vertical_layer_cp(vertical_layers["walls"], rho_cp)
+    vertical_layers["building_frac"]["value"][0] = land_cover["bldgs"]["sfr"]["value"]
+    vertical_layers["veg_frac"]["value"][0] = (
+        land_cover["evetr"]["sfr"]["value"] + land_cover["dectr"]["sfr"]["value"]
+    )
+    vertical_layers["veg_frac"]["value"][2] = 0.0
+    vertical_layers["veg_scale"]["value"][2] = 0.0
+    cfg["model"]["physics"]["net_radiation"] = {"value": 1003}
+    cfg["model"]["physics"]["storage_heat"] = {"value": 5}
+    for internal_key in ("_yaml_path", "_auto_generate_annotated", "_yaml_raw"):
+        cfg.pop(internal_key, None)
+
+    sim.update_config(cfg)
+
+    output = sim.run(end_date=sim._df_forcing.index[11])
+    return output.df[("SUEWS", "QS")].to_numpy()
+
+
 def test_ehc_lumped_storage_is_sensitive_to_surface_rho_cp():
     low_cp_qs = _run_short_ehc_with_surface_cp(1.0e6)
     high_cp_qs = _run_short_ehc_with_surface_cp(4.0e6)
@@ -58,3 +99,11 @@ def test_ehc_lumped_storage_skips_invalid_surface_without_zeroing_grid():
     qs = _run_short_ehc_with_surface_cp(1.0e6, surface_rho_cp={"bldgs": 0.0})
 
     assert np.max(np.abs(qs)) > 1.0
+
+
+def test_ehc_spartacus_facet_storage_is_sensitive_to_building_rho_cp():
+    low_cp_qs = _run_short_spartacus_ehc_with_building_cp(1.0e6)
+    high_cp_qs = _run_short_spartacus_ehc_with_building_cp(4.0e6)
+
+    assert low_cp_qs.shape == high_cp_qs.shape
+    assert np.max(np.abs(high_cp_qs - low_cp_qs)) > 1.0

--- a/test/core/test_ehc_regression.py
+++ b/test/core/test_ehc_regression.py
@@ -15,11 +15,15 @@ pytestmark = [
 SURFACE_NAMES = ("paved", "bldgs", "evetr", "dectr", "grass", "bsoil", "water")
 
 
-def _run_short_ehc_with_surface_cp(rho_cp):
+def _run_short_ehc_with_surface_cp(rho_cp, surface_rho_cp=None):
     sim = sp.SUEWSSimulation.from_sample_data()
-    layer_values = [rho_cp] * 5
+    surface_rho_cp = surface_rho_cp or {}
     surface_updates = {
-        name: {"thermal_layers": {"rho_cp": {"value": layer_values}}}
+        name: {
+            "thermal_layers": {
+                "rho_cp": {"value": [surface_rho_cp.get(name, rho_cp)] * 5}
+            }
+        }
         for name in SURFACE_NAMES
     }
     sim.update_config(
@@ -48,3 +52,9 @@ def test_ehc_lumped_storage_is_sensitive_to_surface_rho_cp():
 
     assert low_cp_qs.shape == high_cp_qs.shape
     assert np.max(np.abs(high_cp_qs - low_cp_qs)) > 1.0
+
+
+def test_ehc_lumped_storage_skips_invalid_surface_without_zeroing_grid():
+    qs = _run_short_ehc_with_surface_cp(1.0e6, surface_rho_cp={"bldgs": 0.0})
+
+    assert np.max(np.abs(qs)) > 1.0


### PR DESCRIPTION
## Summary
- separate EHC roof/wall arrays that follow SPARTACUS vertical layers from standard SUEWS surface arrays that follow the seven SUEWS surface classes
- update the Fortran type allocation, C API packing/unpacking, Rust codec validation, and YAML EHC overrides to preserve those dimensions
- keep the coarse lumped EHC slab for OHM-like non-SPARTACUS benchmarks, while allowing SPARTACUS (`NetRadiationMethod > 1000`) to use the facet-resolved roof/wall vertical-layer conduction path
- handle invalid surface-class thermal layers independently in the lumped EHC slab path so one bad/sentinel surface no longer zeroes the whole grid-cell storage response, and warn for fully degenerate lumped inputs
- add early smoke regression coverage for EHC `rho_cp` sensitivity in both lumped-slab and SPARTACUS facet paths, invalid-surface handling, and the mixed `nlayer`/`NSURF` bridge layout

## Notes
- The Cp sensitivity issue is mainly exposed for building land cover/facet use: non-building standard surfaces continue to use `cp_surf` directly.
- The old bridge path had explicitly forced EHC dimensions through `NSURF`, which made roof/wall vertical-layer data latent or wrong whenever SPARTACUS/building facets were involved.
- The EHC bridge schema version is bumped from 1 to 2 because the packed EHC layout changed.
- `nlayer == 0` remains the existing empty/default EHC payload case; the codec now accepts that zero-element layout even when the YAML loader carries its normal default `ndepth`.

## Validation
- `make -C src/suews all && make dev`
- `cargo test --manifest-path src/suews_bridge/Cargo.toml --features physics zero_layer` (2 passed; 1 existing dead-code warning)
- `python -m pytest test/core/test_ehc_regression.py -q` (3 passed, 30 Pydantic deprecation warnings)
- `make test-smoke` (12 passed, 1728 deselected, 34 Pydantic deprecation warnings)
- `git diff --check`
- `rustfmt --edition 2021 --check src/suews_bridge/src/ehc_prm.rs src/suews_bridge/src/yaml_config.rs`
