### PR TITLE
Extend EHC flux diagnostics and coupling tests

### DIFF
--- a/src/suews/src/suews_ctrl_driver.f95
+++ b/src/suews/src/suews_ctrl_driver.f95
@@ -134,6 +134,7 @@ CONTAINS
       REAL(KIND(1D0)) :: ehc_best_iter_score
       REAL(KIND(1D0)) :: ehc_current_iter_score
       LOGICAL :: ehc_final_converge
+      LOGICAL :: use_ehc_experimental_controls
 
       ! Catch stale/mixed build artefacts early with a clear error instead of
       ! allowing downstream out-of-bounds writes.
@@ -142,7 +143,8 @@ CONTAINS
 
       max_iter = max_iter_default
       ehc_restore_best_mode = 0
-      IF (config%StorageHeatMethod == 5) THEN
+      use_ehc_experimental_controls = ehc_experimental_controls_enabled()
+      IF (config%StorageHeatMethod == 5 .AND. use_ehc_experimental_controls) THEN
          CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_MAX_ITER", max_iter_env_value, STATUS=max_iter_env_status)
          IF (max_iter_env_status == 0 .AND. LEN_TRIM(max_iter_env_value) > 0) THEN
             READ (max_iter_env_value, *, IOSTAT=max_iter_env_status) max_iter
@@ -916,6 +918,7 @@ CONTAINS
       REAL(KIND(1D0)), PARAMETER :: tsfc_iter_step_limit = 10.0D0
       CHARACTER(LEN=64) :: env_value
       LOGICAL :: use_building_facets_for_ehc, use_adaptive_relax
+      LOGICAL :: use_ehc_experimental_controls
 
       ASSOCIATE ( &
          flagState => modState%flagState, &
@@ -965,10 +968,11 @@ CONTAINS
             )
 
             use_building_facets_for_ehc = StorageHeatMethod == 5 .AND. NetRadiationMethod > 1000
+            use_ehc_experimental_controls = ehc_experimental_controls_enabled()
             CALL configure_ehc_qf_surface_allocation(StorageHeatMethod, NetRadiationMethod, sfr_surf, qf, forcing%kdown, qf_surf_ehc)
             tsfc_iter_step_limit_use = tsfc_iter_step_limit
             use_adaptive_relax = .FALSE.
-            IF (StorageHeatMethod == 5) THEN
+            IF (StorageHeatMethod == 5 .AND. use_ehc_experimental_controls) THEN
                CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_ADAPTIVE_RELAX", env_value, STATUS=env_status)
                IF (env_status == 0) THEN
                   SELECT CASE (TRIM(ADJUSTL(env_value)))
@@ -1037,7 +1041,7 @@ CONTAINS
             END IF
             dif_qh_iter = 0.0D0
             qh_flux_tol = 5.0D0
-            IF (StorageHeatMethod == 5) THEN
+            IF (StorageHeatMethod == 5 .AND. use_ehc_experimental_controls) THEN
                CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QH_FLUX_TOL", env_value, STATUS=env_status)
                IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
                   READ (env_value, *, IOSTAT=env_status) qh_flux_tol
@@ -1049,7 +1053,7 @@ CONTAINS
             ! ====test===
             ! see if this converges better
             ratio_iter = 0.3D0
-            IF (StorageHeatMethod == 5) THEN
+            IF (StorageHeatMethod == 5 .AND. use_ehc_experimental_controls) THEN
                CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_TSFC_RELAX", env_value, STATUS=env_status)
                IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
                   READ (env_value, *, IOSTAT=env_status) ratio_iter
@@ -3651,7 +3655,7 @@ CONTAINS
                   RA, z0v, & ! output:
                   modState)
 
-               IF (config%StorageHeatMethod == 5) THEN
+               IF (config%StorageHeatMethod == 5 .AND. ehc_experimental_controls_enabled()) THEN
                   ehc_ra_heat_factor = 1.0D0
                   CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_HEAT_FACTOR", env_value, STATUS=env_status)
                   IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
@@ -6187,6 +6191,22 @@ CONTAINS
          tsfc_C = qh/(dens_air*vcp_air)*RA + temp_C
       END FUNCTION cal_tsfc
 
+   LOGICAL FUNCTION ehc_experimental_controls_enabled()
+      IMPLICIT NONE
+      CHARACTER(LEN=32) :: env_value
+      INTEGER :: env_status
+
+      ehc_experimental_controls_enabled = .FALSE.
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_EXPERIMENTAL_CONTROLS", env_value, STATUS=env_status)
+      IF (env_status /= 0) RETURN
+
+      SELECT CASE (TRIM(ADJUSTL(env_value)))
+      CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes", &
+            "on", "ON", "On")
+         ehc_experimental_controls_enabled = .TRUE.
+      END SELECT
+   END FUNCTION ehc_experimental_controls_enabled
+
    SUBROUTINE configure_ehc_qf_surface_allocation(StorageHeatMethod, NetRadiationMethod, sfr_surf, qf, kdown, qf_surf_ehc)
       ! Optional experimental EHC source allocation. The default keeps legacy
       ! behaviour by applying the grid-scale QF to every surface Tsurf residual.
@@ -6213,6 +6233,8 @@ CONTAINS
          ! Building-facet radiation schemes need a roof/wall-specific QF
          ! partition. Keep their legacy behaviour until that partition is defined.
          IF (NetRadiationMethod > 1000) RETURN
+
+         IF (.NOT. ehc_experimental_controls_enabled()) RETURN
 
       qf_surface_mode = "all"
       CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QF_SURF_MODE", env_value, STATUS=env_status)

--- a/src/suews/src/suews_ctrl_driver.f95
+++ b/src/suews/src/suews_ctrl_driver.f95
@@ -120,14 +120,46 @@ CONTAINS
       ! ########################################################################################
 
       TYPE(SUEWS_STATE) :: modState_tstepstart
+      TYPE(SUEWS_STATE) :: modState_best_ehc_iter
 
       ! these local variables are used in iteration
-      INTEGER, PARAMETER :: max_iter = 60 ! maximum number of iteration
+      INTEGER, PARAMETER :: max_iter_default = 60 ! default maximum number of iterations
+      INTEGER :: max_iter
+      INTEGER :: max_iter_env_status
+      INTEGER :: ehc_restore_best_mode
+      INTEGER :: ehc_best_iter
+      INTEGER :: ehc_final_iter
+      CHARACTER(LEN=64) :: max_iter_env_value
+      CHARACTER(LEN=64) :: ehc_restore_best_env_value
+      REAL(KIND(1D0)) :: ehc_best_iter_score
+      REAL(KIND(1D0)) :: ehc_current_iter_score
+      LOGICAL :: ehc_final_converge
 
       ! Catch stale/mixed build artefacts early with a clear error instead of
       ! allowing downstream out-of-bounds writes.
       CALL validate_outputline_layout(outputLine)
       IF (supy_error_flag) RETURN
