### PR TITLE
CI: run full physics tier on physics-change PRs and in the merge queue (#1576)

### DIFF
--- a/.claude/rules/ci/conventions.md
+++ b/.claude/rules/ci/conventions.md
@@ -232,6 +232,7 @@ Test tiers control which pytest markers run during CI builds. Defined via pytest
 - **core** (`-m "smoke or core"`) -- core physics and logic, includes smoke (~2-3 min)
 - **cfg** (`-m "smoke or cfg"`) -- config/schema validation, includes smoke (~2-3 min)
 - **standard** (`-m "not slow"`) -- all tests except slow-marked ones (~5-10 min)
+- **physics-full** (physics axis `-m physics`, incl. `slow`; api axis identical to `standard`) -- the physics-change tier (gh#1576). Widens only the physics axis to include `slow` so an output shift surfaces in the PR/merge queue rather than in the nightly; the api axis stays as `standard`.
 - **all** (no filter) -- full suite including slow tests (~15-30 min)
 
 Each higher tier is a superset of smoke. The `standard` tier excludes only `slow`-marked tests (>30s each).
@@ -255,10 +256,13 @@ The `determine_matrix` job (`build-publish_to_pypi.yml`) assigns tiers based on 
 - python or util: MINIMAL (1), test tier **standard**
 - ci or tests only: MINIMAL (1), test tier **smoke**
 - Python versions: BOOKEND (2)
+- **`0-physics:change` label override (gh#1576)**: a ready PR carrying this label runs test tier **physics-full** instead, so the full `-m physics` suite (incl. `slow`) gates the PR. Platforms are unchanged; physics tests are binary-determined and run on the build Python.
 
 ### Merge queue (`merge_group`)
 
 Always: PR_PLATFORMS (3), BOOKEND (2), test tier **standard**. No path-based differentiation -- the merge queue uses a fixed reduced matrix to validate the merge commit.
+
+**Exception (gh#1576):** when the queued PR carries `0-physics:change`, the merge queue runs test tier **physics-full** so the `slow` physics regression also gates the merge commit (this is the gap that let a known output-changing PR land in #1570). The PR number is derived from the queue ref and validated before the label is queried; if it cannot be identified (e.g. a batched group), the queue fails safe to **physics-full**.
 
 ### Nightly schedule / tag push
 
@@ -313,7 +317,7 @@ The merge queue deliberately uses a reduced matrix rather than the full matrix. 
 
 - macOS Intel x86_64 (legacy platform, declining user base)
 - Python 3.13 (intermediate version)
-- `slow`-marked tests (>30s each)
+- `slow`-marked tests (>30s each) -- **except** for PRs labelled `0-physics:change`, which run the **physics-full** tier so the `slow` physics regression gates the merge (gh#1576)
 
 **Rationale:** Full matrix (4 platforms x 3 Python = 12 jobs) would make the merge queue too slow for its purpose as a fast gatekeeper before landing on master. The reduced matrix covers all three major OS families and version boundary extremes where compatibility issues most commonly surface.
 

--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'Python version to build for (always cp312 — emits cp312-abi3 wheel)'
     required: true
   test_tier:
-    description: 'Test tier: smoke, core, cfg, standard, or all'
+    description: 'Test tier: smoke, core, cfg, standard, physics-full, or all'
     required: false
     default: 'standard'
   is_testpypi_build:
@@ -179,6 +179,7 @@ runs:
               inputs.test_tier == 'core' && '-m "physics and (smoke or core) and not slow"' ||
               inputs.test_tier == 'cfg' && '-m "physics and (smoke or cfg) and not slow"' ||
               inputs.test_tier == 'standard' && '-m "physics and not slow"' ||
+              inputs.test_tier == 'physics-full' && '-m physics' ||
               inputs.test_tier == 'all' && '-m physics' ||
               '-m physics' }}
         MACOSX_DEPLOYMENT_TARGET: '15.0'

--- a/.github/scripts/determine-matrix.sh
+++ b/.github/scripts/determine-matrix.sh
@@ -28,6 +28,11 @@
 #   INPUT_PLAT_WINDOWS   -- inputs.plat_windows
 #   INPUT_PY312..PY314   -- inputs.py312..py314
 #   INPUT_TEST_TIER      -- inputs.test_tier (dispatch only)
+#   PHYSICS_CHANGE       -- "true" if the PR carries the 0-physics:change label
+#                           (gh#1576). On a ready PR or in the merge queue this
+#                           forces the physics-full tier so the full -m physics
+#                           suite (incl. slow) runs as a required check before
+#                           merge, not only in the nightly. Defaults to false.
 #   GITHUB_REF           -- github.ref (e.g. refs/tags/v2025a1)
 #   PR_PYPROJECT         -- path to the built ref's pyproject.toml (data only;
 #                           the requires-python floor source of truth). The
@@ -40,6 +45,7 @@ set -euo pipefail
 IS_DRAFT="${IS_DRAFT:-false}"
 INPUT_MATRIX_CONFIG="${INPUT_MATRIX_CONFIG:-}"
 INPUT_TEST_TIER="${INPUT_TEST_TIER:-all}"
+PHYSICS_CHANGE="${PHYSICS_CHANGE:-false}"
 GITHUB_REF="${GITHUB_REF:-}"
 
 # Platform presets
@@ -112,14 +118,30 @@ elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
     echo "buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
     TIER=smoke
   fi
+  # gh#1576: a physics-change PR runs the full physics tier (incl. slow) so an
+  # output shift surfaces here rather than in the nightly. Only the physics axis
+  # widens; the api axis stays as standard (see test-api-cross-python EXPR map).
+  if [[ "${PHYSICS_CHANGE}" == "true" ]]; then
+    echo "Physics-change PR (0-physics:change) - forcing full physics tier (incl. slow)"
+    TIER=physics-full
+  fi
   echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
   echo "test_tier=$TIER" >> "$GITHUB_OUTPUT"
 
 elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
-  echo "Merge queue validation - reduced platforms, standard tests"
+  # gh#1576: the merge queue otherwise runs `standard` (slow excluded), which is
+  # how a known output-changing PR landed without the shift being caught. When
+  # the queued PR carries 0-physics:change, run the full physics tier here too.
+  MERGE_TIER=standard
+  if [[ "${PHYSICS_CHANGE}" == "true" ]]; then
+    echo "Merge queue validation - physics-change PR, full physics tier (incl. slow)"
+    MERGE_TIER=physics-full
+  else
+    echo "Merge queue validation - reduced platforms, standard tests"
+  fi
   echo "buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
   echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
-  echo "test_tier=standard" >> "$GITHUB_OUTPUT"
+  echo "test_tier=$MERGE_TIER" >> "$GITHUB_OUTPUT"
 
 elif [[ "${EVENT_NAME}" == "schedule" ]]; then
   echo "Nightly - full matrix, all tests"

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -300,10 +300,52 @@ jobs:
           persist-credentials: false
           path: _pr_meta
 
+      # gh#1576: detect the 0-physics:change label so the matrix can run the
+      # full -m physics tier (incl. slow) before merge rather than only in the
+      # nightly. On a PR the labels are in the event payload; in the merge queue
+      # the queue ref (gh-readonly-queue/<base>/pr-<n>-<sha>) carries the PR
+      # number, which we validate before querying the API.
+      - name: Detect physics-change label
+        id: physics-label
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_LABELS_JSON: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '[]' }}
+          MERGE_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          REPO: ${{ github.repository }}
+          LABEL: '0-physics:change'
+        run: |
+          set -euo pipefail
+          found=false
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            # Labels arrive as a JSON array; match exactly via jq (label names
+            # may contain spaces or colons, so avoid newline/word splitting).
+            if printf '%s' "$PR_LABELS_JSON" | jq -e --arg l "$LABEL" 'any(.[]; . == $l)' >/dev/null; then
+              found=true
+            fi
+          elif [[ "$EVENT_NAME" == "merge_group" ]]; then
+            pr_num="$(printf '%s' "$MERGE_HEAD_REF" | sed -nE 's#.*/pr-([0-9]+)-[0-9a-f]+$#\1#p')"
+            if [[ "$pr_num" =~ ^[0-9]+$ ]]; then
+              if gh api "repos/${REPO}/issues/${pr_num}/labels" --jq '[.[].name]' \
+                   | jq -e --arg l "$LABEL" 'any(.[]; . == $l)' >/dev/null; then
+                found=true
+              fi
+            else
+              # Could not identify the queued PR (e.g. a batched group). Fail
+              # safe: run the full physics tier rather than risk missing a shift.
+              echo "::notice::merge_group PR number not parsed from queue ref; running full physics tier as a safe default"
+              found=true
+            fi
+          fi
+          echo "found=$found" >> "$GITHUB_OUTPUT"
+          echo "physics-change label present: $found"
+
       - name: Set matrix based on trigger type
         id: set-matrix
         env:
           EVENT_NAME: ${{ github.event_name }}
+          PHYSICS_CHANGE: ${{ steps.physics-label.outputs.found || 'false' }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
           FORTRAN_CHANGED: ${{ needs.detect-changes.outputs.fortran-changed || 'false' }}
           RUST_CHANGED: ${{ needs.detect-changes.outputs.rust-changed || 'false' }}

--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       test_tier:
-        description: 'Test tier: smoke, core, cfg, standard, or all'
+        description: 'Test tier: smoke, core, cfg, standard, physics-full, or all'
         required: true
         type: string
       is_testpypi_build:

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -81,6 +81,9 @@ jobs:
             core)     EXPR='api and (smoke or core) and not slow and not qgis' ;;
             cfg)      EXPR='api and (smoke or cfg) and not slow and not qgis' ;;
             standard) EXPR='api and not slow and not qgis' ;;
