### PR TITLE
Add reference metadata examples to sample config

### DIFF
--- a/src/supy/sample_data/sample_config.yml
+++ b/src/supy/sample_data/sample_config.yml
@@ -15,6 +15,10 @@ model:
       dir: "./Output"
       groups:
         - "SUEWS"
+    ref:
+      desc: Ward et al. (2016) benchmark period and output cadence for the sample configuration
+      ID: W16
+      DOI: 10.1016/j.uclim.2016.05.001
   physics:
     # These method selectors use the accepted nested/readable input forms so
     # the chosen physics family or axis is explicit in the sample. Round-trip
@@ -53,6 +57,10 @@ model:
       same_albedo_roof: disabled
       same_emissivity_wall: disabled
       same_emissivity_roof: disabled
+    ref:
+      desc: Ward et al. (2016) model physics choices represented by the sample configuration
+      ID: W16
+      DOI: 10.1016/j.uclim.2016.05.001
 sites:
 - name: KCL
   gridiv: 1
@@ -79,6 +87,10 @@ sites:
       value: 0.0
     narp_trans_site:
       value: 1.0
+    ref:
+      desc: Ward et al. (2016) KCL site properties used by the sample configuration
+      ID: W16
+      DOI: 10.1016/j.uclim.2016.05.001
     # Uncomment below when using observed soil moisture (smdmethod: 1 or 2)
     # soil_observation:
     #   depth: 200.0        # mm - sensor installation depth
@@ -1815,8 +1827,9 @@ sites:
       th:
         value: 55.0
       ref:
-        ID: test id
-        DOI: test doi
+        desc: Ward et al. (2016) SUEWS development and evaluation reference for sample conductance parameters
+        ID: W16
+        DOI: 10.1016/j.uclim.2016.05.001
     irrigation:
       h_maintain:
         value: -999.0
@@ -3253,6 +3266,10 @@ sites:
           value: 0.1
         flowchange:
           value: 0.0
+      ref:
+        desc: Ward et al. (2016) land-cover properties represented by the sample configuration
+        ID: W16
+        DOI: 10.1016/j.uclim.2016.05.001
     vertical_layers:
       nlayer:
         value: 3

--- a/test/data_model/test_schema_version_sync.py
+++ b/test/data_model/test_schema_version_sync.py
@@ -47,3 +47,42 @@ def test_sample_config_schema_version_matches_current():
         ".claude/rules/python/schema-versioning.md for when structural "
         "changes require a CURRENT_SCHEMA_VERSION bump."
     )
+
+
+def _iter_ref_blocks(value, path=""):
+    if isinstance(value, dict):
+        ref = value.get("ref")
+        if isinstance(ref, dict):
+            yield f"{path}.ref" if path else "ref", ref
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            yield from _iter_ref_blocks(child, child_path)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from _iter_ref_blocks(child, f"{path}[{index}]")
+
+
+@pytest.mark.cfg
+def test_sample_config_includes_complete_reference_metadata_example():
+    """`sample_config.yml` should demonstrate refs at several config levels."""
+    assert SAMPLE_CONFIG.exists(), SAMPLE_CONFIG
+
+    payload = yaml.safe_load(SAMPLE_CONFIG.read_text(encoding="utf-8"))
+    complete_ref_paths = {
+        path
+        for path, ref in _iter_ref_blocks(payload)
+        if {"desc", "ID", "DOI"}.issubset(ref)
+    }
+
+    expected_ref_paths = {
+        "model.control.ref",
+        "model.physics.ref",
+        "sites[0].properties.ref",
+        "sites[0].properties.conductance.ref",
+        "sites[0].properties.land_cover.ref",
+    }
+
+    assert expected_ref_paths.issubset(complete_ref_paths), (
+        "sample_config.yml should include complete reference metadata examples "
+        f"with desc, ID, and DOI at: {sorted(expected_ref_paths)}"
+    )


### PR DESCRIPTION
## Summary

- Replace the placeholder sample conductance reference metadata with the Ward et al. (2016) reference already used by the sample configuration context.
- Add complete `ref` metadata examples at several levels of `sample_config.yml`: `model.control`, `model.physics`, `sites[0].properties`, `sites[0].properties.conductance`, and `sites[0].properties.land_cover`.
- Add a regression test requiring those sample locations to keep complete `desc`, `ID`, and `DOI` reference examples.

This keeps #1584 scoped to illustrative reference metadata in the sample. A broader audit to populate references for more or all sample parameters would need separate source review.

Closes #1584.

## Validation

- `source .venv/bin/activate && make clean && make dev`
- `source .venv/bin/activate && python -m pytest test/data_model/test_schema_version_sync.py -q`
- `source .venv/bin/activate && suews validate --format json src/supy/sample_data/sample_config.yml` (no errors; existing warnings/suggestions only)
- `git diff --check -- src/supy/sample_data/sample_config.yml test/data_model/test_schema_version_sync.py`
- `source .venv/bin/activate && make test-smoke`
- After moving the branch to `/Users/tingsun/conductor/workspaces/suews/gh1584-reference-metadata`, rechecked with `suews validate --format json src/supy/sample_data/sample_config.yml`, `git diff --check`, and an equivalent standalone YAML assertion script because this worktree does not have its own `.venv`.