### PR TITLE
docs: correct kdown forcing constraint to >= 0

### DIFF
--- a/docs/source/inputs/forcing-data.rst
+++ b/docs/source/inputs/forcing-data.rst
@@ -68,7 +68,7 @@ SUEWS requires the following meteorological variables:
    * - Incoming shortwave
      - W/m²
      - kdown
-     - Must be > 0
+     - Must be ≥ 0 (0 at night)
    * - Incoming longwave
      - W/m²
      - ldown


### PR DESCRIPTION
## Summary

The forcing-data input table listed incoming shortwave (`kdown`) as "Must be > 0". Incoming shortwave radiation is 0 W/m² at night, so the strict `> 0` is wrong. This corrects it to `≥ 0 (0 at night)`.

This aligns the requirement with the rest of the same page, which already states:
- the valid range is `0 - 1400 W/m²` (Physical ranges table);
- the troubleshooting note "Check kdown is always ≥ 0".

It also matches the model behaviour, which clamps negative shortwave to 0 (`suews_phys_estm.f95`) and sets nighttime `kdown` to 0 in the ERA5 forcing helper.

## Validation

Docs-only, single table-cell text edit; no new RST directives. The `≥` character matches existing usage elsewhere in the same file.

Fixes #1568