+            # physics-full (gh#1576): expand only the physics axis to include
+            # slow; the api axis stays identical to standard.
+            physics-full) EXPR='api and not slow and not qgis' ;;
             all)      EXPR='api' ;;
             *)        echo "::error::Unknown test_tier: $TIER"; exit 1 ;;
           esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ EXAMPLES:
 - [maintenance] Added a recorded-scientific-evidence policy for physics-changing PRs (#1576)
   - New `.claude/rules/physics-change-evidence.md`: PRs that change model physics or move a reference output must carry a `## Scientific evidence` PR-body section, obtain domain-owner sign-off, refresh moved fixtures in the same PR, and run the full `-m physics` CI tier before merge.
   - Wired the `0-physics:change` classification label into `audit-pr`, `triage-pr`, and `triage-issue`; documented it in the `0-` automation namespace and added a contributor pointer in `CONTRIBUTING.md`.
+- [maintenance] CI: run the full physics test tier (incl. `slow`) on `0-physics:change` PRs and in the merge queue (#1576)
+  - Added a `physics-full` test tier that widens only the physics axis to include `slow` (the api axis stays as `standard`); `determine-matrix.sh` selects it when the `0-physics:change` label is present, in both the ready-PR and `merge_group` contexts. This closes the gap where the merge queue's `standard` tier excluded `slow` physics, so a known output-changing PR (#1570) merged without the shift being caught until the nightly.
 
 ### 24 Jun 2026
 


### PR DESCRIPTION
Part 2 of 2 for #1576. **Stacked on #1580** (base branch is `worktree-gh1576-physics-evidence`); review/merge #1580 first, then rebase this onto `master`.

## The gap

Both ready PRs and the merge queue (`merge_group`) run `test_tier=standard`, whose pytest expression is `... and not slow ...`. So the `slow` physics regression tests run **only** in the nightly (`schedule`) and on tag builds. That is exactly why the stale STEBBS fixture in #1570 merged without the output shift being caught until overnight.

## The fix

- **New `physics-full` test tier** that widens *only* the physics axis to `-m physics` (including `slow`); the api axis stays identical to `standard` (no extra slow-api or qgis). Wired in:
  - `.github/actions/build-suews/action.yml` (`CIBW_TEST_COMMAND`)
  - `.github/workflows/test-api-cross-python-reusable.yml` (EXPR map)
- **`determine-matrix.sh`** selects `physics-full` when `PHYSICS_CHANGE=true`, in both the ready-PR and `merge_group` branches. Platforms are unchanged (physics tests are binary-determined and run on the build Python).
- **New "Detect physics-change label" step** in `build-publish_to_pypi.yml`:
  - On `pull_request`, reads labels from the event payload (`toJSON` + `jq` exact match).
  - On `merge_group`, derives the PR number from the queue ref (`gh-readonly-queue/<base>/pr-<n>-<sha>`), **validates it against `^[0-9]+$`** before querying the API, and **fails safe to `physics-full`** if the PR cannot be identified (e.g. a batched group).
- Documented the new tier and the merge-queue exception in `.claude/rules/ci/conventions.md`.

## Verification (local)

- `bash -n determine-matrix.sh` clean; simulated all four paths:
  - ready physics-change PR -> `physics-full`; merge_group + label -> `physics-full`; merge_group no label -> `standard`; ready no-label -> `standard`.
- All four changed workflow/action YAML files parse (`yaml.safe_load`).
- jq exact-match logic and the queue-ref PR-number regex tested (positive + negative cases).

## Security

PR title/body/ref inputs are passed via `env:` and never interpolated into `run:`; the merge-queue PR number is validated before use in the API call.

Closes #1576 once both parts land.