### PR TITLE
Document issue label hierarchy audit workflow

### DIFF
--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Use whenever auditing, clarifying, rewriting, or batch-reviewing SUEWS GitHub issue descriptions so they become maintainer-ready. Trigger for requests like "audit this issue", "make this issue agent-ready", "rewrite issue #123", "clean up open issues", "summarise comments into the issue body", "preserve the original report", or "triage SUEWS backlog". This skill preserves issue-author context, summarises discussion, drafts a clarified issue body, and requires explicit approval before editing GitHub.
+description: Use whenever auditing, clarifying, rewriting, labelling, or batch-reviewing SUEWS GitHub issues so they become maintainer-ready. Trigger for requests like "audit this issue", "make this issue agent-ready", "rewrite issue #123", "clean up open issues", "check issue labels", "audit label hierarchy", "summarise comments into the issue body", "preserve the original report", or "triage SUEWS backlog". This skill preserves issue-author context, summarises discussion, drafts a clarified issue body, audits the SUEWS 1/2/3/4 label hierarchy, and requires explicit approval before editing GitHub.
 ---
 
 # Triage Issue
@@ -22,7 +22,9 @@ an issue body no longer reflects discoveries made in comments.
 - Audit an issue body against a type-specific rubric.
 - Summarise comments into maintainer-ready context.
 - Preserve the original report while drafting a clarified issue body.
-- Propose issue title, label, readiness, and follow-up changes.
+- Propose issue title, label hierarchy, readiness, and follow-up changes.
+- Audit every issue for the SUEWS `1-*` type, `2-*` area, `3-*` priority, and
+  `4-*` status label layers using `references/label-hierarchy.md`.
 - Recommend splitting an oversized or multi-concern issue into focused child
   issues under a parent, and propose that decomposition
   (see `.claude/rules/work-sizing.md`).
@@ -82,7 +84,7 @@ gh issue edit <number> --repo UMEP-dev/SUEWS --body-file <approved-body.md>
 1. Fetch the issue body, labels, assignees, state, comments, and linked PR
    context needed to understand scope.
 2. Classify the issue type and readiness using `references/rubric.md`.
-3. Audit what is missing from the title/body and what has only been clarified
+3. Audit what is missing from the title/body, labels, and what has only been clarified
    in comments.
 4. Preserve the original body, summarise the discussion, and draft a clearer
    maintainer-ready body using `references/rewrite-template.md`.
@@ -92,7 +94,8 @@ gh issue edit <number> --repo UMEP-dev/SUEWS --body-file <approved-body.md>
    approved explanatory comment.
 
 Read `references/methodology.md` for the full step-by-step procedure and
-output format before performing a rewrite or batch audit.
+output format before performing a rewrite or batch audit. Read
+`references/label-hierarchy.md` before any label audit or backlog sweep.
 
 ## Output Format
 
@@ -110,6 +113,10 @@ autonomous mode, end with the machine-readable verdict block defined there.
 - Suggest follow-up categories: add reproduction, add maintainer summary,
   clarify scope, split into focused child issues, supersede, close as duplicate,
   or leave as ready.