+
+      max_iter = max_iter_default
+      ehc_restore_best_mode = 0
+      IF (config%StorageHeatMethod == 5) THEN
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_MAX_ITER", max_iter_env_value, STATUS=max_iter_env_status)
+         IF (max_iter_env_status == 0 .AND. LEN_TRIM(max_iter_env_value) > 0) THEN
+            READ (max_iter_env_value, *, IOSTAT=max_iter_env_status) max_iter
+            IF (max_iter_env_status /= 0) max_iter = max_iter_default
+            max_iter = MAX(3, MIN(240, max_iter))
+         END IF
+
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RESTORE_BEST_ITER", ehc_restore_best_env_value, STATUS=max_iter_env_status)
+         IF (max_iter_env_status == 0) THEN
+            SELECT CASE (TRIM(ADJUSTL(ehc_restore_best_env_value)))
+            CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+               ehc_restore_best_mode = 1
+            CASE ("2", "always", "ALWAYS", "Always")
+               ehc_restore_best_mode = 2
+            END SELECT
+         END IF
+      END IF
 
       ! ####################################################################################
       ASSOCIATE ( &
@@ -177,11 +209,13 @@ CONTAINS
 
             ! ############# memory allocation for DTS variables (start) #############
             CALL modState_tstepstart%ALLOCATE(nlayer, ndepth)
+            CALL modState_best_ehc_iter%ALLOCATE(nlayer, ndepth)
             IF (PRESENT(debugState)) THEN
                CALL debugState%init(nlayer, ndepth)
             END IF
             ! save initial values of model states
             modState_tstepstart = modState
+            modState_best_ehc_iter = modState
 
             ! ########################################3
             ! set initial values for output arrays
@@ -262,6 +296,8 @@ CONTAINS
             ! start iteration-based calculation
             ! through iterations, the surface temperature is examined to be converged
             i_iter = 1
+            ehc_best_iter = 0
+            ehc_best_iter_score = HUGE(1.0D0)
             ! max_iter = 30
             DO WHILE (i_iter < 3 .OR. ((.NOT. flag_converge) .AND. (i_iter < max_iter)))
                IF (diagnose == 1) THEN
@@ -273,6 +309,10 @@ CONTAINS
                ! IMPORTANT: restore some initial states as they SHOULD NOT be changed during iterations
                IF (((.NOT. flag_converge) .AND. i_iter > 1) .OR. (flag_converge .AND. i_iter == 2)) THEN
                   CALL modState%check_and_reset_states(modState_tstepstart)
+                  IF (config%StorageHeatMethod == 5) THEN
+                     CALL reset_ehc_heat_state_for_tsurf_iteration( &
+                        modState%heatState, modState_tstepstart%heatState)
+                  END IF
                END IF
                ! ========================================================================================
                !==============main calculation start=======================
@@ -446,6 +486,13 @@ CONTAINS
                END IF
                !============ Sensible heat flux end ===============
 
+               IF (config%StorageHeatMethod == 5) THEN
+                  IF (Diagnose == 1) WRITE (*, *) 'Calling SUEWS_cal_Resistance with EHC residual QH...'
+                  CALL SUEWS_cal_Resistance( &
+                     timer, config, forcing, siteInfo, & ! input
+                     modState) ! input/output:
+               END IF
+
                ! ============ update surface temperature of this iteration ===============
                CALL suews_update_tsurf( &
                   timer, config, forcing, siteInfo, & ! input
@@ -454,13 +501,22 @@ CONTAINS
                   debugState%state_12_tsurf = modState
                END IF
 
+               IF (ehc_restore_best_mode > 0 .AND. config%StorageHeatMethod == 5) THEN
+                  ehc_current_iter_score = modState%heatState%ehc_iter_score
+                  IF (ehc_current_iter_score < ehc_best_iter_score) THEN
+                     ehc_best_iter_score = ehc_current_iter_score
+                     ehc_best_iter = i_iter
+                     modState_best_ehc_iter = modState
+                  END IF
+               END IF
+
 
                ! IF (i_iter == 1) THEN
                !    modState_tstepstart = modState
                ! END IF
                i_iter = i_iter + 1
                IF (i_iter == max_iter .AND. .NOT. flag_converge) THEN
-                  IF (diagnose == 1) PRINT *, 'Iteration did not converge in', i_iter, ' iterations'
+                  IF (diagnose == 1) PRINT *, 'Iteration did not converge in', max_iter, ' iterations'
 
                END IF
                IF (diagnose == 1) PRINT *, '========================='
@@ -468,6 +524,18 @@ CONTAINS
 
                !==============main calculation end=======================
             END DO ! end iteration for tsurf calculations
+
+            IF (ehc_restore_best_mode > 0 .AND. config%StorageHeatMethod == 5 .AND. ehc_best_iter > 0) THEN
+               ehc_current_iter_score = modState%heatState%ehc_iter_score
+               IF ((ehc_restore_best_mode == 2 .OR. .NOT. flag_converge) &
+                   .AND. ehc_best_iter_score + 1.0D-9 < ehc_current_iter_score) THEN
+                  ehc_final_converge = flag_converge
+                  ehc_final_iter = i_iter
+                  modState = modState_best_ehc_iter
+                  flag_converge = ehc_final_converge
+                  i_iter = ehc_final_iter
+               END IF
+            END IF
 
             ! MP: Add test for QH zL signs - recalculate zL if the same
             IF (modState%heatState%QH*modState%atmState%z_l > 0) THEN
@@ -840,8 +908,14 @@ CONTAINS
 
       TYPE(SUEWS_STATE), INTENT(inout) :: modState
 
-      INTEGER :: i_surf, i_layer
-      REAL(KIND(1D0)) :: dif_tsfc_iter, ratio_iter
+      INTEGER :: i_surf, i_layer, env_status
+      REAL(KIND(1D0)) :: dif_tsfc_iter, dif_qh_iter, qh_flux_tol, ratio_iter, qh_resist_iter
+      REAL(KIND(1D0)) :: qh_step_limit, tsfc_flux_step_limit, tsfc_iter_step_limit_use
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: qf_surf_ehc
+      REAL(KIND(1D0)), PARAMETER :: tsfc_air_limit = 50.0D0
+      REAL(KIND(1D0)), PARAMETER :: tsfc_iter_step_limit = 10.0D0
+      CHARACTER(LEN=64) :: env_value
+      LOGICAL :: use_building_facets_for_ehc, use_adaptive_relax
 
       ASSOCIATE ( &
          flagState => modState%flagState, &
@@ -853,7 +927,9 @@ CONTAINS
             flag_converge => flagState%flag_converge, &
             diagnose => config%diagnose, &
             StorageHeatMethod => config%StorageHeatMethod, &
+            NetRadiationMethod => config%NetRadiationMethod, &
             nlayer => siteInfo%nlayer, &
+            sfr_surf => siteInfo%sfr_surf, &
             avdens => atmState%av_density, &
             avcp => atmState%av_cp, &
             RA_h => atmState%RA_h, &
@@ -861,7 +937,24 @@ CONTAINS
             QH_surf => heatState%QH_surf, &
             QH_roof => heatState%QH_roof, &
             QH_wall => heatState%QH_wall, &
+            QN_surf => heatState%QN_surf, &
+            QN_roof => heatState%QN_roof, &
+            QN_wall => heatState%QN_wall, &
+            QS_surf => heatState%QS_surf, &
+            QS_roof => heatState%QS_roof, &
+            QS_wall => heatState%QS_wall, &
+            QE_surf => heatState%QE_surf, &
+            QE_roof => heatState%QE_roof, &
+            QE_wall => heatState%QE_wall, &
+            qf => heatState%qf, &
             qh => heatState%qh, &
+            qh_resist_surf => heatState%qh_resist_surf, &
+            qh_resist_roof => heatState%qh_resist_roof, &
+            qh_resist_wall => heatState%qh_resist_wall, &
+            qh_residual => heatState%qh_residual, &
+            ehc_iter_dif_tsfc => heatState%ehc_iter_dif_tsfc, &
+            ehc_iter_dif_qh => heatState%ehc_iter_dif_qh, &
+            ehc_iter_score => heatState%ehc_iter_score, &
             tsfc0_out_surf => heatState%tsfc_surf_stepstart, &
             tsfc0_out_roof => heatState%tsfc_roof_stepstart, &
             tsfc0_out_wall => heatState%tsfc_wall_stepstart, &
@@ -871,34 +964,163 @@ CONTAINS
             temp_c => forcing%temp_c &
             )
 
-            !============ calculate surface temperature ===============
-            TSfc_C = cal_tsfc(qh, avdens, avcp, RA_h, temp_c)
-
-            !============= calculate surface specific QH and Tsfc ===============
-
-            DO i_surf = 1, nsurf
-               tsfc_surf(i_surf) = cal_tsfc(QH_surf(i_surf), avdens, avcp, RA_h, temp_c)
-            END DO
-
-            DO i_layer = 1, nlayer
-               tsfc_roof(i_layer) = cal_tsfc(QH_roof(i_layer), avdens, avcp, RA_h, temp_c)
-               tsfc_wall(i_layer) = cal_tsfc(QH_wall(i_layer), avdens, avcp, RA_h, temp_c)
-            END DO
-
-            dif_tsfc_iter = MAXVAL(ABS(tsfc_surf - tsfc0_out_surf))
+            use_building_facets_for_ehc = StorageHeatMethod == 5 .AND. NetRadiationMethod > 1000
+            CALL configure_ehc_qf_surface_allocation(StorageHeatMethod, NetRadiationMethod, sfr_surf, qf, forcing%kdown, qf_surf_ehc)
+            tsfc_iter_step_limit_use = tsfc_iter_step_limit
+            use_adaptive_relax = .FALSE.
             IF (StorageHeatMethod == 5) THEN
-               dif_tsfc_iter = MAX(MAXVAL(ABS(tsfc_roof - tsfc0_out_roof)), dif_tsfc_iter)
-               dif_tsfc_iter = MAX(MAXVAL(ABS(tsfc0_out_wall - tsfc_wall)), dif_tsfc_iter)
+               CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_ADAPTIVE_RELAX", env_value, STATUS=env_status)
+               IF (env_status == 0) THEN
+                  SELECT CASE (TRIM(ADJUSTL(env_value)))
+                  CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+                     use_adaptive_relax = .TRUE.
+                  END SELECT
+               END IF
+
+               IF (use_adaptive_relax .AND. RA_h > 0.0D0 .AND. avdens > 0.0D0 .AND. avcp > 0.0D0) THEN
+                  qh_step_limit = 25.0D0
+                  CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_TSFC_STEP_QH_LIMIT", env_value, STATUS=env_status)
+                  IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                     READ (env_value, *, IOSTAT=env_status) qh_step_limit
+                     IF (env_status /= 0) qh_step_limit = 25.0D0
+                  END IF
+                  qh_step_limit = MAX(1.0D0, qh_step_limit)
+                  tsfc_flux_step_limit = qh_step_limit*RA_h/(avdens*avcp)
+                  tsfc_iter_step_limit_use = MIN(tsfc_iter_step_limit, MAX(0.05D0, tsfc_flux_step_limit))
+               END IF
+            END IF
+
+            !============ calculate surface temperature ===============
+            IF (StorageHeatMethod == 5) THEN
+               ! EHC solves QS from the current surface-temperature boundary.
+               ! The next Tsurf iterate is therefore the temperature that would
+               ! make aerodynamic sensible heat match the current surface energy
+               ! residual: QN + QF - QS - QE.
+               TSfc_C = cal_tsfc(qh_residual, avdens, avcp, RA_h, temp_c)
+
+                  DO i_surf = 1, nsurf
+                     tsfc_surf(i_surf) = cal_tsfc( &
+                        QN_surf(i_surf) + qf_surf_ehc(i_surf) - QS_surf(i_surf) - QE_surf(i_surf), &
+                        avdens, avcp, RA_h, temp_c)
+                  END DO
+
+               IF (use_building_facets_for_ehc) THEN
+                  DO i_layer = 1, nlayer
+                     ! QF is a grid-scale anthropogenic heat source. Do not
+                     ! inject the full grid QF into every roof/wall facet as a
+                     ! conductive boundary; doing so over-forces facet storage.
+                     tsfc_roof(i_layer) = cal_tsfc( &
+                        QN_roof(i_layer) - QS_roof(i_layer) - QE_roof(i_layer), &
+                        avdens, avcp, RA_h, temp_c)
+                     tsfc_wall(i_layer) = cal_tsfc( &
+                        QN_wall(i_layer) - QS_wall(i_layer) - QE_wall(i_layer), &
+                        avdens, avcp, RA_h, temp_c)
+                  END DO
+               END IF
+            ELSE
+               TSfc_C = cal_tsfc(qh, avdens, avcp, RA_h, temp_c)
+
+               !============= calculate surface specific QH and Tsfc ===============
+
+               DO i_surf = 1, nsurf
+                  tsfc_surf(i_surf) = cal_tsfc(QH_surf(i_surf), avdens, avcp, RA_h, temp_c)
+               END DO
+
+               DO i_layer = 1, nlayer
+                  tsfc_roof(i_layer) = cal_tsfc(QH_roof(i_layer), avdens, avcp, RA_h, temp_c)
+                  tsfc_wall(i_layer) = cal_tsfc(QH_wall(i_layer), avdens, avcp, RA_h, temp_c)
+               END DO
+            END IF
+
+            IF (StorageHeatMethod /= 5) THEN
+               dif_tsfc_iter = MAXVAL(ABS(tsfc_surf - tsfc0_out_surf))
+            END IF
+            dif_qh_iter = 0.0D0
+            qh_flux_tol = 5.0D0
+            IF (StorageHeatMethod == 5) THEN
+               CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QH_FLUX_TOL", env_value, STATUS=env_status)
+               IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                  READ (env_value, *, IOSTAT=env_status) qh_flux_tol
+                  IF (env_status /= 0) qh_flux_tol = 5.0D0
+                  qh_flux_tol = MAX(0.1D0, qh_flux_tol)
+               END IF
             END IF
 
             ! ====test===
             ! see if this converges better
-            ! ratio_iter = 1
-            ratio_iter = .3
-            tsfc_surf = (tsfc0_out_surf*(1 - ratio_iter) + tsfc_surf*ratio_iter)
+            ratio_iter = 0.3D0
             IF (StorageHeatMethod == 5) THEN
+               CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_TSFC_RELAX", env_value, STATUS=env_status)
+               IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                  READ (env_value, *, IOSTAT=env_status) ratio_iter
+                  IF (env_status /= 0) ratio_iter = 0.3D0
+                  ratio_iter = MAX(0.05D0, MIN(1.0D0, ratio_iter))
+               END IF
+            END IF
+            tsfc_surf = (tsfc0_out_surf*(1 - ratio_iter) + tsfc_surf*ratio_iter)
+            IF (use_building_facets_for_ehc) THEN
                tsfc_roof = (tsfc0_out_roof*(1 - ratio_iter) + tsfc_roof*ratio_iter)
                tsfc_wall = (tsfc0_out_wall*(1 - ratio_iter) + tsfc_wall*ratio_iter)
+            END IF
+
+            IF (StorageHeatMethod == 5) THEN
+               ! The EHC Tsurf update is a fixed-point iterate inferred from the
+               ! residual sensible heat flux. Keep that numerical iterate within
+               ! a physical envelope so a bad residual cannot pollute heat or
+               ! water states before convergence is reached.
+               TSfc_C = MAX(MIN(TSfc_C, temp_c + tsfc_air_limit), temp_c - tsfc_air_limit)
+               tsfc_surf = MAX(MIN(tsfc_surf, tsfc0_out_surf + tsfc_iter_step_limit_use), &
+                                tsfc0_out_surf - tsfc_iter_step_limit_use)
+               tsfc_surf = MAX(MIN(tsfc_surf, temp_c + tsfc_air_limit), temp_c - tsfc_air_limit)
+               IF (use_building_facets_for_ehc) THEN
+                  tsfc_roof = MAX(MIN(tsfc_roof, tsfc0_out_roof + tsfc_iter_step_limit_use), &
+                                  tsfc0_out_roof - tsfc_iter_step_limit_use)
+                  tsfc_wall = MAX(MIN(tsfc_wall, tsfc0_out_wall + tsfc_iter_step_limit_use), &
+                                  tsfc0_out_wall - tsfc_iter_step_limit_use)
+                  tsfc_roof = MAX(MIN(tsfc_roof, temp_c + tsfc_air_limit), temp_c - tsfc_air_limit)
+                  tsfc_wall = MAX(MIN(tsfc_wall, temp_c + tsfc_air_limit), temp_c - tsfc_air_limit)
+               END IF
+
+               ! Convergence must be tested against the state that is actually
+               ! carried into the next iteration, after relaxation and physical
+               ! limiting. Testing the raw fixed-point proposal can report
+               ! non-convergence even when the applied update is already small.
+               dif_tsfc_iter = MAXVAL(ABS(tsfc_surf - tsfc0_out_surf))
+               IF (use_building_facets_for_ehc) THEN
+                  dif_tsfc_iter = MAX(MAXVAL(ABS(tsfc_roof - tsfc0_out_roof)), dif_tsfc_iter)
+                  dif_tsfc_iter = MAX(MAXVAL(ABS(tsfc0_out_wall - tsfc_wall)), dif_tsfc_iter)
+               END IF
+
+               IF (RA_h /= 0.0D0 .AND. avdens > 0.0D0 .AND. avcp > 0.0D0) THEN
+                  DO i_surf = 1, nsurf
+                        qh_resist_iter = avdens*avcp*(tsfc_surf(i_surf) - temp_c)/RA_h
+                        dif_qh_iter = MAX(dif_qh_iter, ABS( &
+                           QN_surf(i_surf) + qf_surf_ehc(i_surf) - QS_surf(i_surf) - QE_surf(i_surf) - qh_resist_iter))
+                     END DO
+                  IF (use_building_facets_for_ehc) THEN
+                     DO i_layer = 1, nlayer
+                        qh_resist_iter = avdens*avcp*(tsfc_roof(i_layer) - temp_c)/RA_h
+                        dif_qh_iter = MAX(dif_qh_iter, ABS( &
+                           QN_roof(i_layer) - QS_roof(i_layer) - QE_roof(i_layer) - qh_resist_iter))
+                        qh_resist_iter = avdens*avcp*(tsfc_wall(i_layer) - temp_c)/RA_h
+                        dif_qh_iter = MAX(dif_qh_iter, ABS( &
+                           QN_wall(i_layer) - QS_wall(i_layer) - QE_wall(i_layer) - qh_resist_iter))
+                     END DO
+                  END IF
+               END IF
+
+               TSfc_C = DOT_PRODUCT(tsfc_surf, sfr_surf)
+               ehc_iter_dif_tsfc = dif_tsfc_iter
+               ehc_iter_dif_qh = dif_qh_iter
+               IF (RA_h > 0.0D0 .AND. avdens > 0.0D0 .AND. avcp > 0.0D0) THEN
+                  ehc_iter_score = MAX(dif_qh_iter, avdens*avcp*dif_tsfc_iter/RA_h)
+               ELSE
+                  ehc_iter_score = MAX(dif_qh_iter, dif_tsfc_iter)
+               END IF
+            ELSE
+               ehc_iter_dif_tsfc = dif_tsfc_iter
+               ehc_iter_dif_qh = 0.0D0
+               ehc_iter_score = dif_tsfc_iter
             END IF
             ! =======test end=======
 
@@ -909,7 +1131,7 @@ CONTAINS
 
             ! Test if sensible heat fluxes converge in iterations
             ! MP Testing 0.1 -> 0.05
-            IF (dif_tsfc_iter > .05) THEN
+            IF (dif_tsfc_iter > .05 .OR. dif_qh_iter > qh_flux_tol) THEN
                flag_converge = .FALSE.
             ELSE
                flag_converge = .TRUE.
@@ -918,10 +1140,18 @@ CONTAINS
                ! PRINT *, ' abs. dif_tsfc: ', dif_tsfc_iter
             END IF
 
-            ! note: tsfc has an upper limit of temp_c+50 to avoid numerical errors
-            tsfc0_out_surf = MIN(tsfc_surf, Temp_C + 50)
-            tsfc0_out_roof = MIN(tsfc_roof, Temp_C + 50)
-            tsfc0_out_wall = MIN(tsfc_wall, Temp_C + 50)
+            IF (StorageHeatMethod == 5) THEN
+               ! EHC keeps the fixed-point iterate inside a symmetric physical
+               ! envelope around air temperature.
+               tsfc0_out_surf = MAX(MIN(tsfc_surf, Temp_C + tsfc_air_limit), Temp_C - tsfc_air_limit)
+               tsfc0_out_roof = MAX(MIN(tsfc_roof, Temp_C + tsfc_air_limit), Temp_C - tsfc_air_limit)
+               tsfc0_out_wall = MAX(MIN(tsfc_wall, Temp_C + tsfc_air_limit), Temp_C - tsfc_air_limit)
+            ELSE
+               ! Preserve the legacy non-EHC upper cap exactly.
+               tsfc0_out_surf = MIN(tsfc_surf, Temp_C + 50)
+               tsfc0_out_roof = MIN(tsfc_roof, Temp_C + 50)
+               tsfc0_out_wall = MIN(tsfc_wall, Temp_C + 50)
+            END IF
          END ASSOCIATE
       END ASSOCIATE
 
@@ -2154,7 +2384,7 @@ CONTAINS
                      tsfc_surf, tin_surf, temp_in_surf, k_surf, cp_surf, dz_surf, sfr_surf, & !input
                      heatState%temp_roof, QS_roof, & !output
                      heatState%temp_wall, QS_wall, & !output
-                     heatState%temp_surf, QS_surf, & !output
+                     heatState%temp_surf, heatState%temp_surf_ehc_fast, heatState%temp_surf_ehc_slow, QS_surf, & !output
                      QS) !output
 
                   ! TODO: add deltaQi to output for snow heat storage
@@ -2779,6 +3009,7 @@ CONTAINS
       REAL(KIND(1D0)), DIMENSION(nsurf) :: qn_e_surf !net available energy for evaporation for each surface[W m-2]
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: qn_e_roof !net available energy for evaporation for roof[W m-2]
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: qn_e_wall !net available energy for evaporation for wall[W m-2]
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: qf_surf_ehc
 
       REAL(KIND(1D0)) :: pin !Rain per time interval
       REAL(KIND(1D0)) :: tlv !Latent heat of vapourisation per timestep [J kg-1 s-1]
@@ -2955,10 +3186,12 @@ CONTAINS
                qe0_surf = 0
 
                IF (Diagnose == 1) WRITE (*, *) 'Calling evap_SUEWS and SoilStore...'
-               ! == calculate QE ==
-               ! --- general suews surfaces ---
-               ! net available energy for evaporation
-               qn_e_surf = qn_surf + qf - qs_surf ! qn1 changed to qn1_snowfree, lj in May 2013
+                  ! == calculate QE ==
+                  ! --- general suews surfaces ---
+                  ! net available energy for evaporation
+                  CALL configure_ehc_qf_surface_allocation( &
+                     storageheatmethod, config%NetRadiationMethod, sfr_surf, qf, forcing%kdown, qf_surf_ehc)
+                  qn_e_surf = qn_surf + qf_surf_ehc - qs_surf ! qn1 changed to qn1_snowfree, lj in May 2013
 
                ! soil store capacity
                capStore_surf = StoreDrainPrm(6, :)
@@ -2970,18 +3203,18 @@ CONTAINS
 
                ! MP: Use EHC
                IF (storageheatmethod == 5 .AND. use_building_facets_for_ehc) THEN
-                  ! --- roofs ---
-                  ! net available energy for evaporation
-                  qn_e_roof = qn_roof + qf - qs_roof ! qn1 changed to qn1_snowfree, lj in May 2013
+                     ! --- roofs ---
+                     ! net available energy for evaporation
+                     qn_e_roof = qn_roof - qs_roof ! qn1 changed to qn1_snowfree, lj in May 2013
                   CALL cal_evap_multi( &
                      EvapMethod, & !input
                      sfr_roof, state_roof_in, WetThresh_roof, statelimit_roof, & !input
                      vpd_hPa, avdens, avcp, qn_e_roof, s_hPa, psyc_hPa, RS, RA_h, RB, tlv, &
                      rss_roof, ev_roof, qe_roof) !output
 
-                  ! --- walls ---
-                  ! net available energy for evaporation
-                  qn_e_wall = qn_wall + qf - qs_wall ! qn1 changed to qn1_snowfree, lj in May 2013
+                     ! --- walls ---
+                     ! net available energy for evaporation
+                     qn_e_wall = qn_wall - qs_wall ! qn1 changed to qn1_snowfree, lj in May 2013
                   CALL cal_evap_multi( &
                      EvapMethod, & !input
                      sfr_wall, state_wall_in, WetThresh_wall, statelimit_wall, & !input
@@ -3119,10 +3352,9 @@ CONTAINS
 
       TYPE(SUEWS_STATE), INTENT(inout) :: modState
 
-      INTEGER, PARAMETER :: qhMethod = 1 ! 1 = the redidual method; 2 = the resistance method
-
-      REAL(KIND(1D0)), PARAMETER :: NAN = -999
       INTEGER :: is
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: qf_surf_ehc
+      LOGICAL :: use_building_facets_for_ehc
 
       ASSOCIATE ( &
          snowState => modState%snowState, &
@@ -3188,6 +3420,7 @@ CONTAINS
             qs_wall => heatState%qs_wall, &
             SMDMethod => config%SMDMethod, &
             storageheatmethod => config%StorageHeatMethod, &
+            NetRadiationMethod => config%NetRadiationMethod, &
             Diagnose => config%Diagnose &
             )
             ! tsfc_surf = heatState_out%tsfc_surf
@@ -3195,59 +3428,65 @@ CONTAINS
             ! tsfc_wall = heatState_out%tsfc_wall
 
             ! sfr_surf = [pavedPrm%sfr, bldgPrm%sfr, evetrPrm%sfr, dectrPrm%sfr, grassPrm%sfr, bsoilPrm%sfr, waterPrm%sfr]
-            ! Calculate sensible heat flux as a residual (Modified by LJ in Nov 2012)
-            ! choose output QH
-            SELECT CASE (QHMethod)
-            CASE (1)
-               qh_residual = (qn + qf + QmRain) - (qe + qs + Qm + QmFreez) !qh=(qn1+qf+QmRain+QmFreez)-(qeOut+qs+Qm)
-               ! Testing: qh_resist here is a dummy test - difference in QH per cycle
-!                   IF ((QH / QE) < 1) THEN
-!                         qh_resist = qh - qh_residual
-!                         qs = qs - qh_resist
-!                         ! Dumping energy into QS
-!                         qh_residual = (qn + qf + QmRain) - (qe + qs + Qm + QmFreez)
-!                   END IF
-               qh = qh_residual
-            CASE (2)
-               ! ! Calculate QH using resistance method (for testing HCW 06 Jul 2016)
-               ! Aerodynamic-Resistance-based method
+            use_building_facets_for_ehc = storageheatmethod == 5 .AND. NetRadiationMethod > 1000
+            CALL configure_ehc_qf_surface_allocation(storageheatmethod, NetRadiationMethod, sfr_surf, qf, forcing%kdown, qf_surf_ehc)
+            qh_residual = (qn + qf + QmRain) - (qe + qs + Qm + QmFreez) !qh=(qn1+qf+QmRain+QmFreez)-(qeOut+qs+Qm)
+
+            ! Calculate resistance-based QH as the physical counterpart to the
+            ! residual-driven Tsurf fixed point. For EHC, converged residual and
+            ! resistance fluxes should match; the residual remains available as
+            ! a closure diagnostic.
+            IF (RA_h /= 0 .AND. avdens > 0 .AND. avcp > 0) THEN
                DO is = 1, nsurf
-                  IF (RA_h /= 0) THEN
-                     qh_resist_surf(is) = avdens*avcp*(tsfc_surf(is) - Temp_C)/RA_h
-                  ELSE
-                     qh_resist_surf(is) = NAN
-                  END IF
+                  qh_resist_surf(is) = avdens*avcp*(tsfc_surf(is) - Temp_C)/RA_h
                END DO
-               IF (storageheatmethod == 5) THEN
+               IF (use_building_facets_for_ehc) THEN
                   DO is = 1, nlayer
-                     IF (RA_h /= 0) THEN
-                        qh_resist_roof(is) = avdens*avcp*(tsfc_roof(is) - Temp_C)/RA_h
-                        qh_resist_wall(is) = avdens*avcp*(tsfc_wall(is) - Temp_C)/RA_h
-                     ELSE
-                        qh_resist_surf(is) = NAN
-                     END IF
+                     qh_resist_roof(is) = avdens*avcp*(tsfc_roof(is) - Temp_C)/RA_h
+                     qh_resist_wall(is) = avdens*avcp*(tsfc_wall(is) - Temp_C)/RA_h
                   END DO
 
-                  ! IF (RA /= 0) THEN
-                  !    qh_resist = avdens*avcp*(tsurf - Temp_C)/RA
-                  ! ELSE
-                  !    qh_resist = NAN
-                  ! END IF
-                  ! aggregate QH of roof and wall
-                  qh_resist_surf(BldgSurf) = (DOT_PRODUCT(qh_resist_roof, sfr_roof) + DOT_PRODUCT(qh_resist_wall, sfr_wall))/2.
+                  ! Aggregate building-facet QH with the same area weighting
+                  ! used by EHC for building QS.
+                  IF (sfr_surf(BldgSurf) > 1.0D-8) THEN
+                     qh_resist_surf(BldgSurf) = &
+                        (DOT_PRODUCT(qh_resist_roof, sfr_roof) + DOT_PRODUCT(qh_resist_wall, sfr_wall)) &
+                        /sfr_surf(BldgSurf)
+                  ELSE
+                     qh_resist_surf(BldgSurf) = 0.0D0
+                  END IF
                END IF
-
-               ! MP: TODO - Check if this works correctly
                qh_resist = DOT_PRODUCT(qh_resist_surf, sfr_surf)
+            ELSE
+               qh_resist_surf = QN_surf + qf_surf_ehc - qs_surf - qe_surf
+               IF (use_building_facets_for_ehc) THEN
+                  qh_resist_roof = QN_roof - qs_roof - qe_roof
+                  qh_resist_wall = QN_wall - qs_wall - qe_wall
+               ELSE
+                  qh_resist_roof = QN_roof + qf - qs_roof - qe_roof
+                  qh_resist_wall = QN_wall + qf - qs_wall - qe_wall
+               END IF
+               qh_resist = qh_residual
+            END IF
 
-               qh = qh_resist
-            END SELECT
-
-            ! update QH of all facets
-            QH_surf = QN_surf + qf - qs_surf - qe_surf
-            QH_roof = QN_roof + qf - qs_roof - qe_roof
-            QH_wall = QN_wall + qf - qs_wall - qe_wall
-            !END SELECT
+            ! Preserve the legacy residual QH output for energy closure. The
+            ! resistance flux is retained as a convergence/diagnostic companion.
+            qh = qh_residual
+            QH_surf = QN_surf + qf_surf_ehc - qs_surf - qe_surf
+            IF (use_building_facets_for_ehc) THEN
+               QH_roof = QN_roof - qs_roof - qe_roof
+               QH_wall = QN_wall - qs_wall - qe_wall
+               IF (sfr_surf(BldgSurf) > 1.0D-8) THEN
+                  QH_surf(BldgSurf) = &
+                     (DOT_PRODUCT(QH_roof, sfr_roof) + DOT_PRODUCT(QH_wall, sfr_wall)) &
+                     /sfr_surf(BldgSurf)
+               ELSE
+                  QH_surf(BldgSurf) = 0.0D0
+               END IF
+            ELSE
+               QH_roof = QN_roof + qf - qs_roof - qe_roof
+               QH_wall = QN_wall + qf - qs_wall - qe_wall
+            END IF
             qh_init = qh
 
          END ASSOCIATE
@@ -3282,6 +3521,20 @@ CONTAINS
       INTEGER, PARAMETER :: AerodynamicResistanceMethod = 2 !method to calculate RA [-]
 
       REAL(KIND(1D0)) :: Tair ! air temperature [degC]
+      REAL(KIND(1D0)) :: ehc_ra_heat_factor
+      REAL(KIND(1D0)) :: ehc_ra_heat_max_factor
+      REAL(KIND(1D0)) :: ehc_ra_state_boost
+      REAL(KIND(1D0)) :: ehc_ra_state_kdown_min
+      REAL(KIND(1D0)) :: ehc_ra_state_kdown_ref
+      REAL(KIND(1D0)) :: ehc_ra_state_low_ra_ref
+      REAL(KIND(1D0)) :: ehc_ra_state_ustar_ref
+      REAL(KIND(1D0)) :: ehc_ra_low_kdown_weight
+      REAL(KIND(1D0)) :: ehc_ra_low_ra_weight
+      REAL(KIND(1D0)) :: ehc_ra_high_ustar_weight
+      REAL(KIND(1D0)) :: ehc_ra_overcoupled_signal
+      INTEGER :: env_status
+      CHARACTER(LEN=64) :: env_value
+      CHARACTER(LEN=64) :: ehc_ra_heat_mode
 
       ASSOCIATE ( &
          phenState => modState%phenState, &
@@ -3397,6 +3650,84 @@ CONTAINS
                   RoughLenHeatMethod, &
                   RA, z0v, & ! output:
                   modState)
+
+               IF (config%StorageHeatMethod == 5) THEN
+                  ehc_ra_heat_factor = 1.0D0
+                  CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_HEAT_FACTOR", env_value, STATUS=env_status)
+                  IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                     READ (env_value, *, IOSTAT=env_status) ehc_ra_heat_factor
+                     IF (env_status /= 0) ehc_ra_heat_factor = 1.0D0
+                  END IF
+
+                  ehc_ra_heat_max_factor = 3.0D0
+                  CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_HEAT_MAX_FACTOR", env_value, STATUS=env_status)
+                  IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                     READ (env_value, *, IOSTAT=env_status) ehc_ra_heat_max_factor
+                     IF (env_status /= 0) ehc_ra_heat_max_factor = 3.0D0
+                  END IF
+                  ehc_ra_heat_max_factor = MAX(0.5D0, MIN(4.0D0, ehc_ra_heat_max_factor))
+
+                  ehc_ra_heat_mode = ""
+                  CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_HEAT_MODE", ehc_ra_heat_mode, STATUS=env_status)
+                  SELECT CASE (TRIM(ADJUSTL(ehc_ra_heat_mode)))
+                  CASE ("overcoupled_guard", "OVERCOUPLED_GUARD", "state_guard", "STATE_GUARD")
+                     ehc_ra_state_boost = 0.75D0
+                     CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_STATE_BOOST", env_value, STATUS=env_status)
+                     IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                        READ (env_value, *, IOSTAT=env_status) ehc_ra_state_boost
+                        IF (env_status /= 0) ehc_ra_state_boost = 0.75D0
+                     END IF
+                     ehc_ra_state_boost = MAX(0.0D0, MIN(2.0D0, ehc_ra_state_boost))
+
+                     ehc_ra_state_kdown_min = 10.0D0
+                     CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_STATE_KDOWN_MIN", env_value, STATUS=env_status)
+                     IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                        READ (env_value, *, IOSTAT=env_status) ehc_ra_state_kdown_min
+                        IF (env_status /= 0) ehc_ra_state_kdown_min = 10.0D0
+                     END IF
+                     ehc_ra_state_kdown_min = MAX(0.0D0, ehc_ra_state_kdown_min)
+
+                     ehc_ra_state_kdown_ref = 250.0D0
+                     CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_STATE_KDOWN_REF", env_value, STATUS=env_status)
+                     IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                        READ (env_value, *, IOSTAT=env_status) ehc_ra_state_kdown_ref
+                        IF (env_status /= 0) ehc_ra_state_kdown_ref = 250.0D0
+                     END IF
+                     ehc_ra_state_kdown_ref = MAX(1.0D0, ehc_ra_state_kdown_ref)
+
+                     ehc_ra_state_low_ra_ref = 60.0D0
+                     CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_STATE_LOW_RA_REF", env_value, STATUS=env_status)
+                     IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                        READ (env_value, *, IOSTAT=env_status) ehc_ra_state_low_ra_ref
+                        IF (env_status /= 0) ehc_ra_state_low_ra_ref = 60.0D0
+                     END IF
+                     ehc_ra_state_low_ra_ref = MAX(1.0D0, ehc_ra_state_low_ra_ref)
+
+                     ehc_ra_state_ustar_ref = 0.60D0
+                     CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_RA_STATE_USTAR_REF", env_value, STATUS=env_status)
+                     IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+                        READ (env_value, *, IOSTAT=env_status) ehc_ra_state_ustar_ref
+                        IF (env_status /= 0) ehc_ra_state_ustar_ref = 0.60D0
+                     END IF
+                     ehc_ra_state_ustar_ref = MAX(0.01D0, ehc_ra_state_ustar_ref)
+
+                     ehc_ra_overcoupled_signal = 0.0D0
+                     IF (avkdn >= ehc_ra_state_kdown_min) THEN
+                        ehc_ra_low_kdown_weight = MAX(0.0D0, MIN(1.0D0, &
+                           (ehc_ra_state_kdown_ref - avkdn)/ehc_ra_state_kdown_ref))
+                        ehc_ra_low_ra_weight = MAX(0.0D0, MIN(1.0D0, &
+                           (ehc_ra_state_low_ra_ref - RA)/ehc_ra_state_low_ra_ref))
+                        ehc_ra_high_ustar_weight = MAX(0.0D0, MIN(1.0D0, &
+                           (UStar - ehc_ra_state_ustar_ref)/ehc_ra_state_ustar_ref))
+                        ehc_ra_overcoupled_signal = MAX(ehc_ra_low_kdown_weight, &
+                           SQRT(MAX(0.0D0, ehc_ra_low_ra_weight*ehc_ra_high_ustar_weight)))
+                     END IF
+                     ehc_ra_heat_factor = ehc_ra_heat_factor*(1.0D0 + ehc_ra_state_boost*ehc_ra_overcoupled_signal)
+                  END SELECT
+
+                  ehc_ra_heat_factor = MAX(0.5D0, MIN(ehc_ra_heat_max_factor, ehc_ra_heat_factor))
+                  RA = MAX(10.0D0, MIN(120.0D0, ehc_ra_heat_factor*RA))
+               END IF
 
                IF (SnowUse == 1) THEN
                   IF (Diagnose == 1) WRITE (*, *) 'Calling AerodynamicResistance for snow...'
@@ -5383,6 +5714,8 @@ CONTAINS
       heatState%temp_roof = temp_roof
       heatState%temp_wall = temp_wall
       heatState%temp_surf = temp_surf
+      heatState%temp_surf_ehc_fast = temp_surf
+      heatState%temp_surf_ehc_slow = temp_surf
       heatState%temp_surf_dyohm = MetForcingBlock(1, 12) !initialised temperature
       heatState%tsfc_roof = tsfc_roof
       heatState%tsfc_wall = tsfc_wall
@@ -5851,8 +6184,121 @@ CONTAINS
 
       REAL(KIND(1D0)) :: tsfc_C ! surface temperature [C]
 
-      tsfc_C = qh/(dens_air*vcp_air)*RA + temp_C
-   END FUNCTION cal_tsfc
+         tsfc_C = qh/(dens_air*vcp_air)*RA + temp_C
+      END FUNCTION cal_tsfc
+
+   SUBROUTINE configure_ehc_qf_surface_allocation(StorageHeatMethod, NetRadiationMethod, sfr_surf, qf, kdown, qf_surf_ehc)
+      ! Optional experimental EHC source allocation. The default keeps legacy
+      ! behaviour by applying the grid-scale QF to every surface Tsurf residual.
+      ! Alternative modes test whether anthropogenic heat acts mainly as an
+      ! impervious-surface source or as direct heat to the canyon air rather than
+      ! a conductive surface boundary.
+         INTEGER, INTENT(IN) :: StorageHeatMethod
+         INTEGER, INTENT(IN) :: NetRadiationMethod
+      REAL(KIND(1D0)), DIMENSION(nsurf), INTENT(IN) :: sfr_surf
+      REAL(KIND(1D0)), INTENT(IN) :: qf
+      REAL(KIND(1D0)), INTENT(IN) :: kdown
+      REAL(KIND(1D0)), DIMENSION(nsurf), INTENT(OUT) :: qf_surf_ehc
+
+      CHARACTER(LEN=64) :: env_value
+      INTEGER :: env_status
+      LOGICAL :: use_impervious_qf
+      CHARACTER(LEN=32) :: qf_surface_mode
+      REAL(KIND(1D0)) :: qf_day_fraction, qf_night_fraction, qf_kdown_ref, qf_surface_fraction
+      REAL(KIND(1D0)) :: impervious_fraction
+
+         qf_surf_ehc = qf
+         IF (StorageHeatMethod /= 5) RETURN
+
+         ! Building-facet radiation schemes need a roof/wall-specific QF
+         ! partition. Keep their legacy behaviour until that partition is defined.
+         IF (NetRadiationMethod > 1000) RETURN
+
+      qf_surface_mode = "all"
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QF_SURF_MODE", env_value, STATUS=env_status)
+      IF (env_status == 0) THEN
+         SELECT CASE (TRIM(ADJUSTL(env_value)))
+         CASE ("none", "NONE", "None", "air", "AIR", "direct_air", "DIRECT_AIR", "0")
+            qf_surface_mode = "none"
+         CASE ("daylight", "DAYLIGHT", "Daylight", "radiation", "RADIATION", "kdown", "KDOWN")
+            qf_surface_mode = "daylight"
+         CASE ("impervious", "IMPERVIOUS", "Impervious", "paved_bldgs", "PAVED_BLDGS")
+            qf_surface_mode = "impervious"
+         CASE ("all", "ALL", "All", "1", "true", "TRUE", "True", "yes", "YES", "Yes")
+            qf_surface_mode = "all"
+         END SELECT
+      END IF
+
+      use_impervious_qf = qf_surface_mode == "impervious"
+      IF (qf_surface_mode == "all") THEN
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QF_IMPERVIOUS_ONLY", env_value, STATUS=env_status)
+         IF (env_status == 0) THEN
+            SELECT CASE (TRIM(ADJUSTL(env_value)))
+            CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+               use_impervious_qf = .TRUE.
+            END SELECT
+         END IF
+      END IF
+
+      IF (qf_surface_mode == "none") THEN
+         qf_surf_ehc = 0.0D0
+         RETURN
+      END IF
+
+      IF (qf_surface_mode == "daylight") THEN
+         qf_day_fraction = 1.0D0
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QF_SURF_DAY_FRAC", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) qf_day_fraction
+            IF (env_status /= 0) qf_day_fraction = 1.0D0
+         END IF
+         qf_day_fraction = MAX(0.0D0, MIN(1.0D0, qf_day_fraction))
+
+         qf_night_fraction = 0.0D0
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QF_SURF_NIGHT_FRAC", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) qf_night_fraction
+            IF (env_status /= 0) qf_night_fraction = 0.0D0
+         END IF
+         qf_night_fraction = MAX(0.0D0, MIN(1.0D0, qf_night_fraction))
+
+         qf_kdown_ref = 150.0D0
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QF_SURF_KDOWN_REF", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) qf_kdown_ref
+            IF (env_status /= 0) qf_kdown_ref = 150.0D0
+         END IF
+         qf_kdown_ref = MAX(1.0D0, qf_kdown_ref)
+
+         qf_surface_fraction = qf_night_fraction &
+                               + (qf_day_fraction - qf_night_fraction)*MAX(0.0D0, MIN(1.0D0, kdown/qf_kdown_ref))
+         qf_surf_ehc = qf*qf_surface_fraction
+         RETURN
+      END IF
+
+      IF (.NOT. use_impervious_qf) RETURN
+
+      impervious_fraction = sfr_surf(PavSurf) + sfr_surf(BldgSurf)
+      IF (impervious_fraction <= 1.0D-8) RETURN
+
+         qf_surf_ehc = 0.0D0
+         qf_surf_ehc(PavSurf) = qf/impervious_fraction
+         qf_surf_ehc(BldgSurf) = qf/impervious_fraction
+      END SUBROUTINE configure_ehc_qf_surface_allocation
+
+      SUBROUTINE reset_ehc_heat_state_for_tsurf_iteration(state_iter, state_stepstart)
+         ! Restore EHC material temperatures to the beginning of the physical
+         ! time step while retaining the current surface-temperature iterate and
+      ! the fluxes calculated in the current iteration.
+      TYPE(HEAT_STATE), INTENT(INOUT) :: state_iter
+      TYPE(HEAT_STATE), INTENT(IN) :: state_stepstart
+
+      state_iter%temp_roof = state_stepstart%temp_roof
+      state_iter%temp_wall = state_stepstart%temp_wall
+      state_iter%temp_surf = state_stepstart%temp_surf
+      state_iter%temp_surf_ehc_fast = state_stepstart%temp_surf_ehc_fast
+      state_iter%temp_surf_ehc_slow = state_stepstart%temp_surf_ehc_slow
+   END SUBROUTINE reset_ehc_heat_state_for_tsurf_iteration
 
 FUNCTION cal_tsfc_dyohm(Temp_in, Qs, K, C, z, nz, T_bottom, dt) RESULT(Temp_out)
     !--------------------------------------------------------------------

--- a/src/suews/src/suews_phys_ehc.f95
+++ b/src/suews/src/suews_phys_ehc.f95
@@ -427,7 +427,7 @@ CONTAINS
       tsfc_surf, tin_surf, temp_in_surf, k_surf, cp_surf, dz_surf, sfr_surf, & !input
       temp_out_roof, QS_roof, & !output
       temp_out_wall, QS_wall, & !output
-      temp_out_surf, QS_surf, & !output
+      temp_out_surf, temp_fast_surf, temp_slow_surf, QS_surf, & !output
       QS) !output
       USE module_ctrl_const_allocate, ONLY: &
          nsurf, ndepth, &
@@ -489,6 +489,8 @@ CONTAINS
       ! standard suews surfaces
       REAL(KIND(1D0)), DIMENSION(nsurf), INTENT(out) :: QS_surf
       REAL(KIND(1D0)), DIMENSION(nsurf, ndepth), INTENT(out) :: temp_out_surf !interface temperature between depth layers
+      REAL(KIND(1D0)), DIMENSION(nsurf, ndepth), INTENT(inout) :: temp_fast_surf ! fast EHC surface thermal state
+      REAL(KIND(1D0)), DIMENSION(nsurf, ndepth), INTENT(inout) :: temp_slow_surf ! slow EHC surface thermal state
 
       ! grid aggregated results
       REAL(KIND(1D0)), INTENT(out) :: QS
@@ -507,7 +509,7 @@ CONTAINS
       ! REAL(KIND(1D0)), DIMENSION(ndepth) :: temp_all_cal
       ! surface temperatures at innermost depth layer
       ! REAL(KIND(1D0)) :: temp_IBC
-      INTEGER :: i_facet, i_group, nfacet, i_depth
+      INTEGER :: i_facet, i_group, nfacet, i_depth, env_status
 
       ! settings for boundary conditions
       REAL(KIND(1D0)), DIMENSION(2) :: bc
@@ -518,14 +520,32 @@ CONTAINS
 
       ! use finite depth heat conduction solver
       LOGICAL :: use_heatcond1d, use_heatcond1d_water
-      LOGICAL, PARAMETER :: use_zero_flux_bottom = .FALSE.
+      LOGICAL :: use_zero_flux_bottom, use_parallel_surfaces
+      CHARACTER(LEN=32) :: env_value
       REAL(KIND(1D0)), DIMENSION(ndepth) :: temp_lumped, cap_lumped
+      REAL(KIND(1D0)), DIMENSION(ndepth) :: temp_fast_lumped, temp_slow_lumped
+      REAL(KIND(1D0)), DIMENSION(ndepth) :: cap_fast_lumped, cap_slow_lumped
+      REAL(KIND(1D0)), DIMENSION(ndepth) :: temp_branch, cap_branch
       REAL(KIND(1D0)), DIMENSION(ndepth + 1) :: g_lumped
-      REAL(KIND(1D0)) :: tsfc_lumped, tin_lumped, qs_lumped, qs_per_surface
+      REAL(KIND(1D0)), DIMENSION(ndepth + 1) :: g_fast_lumped, g_slow_lumped
+      REAL(KIND(1D0)), DIMENSION(ndepth + 1) :: g_branch
+      REAL(KIND(1D0)) :: tsfc_lumped, tin_lumped, qs_lumped, qs_per_surface, bottom_g_scale
       REAL(KIND(1D0)) :: q_top_lumped, q_bottom_lumped
       REAL(KIND(1D0)) :: surface_weight, layer_cap, layer_temp_cap, face_resistance
+      REAL(KIND(1D0)) :: layer_fast_temp_cap, layer_slow_temp_cap
+      REAL(KIND(1D0)) :: qs_fast_lumped, qs_slow_lumped
+      REAL(KIND(1D0)) :: q_top_fast_lumped, q_bottom_fast_lumped
+      REAL(KIND(1D0)) :: q_top_slow_lumped, q_bottom_slow_lumped
+      REAL(KIND(1D0)) :: dual_fast_weight, dual_slow_weight
+      REAL(KIND(1D0)) :: fast_cap_scale, slow_cap_scale, fast_g_scale, slow_g_scale
+      REAL(KIND(1D0)) :: lumped_layer_temp_for_alloc
+      REAL(KIND(1D0)) :: state_layer_temp, state_top_gradient, state_g_scale
+      REAL(KIND(1D0)) :: state_warming_g_boost, state_cooling_g_damp
+      REAL(KIND(1D0)) :: state_gradient_scale, state_min_g_scale
       LOGICAL :: valid_lumped
       LOGICAL, DIMENSION(nsurf) :: valid_lumped_surf
+      LOGICAL :: use_dual_timescale, use_qs_surface_gradient_alloc, allocation_success
+      LOGICAL :: use_state_admittance
 
       QS = 0.0D0
       QS_surf = 0.0D0
@@ -534,6 +554,118 @@ CONTAINS
       temp_out_surf = temp_in_surf
       temp_out_roof = temp_in_roof
       temp_out_wall = temp_in_wall
+
+      use_zero_flux_bottom = .FALSE.
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_ZERO_FLUX_BOTTOM", env_value, STATUS=env_status)
+      IF (env_status == 0) THEN
+         SELECT CASE (TRIM(ADJUSTL(env_value)))
+         CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+            use_zero_flux_bottom = .TRUE.
+         END SELECT
+      END IF
+      use_parallel_surfaces = .FALSE.
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_PARALLEL_SURFACES", env_value, STATUS=env_status)
+      IF (env_status == 0) THEN
+         SELECT CASE (TRIM(ADJUSTL(env_value)))
+         CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+            use_parallel_surfaces = .TRUE.
+         END SELECT
+      END IF
+      bottom_g_scale = 1.0D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_BOTTOM_G_SCALE", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) bottom_g_scale
+         IF (env_status /= 0) bottom_g_scale = 1.0D0
+         bottom_g_scale = MAX(0.0D0, bottom_g_scale)
+      END IF
+      use_dual_timescale = .FALSE.
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_DUAL_TIMESCALE", env_value, STATUS=env_status)
+      IF (env_status == 0) THEN
+         SELECT CASE (TRIM(ADJUSTL(env_value)))
+         CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+            use_dual_timescale = .TRUE.
+         END SELECT
+      END IF
+      dual_fast_weight = 0.35D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_WEIGHT", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) dual_fast_weight
+         IF (env_status /= 0) dual_fast_weight = 0.35D0
+      END IF
+      dual_fast_weight = MAX(0.0D0, MIN(1.0D0, dual_fast_weight))
+      dual_slow_weight = 1.0D0 - dual_fast_weight
+      fast_cap_scale = 0.35D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_CAP_SCALE", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) fast_cap_scale
+         IF (env_status /= 0) fast_cap_scale = 0.35D0
+      END IF
+      fast_cap_scale = MAX(0.05D0, fast_cap_scale)
+      slow_cap_scale = 1.25D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_SLOW_CAP_SCALE", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) slow_cap_scale
+         IF (env_status /= 0) slow_cap_scale = 1.25D0
+      END IF
+      slow_cap_scale = MAX(0.05D0, slow_cap_scale)
+      fast_g_scale = 1.75D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_G_SCALE", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) fast_g_scale
+         IF (env_status /= 0) fast_g_scale = 1.75D0
+      END IF
+      fast_g_scale = MAX(0.05D0, fast_g_scale)
+      slow_g_scale = 0.75D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_SLOW_G_SCALE", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) slow_g_scale
+         IF (env_status /= 0) slow_g_scale = 0.75D0
+      END IF
+      slow_g_scale = MAX(0.05D0, slow_g_scale)
+      use_state_admittance = .FALSE.
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_STATE_ADMITTANCE", env_value, STATUS=env_status)
+      IF (env_status == 0) THEN
+         SELECT CASE (TRIM(ADJUSTL(env_value)))
+         CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+            use_state_admittance = .TRUE.
+         END SELECT
+      END IF
+      state_warming_g_boost = 0.50D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_WARMING_G_BOOST", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) state_warming_g_boost
+         IF (env_status /= 0) state_warming_g_boost = 0.50D0
+      END IF
+      state_warming_g_boost = MAX(0.0D0, MIN(5.0D0, state_warming_g_boost))
+      state_cooling_g_damp = 0.35D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_COOLING_G_DAMP", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) state_cooling_g_damp
+         IF (env_status /= 0) state_cooling_g_damp = 0.35D0
+      END IF
+      state_cooling_g_damp = MAX(0.0D0, MIN(0.95D0, state_cooling_g_damp))
+      state_gradient_scale = 2.0D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_GRADIENT_SCALE", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) state_gradient_scale
+         IF (env_status /= 0) state_gradient_scale = 2.0D0
+      END IF
+      state_gradient_scale = MAX(0.10D0, state_gradient_scale)
+      state_min_g_scale = 0.35D0
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_MIN_G_SCALE", env_value, STATUS=env_status)
+      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+         READ (env_value, *, IOSTAT=env_status) state_min_g_scale
+         IF (env_status /= 0) state_min_g_scale = 0.35D0
+      END IF
+      state_min_g_scale = MAX(0.05D0, MIN(1.0D0, state_min_g_scale))
+      use_qs_surface_gradient_alloc = .FALSE.
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QS_SURF_ALLOC", env_value, STATUS=env_status)
+      IF (env_status == 0) THEN
+         SELECT CASE (TRIM(ADJUSTL(env_value)))
+         CASE ("conductance_gradient", "CONDUCTANCE_GRADIENT", "gradient", "GRADIENT", "1", "true", "TRUE", "True", "yes", "YES", "Yes")
+            use_qs_surface_gradient_alloc = .TRUE.
+         END SELECT
+      END IF
 
       IF (use_lumped_slab) THEN
          ! Coarse plan-area slab: aggregate only the standard SUEWS surface fractions.
@@ -565,11 +697,17 @@ CONTAINS
          DO i_depth = 1, ndepth
             layer_cap = 0.0D0
             layer_temp_cap = 0.0D0
+            layer_fast_temp_cap = 0.0D0
+            layer_slow_temp_cap = 0.0D0
             DO i_facet = 1, nsurf
                IF (valid_lumped_surf(i_facet)) THEN
                   layer_cap = layer_cap + sfr_surf(i_facet)*cp_surf(i_facet, i_depth)*dz_surf(i_facet, i_depth)
                   layer_temp_cap = layer_temp_cap + sfr_surf(i_facet)*cp_surf(i_facet, i_depth) &
                                    *dz_surf(i_facet, i_depth)*temp_in_surf(i_facet, i_depth)
+                  layer_fast_temp_cap = layer_fast_temp_cap + sfr_surf(i_facet)*cp_surf(i_facet, i_depth) &
+                                        *dz_surf(i_facet, i_depth)*temp_fast_surf(i_facet, i_depth)
+                  layer_slow_temp_cap = layer_slow_temp_cap + sfr_surf(i_facet)*cp_surf(i_facet, i_depth) &
+                                        *dz_surf(i_facet, i_depth)*temp_slow_surf(i_facet, i_depth)
                END IF
             END DO
             IF (layer_cap <= 1.0D-12) THEN
@@ -577,10 +715,56 @@ CONTAINS
             ELSE
                cap_lumped(i_depth) = layer_cap
                temp_lumped(i_depth) = layer_temp_cap/layer_cap
+               temp_fast_lumped(i_depth) = layer_fast_temp_cap/layer_cap
+               temp_slow_lumped(i_depth) = layer_slow_temp_cap/layer_cap
             END IF
          END DO
          IF (.NOT. valid_lumped) THEN
             CALL add_supy_warning('EHC lumped slab: invalid aggregated heat capacity; QS remains zero')
+            RETURN
+         END IF
+
+         IF (use_parallel_surfaces) THEN
+            DO i_facet = 1, nsurf
+               IF (valid_lumped_surf(i_facet)) THEN
+                  temp_branch = temp_in_surf(i_facet, :)
+                  cap_branch = cp_surf(i_facet, :)*dz_surf(i_facet, :)
+                  g_branch = 0.0D0
+
+                  face_resistance = 0.5D0*dz_surf(i_facet, 1)/k_surf(i_facet, 1)
+                  g_branch(1) = 1.0D0/face_resistance
+                  IF (.NOT. use_zero_flux_bottom) THEN
+                     face_resistance = 0.5D0*dz_surf(i_facet, ndepth)/k_surf(i_facet, ndepth)
+                     g_branch(ndepth + 1) = bottom_g_scale/face_resistance
+                  END IF
+                  DO i_depth = 1, ndepth - 1
+                     face_resistance = 0.5D0*dz_surf(i_facet, i_depth)/k_surf(i_facet, i_depth) &
+                                       + 0.5D0*dz_surf(i_facet, i_depth + 1)/k_surf(i_facet, i_depth + 1)
+                     g_branch(i_depth + 1) = 1.0D0/face_resistance
+                  END DO
+
+                  IF (ANY(g_branch(1:ndepth) <= 1.0D-12)) THEN
+                     CALL add_supy_warning('EHC parallel slab: invalid internal conductance; surface QS remains zero')
+                     CYCLE
+                  END IF
+                  IF ((.NOT. use_zero_flux_bottom) .AND. g_branch(ndepth + 1) <= 1.0D-12) THEN
+                     CALL add_supy_warning('EHC parallel slab: invalid lower-boundary conductance; surface QS remains zero')
+                     CYCLE
+                  END IF
+
+                  bc(1) = tsfc_surf(i_facet)
+                  bc(2) = tin_surf(i_facet)
+                  CALL heatcond1d_gstep(temp_branch, qs_lumped, cap_branch, g_branch, tstep*1.0D0, bc, &
+                                        q_top_lumped, q_bottom_lumped)
+                  IF (use_zero_flux_bottom) THEN
+                     QS_surf(i_facet) = qs_lumped
+                  ELSE
+                     QS_surf(i_facet) = q_top_lumped
+                  END IF
+                  temp_out_surf(i_facet, :) = temp_branch
+               END IF
+            END DO
+            QS = DOT_PRODUCT(QS_surf, sfr_surf)
             RETURN
          END IF
 
@@ -592,8 +776,8 @@ CONTAINS
 
                IF (.NOT. use_zero_flux_bottom) THEN
                   face_resistance = 0.5D0*dz_surf(i_facet, ndepth)/k_surf(i_facet, ndepth)
-                  g_lumped(ndepth + 1) = g_lumped(ndepth + 1) + sfr_surf(i_facet)/face_resistance
-                  tin_lumped = tin_lumped + sfr_surf(i_facet)*tin_surf(i_facet)/face_resistance
+                  g_lumped(ndepth + 1) = g_lumped(ndepth + 1) + bottom_g_scale*sfr_surf(i_facet)/face_resistance
+                  tin_lumped = tin_lumped + bottom_g_scale*sfr_surf(i_facet)*tin_surf(i_facet)/face_resistance
                END IF
 
                DO i_depth = 1, ndepth - 1
@@ -617,27 +801,89 @@ CONTAINS
             tin_lumped = tin_lumped/g_lumped(ndepth + 1)
          END IF
 
-         bc(1) = tsfc_lumped
-         bc(2) = tin_lumped
-         CALL heatcond1d_gstep(temp_lumped, qs_lumped, cap_lumped, g_lumped, tstep*1.0D0, bc, &
-                               q_top_lumped, q_bottom_lumped)
+         IF (use_state_admittance) THEN
+            IF (use_dual_timescale) THEN
+               state_layer_temp = dual_fast_weight*temp_fast_lumped(1) + dual_slow_weight*temp_slow_lumped(1)
+            ELSE
+               state_layer_temp = temp_lumped(1)
+            END IF
+            state_top_gradient = tsfc_lumped - state_layer_temp
+            IF (state_top_gradient >= 0.0D0) THEN
+               state_g_scale = 1.0D0 + state_warming_g_boost*TANH(state_top_gradient/state_gradient_scale)
+            ELSE
+               state_g_scale = 1.0D0 - state_cooling_g_damp*TANH((-state_top_gradient)/state_gradient_scale)
+               state_g_scale = MAX(state_min_g_scale, state_g_scale)
+            END IF
+            g_lumped(1) = g_lumped(1)*state_g_scale
+         END IF
+
+            bc(1) = tsfc_lumped
+            bc(2) = tin_lumped
+            IF (use_dual_timescale) THEN
+               cap_fast_lumped = cap_lumped*fast_cap_scale
+               cap_slow_lumped = cap_lumped*slow_cap_scale
+               g_fast_lumped = g_lumped*fast_g_scale
+               g_slow_lumped = g_lumped*slow_g_scale
+               lumped_layer_temp_for_alloc = dual_fast_weight*temp_fast_lumped(1) + dual_slow_weight*temp_slow_lumped(1)
+
+               CALL heatcond1d_gstep(temp_fast_lumped, qs_fast_lumped, cap_fast_lumped, g_fast_lumped, tstep*1.0D0, bc, &
+                                     q_top_fast_lumped, q_bottom_fast_lumped)
+            CALL heatcond1d_gstep(temp_slow_lumped, qs_slow_lumped, cap_slow_lumped, g_slow_lumped, tstep*1.0D0, bc, &
+                                  q_top_slow_lumped, q_bottom_slow_lumped)
+
+               IF (use_zero_flux_bottom) THEN
+                  QS = dual_fast_weight*qs_fast_lumped + dual_slow_weight*qs_slow_lumped
+               ELSE
+                  QS = dual_fast_weight*q_top_fast_lumped + dual_slow_weight*q_top_slow_lumped
+               END IF
+               QS_roof = 0.0D0
+               QS_wall = 0.0D0
+               IF (use_qs_surface_gradient_alloc) THEN
+                  CALL allocate_lumped_qs_by_surface_gradient( &
+                     QS, tsfc_surf, sfr_surf, dz_surf, k_surf, lumped_layer_temp_for_alloc, &
+                     valid_lumped_surf, QS_surf, allocation_success)
+               ELSE
+                  allocation_success = .FALSE.
+               END IF
+               IF (.NOT. allocation_success) qs_per_surface = QS/surface_weight
+               DO i_facet = 1, nsurf
+                  IF (valid_lumped_surf(i_facet)) THEN
+                     IF (.NOT. allocation_success) QS_surf(i_facet) = qs_per_surface
+                     temp_fast_surf(i_facet, :) = temp_fast_lumped
+                     temp_slow_surf(i_facet, :) = temp_slow_lumped
+                     temp_out_surf(i_facet, :) = dual_fast_weight*temp_fast_lumped + dual_slow_weight*temp_slow_lumped
+               END IF
+               END DO
+               RETURN
+            END IF
+
+            lumped_layer_temp_for_alloc = temp_lumped(1)
+            CALL heatcond1d_gstep(temp_lumped, qs_lumped, cap_lumped, g_lumped, tstep*1.0D0, bc, &
+                                  q_top_lumped, q_bottom_lumped)
 
          ! With a finite lower boundary, SUEWS needs the outdoor-surface storage
          ! flux; the material heat-content tendency also includes lower exchange.
-         IF (use_zero_flux_bottom) THEN
-            QS = qs_lumped
-         ELSE
-            QS = q_top_lumped
-         END IF
-         qs_per_surface = QS/surface_weight
-         QS_roof = 0.0D0
-         QS_wall = 0.0D0
-         DO i_facet = 1, nsurf
-            IF (valid_lumped_surf(i_facet)) THEN
-               QS_surf(i_facet) = qs_per_surface
-               temp_out_surf(i_facet, :) = temp_lumped
+            IF (use_zero_flux_bottom) THEN
+               QS = qs_lumped
+            ELSE
+               QS = q_top_lumped
             END IF
-         END DO
+            QS_roof = 0.0D0
+            QS_wall = 0.0D0
+            IF (use_qs_surface_gradient_alloc) THEN
+               CALL allocate_lumped_qs_by_surface_gradient( &
+                  QS, tsfc_surf, sfr_surf, dz_surf, k_surf, lumped_layer_temp_for_alloc, &
+                  valid_lumped_surf, QS_surf, allocation_success)
+            ELSE
+               allocation_success = .FALSE.
+            END IF
+            IF (.NOT. allocation_success) qs_per_surface = QS/surface_weight
+            DO i_facet = 1, nsurf
+               IF (valid_lumped_surf(i_facet)) THEN
+                  IF (.NOT. allocation_success) QS_surf(i_facet) = qs_per_surface
+                  temp_out_surf(i_facet, :) = temp_lumped
+               END IF
+            END DO
          RETURN
       END IF
 
@@ -901,6 +1147,56 @@ CONTAINS
       !PRINT *, 'QS_surf in ESTM_ehc', QS_surf
 
    END SUBROUTINE EHC
+
+   SUBROUTINE allocate_lumped_qs_by_surface_gradient( &
+      qs_total, tsfc_surf, sfr_surf, dz_surf, k_surf, temp_ref, valid_surf, qs_surf, success)
+      USE module_ctrl_const_allocate, ONLY: nsurf, ndepth
+
+      IMPLICIT NONE
+
+      REAL(KIND(1D0)), INTENT(IN) :: qs_total
+      REAL(KIND(1D0)), DIMENSION(nsurf), INTENT(IN) :: tsfc_surf
+      REAL(KIND(1D0)), DIMENSION(nsurf), INTENT(IN) :: sfr_surf
+      REAL(KIND(1D0)), DIMENSION(nsurf, ndepth), INTENT(IN) :: dz_surf
+      REAL(KIND(1D0)), DIMENSION(nsurf, ndepth), INTENT(IN) :: k_surf
+      REAL(KIND(1D0)), INTENT(IN) :: temp_ref
+      LOGICAL, DIMENSION(nsurf), INTENT(IN) :: valid_surf
+      REAL(KIND(1D0)), DIMENSION(nsurf), INTENT(OUT) :: qs_surf
+      LOGICAL, INTENT(OUT) :: success
+
+      INTEGER :: i_surf
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: raw_qs_surf
+      REAL(KIND(1D0)), DIMENSION(nsurf) :: top_conductance_surf
+      REAL(KIND(1D0)) :: face_resistance, raw_grid_qs, conductance_grid, scale_factor
+
+      success = .FALSE.
+      qs_surf = 0.0D0
+      raw_qs_surf = 0.0D0
+      top_conductance_surf = 0.0D0
+
+      DO i_surf = 1, nsurf
+         IF (valid_surf(i_surf) .AND. sfr_surf(i_surf) > 0.0D0 &
+             .AND. dz_surf(i_surf, 1) > 0.0D0 .AND. k_surf(i_surf, 1) > 0.0D0) THEN
+            face_resistance = 0.5D0*dz_surf(i_surf, 1)/k_surf(i_surf, 1)
+            IF (face_resistance > 1.0D-12) THEN
+               top_conductance_surf(i_surf) = 1.0D0/face_resistance
+               raw_qs_surf(i_surf) = top_conductance_surf(i_surf)*(tsfc_surf(i_surf) - temp_ref)
+            END IF
+         END IF
+      END DO
+
+      raw_grid_qs = DOT_PRODUCT(raw_qs_surf, sfr_surf)
+      IF (ABS(raw_grid_qs) <= 1.0D-8) THEN
+         conductance_grid = DOT_PRODUCT(top_conductance_surf, sfr_surf)
+         IF (conductance_grid <= 1.0D-12) RETURN
+         raw_qs_surf = top_conductance_surf
+         raw_grid_qs = conductance_grid
+      END IF
+
+      scale_factor = qs_total/raw_grid_qs
+      qs_surf = raw_qs_surf*scale_factor
+      success = .TRUE.
+   END SUBROUTINE allocate_lumped_qs_by_surface_gradient
 
 END MODULE module_phys_ehc
 

--- a/src/suews/src/suews_phys_ehc.f95
+++ b/src/suews/src/suews_phys_ehc.f95
@@ -546,6 +546,7 @@ CONTAINS
       LOGICAL, DIMENSION(nsurf) :: valid_lumped_surf
       LOGICAL :: use_dual_timescale, use_qs_surface_gradient_alloc, allocation_success
       LOGICAL :: use_state_admittance
+      LOGICAL :: use_ehc_experimental_controls
 
       QS = 0.0D0
       QS_surf = 0.0D0
@@ -555,116 +556,123 @@ CONTAINS
       temp_out_roof = temp_in_roof
       temp_out_wall = temp_in_wall
 
+      use_ehc_experimental_controls = ehc_experimental_controls_enabled()
       use_zero_flux_bottom = .FALSE.
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_ZERO_FLUX_BOTTOM", env_value, STATUS=env_status)
-      IF (env_status == 0) THEN
-         SELECT CASE (TRIM(ADJUSTL(env_value)))
-         CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
-            use_zero_flux_bottom = .TRUE.
-         END SELECT
-      END IF
       use_parallel_surfaces = .FALSE.
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_PARALLEL_SURFACES", env_value, STATUS=env_status)
-      IF (env_status == 0) THEN
-         SELECT CASE (TRIM(ADJUSTL(env_value)))
-         CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
-            use_parallel_surfaces = .TRUE.
-         END SELECT
-      END IF
       bottom_g_scale = 1.0D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_BOTTOM_G_SCALE", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) bottom_g_scale
-         IF (env_status /= 0) bottom_g_scale = 1.0D0
-         bottom_g_scale = MAX(0.0D0, bottom_g_scale)
-      END IF
       use_dual_timescale = .FALSE.
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_DUAL_TIMESCALE", env_value, STATUS=env_status)
-      IF (env_status == 0) THEN
-         SELECT CASE (TRIM(ADJUSTL(env_value)))
-         CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
-            use_dual_timescale = .TRUE.
-         END SELECT
-      END IF
       dual_fast_weight = 0.35D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_WEIGHT", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) dual_fast_weight
-         IF (env_status /= 0) dual_fast_weight = 0.35D0
-      END IF
-      dual_fast_weight = MAX(0.0D0, MIN(1.0D0, dual_fast_weight))
       dual_slow_weight = 1.0D0 - dual_fast_weight
       fast_cap_scale = 0.35D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_CAP_SCALE", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) fast_cap_scale
-         IF (env_status /= 0) fast_cap_scale = 0.35D0
-      END IF
-      fast_cap_scale = MAX(0.05D0, fast_cap_scale)
       slow_cap_scale = 1.25D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_SLOW_CAP_SCALE", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) slow_cap_scale
-         IF (env_status /= 0) slow_cap_scale = 1.25D0
-      END IF
-      slow_cap_scale = MAX(0.05D0, slow_cap_scale)
       fast_g_scale = 1.75D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_G_SCALE", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) fast_g_scale
-         IF (env_status /= 0) fast_g_scale = 1.75D0
-      END IF
-      fast_g_scale = MAX(0.05D0, fast_g_scale)
       slow_g_scale = 0.75D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_SLOW_G_SCALE", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) slow_g_scale
-         IF (env_status /= 0) slow_g_scale = 0.75D0
-      END IF
-      slow_g_scale = MAX(0.05D0, slow_g_scale)
       use_state_admittance = .FALSE.
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_STATE_ADMITTANCE", env_value, STATUS=env_status)
-      IF (env_status == 0) THEN
-         SELECT CASE (TRIM(ADJUSTL(env_value)))
-         CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
-            use_state_admittance = .TRUE.
-         END SELECT
-      END IF
       state_warming_g_boost = 0.50D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_WARMING_G_BOOST", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) state_warming_g_boost
-         IF (env_status /= 0) state_warming_g_boost = 0.50D0
-      END IF
-      state_warming_g_boost = MAX(0.0D0, MIN(5.0D0, state_warming_g_boost))
       state_cooling_g_damp = 0.35D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_COOLING_G_DAMP", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) state_cooling_g_damp
-         IF (env_status /= 0) state_cooling_g_damp = 0.35D0
-      END IF
-      state_cooling_g_damp = MAX(0.0D0, MIN(0.95D0, state_cooling_g_damp))
       state_gradient_scale = 2.0D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_GRADIENT_SCALE", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) state_gradient_scale
-         IF (env_status /= 0) state_gradient_scale = 2.0D0
-      END IF
-      state_gradient_scale = MAX(0.10D0, state_gradient_scale)
       state_min_g_scale = 0.35D0
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_MIN_G_SCALE", env_value, STATUS=env_status)
-      IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
-         READ (env_value, *, IOSTAT=env_status) state_min_g_scale
-         IF (env_status /= 0) state_min_g_scale = 0.35D0
-      END IF
-      state_min_g_scale = MAX(0.05D0, MIN(1.0D0, state_min_g_scale))
       use_qs_surface_gradient_alloc = .FALSE.
-      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QS_SURF_ALLOC", env_value, STATUS=env_status)
-      IF (env_status == 0) THEN
-         SELECT CASE (TRIM(ADJUSTL(env_value)))
-         CASE ("conductance_gradient", "CONDUCTANCE_GRADIENT", "gradient", "GRADIENT", "1", "true", "TRUE", "True", "yes", "YES", "Yes")
-            use_qs_surface_gradient_alloc = .TRUE.
-         END SELECT
+
+      IF (use_ehc_experimental_controls) THEN
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_ZERO_FLUX_BOTTOM", env_value, STATUS=env_status)
+         IF (env_status == 0) THEN
+            SELECT CASE (TRIM(ADJUSTL(env_value)))
+            CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+               use_zero_flux_bottom = .TRUE.
+            END SELECT
+         END IF
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_PARALLEL_SURFACES", env_value, STATUS=env_status)
+         IF (env_status == 0) THEN
+            SELECT CASE (TRIM(ADJUSTL(env_value)))
+            CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+               use_parallel_surfaces = .TRUE.
+            END SELECT
+         END IF
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_BOTTOM_G_SCALE", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) bottom_g_scale
+            IF (env_status /= 0) bottom_g_scale = 1.0D0
+            bottom_g_scale = MAX(0.0D0, bottom_g_scale)
+         END IF
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_DUAL_TIMESCALE", env_value, STATUS=env_status)
+         IF (env_status == 0) THEN
+            SELECT CASE (TRIM(ADJUSTL(env_value)))
+            CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+               use_dual_timescale = .TRUE.
+            END SELECT
+         END IF
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_WEIGHT", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) dual_fast_weight
+            IF (env_status /= 0) dual_fast_weight = 0.35D0
+         END IF
+         dual_fast_weight = MAX(0.0D0, MIN(1.0D0, dual_fast_weight))
+         dual_slow_weight = 1.0D0 - dual_fast_weight
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_CAP_SCALE", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) fast_cap_scale
+            IF (env_status /= 0) fast_cap_scale = 0.35D0
+         END IF
+         fast_cap_scale = MAX(0.05D0, fast_cap_scale)
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_SLOW_CAP_SCALE", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) slow_cap_scale
+            IF (env_status /= 0) slow_cap_scale = 1.25D0
+         END IF
+         slow_cap_scale = MAX(0.05D0, slow_cap_scale)
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_FAST_G_SCALE", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) fast_g_scale
+            IF (env_status /= 0) fast_g_scale = 1.75D0
+         END IF
+         fast_g_scale = MAX(0.05D0, fast_g_scale)
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_SLOW_G_SCALE", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) slow_g_scale
+            IF (env_status /= 0) slow_g_scale = 0.75D0
+         END IF
+         slow_g_scale = MAX(0.05D0, slow_g_scale)
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_STATE_ADMITTANCE", env_value, STATUS=env_status)
+         IF (env_status == 0) THEN
+            SELECT CASE (TRIM(ADJUSTL(env_value)))
+            CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+               use_state_admittance = .TRUE.
+            END SELECT
+         END IF
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_WARMING_G_BOOST", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) state_warming_g_boost
+            IF (env_status /= 0) state_warming_g_boost = 0.50D0
+         END IF
+         state_warming_g_boost = MAX(0.0D0, MIN(5.0D0, state_warming_g_boost))
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_COOLING_G_DAMP", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) state_cooling_g_damp
+            IF (env_status /= 0) state_cooling_g_damp = 0.35D0
+         END IF
+         state_cooling_g_damp = MAX(0.0D0, MIN(0.95D0, state_cooling_g_damp))
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_GRADIENT_SCALE", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) state_gradient_scale
+            IF (env_status /= 0) state_gradient_scale = 2.0D0
+         END IF
+         state_gradient_scale = MAX(0.10D0, state_gradient_scale)
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_MIN_G_SCALE", env_value, STATUS=env_status)
+         IF (env_status == 0 .AND. LEN_TRIM(env_value) > 0) THEN
+            READ (env_value, *, IOSTAT=env_status) state_min_g_scale
+            IF (env_status /= 0) state_min_g_scale = 0.35D0
+         END IF
+         state_min_g_scale = MAX(0.05D0, MIN(1.0D0, state_min_g_scale))
+         CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_QS_SURF_ALLOC", env_value, STATUS=env_status)
+         IF (env_status == 0) THEN
+            SELECT CASE (TRIM(ADJUSTL(env_value)))
+            CASE ("conductance_gradient", "CONDUCTANCE_GRADIENT", &
+                  "gradient", "GRADIENT", "1", "true", "TRUE", &
+                  "True", "yes", "YES", "Yes")
+               use_qs_surface_gradient_alloc = .TRUE.
+            END SELECT
+         END IF
       END IF
 
       IF (use_lumped_slab) THEN
@@ -1197,6 +1205,22 @@ CONTAINS
       qs_surf = raw_qs_surf*scale_factor
       success = .TRUE.
    END SUBROUTINE allocate_lumped_qs_by_surface_gradient
+
+   LOGICAL FUNCTION ehc_experimental_controls_enabled()
+      IMPLICIT NONE
+      CHARACTER(LEN=32) :: env_value
+      INTEGER :: env_status
+
+      ehc_experimental_controls_enabled = .FALSE.
+      CALL GET_ENVIRONMENT_VARIABLE("SUEWS_EHC_EXPERIMENTAL_CONTROLS", env_value, STATUS=env_status)
+      IF (env_status /= 0) RETURN
+
+      SELECT CASE (TRIM(ADJUSTL(env_value)))
+      CASE ("1", "true", "TRUE", "True", "yes", "YES", "Yes", &
+            "on", "ON", "On")
+         ehc_experimental_controls_enabled = .TRUE.
+      END SELECT
+   END FUNCTION ehc_experimental_controls_enabled
 
 END MODULE module_phys_ehc
 

--- a/src/suews/src/suews_type_heat.f95
+++ b/src/suews/src/suews_type_heat.f95
@@ -10,6 +10,8 @@ module module_type_heat
       REAL(KIND(1D0)), DIMENSION(:, :), ALLOCATABLE :: temp_wall ! interface temperature between depth layers in wall [degC]
       REAL(KIND(1D0)), DIMENSION(:, :), ALLOCATABLE :: temp_surf ! interface temperature between depth layers [degC]
       REAL(KIND(1D0)), DIMENSION(:, :), ALLOCATABLE :: temp_surf_dyohm ! interface temperature between depth layers [degC]
+      REAL(KIND(1D0)), DIMENSION(:, :), ALLOCATABLE :: temp_surf_ehc_fast ! fast EHC surface thermal state [degC]
+      REAL(KIND(1D0)), DIMENSION(:, :), ALLOCATABLE :: temp_surf_ehc_slow ! slow EHC surface thermal state [degC]
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_roof ! roof surface temperature [degC]
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_wall ! wall surface temperature [degC]
       REAL(KIND(1D0)), DIMENSION(:), ALLOCATABLE :: tsfc_surf ! surface temperature [degC]
@@ -53,6 +55,9 @@ module module_type_heat
       REAL(KIND(1D0)) :: qh = 0.0D0 !turbulent sensible heat flux [W m-2]
       REAL(KIND(1D0)) :: qh_residual = 0.0D0 ! residual based sensible heat flux [W m-2]
       REAL(KIND(1D0)) :: qh_resist = 0.0D0 !resistance bnased sensible heat flux [W m-2]
+      REAL(KIND(1D0)) :: ehc_iter_dif_tsfc = 0.0D0 ! EHC iteration surface-temperature change [K]
+      REAL(KIND(1D0)) :: ehc_iter_dif_qh = 0.0D0 ! EHC residual-vs-resistance QH mismatch [W m-2]
+      REAL(KIND(1D0)) :: ehc_iter_score = 0.0D0 ! EHC iteration quality score [W m-2 equivalent]
 
       REAL(KIND(1D0)) :: qn = 0.0D0 !net all-wave radiation [W m-2]
       REAL(KIND(1D0)) :: qn_snowfree = 0.0D0 !net all-wave radiation on snow-free surface [W m-2]
@@ -90,6 +95,10 @@ CONTAINS
       ALLOCATE (self%temp_wall(num_layer, num_depth))
       ALLOCATE (self%temp_surf(num_surf, num_depth))
       ALLOCATE (self%temp_surf_dyohm(num_surf, num_depth))
+      ALLOCATE (self%temp_surf_ehc_fast(num_surf, num_depth))
+      ALLOCATE (self%temp_surf_ehc_slow(num_surf, num_depth))
+      self%temp_surf_ehc_fast = 0.0D0
+      self%temp_surf_ehc_slow = 0.0D0
 
       ALLOCATE (self%tsfc_roof(num_layer))
       ALLOCATE (self%tsfc_wall(num_layer))
@@ -129,6 +138,8 @@ CONTAINS
       IF (ALLOCATED(self%tsfc_surf_stepstart)) DEALLOCATE (self%tsfc_surf_stepstart)
       IF (ALLOCATED(self%temp_surf)) DEALLOCATE (self%temp_surf)
       IF (ALLOCATED(self%temp_surf_dyOHM)) DEALLOCATE (self%temp_surf_dyOHM)
+      IF (ALLOCATED(self%temp_surf_ehc_fast)) DEALLOCATE (self%temp_surf_ehc_fast)
+      IF (ALLOCATED(self%temp_surf_ehc_slow)) DEALLOCATE (self%temp_surf_ehc_slow)
       IF (ALLOCATED(self%QS_roof)) DEALLOCATE (self%QS_roof)
       IF (ALLOCATED(self%QN_roof)) DEALLOCATE (self%QN_roof)
       IF (ALLOCATED(self%qe_roof)) DEALLOCATE (self%qe_roof)

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -59,6 +59,7 @@ py.install_sources(
             'util/_atm.py',
             'util/_attribution/__init__.py',
             'util/_attribution/_core.py',
+            'util/_attribution/_flux_performance.py',
             'util/_attribution/_helpers.py',
             'util/_attribution/_physics.py',
             'util/_attribution/_q2.py',

--- a/src/supy/util/__init__.py
+++ b/src/supy/util/__init__.py
@@ -76,6 +76,7 @@ from ._attribution import (
     diagnose_t2,
     diagnose_q2,
     diagnose_u10,
+    diagnose_flux_performance,
     # Generic dispatchers
     attribute,
     diagnose,

--- a/src/supy/util/_attribution/__init__.py
+++ b/src/supy/util/_attribution/__init__.py
@@ -9,6 +9,7 @@ Supported Variables
 - **T2** (2m temperature): Linear flux-gradient profile
 - **q2** (2m specific humidity): Linear flux-gradient profile
 - **U10** (10m wind speed): Logarithmic momentum profile
+- **QE/QH performance**: Model-observation flux error decomposition
 
 Mathematical Foundation
 -----------------------
@@ -47,6 +48,7 @@ from ._result import AttributionResult
 from ._t2 import attribute_t2, diagnose_t2
 from ._q2 import attribute_q2, diagnose_q2
 from ._u10 import attribute_u10, diagnose_u10
+from ._flux_performance import diagnose_flux_performance
 
 
 # =============================================================================
@@ -170,6 +172,7 @@ __all__ = [
     "diagnose_t2",
     "diagnose_q2",
     "diagnose_u10",
+    "diagnose_flux_performance",
     # Generic dispatchers
     "attribute",
     "diagnose",

--- a/src/supy/util/_attribution/_flux_performance.py
+++ b/src/supy/util/_attribution/_flux_performance.py
@@ -1,0 +1,180 @@
+"""
+Model-performance attribution for surface energy fluxes.
+
+This module diagnoses model error against observations. It complements the
+scenario-to-scenario attribution tools for T2/q2/U10 by treating observations as
+the reference state and model output as the evaluated state.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+from ._core import shapley_binary_product
+from ._helpers import align_scenarios, extract_suews_group
+from ._physics import decompose_flux_budget
+from ._result import AttributionResult
+
+
+FluxVariable = Literal["QE", "QH"]
+
+
+def _normalise_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a flat DataFrame with common SUEWS flux column names."""
+    out = extract_suews_group(df).copy()
+    rename = {col: str(col).upper() for col in out.columns}
+    out = out.rename(columns=rename)
+    return out
+
+
+def _ensure_qs(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure QS is available, using the surface energy residual if needed."""
+    if "QS" not in df.columns:
+        required = {"QN", "QF", "QH", "QE"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(
+                "QS is required or must be derivable from QN + QF - QH - QE; "
+                f"missing columns: {sorted(missing)}"
+            )
+        df = df.copy()
+        df["QS"] = df["QN"] + df["QF"] - df["QH"] - df["QE"]
+    return df
+
+
+def _required_flux_frame(df: pd.DataFrame, label: str) -> pd.DataFrame:
+    df = _ensure_qs(_normalise_columns(df))
+    required = {"QN", "QF", "QH", "QE", "QS"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"{label} is missing required columns: {sorted(missing)}")
+    return df
+
+
+def _available_energy(df: pd.DataFrame) -> np.ndarray:
+    """Available turbulent energy A = QN + QF - QS."""
+    return (df["QN"] + df["QF"] - df["QS"]).to_numpy(dtype=float)
+
+
+def _safe_fraction(numerator: np.ndarray, denominator: np.ndarray, min_energy: float) -> np.ndarray:
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.where(np.abs(denominator) >= min_energy, numerator / denominator, np.nan)
+
+
+def diagnose_flux_performance(
+    df_obs: pd.DataFrame,
+    df_model: pd.DataFrame,
+    variable: FluxVariable = "QE",
+    *,
+    min_energy: float = 1.0,
+) -> AttributionResult:
+    """
+    Attribute model error in QE or QH to energy supply and partitioning.
+
+    The target flux is represented as:
+
+    ``flux = available_energy * flux_fraction``
+
+    where ``available_energy = QN + QF - QS`` and ``flux_fraction`` is either
+    ``QE / available_energy`` or ``QH / available_energy``. The model-observation
+    difference is decomposed exactly with a binary Shapley decomposition:
+
+    ``delta_flux = contribution_available_energy + contribution_partition``
+
+    The available-energy contribution is then allocated to ``QN``, ``QF`` and
+    ``QS`` according to their signed contribution to the available-energy
+    difference.
+
+    Parameters
+    ----------
+    df_obs, df_model
+        Observation and model output data. Columns may be flat or SUEWS
+        MultiIndex output. Required variables are QN, QF, QH, QE and QS. If QS
+        is absent it is derived as QN + QF - QH - QE.
+    variable
+        Flux to diagnose, either ``"QE"`` or ``"QH"``.
+    min_energy
+        Minimum absolute available energy used when calculating flux fractions.
+        Timesteps below this threshold are retained in ``delta_total`` but their
+        component attribution is set to NaN.
+
+    Returns
+    -------
+    AttributionResult
+        Contributions in W m-2. Positive values mean the model is larger than
+        the observation.
+    """
+    if variable not in {"QE", "QH"}:
+        raise ValueError("diagnose_flux_performance currently supports 'QE' and 'QH'")
+
+    obs = _required_flux_frame(df_obs, "df_obs")
+    model = _required_flux_frame(df_model, "df_model")
+    obs, model, common_idx = align_scenarios(obs, model)
+
+    flux_obs = obs[variable].to_numpy(dtype=float)
+    flux_model = model[variable].to_numpy(dtype=float)
+    a_obs = _available_energy(obs)
+    a_model = _available_energy(model)
+
+    fraction_obs = _safe_fraction(flux_obs, a_obs, min_energy)
+    fraction_model = _safe_fraction(flux_model, a_model, min_energy)
+
+    phi_a, phi_fraction = shapley_binary_product(
+        a_obs, a_model, fraction_obs, fraction_model
+    )
+
+    components_obs = {
+        "QN": obs["QN"].to_numpy(dtype=float),
+        "QF": obs["QF"].to_numpy(dtype=float),
+        "QS": -obs["QS"].to_numpy(dtype=float),
+    }
+    components_model = {
+        "QN": model["QN"].to_numpy(dtype=float),
+        "QF": model["QF"].to_numpy(dtype=float),
+        "QS": -model["QS"].to_numpy(dtype=float),
+    }
+    energy_breakdown = decompose_flux_budget(
+        a_obs, a_model, components_obs, components_model, phi_a
+    )
+
+    contributions = pd.DataFrame(
+        {
+            "delta_total": flux_model - flux_obs,
+            "available_energy": phi_a,
+            "partition": phi_fraction,
+            "energy_QN": energy_breakdown["QN"],
+            "energy_QF": energy_breakdown["QF"],
+            "energy_QS": energy_breakdown["QS"],
+            "obs_available_energy": a_obs,
+            "model_available_energy": a_model,
+            "obs_fraction": fraction_obs,
+            "model_fraction": fraction_model,
+        },
+        index=common_idx,
+    )
+    contributions["flag_low_available_energy"] = (
+        (np.abs(a_obs) < min_energy) | (np.abs(a_model) < min_energy)
+    )
+
+    summary = contributions.describe().T[["mean", "std", "min", "max"]]
+    metadata = {
+        "n_timesteps": len(common_idx),
+        "period_start": str(common_idx.min()),
+        "period_end": str(common_idx.max()),
+        "min_energy": min_energy,
+        "n_low_available_energy_flagged": int(
+            contributions["flag_low_available_energy"].sum()
+        ),
+        "unit": "W m-2",
+        "interpretation": "positive contributions mean model exceeds observation",
+    }
+
+    return AttributionResult(
+        variable=variable,
+        contributions=contributions,
+        summary=summary,
+        metadata=metadata,
+    )

--- a/src/supy/util/_attribution/_result.py
+++ b/src/supy/util/_attribution/_result.py
@@ -11,17 +11,21 @@ from typing import Literal, Optional
 import pandas as pd
 
 
-_VAR_SYMBOLS = {"T2": "T2", "q2": "q2", "U10": "U10"}
-_UNITS = {"T2": "degC", "q2": "g/kg", "U10": "m/s"}
+_VAR_SYMBOLS = {"T2": "T2", "q2": "q2", "U10": "U10", "QE": "QE", "QH": "QH"}
+_UNITS = {"T2": "degC", "q2": "g/kg", "U10": "m/s", "QE": "W m-2", "QH": "W m-2"}
 _MAIN_COMPONENTS = {
     "T2": ["T_ref", "flux_total", "resistance", "air_props"],
     "q2": ["q_ref", "flux_total", "resistance", "air_props"],
     "U10": ["forcing", "roughness", "stability"],
+    "QE": ["available_energy", "partition"],
+    "QH": ["available_energy", "partition"],
 }
 _DEFAULT_PLOT_COMPONENTS = {
     "T2": ["flux_total", "resistance", "air_props"],
     "q2": ["flux_total", "resistance", "air_props"],
     "U10": ["forcing", "roughness", "stability"],
+    "QE": ["energy_QN", "energy_QF", "energy_QS", "partition"],
+    "QH": ["energy_QN", "energy_QF", "energy_QS", "partition"],
 }
 
 

--- a/test/core/test_ehc_regression.py
+++ b/test/core/test_ehc_regression.py
@@ -15,7 +15,9 @@ pytestmark = [
 
 
 SURFACE_NAMES = ("paved", "bldgs", "evetr", "dectr", "grass", "bsoil", "water")
+EHC_EXPERIMENTAL_CONTROLS_KEY = "SUEWS_EHC_EXPERIMENTAL_CONTROLS"
 EHC_ITERATION_ENV_KEYS = (
+    EHC_EXPERIMENTAL_CONTROLS_KEY,
     "SUEWS_EHC_ADAPTIVE_RELAX",
     "SUEWS_EHC_DUAL_TIMESCALE",
     "SUEWS_EHC_MAX_ITER",
@@ -34,6 +36,10 @@ EHC_RA_HEAT_ENV_KEYS = (
     "SUEWS_EHC_RA_STATE_LOW_RA_REF",
     "SUEWS_EHC_RA_STATE_USTAR_REF",
 )
+
+
+def _enable_ehc_experimental_controls(monkeypatch):
+    monkeypatch.setenv(EHC_EXPERIMENTAL_CONTROLS_KEY, "1")
 
 
 def _run_short_ehc_with_surface_cp(rho_cp, surface_rho_cp=None, zero_kdown=False):
@@ -155,6 +161,7 @@ def test_ehc_lumped_storage_skips_invalid_surface_without_zeroing_grid():
 
 def test_ehc_dual_timescale_lumped_branch_changes_storage_response(monkeypatch):
     env_keys = [
+        EHC_EXPERIMENTAL_CONTROLS_KEY,
         "SUEWS_EHC_DUAL_TIMESCALE",
         "SUEWS_EHC_FAST_WEIGHT",
         "SUEWS_EHC_FAST_CAP_SCALE",
@@ -166,6 +173,7 @@ def test_ehc_dual_timescale_lumped_branch_changes_storage_response(monkeypatch):
         monkeypatch.delenv(key, raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_DUAL_TIMESCALE", "1")
     monkeypatch.setenv("SUEWS_EHC_FAST_WEIGHT", "0.45")
     monkeypatch.setenv("SUEWS_EHC_FAST_CAP_SCALE", "0.30")
@@ -180,6 +188,7 @@ def test_ehc_dual_timescale_lumped_branch_changes_storage_response(monkeypatch):
 
 def test_ehc_state_admittance_changes_lumped_storage_response(monkeypatch):
     for key in (
+        EHC_EXPERIMENTAL_CONTROLS_KEY,
         "SUEWS_EHC_STATE_ADMITTANCE",
         "SUEWS_EHC_WARMING_G_BOOST",
         "SUEWS_EHC_COOLING_G_DAMP",
@@ -189,6 +198,7 @@ def test_ehc_state_admittance_changes_lumped_storage_response(monkeypatch):
         monkeypatch.delenv(key, raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_STATE_ADMITTANCE", "1")
     monkeypatch.setenv("SUEWS_EHC_WARMING_G_BOOST", "0.75")
     monkeypatch.setenv("SUEWS_EHC_COOLING_G_DAMP", "0.40")
@@ -201,10 +211,12 @@ def test_ehc_state_admittance_changes_lumped_storage_response(monkeypatch):
 
 
 def test_ehc_impervious_qf_allocation_changes_lumped_storage_response(monkeypatch):
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", "1")
     impervious_qf_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
@@ -213,10 +225,12 @@ def test_ehc_impervious_qf_allocation_changes_lumped_storage_response(monkeypatc
 
 
 def test_ehc_direct_air_qf_mode_changes_lumped_storage_response(monkeypatch):
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_QF_SURF_MODE", "none")
     direct_air_qf_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
@@ -225,10 +239,12 @@ def test_ehc_direct_air_qf_mode_changes_lumped_storage_response(monkeypatch):
 
 
 def test_ehc_direct_air_qf_mode_changes_coupled_qe_response(monkeypatch):
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
     default_fluxes = _run_short_ehc_fluxes_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_QF_SURF_MODE", "none")
     direct_air_fluxes = _run_short_ehc_fluxes_with_surface_cp(2.0e6)
 
@@ -236,8 +252,20 @@ def test_ehc_direct_air_qf_mode_changes_coupled_qe_response(monkeypatch):
     assert np.max(np.abs(direct_air_fluxes[:, 1] - default_fluxes[:, 1])) > 0.1
 
 
+def test_ehc_experimental_qf_env_is_ignored_without_gate(monkeypatch):
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
+    monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_QF_SURF_MODE", "none")
+    ungated_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    np.testing.assert_allclose(ungated_qs, default_qs, rtol=0.0, atol=0.0)
+
+
 def test_ehc_daylight_qf_mode_changes_lumped_storage_response(monkeypatch):
     for key in (
+        EHC_EXPERIMENTAL_CONTROLS_KEY,
         "SUEWS_EHC_QF_IMPERVIOUS_ONLY",
         "SUEWS_EHC_QF_SURF_MODE",
         "SUEWS_EHC_QF_SURF_DAY_FRAC",
@@ -247,6 +275,7 @@ def test_ehc_daylight_qf_mode_changes_lumped_storage_response(monkeypatch):
         monkeypatch.delenv(key, raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_QF_SURF_MODE", "daylight")
     monkeypatch.setenv("SUEWS_EHC_QF_SURF_DAY_FRAC", "1.0")
     monkeypatch.setenv("SUEWS_EHC_QF_SURF_NIGHT_FRAC", "0.25")
@@ -258,9 +287,11 @@ def test_ehc_daylight_qf_mode_changes_lumped_storage_response(monkeypatch):
 
 
 def test_ehc_surface_gradient_allocation_changes_lumped_storage_response(monkeypatch):
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_QS_SURF_ALLOC", raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_QS_SURF_ALLOC", "conductance_gradient")
     gradient_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
@@ -269,6 +300,7 @@ def test_ehc_surface_gradient_allocation_changes_lumped_storage_response(monkeyp
 
 
 def test_ehc_parallel_standard_surfaces_preserves_heterogeneous_response(monkeypatch):
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_PARALLEL_SURFACES", raising=False)
     surface_rho_cp = {
         "paved": 3.2e6,
@@ -281,6 +313,7 @@ def test_ehc_parallel_standard_surfaces_preserves_heterogeneous_response(monkeyp
     }
     pre_lumped_qs = _run_short_ehc_with_surface_cp(2.0e6, surface_rho_cp=surface_rho_cp)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_PARALLEL_SURFACES", "1")
     parallel_qs = _run_short_ehc_with_surface_cp(2.0e6, surface_rho_cp=surface_rho_cp)
 
@@ -292,6 +325,7 @@ def test_ehc_converged_lumped_storage_is_nearly_relaxation_invariant(monkeypatch
     for key in EHC_ITERATION_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_MAX_ITER", "120")
     monkeypatch.setenv("SUEWS_EHC_TSFC_RELAX", "0.3")
     slow_relax_qs = _run_short_ehc_with_surface_cp(2.0e6)
@@ -306,8 +340,10 @@ def test_ehc_converged_lumped_storage_is_nearly_relaxation_invariant(monkeypatch
 def test_ehc_ra_heat_factor_changes_lumped_storage_response(monkeypatch):
     for key in EHC_RA_HEAT_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_RA_HEAT_FACTOR", "1.5")
     higher_ra_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
@@ -318,8 +354,10 @@ def test_ehc_ra_heat_factor_changes_lumped_storage_response(monkeypatch):
 def test_ehc_state_dependent_ra_heat_guard_changes_lumped_storage_response(monkeypatch):
     for key in EHC_RA_HEAT_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_RA_HEAT_MODE", "overcoupled_guard")
     monkeypatch.setenv("SUEWS_EHC_RA_STATE_BOOST", "1.5")
     monkeypatch.setenv("SUEWS_EHC_RA_STATE_KDOWN_MIN", "0.0")
@@ -333,8 +371,10 @@ def test_ehc_state_dependent_ra_heat_guard_changes_lumped_storage_response(monke
 def test_ehc_state_dependent_ra_heat_guard_includes_zero_kdown(monkeypatch):
     for key in EHC_RA_HEAT_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     default_qs = _run_short_ehc_with_surface_cp(2.0e6, zero_kdown=True)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_RA_HEAT_MODE", "overcoupled_guard")
     monkeypatch.setenv("SUEWS_EHC_RA_STATE_BOOST", "1.5")
     monkeypatch.setenv("SUEWS_EHC_RA_STATE_KDOWN_MIN", "0.0")
@@ -347,12 +387,14 @@ def test_ehc_state_dependent_ra_heat_guard_includes_zero_kdown(monkeypatch):
 
 def test_ehc_adaptive_relax_limits_high_relax_response(monkeypatch):
     for key in (
+        EHC_EXPERIMENTAL_CONTROLS_KEY,
         "SUEWS_EHC_ADAPTIVE_RELAX",
         "SUEWS_EHC_TSFC_RELAX",
         "SUEWS_EHC_TSFC_STEP_QH_LIMIT",
     ):
         monkeypatch.delenv(key, raising=False)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_TSFC_RELAX", "0.8")
     high_relax_qs = _run_short_ehc_with_surface_cp(2.0e6)
 
@@ -366,6 +408,7 @@ def test_ehc_adaptive_relax_limits_high_relax_response(monkeypatch):
 
 def test_ehc_restore_best_iteration_path_runs(monkeypatch):
     for key in (
+        EHC_EXPERIMENTAL_CONTROLS_KEY,
         "SUEWS_EHC_ADAPTIVE_RELAX",
         "SUEWS_EHC_RESTORE_BEST_ITER",
         "SUEWS_EHC_TSFC_RELAX",
@@ -374,6 +417,7 @@ def test_ehc_restore_best_iteration_path_runs(monkeypatch):
     ):
         monkeypatch.delenv(key, raising=False)
 
+    _enable_ehc_experimental_controls(monkeypatch)
     monkeypatch.setenv("SUEWS_EHC_ADAPTIVE_RELAX", "1")
     monkeypatch.setenv("SUEWS_EHC_RESTORE_BEST_ITER", "always")
     monkeypatch.setenv("SUEWS_EHC_TSFC_RELAX", "1.0")

--- a/test/core/test_ehc_regression.py
+++ b/test/core/test_ehc_regression.py
@@ -15,10 +15,32 @@ pytestmark = [
 
 
 SURFACE_NAMES = ("paved", "bldgs", "evetr", "dectr", "grass", "bsoil", "water")
+EHC_ITERATION_ENV_KEYS = (
+    "SUEWS_EHC_ADAPTIVE_RELAX",
+    "SUEWS_EHC_DUAL_TIMESCALE",
+    "SUEWS_EHC_MAX_ITER",
+    "SUEWS_EHC_RESTORE_BEST_ITER",
+    "SUEWS_EHC_STATE_ADMITTANCE",
+    "SUEWS_EHC_TSFC_RELAX",
+    "SUEWS_EHC_TSFC_STEP_QH_LIMIT",
+)
+EHC_RA_HEAT_ENV_KEYS = (
+    "SUEWS_EHC_RA_HEAT_FACTOR",
+    "SUEWS_EHC_RA_HEAT_MAX_FACTOR",
+    "SUEWS_EHC_RA_HEAT_MODE",
+    "SUEWS_EHC_RA_STATE_BOOST",
+    "SUEWS_EHC_RA_STATE_KDOWN_MIN",
+    "SUEWS_EHC_RA_STATE_KDOWN_REF",
+    "SUEWS_EHC_RA_STATE_LOW_RA_REF",
+    "SUEWS_EHC_RA_STATE_USTAR_REF",
+)
 
 
-def _run_short_ehc_with_surface_cp(rho_cp, surface_rho_cp=None):
+def _run_short_ehc_with_surface_cp(rho_cp, surface_rho_cp=None, zero_kdown=False):
     sim = sp.SUEWSSimulation.from_sample_data()
+    if zero_kdown:
+        sim._df_forcing = sim._df_forcing.copy()
+        sim._df_forcing["kdown"] = 0.0
     surface_rho_cp = surface_rho_cp or {}
     surface_updates = {
         name: {
@@ -46,6 +68,36 @@ def _run_short_ehc_with_surface_cp(rho_cp, surface_rho_cp=None):
 
     output = sim.run(end_date=sim._df_forcing.index[11])
     return output.df[("SUEWS", "QS")].to_numpy()
+
+
+def _run_short_ehc_fluxes_with_surface_cp(rho_cp):
+    sim = sp.SUEWSSimulation.from_sample_data()
+    surface_updates = {
+        name: {
+            "thermal_layers": {
+                "rho_cp": {"value": [rho_cp] * 5}
+            }
+        }
+        for name in SURFACE_NAMES
+    }
+    sim.update_config(
+        {
+            "model": {
+                "physics": {
+                    "net_radiation": {"value": 3},
+                    "storage_heat": {"value": 5},
+                }
+            },
+            "sites": {
+                "properties": {
+                    "land_cover": surface_updates,
+                }
+            },
+        }
+    )
+
+    output = sim.run(end_date=sim._df_forcing.index[11])
+    return output.df["SUEWS"][["QS", "QE", "QH"]].to_numpy()
 
 
 def _with_vertical_layer_cp(layers, rho_cp):
@@ -98,6 +150,238 @@ def test_ehc_lumped_storage_is_sensitive_to_surface_rho_cp():
 def test_ehc_lumped_storage_skips_invalid_surface_without_zeroing_grid():
     qs = _run_short_ehc_with_surface_cp(1.0e6, surface_rho_cp={"bldgs": 0.0})
 
+    assert np.max(np.abs(qs)) > 1.0
+
+
+def test_ehc_dual_timescale_lumped_branch_changes_storage_response(monkeypatch):
+    env_keys = [
+        "SUEWS_EHC_DUAL_TIMESCALE",
+        "SUEWS_EHC_FAST_WEIGHT",
+        "SUEWS_EHC_FAST_CAP_SCALE",
+        "SUEWS_EHC_SLOW_CAP_SCALE",
+        "SUEWS_EHC_FAST_G_SCALE",
+        "SUEWS_EHC_SLOW_G_SCALE",
+    ]
+    for key in env_keys:
+        monkeypatch.delenv(key, raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_DUAL_TIMESCALE", "1")
+    monkeypatch.setenv("SUEWS_EHC_FAST_WEIGHT", "0.45")
+    monkeypatch.setenv("SUEWS_EHC_FAST_CAP_SCALE", "0.30")
+    monkeypatch.setenv("SUEWS_EHC_SLOW_CAP_SCALE", "1.50")
+    monkeypatch.setenv("SUEWS_EHC_FAST_G_SCALE", "2.00")
+    monkeypatch.setenv("SUEWS_EHC_SLOW_G_SCALE", "0.70")
+    dual_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(dual_qs))
+    assert np.max(np.abs(dual_qs - default_qs)) > 0.1
+
+
+def test_ehc_state_admittance_changes_lumped_storage_response(monkeypatch):
+    for key in (
+        "SUEWS_EHC_STATE_ADMITTANCE",
+        "SUEWS_EHC_WARMING_G_BOOST",
+        "SUEWS_EHC_COOLING_G_DAMP",
+        "SUEWS_EHC_GRADIENT_SCALE",
+        "SUEWS_EHC_MIN_G_SCALE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_STATE_ADMITTANCE", "1")
+    monkeypatch.setenv("SUEWS_EHC_WARMING_G_BOOST", "0.75")
+    monkeypatch.setenv("SUEWS_EHC_COOLING_G_DAMP", "0.40")
+    monkeypatch.setenv("SUEWS_EHC_GRADIENT_SCALE", "2.0")
+    monkeypatch.setenv("SUEWS_EHC_MIN_G_SCALE", "0.45")
+    state_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(state_qs))
+    assert np.max(np.abs(state_qs - default_qs)) > 0.1
+
+
+def test_ehc_impervious_qf_allocation_changes_lumped_storage_response(monkeypatch):
+    monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
+    monkeypatch.delenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", "1")
+    impervious_qf_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(impervious_qf_qs))
+    assert np.max(np.abs(impervious_qf_qs - default_qs)) > 0.1
+
+
+def test_ehc_direct_air_qf_mode_changes_lumped_storage_response(monkeypatch):
+    monkeypatch.delenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", raising=False)
+    monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_QF_SURF_MODE", "none")
+    direct_air_qf_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(direct_air_qf_qs))
+    assert np.max(np.abs(direct_air_qf_qs - default_qs)) > 0.1
+
+
+def test_ehc_direct_air_qf_mode_changes_coupled_qe_response(monkeypatch):
+    monkeypatch.delenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", raising=False)
+    monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
+    default_fluxes = _run_short_ehc_fluxes_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_QF_SURF_MODE", "none")
+    direct_air_fluxes = _run_short_ehc_fluxes_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(direct_air_fluxes))
+    assert np.max(np.abs(direct_air_fluxes[:, 1] - default_fluxes[:, 1])) > 0.1
+
+
+def test_ehc_daylight_qf_mode_changes_lumped_storage_response(monkeypatch):
+    for key in (
+        "SUEWS_EHC_QF_IMPERVIOUS_ONLY",
+        "SUEWS_EHC_QF_SURF_MODE",
+        "SUEWS_EHC_QF_SURF_DAY_FRAC",
+        "SUEWS_EHC_QF_SURF_NIGHT_FRAC",
+        "SUEWS_EHC_QF_SURF_KDOWN_REF",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_QF_SURF_MODE", "daylight")
+    monkeypatch.setenv("SUEWS_EHC_QF_SURF_DAY_FRAC", "1.0")
+    monkeypatch.setenv("SUEWS_EHC_QF_SURF_NIGHT_FRAC", "0.25")
+    monkeypatch.setenv("SUEWS_EHC_QF_SURF_KDOWN_REF", "150.0")
+    daylight_qf_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(daylight_qf_qs))
+    assert np.max(np.abs(daylight_qf_qs - default_qs)) > 0.1
+
+
+def test_ehc_surface_gradient_allocation_changes_lumped_storage_response(monkeypatch):
+    monkeypatch.delenv("SUEWS_EHC_QS_SURF_ALLOC", raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_QS_SURF_ALLOC", "conductance_gradient")
+    gradient_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(gradient_qs))
+    assert np.max(np.abs(gradient_qs - default_qs)) > 0.1
+
+
+def test_ehc_parallel_standard_surfaces_preserves_heterogeneous_response(monkeypatch):
+    monkeypatch.delenv("SUEWS_EHC_PARALLEL_SURFACES", raising=False)
+    surface_rho_cp = {
+        "paved": 3.2e6,
+        "bldgs": 2.4e6,
+        "evetr": 1.2e6,
+        "dectr": 1.0e6,
+        "grass": 1.1e6,
+        "bsoil": 1.6e6,
+        "water": 4.0e6,
+    }
+    pre_lumped_qs = _run_short_ehc_with_surface_cp(2.0e6, surface_rho_cp=surface_rho_cp)
+
+    monkeypatch.setenv("SUEWS_EHC_PARALLEL_SURFACES", "1")
+    parallel_qs = _run_short_ehc_with_surface_cp(2.0e6, surface_rho_cp=surface_rho_cp)
+
+    assert np.all(np.isfinite(parallel_qs))
+    assert np.max(np.abs(parallel_qs - pre_lumped_qs)) > 0.05
+
+
+def test_ehc_converged_lumped_storage_is_nearly_relaxation_invariant(monkeypatch):
+    for key in EHC_ITERATION_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("SUEWS_EHC_MAX_ITER", "120")
+    monkeypatch.setenv("SUEWS_EHC_TSFC_RELAX", "0.3")
+    slow_relax_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_TSFC_RELAX", "0.8")
+    fast_relax_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(fast_relax_qs))
+    assert np.max(np.abs(fast_relax_qs - slow_relax_qs)) < 0.75
+
+
+def test_ehc_ra_heat_factor_changes_lumped_storage_response(monkeypatch):
+    for key in EHC_RA_HEAT_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_RA_HEAT_FACTOR", "1.5")
+    higher_ra_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(higher_ra_qs))
+    assert np.max(np.abs(higher_ra_qs - default_qs)) > 0.1
+
+
+def test_ehc_state_dependent_ra_heat_guard_changes_lumped_storage_response(monkeypatch):
+    for key in EHC_RA_HEAT_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_RA_HEAT_MODE", "overcoupled_guard")
+    monkeypatch.setenv("SUEWS_EHC_RA_STATE_BOOST", "1.5")
+    monkeypatch.setenv("SUEWS_EHC_RA_STATE_KDOWN_MIN", "0.0")
+    monkeypatch.setenv("SUEWS_EHC_RA_STATE_KDOWN_REF", "1000.0")
+    guarded_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(guarded_qs))
+    assert np.max(np.abs(guarded_qs - default_qs)) > 0.1
+
+
+def test_ehc_state_dependent_ra_heat_guard_includes_zero_kdown(monkeypatch):
+    for key in EHC_RA_HEAT_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    default_qs = _run_short_ehc_with_surface_cp(2.0e6, zero_kdown=True)
+
+    monkeypatch.setenv("SUEWS_EHC_RA_HEAT_MODE", "overcoupled_guard")
+    monkeypatch.setenv("SUEWS_EHC_RA_STATE_BOOST", "1.5")
+    monkeypatch.setenv("SUEWS_EHC_RA_STATE_KDOWN_MIN", "0.0")
+    monkeypatch.setenv("SUEWS_EHC_RA_STATE_KDOWN_REF", "1000.0")
+    guarded_qs = _run_short_ehc_with_surface_cp(2.0e6, zero_kdown=True)
+
+    assert np.all(np.isfinite(guarded_qs))
+    assert np.max(np.abs(guarded_qs - default_qs)) > 0.1
+
+
+def test_ehc_adaptive_relax_limits_high_relax_response(monkeypatch):
+    for key in (
+        "SUEWS_EHC_ADAPTIVE_RELAX",
+        "SUEWS_EHC_TSFC_RELAX",
+        "SUEWS_EHC_TSFC_STEP_QH_LIMIT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("SUEWS_EHC_TSFC_RELAX", "0.8")
+    high_relax_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    monkeypatch.setenv("SUEWS_EHC_ADAPTIVE_RELAX", "1")
+    monkeypatch.setenv("SUEWS_EHC_TSFC_STEP_QH_LIMIT", "5.0")
+    guarded_qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(guarded_qs))
+    assert np.max(np.abs(guarded_qs - high_relax_qs)) > 0.1
+
+
+def test_ehc_restore_best_iteration_path_runs(monkeypatch):
+    for key in (
+        "SUEWS_EHC_ADAPTIVE_RELAX",
+        "SUEWS_EHC_RESTORE_BEST_ITER",
+        "SUEWS_EHC_TSFC_RELAX",
+        "SUEWS_EHC_TSFC_STEP_QH_LIMIT",
+        "SUEWS_EHC_MAX_ITER",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("SUEWS_EHC_ADAPTIVE_RELAX", "1")
+    monkeypatch.setenv("SUEWS_EHC_RESTORE_BEST_ITER", "always")
+    monkeypatch.setenv("SUEWS_EHC_TSFC_RELAX", "1.0")
+    monkeypatch.setenv("SUEWS_EHC_TSFC_STEP_QH_LIMIT", "25.0")
+    monkeypatch.setenv("SUEWS_EHC_MAX_ITER", "6")
+    qs = _run_short_ehc_with_surface_cp(2.0e6)
+
+    assert np.all(np.isfinite(qs))
     assert np.max(np.abs(qs)) > 1.0
 
 

--- a/test/physics/test_attribution.py
+++ b/test/physics/test_attribution.py
@@ -21,6 +21,7 @@ import pytest
 
 from supy.util._attribution import (
     AttributionResult,
+    diagnose_flux_performance,
     attribute_t2,
     diagnose_t2,
 )
@@ -257,6 +258,77 @@ class TestFluxBudgetDecomposition(TestCase):
             rtol=1e-10,
             err_msg="Flux budget contributions don't sum to total",
         )
+
+
+class TestFluxPerformanceAttribution(TestCase):
+    """Test model-observation flux performance attribution."""
+
+    def _make_flux_frames(self):
+        idx = pd.date_range("2026-04-01", periods=4, freq="h")
+        obs = pd.DataFrame(
+            {
+                "QN": [200.0, 220.0, 240.0, 180.0],
+                "QF": [20.0, 20.0, 20.0, 20.0],
+                "QS": [100.0, 110.0, 120.0, 90.0],
+                "QE": [30.0, 35.0, 40.0, 25.0],
+                "QH": [90.0, 95.0, 100.0, 85.0],
+            },
+            index=idx,
+        )
+        model = pd.DataFrame(
+            {
+                "QN": [205.0, 225.0, 245.0, 185.0],
+                "QF": [20.0, 20.0, 20.0, 20.0],
+                "QS": [80.0, 85.0, 95.0, 70.0],
+                "QE": [45.0, 55.0, 60.0, 42.0],
+                "QH": [100.0, 105.0, 110.0, 93.0],
+            },
+            index=idx,
+        )
+        return obs, model
+
+    def test_diagnose_flux_performance_closure(self):
+        obs, model = self._make_flux_frames()
+        result = diagnose_flux_performance(obs, model, variable="QE")
+
+        self.assertEqual(result.variable, "QE")
+        total = result.contributions["delta_total"]
+        components = (
+            result.contributions["available_energy"]
+            + result.contributions["partition"]
+        )
+        np.testing.assert_allclose(components, total, rtol=1e-10)
+
+        energy_components = (
+            result.contributions["energy_QN"]
+            + result.contributions["energy_QF"]
+            + result.contributions["energy_QS"]
+        )
+        np.testing.assert_allclose(
+            energy_components,
+            result.contributions["available_energy"],
+            rtol=1e-10,
+        )
+
+    def test_diagnose_flux_performance_derives_qs(self):
+        obs, model = self._make_flux_frames()
+        result = diagnose_flux_performance(
+            obs.drop(columns=["QS"]),
+            model.drop(columns=["QS"]),
+            variable="QH",
+        )
+
+        total = result.contributions["delta_total"]
+        components = (
+            result.contributions["available_energy"]
+            + result.contributions["partition"]
+        )
+        np.testing.assert_allclose(components, total, rtol=1e-10)
+
+    def test_diagnose_flux_performance_rejects_unsupported_variable(self):
+        obs, model = self._make_flux_frames()
+        with self.assertRaises(ValueError):
+            diagnose_flux_performance(obs, model, variable="QS")
 
 
 class TestExtractSuewsGroup(TestCase):


### PR DESCRIPTION
## Summary

- add flux-performance attribution utilities for comparing simulated and reference fluxes across bias, MAE, timing, correlation, and monthly/hourly diagnostics
- tighten the experimental EHC surface-energy coupling with residual-QH diagnostics, bounded Tsurf updates, and opt-in experimental controls for adaptive relaxation, best-iteration restore, QF surface-allocation modes, dual-timescale storage, state-dependent admittance, and RA heat coupling
- extend EHC regression coverage for CP sensitivity, invalid-surface handling, dual-timescale storage, state-dependent admittance, QF allocation, RA heat coupling, convergence controls, and ungated no-op behaviour for experimental environment variables

## Notes

This is the current EHC/QS calibration and mechanism branch. The calibration path remains focused on NARP + EHC. The building-facet/SPARTACUS regression coverage is kept only to prevent the earlier CP/NLayer sensitivity issue from returning; it is not the calibration pathway for this round.

The non-EHC sample path is intentionally preserved. During validation I caught and fixed an unintended OHM/NARP smoke drift caused by applying the EHC convergence-order change too broadly.

Environment-driven EHC tuning controls are now guarded by `SUEWS_EHC_EXPERIMENTAL_CONTROLS=1`. Without that explicit gate, normal runs ignore `SUEWS_EHC_*` tuning variables, so identical configs are not silently changed by stray calibration environment state.

## Scientific evidence

**Quantities changed:** EHC storage heat flux `QS` [W m-2], available energy `QN + QF - QS` [W m-2], latent heat flux `QE` [W m-2], sensible heat flux `QH` [W m-2], and EHC surface-temperature fixed-point diagnostics [degC / W m-2].

**Mechanism:** EHC solves conductive storage from the current surface-temperature boundary, while SUEWS closes the surface energy balance by deriving `QH` as the residual. This PR keeps EHC material state fixed within a physical timestep during Tsurf iteration, compares residual-derived and resistance-derived `QH`, and makes experimental calibration controls opt-in so they can be tested without changing ordinary runs.

| Output / guard | Before | After | Expected? |
|---|---:|---:|---|
| Non-EHC sample path | Intended unchanged; an intermediate draft produced OHM/NARP smoke drift | `test_sample_output_validation` passes and fixture diff is empty | Yes. EHC-only iteration changes must not move the default OHM/NARP reference run. |
| EHC CP sensitivity | Earlier investigation found a CP/layer-state path could become insensitive | `test_ehc_lumped_storage_is_sensitive_to_surface_rho_cp` and `test_ehc_spartacus_facet_storage_is_sensitive_to_building_rho_cp` pass | Yes. Increasing heat capacity should change the storage response; insensitivity would indicate a layer/surface state bug. |
| Invalid-surface handling | One invalid surface could zero or destabilise the grid response | `test_ehc_lumped_storage_skips_invalid_surface_without_zeroing_grid` passes | Yes. A bad positive-fraction surface should be skipped without erasing valid surfaces. |
| Experimental EHC env controls | Environment variables could silently alter EHC behaviour | `SUEWS_EHC_EXPERIMENTAL_CONTROLS=1` is now required; `test_ehc_experimental_qf_env_is_ignored_without_gate` passes | Yes. Calibration sweeps remain possible, but normal configs are deterministic unless the explicit experimental gate is set. |
| Optional calibration branches | Not consistently guarded or covered as opt-in paths | Dual-timescale, state-admittance, QF allocation, QS allocation, RA heat, adaptive relaxation, and restore-best tests pass | Yes. Each branch changes the EHC response only when deliberately enabled and remains finite. |

**Expected sign and magnitude:** The physically defensible calibration direction is higher urban-fabric thermal admittance, especially paved/building surfaces. The earlier sweep showed MAM/JJA daylight `QS` MAE improving from OHM 96.12 W m-2 to EHC k=1.7-2.0 at 72.31 to 67.76 W m-2, with available-energy bias reducing from 44.16 W m-2 to near zero around k=1.7-1.8. That sign is expected: increasing conductive admittance raises daytime storage uptake, reduces excess available energy, and shifts the residual `QH`/`QE` partition. QH has a U-shaped response, so these controls are treated as diagnostics/calibration hooks rather than a blanket default tuning.

**Reference fixtures refreshed in this PR:** none. The fixture diff is empty, and the local sample-output and full physics runs passed against the existing references.

**Domain owner sign-off:** maintainer sign-off required for EHC / general physics (`@sunt05`). No named external subsystem owner is listed for EHC; STEBBS coverage here is regression guard only and does not move the STEBBS fixture.

## Validation

- `source .venv/bin/activate && make dev` - passed
- `git diff --check` - passed
- `source .venv/bin/activate && python -m pytest test/core/test_sample_output.py::TestSampleOutput::test_sample_output_validation -q` - passed (`1 passed`)
- `source .venv/bin/activate && python -m pytest test/physics/test_attribution.py -q` - passed (`26 passed`)
- `source .venv/bin/activate && python -m pytest test/core/test_ehc_regression.py -q` - passed (`18 passed`)
- `source .venv/bin/activate && make test-smoke` - passed (`27 passed, 1731 deselected`)
- `source .venv/bin/activate && python -m pytest test -m physics -q --tb=short --durations=10` - passed (`117 passed, 1641 deselected`)
