### PR TITLE
Add flux performance attribution diagnostics

### DIFF
--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -59,6 +59,7 @@ py.install_sources(
             'util/_atm.py',
             'util/_attribution/__init__.py',
             'util/_attribution/_core.py',
+            'util/_attribution/_flux_performance.py',
             'util/_attribution/_helpers.py',
             'util/_attribution/_physics.py',
             'util/_attribution/_q2.py',

--- a/src/supy/util/__init__.py
+++ b/src/supy/util/__init__.py
@@ -76,6 +76,7 @@ from ._attribution import (
     diagnose_t2,
     diagnose_q2,
     diagnose_u10,
+    diagnose_flux_performance,
     # Generic dispatchers
     attribute,
     diagnose,

--- a/src/supy/util/_attribution/__init__.py
+++ b/src/supy/util/_attribution/__init__.py
@@ -9,6 +9,7 @@ Supported Variables
 - **T2** (2m temperature): Linear flux-gradient profile
 - **q2** (2m specific humidity): Linear flux-gradient profile
 - **U10** (10m wind speed): Logarithmic momentum profile
+- **QE/QH performance**: Model-observation flux error decomposition
 
 Mathematical Foundation
 -----------------------
@@ -47,6 +48,7 @@ from ._result import AttributionResult
 from ._t2 import attribute_t2, diagnose_t2
 from ._q2 import attribute_q2, diagnose_q2
 from ._u10 import attribute_u10, diagnose_u10
+from ._flux_performance import diagnose_flux_performance
 
 
 # =============================================================================
@@ -170,6 +172,7 @@ __all__ = [
     "diagnose_t2",
     "diagnose_q2",
     "diagnose_u10",
+    "diagnose_flux_performance",
     # Generic dispatchers
     "attribute",
     "diagnose",

--- a/src/supy/util/_attribution/_flux_performance.py
+++ b/src/supy/util/_attribution/_flux_performance.py
@@ -1,0 +1,180 @@
+"""
+Model-performance attribution for surface energy fluxes.
+
+This module diagnoses model error against observations. It complements the
+scenario-to-scenario attribution tools for T2/q2/U10 by treating observations as
+the reference state and model output as the evaluated state.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+from ._core import shapley_binary_product
+from ._helpers import align_scenarios, extract_suews_group
+from ._physics import decompose_flux_budget
+from ._result import AttributionResult
+
+
+FluxVariable = Literal["QE", "QH"]
+
+
+def _normalise_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a flat DataFrame with common SUEWS flux column names."""
+    out = extract_suews_group(df).copy()
+    rename = {col: str(col).upper() for col in out.columns}
+    out = out.rename(columns=rename)
+    return out
+
+
+def _ensure_qs(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure QS is available, using the surface energy residual if needed."""
+    if "QS" not in df.columns:
+        required = {"QN", "QF", "QH", "QE"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(
+                "QS is required or must be derivable from QN + QF - QH - QE; "
+                f"missing columns: {sorted(missing)}"
+            )
+        df = df.copy()
+        df["QS"] = df["QN"] + df["QF"] - df["QH"] - df["QE"]
+    return df
+
+
+def _required_flux_frame(df: pd.DataFrame, label: str) -> pd.DataFrame:
+    df = _ensure_qs(_normalise_columns(df))
+    required = {"QN", "QF", "QH", "QE", "QS"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"{label} is missing required columns: {sorted(missing)}")
+    return df
+
+
+def _available_energy(df: pd.DataFrame) -> np.ndarray:
+    """Available turbulent energy A = QN + QF - QS."""
+    return (df["QN"] + df["QF"] - df["QS"]).to_numpy(dtype=float)
+
+
+def _safe_fraction(numerator: np.ndarray, denominator: np.ndarray, min_energy: float) -> np.ndarray:
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.where(np.abs(denominator) >= min_energy, numerator / denominator, np.nan)
+
+
+def diagnose_flux_performance(
+    df_obs: pd.DataFrame,
+    df_model: pd.DataFrame,
+    variable: FluxVariable = "QE",
+    *,
+    min_energy: float = 1.0,
+) -> AttributionResult:
+    """
+    Attribute model error in QE or QH to energy supply and partitioning.
+
+    The target flux is represented as:
+
+    ``flux = available_energy * flux_fraction``
+
+    where ``available_energy = QN + QF - QS`` and ``flux_fraction`` is either
+    ``QE / available_energy`` or ``QH / available_energy``. The model-observation
+    difference is decomposed exactly with a binary Shapley decomposition:
+
+    ``delta_flux = contribution_available_energy + contribution_partition``
+
+    The available-energy contribution is then allocated to ``QN``, ``QF`` and
+    ``QS`` according to their signed contribution to the available-energy
+    difference.
+
+    Parameters
+    ----------
+    df_obs, df_model
+        Observation and model output data. Columns may be flat or SUEWS
+        MultiIndex output. Required variables are QN, QF, QH, QE and QS. If QS
+        is absent it is derived as QN + QF - QH - QE.
+    variable
+        Flux to diagnose, either ``"QE"`` or ``"QH"``.
+    min_energy
+        Minimum absolute available energy used when calculating flux fractions.
+        Timesteps below this threshold are retained in ``delta_total`` but their
+        component attribution is set to NaN.
+
+    Returns
+    -------
+    AttributionResult
+        Contributions in W m-2. Positive values mean the model is larger than
+        the observation.
+    """
+    if variable not in {"QE", "QH"}:
+        raise ValueError("diagnose_flux_performance currently supports 'QE' and 'QH'")
+
+    obs = _required_flux_frame(df_obs, "df_obs")
+    model = _required_flux_frame(df_model, "df_model")
+    obs, model, common_idx = align_scenarios(obs, model)
+
+    flux_obs = obs[variable].to_numpy(dtype=float)
+    flux_model = model[variable].to_numpy(dtype=float)
+    a_obs = _available_energy(obs)
+    a_model = _available_energy(model)
+
+    fraction_obs = _safe_fraction(flux_obs, a_obs, min_energy)
+    fraction_model = _safe_fraction(flux_model, a_model, min_energy)
+
+    phi_a, phi_fraction = shapley_binary_product(
+        a_obs, a_model, fraction_obs, fraction_model
+    )
+
+    components_obs = {
+        "QN": obs["QN"].to_numpy(dtype=float),
+        "QF": obs["QF"].to_numpy(dtype=float),
+        "QS": -obs["QS"].to_numpy(dtype=float),
+    }
+    components_model = {
+        "QN": model["QN"].to_numpy(dtype=float),
+        "QF": model["QF"].to_numpy(dtype=float),
+        "QS": -model["QS"].to_numpy(dtype=float),
+    }
+    energy_breakdown = decompose_flux_budget(
+        a_obs, a_model, components_obs, components_model, phi_a
+    )
+
+    contributions = pd.DataFrame(
+        {
+            "delta_total": flux_model - flux_obs,
+            "available_energy": phi_a,
+            "partition": phi_fraction,
+            "energy_QN": energy_breakdown["QN"],
+            "energy_QF": energy_breakdown["QF"],
+            "energy_QS": energy_breakdown["QS"],
+            "obs_available_energy": a_obs,
+            "model_available_energy": a_model,
+            "obs_fraction": fraction_obs,
+            "model_fraction": fraction_model,
+        },
+        index=common_idx,
+    )
+    contributions["flag_low_available_energy"] = (
+        (np.abs(a_obs) < min_energy) | (np.abs(a_model) < min_energy)
+    )
+
+    summary = contributions.describe().T[["mean", "std", "min", "max"]]
+    metadata = {
+        "n_timesteps": len(common_idx),
+        "period_start": str(common_idx.min()),
+        "period_end": str(common_idx.max()),
+        "min_energy": min_energy,
+        "n_low_available_energy_flagged": int(
+            contributions["flag_low_available_energy"].sum()
+        ),
+        "unit": "W m-2",
+        "interpretation": "positive contributions mean model exceeds observation",
+    }
+
+    return AttributionResult(
+        variable=variable,
+        contributions=contributions,
+        summary=summary,
+        metadata=metadata,
+    )

--- a/src/supy/util/_attribution/_result.py
+++ b/src/supy/util/_attribution/_result.py
@@ -11,17 +11,21 @@ from typing import Literal, Optional
 import pandas as pd
 
 
-_VAR_SYMBOLS = {"T2": "T2", "q2": "q2", "U10": "U10"}
-_UNITS = {"T2": "degC", "q2": "g/kg", "U10": "m/s"}
+_VAR_SYMBOLS = {"T2": "T2", "q2": "q2", "U10": "U10", "QE": "QE", "QH": "QH"}
+_UNITS = {"T2": "degC", "q2": "g/kg", "U10": "m/s", "QE": "W m-2", "QH": "W m-2"}
 _MAIN_COMPONENTS = {
     "T2": ["T_ref", "flux_total", "resistance", "air_props"],
     "q2": ["q_ref", "flux_total", "resistance", "air_props"],
     "U10": ["forcing", "roughness", "stability"],
+    "QE": ["available_energy", "partition"],
+    "QH": ["available_energy", "partition"],
 }
 _DEFAULT_PLOT_COMPONENTS = {
     "T2": ["flux_total", "resistance", "air_props"],
     "q2": ["flux_total", "resistance", "air_props"],
     "U10": ["forcing", "roughness", "stability"],
+    "QE": ["energy_QN", "energy_QF", "energy_QS", "partition"],
+    "QH": ["energy_QN", "energy_QF", "energy_QS", "partition"],
 }
 
 

--- a/test/physics/test_attribution.py
+++ b/test/physics/test_attribution.py
@@ -21,6 +21,7 @@ import pytest
 
 from supy.util._attribution import (
     AttributionResult,
+    diagnose_flux_performance,
     attribute_t2,
     diagnose_t2,
 )
@@ -257,6 +258,77 @@ class TestFluxBudgetDecomposition(TestCase):
             rtol=1e-10,
             err_msg="Flux budget contributions don't sum to total",
         )
+
+
+class TestFluxPerformanceAttribution(TestCase):
+    """Test model-observation flux performance attribution."""
+
+    def _make_flux_frames(self):
+        idx = pd.date_range("2026-04-01", periods=4, freq="h")
+        obs = pd.DataFrame(
+            {
+                "QN": [200.0, 220.0, 240.0, 180.0],
+                "QF": [20.0, 20.0, 20.0, 20.0],
+                "QS": [100.0, 110.0, 120.0, 90.0],
+                "QE": [30.0, 35.0, 40.0, 25.0],
+                "QH": [90.0, 95.0, 100.0, 85.0],
+            },
+            index=idx,
+        )
+        model = pd.DataFrame(
+            {
+                "QN": [205.0, 225.0, 245.0, 185.0],
+                "QF": [20.0, 20.0, 20.0, 20.0],
+                "QS": [80.0, 85.0, 95.0, 70.0],
+                "QE": [45.0, 55.0, 60.0, 42.0],
+                "QH": [100.0, 105.0, 110.0, 93.0],
+            },
+            index=idx,
+        )
+        return obs, model
+
+    def test_diagnose_flux_performance_closure(self):
+        obs, model = self._make_flux_frames()
+        result = diagnose_flux_performance(obs, model, variable="QE")
+
+        self.assertEqual(result.variable, "QE")
+        total = result.contributions["delta_total"]
+        components = (
+            result.contributions["available_energy"]
+            + result.contributions["partition"]
+        )
+        np.testing.assert_allclose(components, total, rtol=1e-10)
+
+        energy_components = (
+            result.contributions["energy_QN"]
+            + result.contributions["energy_QF"]
+            + result.contributions["energy_QS"]
+        )
+        np.testing.assert_allclose(
+            energy_components,
+            result.contributions["available_energy"],
+            rtol=1e-10,
+        )
+
+    def test_diagnose_flux_performance_derives_qs(self):
+        obs, model = self._make_flux_frames()
+        result = diagnose_flux_performance(
+            obs.drop(columns=["QS"]),
+            model.drop(columns=["QS"]),
+            variable="QH",
+        )
+
+        total = result.contributions["delta_total"]
+        components = (
+            result.contributions["available_energy"]
+            + result.contributions["partition"]
+        )
+        np.testing.assert_allclose(components, total, rtol=1e-10)
+
+    def test_diagnose_flux_performance_rejects_unsupported_variable(self):
+        obs, model = self._make_flux_frames()
+        with self.assertRaises(ValueError):
+            diagnose_flux_performance(obs, model, variable="QS")
 
 
 class TestExtractSuewsGroup(TestCase):


### PR DESCRIPTION
## Summary

- Add `diagnose_flux_performance` for model-observation attribution of QE and QH errors.
- Decompose target flux error into available-energy and partitioning terms, then break available-energy attribution into QN, QF and QS components.
- Support flat or SUEWS MultiIndex output columns, derive QS from the surface energy residual when needed, and expose the tool through `supy.util`.
- Add regression tests for exact closure, QS derivation, and unsupported-variable validation.

## Validation

- `git diff --check`
- `uv run python -m pytest test/physics/test_attribution.py -q` (26 passed)
- `uv run make test-smoke` (12 passed, 1731 deselected)