+- For whole-backlog audits, include a label-hierarchy coverage pass. Report
+  missing or conflicting `1-*`, `2-*`, `3-*`, and `4-*` layers separately from
+  issue-body readiness, and propose exact label add/remove changes with
+  reasoning.
 - Whenever the input set is bounded (label filter, recency window, `--limit`, or
   gh's default cap), emit a `Scope:` line stating the filter and the returned
   count against an independently-obtained total open count (see Quick Start), and
@@ -145,6 +152,8 @@ Auto-applicable (additive, reversible):
   for idempotency.
 - Apply a readiness label only if that exact label already exists in the repo.
   Never create labels.
+- For label-hierarchy audits, default to report-only in autonomous mode unless
+  the user has explicitly approved the exact add/remove set for that batch.
 - Mark the issue as processed: apply the `0-auto:audited` label if it exists in
   the repo. It records that an autonomous pass handled the issue so batch re-runs
   can skip it unless it is later updated. It is bookkeeping, not substantive work,
@@ -244,5 +253,7 @@ internal tracker IDs or private paths reach a posted comment or body.
 ## References
 
 - `references/rubric.md` - Issue type rubric and readiness statuses.
+- `references/label-hierarchy.md` - Four-layer SUEWS issue label taxonomy and
+  audit rules.
 - `references/rewrite-template.md` - Maintainer-ready body template.
 - `references/methodology.md` - Detailed audit workflow and output formats.

--- a/.claude/skills/triage-issue/references/label-hierarchy.md
+++ b/.claude/skills/triage-issue/references/label-hierarchy.md
@@ -1,0 +1,103 @@
+# SUEWS Issue Label Hierarchy
+
+Use this reference when auditing labels on SUEWS GitHub issues. The hierarchy is
+orthogonal to issue-body readiness: an issue can be well framed but badly
+labelled, or correctly labelled but still need a summary, scope decision, or
+split.
+
+## Required Layers
+
+Every open issue should normally carry:
+
+- one `1-*` type label;
+- one or more `2-*` area labels;
+- one `3-*` priority label;
+- one `4-*` status label.
+
+`0-*` labels are automation, CI, physics, or source metadata. Do not count them
+as part of the four-layer hierarchy.
+
+## Layer Meanings
+
+### `1-*` Type
+
+Use exactly one unless the user explicitly approves an exception.
+
+- `1-bug`: observed incorrect behaviour, wrong docs, crash, validation failure,
+  regression, or mismatch against intended model/API behaviour.
+- `1-feature`: new capability, new validation rule, new workflow support, or
+  intentionally expanded behaviour.
+- `1-maintenance`: cleanup, refactor, docs maintenance, process/tooling cleanup,
+  or wording improvements that do not change behaviour.
+- `1-question`: support question, uncertainty, or design question that is not yet
+  framed as an implementation task.
+
+### `2-*` Area
+
+Use one or more labels for affected code, documentation, process, or physics
+areas. Multiple `2-*` labels are expected for cross-cutting issues, for example a
+validator issue that also needs user docs.
+
+Prefer the most specific module label (`2-module:*`) when the issue concerns a
+named physics module. Use infrastructure labels (`2-infra:*`) for validation,
+data model, CI, build, packaging, input/output, logging, type safety, schema,
+site, tests, and bridge work. Use `2-doc:*` for documentation surfaces and
+`2-meta:*` for governance or release process.
+
+### `3-*` Priority
+
+Use exactly one.
+
+- `3-P0`: critical breakage or release-stopping issue.
+- `3-P1`: high-priority bug, correctness problem, active release blocker, or
+  important validator/data-model/user-facing problem.
+- `3-P2`: valid medium-priority work, nice-to-have feature, cleanup, docs
+  improvement, or backlog task.
+
+### `4-*` Status
+
+Use exactly one status label by default. If an issue carries multiple `4-*`
+labels, flag it as a status conflict and suggest the primary status.
+
+- `4-ready`: near-term work that is clear enough to implement or review.
+- `4-in-progress`: actively being worked on or already covered by an open PR.
+- `4-needs-deps`: waiting on another issue, PR, release, or design prerequisite.
+- `4-needs-discussion`: needs a maintainer/catch-up decision before execution.
+- `4-needs-science`: needs scientific input, evidence, benchmark decision, or
+  model-design judgement.
+- `4-deferred`: valid issue, but not planned for near-term work. Use this for
+  old feature requests, broad master issues, unowned nice-to-haves, and work that
+  is technically clear but not a current support priority.
+
+## Audit Procedure
+
+1. Fetch live repo labels first; do not invent label names.
+2. For each issue, list current `1-*`, `2-*`, `3-*`, and `4-*` labels.
+3. Flag missing layers, duplicate single-choice layers (`1-*`, `3-*`, `4-*`),
+   and `4-ready` labels that are not near-term priorities.
+4. Suggest exact additions and removals. Keep reasoning short and evidence-based:
+   title/body/comments, assignee, linked PRs, active umbrella issues, or current
+   team priority.
+5. In interactive mode, stop at suggestions until the user approves the exact
+   label edits.
+6. In autonomous scheduled sweeps, report suggestions only unless the automation
+   contract explicitly grants label edits for the exact tier being changed.
+
+## Batch Output
+
+For each issue needing label action, use:
+
+```text
+#<number> - <title>
+Current: <current relevant labels>
+Suggest: add <labels>; remove <labels>
+Reasoning: <one or two concise reasons>
+Approval: required before editing
+```
+
+Group the final report by action type:
+
+- missing required layer;
+- conflicting layer;
+- `4-ready` but should be `4-deferred`;
+- already complete / no action.

--- a/.claude/skills/triage-issue/references/methodology.md
+++ b/.claude/skills/triage-issue/references/methodology.md
@@ -17,6 +17,9 @@ rubric and rewrite template.
      or meta/process.
    - Assign an issue-readiness status from `rubric.md`.
    - Note whether the title/body still match the current understanding.
+   - Audit the current `1-*`, `2-*`, `3-*`, and `4-*` labels using
+     `label-hierarchy.md` when the user asks about labels, priority, status, or
+     backlog triage.
 
 3. **Audit**
    - Identify missing elements for the issue type.
@@ -48,7 +51,8 @@ rubric and rewrite template.
    - Show audit result and readiness status.
    - Show a concise comment summary.
    - Show the proposed title/body rewrite.
-   - Show suggested labels or status changes, if any.
+   - Show suggested label additions/removals or status changes, if any, with
+     reasoning for each label layer.
    - State uncertainties or information still needed.
    - Ask for approval before editing.
 
@@ -104,6 +108,15 @@ After the list, group follow-up actions as:
 - supersede
 - close as duplicate
 - leave as ready
+
+For label audits, add a label-hierarchy section using
+`references/label-hierarchy.md`:
+
+```text
+Label hierarchy:
+- #123 - add 2-infra:input; remove none (input validator issue; missing area layer)
+- #145 - add 4-deferred; remove 4-ready (valid old feature, not near-term priority)
+```
 
 ## Proposing a Split
 


### PR DESCRIPTION
## Summary
- Extend the `triage-issue` skill triggers and workflow for SUEWS issue label hierarchy audits.
- Add a `label-hierarchy` reference covering the `1-*`, `2-*`, `3-*`, and `4-*` layers.
- Update batch methodology output so label add/remove suggestions include reasoning and approval gating.

## Validation
- `python3 /Users/tingsun/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/triage-issue`
- `git diff --check`