### PR TITLE
Cap pandas<3 on manylinux2014 matrix to fix numpy/pandas ABI segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ EXAMPLES:
 
 ## 2026
 
+### 29 Jun 2026
+
+- [bugfix] Capped `pandas<3` on the manylinux2014 matrix to stop a numpy/pandas ABI segfault
+  - On CPython 3.10-3.12 Linux, `scipy<1.15` (pinned to retain manylinux2014 wheels) transitively pins `numpy<2.3`. With `pandas` left unpinned, the resolver pulled pandas 3.0.x, whose wheels are ABI-built against numpy>=2.3; running them against numpy 2.2.6 segfaulted inside `DatetimeIndex.shift` (reached via `supy._load.resample_linear_inst`), crashing the nightly `cp312-manylinux` API test job with exit 139.
+  - `pandas` is now constrained to `<3` under exactly the same environment marker as the `scipy<1.15` cap; newer interpreters and non-Linux platforms (which resolve numpy>=2.3) continue to use pandas 3.
+
 ### 28 Jun 2026
 
 - [bugfix] Fixed the flood of `PydanticSerializationUnexpectedValue` warnings when serialising a `SUEWSConfig` (#1569)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,12 @@ readme = "README.md"
 # Core runtime dependencies only
 dependencies = [
     # Data processing
-    "pandas",
+    # pandas 3.0 wheels are ABI-built against numpy>=2.3. On the manylinux2014
+    # matrix below, scipy<1.15 transitively pins numpy<2.3, which is ABI-
+    # incompatible with pandas 3.0 and segfaults DatetimeIndex.shift. Keep pandas
+    # <3 there; let newer interpreters/platforms (numpy>=2.3) use pandas 3.
+    "pandas<3; python_version < '3.13' and platform_system == 'Linux'",  # numpy<2.3 (manylinux2014 scipy) is ABI-incompatible with pandas 3.0
+    "pandas; python_version >= '3.13' or platform_system != 'Linux'",  # Others use latest
     "numpy>=1.22",  # Covers current QGIS 3 LTR / QGIS 4 NumPy stacks; no ABI constraint (Rust bridge is NumPy-free)
     "scipy<1.15; python_version < '3.13' and platform_system == 'Linux'",  # 3.12 Linux: manylinux2014 wheels
     "scipy; python_version >= '3.13' or platform_system != 'Linux'",  # Others use latest


### PR DESCRIPTION
## Problem

The nightly wheel-build workflow's `API cross-CPython tests / cp312-manylinux x86_64` job crashes with a segmentation fault (exit 139) inside pandas `DatetimeIndex.shift`, reached via `supy._load.resample_linear_inst` during `test_functional_matches_oop`.

## Root cause

A dependency ABI mismatch, not a code bug:

- `pyproject.toml` pins `scipy<1.15` on CPython <3.13 Linux to retain manylinux2014 wheels. scipy 1.14.x transitively requires `numpy<2.3`, so cp312-Linux resolves numpy 2.2.6.
- `pandas` was unpinned, so the resolver pulled pandas 3.0.4, whose cp312 manylinux wheels are built against the numpy >=2.3 ABI. Loading them against numpy 2.2.6 segfaults.
- cp313/cp314 manylinux pass because their newer scipy permits numpy 2.5.0 + pandas 3. An earlier cp312 job in the same run that resolved pandas 2.3.2 + numpy 2.2.6 passed the full API tier, confirming pandas 2.x is compatible with the capped numpy.

pandas 3.0.4's own metadata declares `numpy>=1.26.0`, so the bad combination is resolver-valid; an explicit cap is required.

## Fix

Cap `pandas<3` under exactly the same environment marker as the `scipy<1.15` cap, mirroring the repo's existing conditional-pin idiom (scipy, pyarrow). Newer interpreters and non-Linux platforms (numpy >=2.3) keep using pandas 3.

## Validation

- TOML parses; supy builds from the changed pyproject.
- Marker resolution verified per matrix cell (mutually exclusive, exhaustive): cp310/311/312-Linux -> `pandas<3`; cp313/314-Linux and all macOS/Windows -> pandas 3.
- No other unconditional `pandas` requirement exists in pyproject.
- No supy code change: cp313/cp314 ran the identical code path on pandas 3.0.4 and passed, ruling out an API-level cause.

Reference: failed run https://github.com/UMEP-dev/SUEWS/actions/runs/28345905124
