### PR TITLE
ci: pin macOS arm64 wheel runner to macos-15

### DIFF
--- a/.github/scripts/determine-matrix.sh
+++ b/.github/scripts/determine-matrix.sh
@@ -43,8 +43,8 @@ INPUT_TEST_TIER="${INPUT_TEST_TIER:-all}"
 GITHUB_REF="${GITHUB_REF:-}"
 
 # Platform presets
-FULL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-15-intel", "macosx", "x86_64"], ["macos-latest", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
-PR_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-latest", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
+FULL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-15-intel", "macosx", "x86_64"], ["macos-15", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
+PR_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-15", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
 MINIMAL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"]]'
 
 # Python version policy.
@@ -153,7 +153,7 @@ elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
       PLATFORMS="["
       [[ "${INPUT_PLAT_LINUX}" == "true" ]] && PLATFORMS+='["ubuntu-latest", "manylinux", "x86_64"],'
       [[ "${INPUT_PLAT_MACOS_INTEL}" == "true" ]] && PLATFORMS+='["macos-15-intel", "macosx", "x86_64"],'
-      [[ "${INPUT_PLAT_MACOS_ARM}" == "true" ]] && PLATFORMS+='["macos-latest", "macosx", "arm64"],'
+      [[ "${INPUT_PLAT_MACOS_ARM}" == "true" ]] && PLATFORMS+='["macos-15", "macosx", "arm64"],'
       [[ "${INPUT_PLAT_WINDOWS}" == "true" ]] && PLATFORMS+='["windows-2025", "win", "AMD64"],'
       PLATFORMS="${PLATFORMS%,}]"
 


### PR DESCRIPTION
## Summary

The `macos-latest` runner rolled to **macOS 26**. Its Homebrew gcc 16.1.0 bottle ships `libgfortran.5.dylib` and `libquadmath.0.dylib` with a minimum target of macOS 26.0. `delocate` bundles these into the arm64 wheel and then rejects the repair, because the wheel is tagged `macosx_15_0`:

```
DelocationError: Library dependencies do not satisfy target MacOS version 15.0:
  .../libgfortran.5.dylib has a minimum target of 26.0
  .../libquadmath.0.dylib has a minimum target of 26.0
```

This currently breaks **`Build standard wheels / cp312-macosx arm64`** and the downstream **`PR build validation`** on every PR (e.g. #1570).

## Fix

Pin the arm64 macOS runner to `macos-15` (Apple Silicon) in `determine-matrix.sh`, so Homebrew serves the macOS 15 gcc bottle whose runtime libraries target 15.0 — matching the wheel tag. `macos-15` is the current stable image, [supported through ~August 2027](https://endoflife.date/github-actions-runner-images), so this is a durable pin, not a stop-gap.

Rejected alternative: setting `MACOSX_DEPLOYMENT_TARGET=26.0` (delocate's own suggestion) would clear the error but tag the wheels `macosx_26_0`, making them installable only on macOS 26+ and breaking the entire current macOS user base.

Notes:
- The Intel `macos-15-intel` runner is unchanged.
- The check name is derived from the build name/arch (`macosx arm64`), not the runner label, so required-check names are unaffected.

## Self-bootstrap caveat

The `Determine build matrix` job checks out `determine-matrix.sh` from `github.event.pull_request.base.sha` (master), so **this PR's own arm64 wheel check runs the old `macos-latest` script and will be red until it merges**. It needs an admin merge past that one check. Once on master, every PR's macOS-arm64 build (including #1570) goes green on the next run.