### PR TITLE
Auto-parametrise RefValue to stop config-dump serializer warning flood (#1569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ EXAMPLES:
 
 ## 2026
 
+### 28 Jun 2026
+
+- [bugfix] Fixed the flood of `PydanticSerializationUnexpectedValue` warnings when serialising a `SUEWSConfig` (#1569)
+  - `FlexibleRefValue(T)` is `Union[RefValue[T], T]`; Pydantic's union serializer only routes a value to the `RefValue[T]` branch cleanly when the instance is parametrised. Bare `RefValue(value)` constructions (used throughout the `df_state` reconstruction path) produced unparametrised instances, emitting one spurious warning per populated field — hundreds for a config rebuilt via `from_state`/`from_output`.
+  - `RefValue(value)` now auto-parametrises to `RefValue[type(value)]`, matching what validation from YAML already produces, so the warnings no longer arise. No diagnostics are suppressed; serialized output is unchanged.
+
 ### 26 Jun 2026
 
 - [maintenance] Added a recorded-scientific-evidence policy for physics-changing PRs (#1576)

--- a/src/supy/data_model/core/type.py
+++ b/src/supy/data_model/core/type.py
@@ -74,6 +74,42 @@ class RefValue(BaseModel, Generic[T]):
         extra="forbid",
     )
 
+    def __new__(cls, value=_REF_VALUE_UNSET, ref=None, **data):
+        """Auto-parametrise the bare generic so ``RefValue(x)`` is ``RefValue[type(x)]``.
+
+        The data model declares fields as ``FlexibleRefValue(T)`` =
+        ``Union[RefValue[T], T]``. Pydantic's union serializer only routes a
+        value cleanly to the ``RefValue[T]`` branch when the instance carries
+        the matching generic parameter; a bare, unparametrised ``RefValue``
+        (from ``RefValue(x)``) matches neither branch's schema and triggers a
+        ``PydanticSerializationUnexpectedValue`` warning per field on dump --
+        hundreds for a config rebuilt from ``df_state`` (gh#1569). Validation
+        from YAML already yields ``RefValue[T]``; this makes the dozens of
+        direct ``RefValue(value)`` reconstruction sites consistent with it.
+
+        Only the bare base class with a concrete, non-``None`` scalar is
+        redirected; already-parametrised subclasses, the keyword-only / unset
+        call shape used during validation and ``model_construct``, and ``None``
+        values (no inferable type) are left untouched.
+        """
+        if cls is RefValue:
+            concrete = value if value is not _REF_VALUE_UNSET else data.get(
+                "value", _REF_VALUE_UNSET
+            )
+            # Resolve numpy scalars to their Python native, so we parametrise on
+            # the Python type (RefValue[float], not RefValue[numpy.float64]) and
+            # never ask Pydantic to build a schema for a numpy type it cannot.
+            if isinstance(concrete, np.generic):
+                concrete = concrete.item()
+            # Only parametrise on the plain types FlexibleRefValue actually uses
+            # and that Pydantic can build a RefValue[T] schema for. Anything else
+            # (None, pandas Timestamps, containers, ...) stays the bare generic.
+            if type(concrete) in (bool, int, float, str) or isinstance(
+                concrete, Enum
+            ):
+                cls = RefValue[type(concrete)]
+        return super().__new__(cls)
+
     def __init__(self, value=_REF_VALUE_UNSET, ref=None, **data):
         # Two call shapes are supported:
         # 1. Direct construction: `RefValue(3.0)` or `RefValue(value=3.0, ref=...)`.
@@ -97,6 +133,10 @@ class RefValue(BaseModel, Generic[T]):
             return float(v)
         if isinstance(v, (np.int64, np.int32)):
             return int(v)
+        if isinstance(v, np.bool_):
+            return bool(v)
+        if isinstance(v, np.str_):
+            return str(v)
         return v
 
     def model_dump(self, **kwargs):

--- a/test/data_model/test_to_yaml_roundtrip.py
+++ b/test/data_model/test_to_yaml_roundtrip.py
@@ -5,6 +5,7 @@ Verifies both lossless round-tripping and clean-export behaviour.
 """
 
 import tempfile
+import warnings
 from pathlib import Path
 
 import pytest
@@ -213,3 +214,101 @@ class TestToYamlRoundTrip:
                 getattr(reloaded_land_cover, surface_type).alpha_enh_bioco2.value
                 is None
             )
+
+
+@pytest.mark.cfg
+class TestRefValueSerialisationNoWarnings:
+    """gh#1569: serialising a config must not flood serializer warnings.
+
+    ``FlexibleRefValue(T)`` is ``Union[RefValue[T], T]``. Pydantic's union
+    serializer only routes a value cleanly to the ``RefValue[T]`` branch when the
+    instance carries the matching generic parameter. A bare, unparametrised
+    ``RefValue`` (from ``RefValue(value)``) matches neither branch and triggers a
+    ``PydanticSerializationUnexpectedValue`` warning per field on dump -- hundreds
+    for a config rebuilt from ``df_state``. ``RefValue.__new__`` now
+    auto-parametrises bare construction (``RefValue(x)`` -> ``RefValue[type(x)]``)
+    so the warnings never arise; nothing is suppressed.
+    """
+
+    @staticmethod
+    def _serialization_warnings(func):
+        """Return the serializer warnings emitted by calling ``func``."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            func()
+        return [
+            w
+            for w in caught
+            if "PydanticSerializationUnexpectedValue" in str(w.message)
+            or "serialized value may not be as expected" in str(w.message)
+        ]
+
+    def test_bare_construction_is_parametrised(self):
+        """``RefValue(x)`` yields ``RefValue[type(x)]`` so unions serialise cleanly."""
+        assert type(RefValue(0.4)).__name__ == "RefValue[float]"
+        assert type(RefValue(3)).__name__ == "RefValue[int]"
+        # value is preserved unchanged
+        assert RefValue(0.4).value == pytest.approx(0.4)
+        assert RefValue(3).value == 3
+
+    def test_none_construction_stays_bare(self):
+        """``RefValue(None)`` has no inferable type, so it stays the bare generic."""
+        rv = RefValue(None)
+        assert type(rv).__name__ == "RefValue"
+        assert rv.value is None
+
+    def test_parametrised_construction_unchanged(self):
+        """Explicit ``RefValue[T](x)`` is left exactly as-is."""
+        rv = RefValue[float](1.0)
+        assert type(rv).__name__ == "RefValue[float]"
+        assert rv.value == pytest.approx(1.0)
+
+    @pytest.fixture
+    def df_state_config(self, sample_config):
+        """A config reconstructed from a ``df_state`` round-trip.
+
+        ``from_df_state`` rebuilds ``RefValue`` fields via bare ``RefValue(value)``
+        constructions -- the path that triggered the warning flood before the
+        auto-parametrisation fix.
+        """
+        return SUEWSConfig.from_df_state(sample_config.to_df_state())
+
+    def test_model_dump_emits_no_serialization_warnings(self, df_state_config):
+        warns = self._serialization_warnings(
+            lambda: df_state_config.model_dump(mode="json")
+        )
+        assert warns == [], (
+            f"model_dump() emitted {len(warns)} serializer warning(s); "
+            "expected none (gh#1569)"
+        )
+
+    def test_model_dump_json_emits_no_serialization_warnings(self, df_state_config):
+        warns = self._serialization_warnings(df_state_config.model_dump_json)
+        assert warns == [], (
+            f"model_dump_json() emitted {len(warns)} serializer warning(s); "
+            "expected none (gh#1569)"
+        )
+
+    def test_to_yaml_emits_no_serialization_warnings(self, df_state_config, tmp_path):
+        out_path = tmp_path / "gh1569.yml"
+        warns = self._serialization_warnings(
+            lambda: df_state_config.to_yaml(str(out_path))
+        )
+        assert warns == [], (
+            f"to_yaml() emitted {len(warns)} serializer warning(s); "
+            "expected none (gh#1569)"
+        )
+
+    def test_df_state_roundtrip_preserves_values(self, df_state_config, tmp_path):
+        """The clean dump must still round-trip the data losslessly."""
+        # ARRANGE
+        out_path = tmp_path / "gh1569-roundtrip.yml"
+        before = df_state_config.sites[0].properties.land_cover.paved.sfr.value
+
+        # ACT
+        df_state_config.to_yaml(str(out_path))
+        reloaded = SUEWSConfig.from_yaml(str(out_path))
+
+        # ASSERT
+        after = reloaded.sites[0].properties.land_cover.paved.sfr.value
+        assert after == pytest.approx(before)


### PR DESCRIPTION
Fixes #1569

## Problem

Serialising a `SUEWSConfig` (`config.to_yaml()` / `config.model_dump()`) emits a `PydanticSerializationUnexpectedValue` warning **per populated `RefValue` field** — hundreds for a config rebuilt from a `df_state` round-trip (`from_state` / `from_output` / restart), burying genuine output.

## Root cause

Fields are declared as `FlexibleRefValue(T)` = `Union[RefValue[T], T]`. Pydantic's union serializer only routes a value cleanly to the `RefValue[T]` branch when the held instance carries the matching generic parameter. Validation from YAML produces parametrised `RefValue[float]` (clean), but the `df_state` reconstruction path builds fields with **bare `RefValue(value)`** (the unparametrised generic). A bare instance matches *neither* union branch's schema, so pydantic emits two warnings per field (one per branch) and then serialises it correctly anyway.

Verified: the data is correct and lossless (value preserved, round-trips, output byte-identical) — the warnings are spurious. The defect is the inconsistency between the YAML path (typed) and the `df_state` path (bare).

## Fix

Fix at the source rather than masking the diagnostic: `RefValue(value)` now auto-parametrises to `RefValue[type(value)]` in `__new__`, making direct construction consistent with what validation already produces. The warnings never arise; **nothing is suppressed** and serialized output is unchanged.

Guards so this is safe across the ~470 construction sites:
- numpy scalars are resolved to their Python native first (and the value converter now also handles numpy `bool`/`str`), so pydantic is never asked to build a schema for a numpy/pandas type;
- only `bool`/`int`/`float`/`str`/`Enum` values are parametrised; `None` and unparametrisable values (e.g. pandas `Timestamp`) stay the bare generic;
- already-parametrised `RefValue[T](x)`, and the unset/keyword call shape used by validation and `model_construct`, are untouched.

An earlier revision of this PR defaulted `warnings=False` on the config dump methods; that was dropped in favour of this root-cause fix, which keeps the public diagnostic intact.

## Validation

- New regression tests in `test/data_model/test_to_yaml_roundtrip.py` (`TestRefValueSerialisationNoWarnings`): bare-vs-typed construction, `None`/parametrised passthroughs, and zero serializer warnings with lossless round-trip on a `df_state`-reconstructed config across `model_dump` / `model_dump_json` / `to_yaml`.
- `pytest test/data_model` — 950 passed, 1 skipped.
- `pytest test/data_model/test_legacy_table_roundtrip.py` — 50 passed (legacy table faithfulness across versions).
- `pytest test/cmd/test_df_state_conversion.py test/core/test_suews_simulation.py` — 101 passed.
- `pytest -m smoke` — 12 passed.
- ruff — no new findings.