### PR TITLE
Document review panel governance

### DIFF
--- a/.claude/skills/audit-pr/SKILL.md
+++ b/.claude/skills/audit-pr/SKILL.md
@@ -42,6 +42,9 @@ recommendation instead of spending the review on an unreviewable diff:
 - **Testing**: Coverage, FIRST principles
 - **Docs**: CHANGELOG, PR description
 - **Governance**: Check feature status tags (see below)
+- **Suggested reviewers**: Derive reviewer suggestions from changed files,
+  `.github/CODEOWNERS`, and `dev-ref/REVIEW_PROCESS.md`; include them in the
+  draft summary without treating them as automatic blockers.
 - **Schema version audit**: If the PR touches `src/supy/data_model/`, apply the triggers in `.claude/rules/python/schema-versioning.md`. Field rename, removal, type change, or required-field addition should be accompanied by a bump to `CURRENT_SCHEMA_VERSION`, a new `SCHEMA_VERSIONS` entry, a matching handler in `src/supy/util/converter/yaml_upgrade.py`, and a `sample_config.yml` resync. Flag any of these that are missing. CI gate `.github/workflows/schema-version-audit.yml` runs the automated check; if the PR carries the `0-ci:schema-audit-ok` bypass label, verify from the diff yourself that the reason is genuinely cosmetic before approving.
 - **Physics-change evidence audit**: If the diff touches physics source (`suews_phys_*.f95`, Rust physics backend), moves a reference fixture (`test/fixtures/data_test/sample_output.csv.gz`, `.../stebbs_test/sample_output_stebbs.csv`, `test/fixtures/benchmark1/*.pkl`), or changes a physics-affecting data-model default, apply `.claude/rules/physics-change-evidence.md`. Confirm the `0-physics:change` label is present (apply or flag if missing), the PR body has a `## Scientific evidence` section (quantities + mechanism, before/after comparison, sign/magnitude reasoning -- a bare "outputs changed" is blocking), the owner sign-off is present for any owned subsystem (STEBBS -> `@yiqing1021`), any moved fixture is refreshed in this PR (or a linked PR), and the full `-m physics` tier (including `slow`) has run green.
 - **Build**: CI status, meson.build
@@ -64,6 +67,24 @@ For PRs that add new features or breaking changes:
 - Has the governance panel reviewed it?
 
 Details: `references/workflow-steps.md`
+
+## Suggested Reviewers
+
+In every audit summary, include suggested reviewers based on the PR diff:
+
+1. Start from changed files (`gh pr diff {pr} --name-only`).
+2. Match file paths against `.github/CODEOWNERS`; use the last matching entry,
+   which is the rule GitHub applies when several patterns match.
+3. For physics files, cross-check the module owner list in
+   `dev-ref/REVIEW_PROCESS.md` and `references/review-checklist.md`.
+4. For modules without named domain reviewers, suggest the default scientific
+   owners documented in `dev-ref/REVIEW_PROCESS.md`.
+5. For coding style, linting, naming, issue-triage, or review-process changes,
+   suggest the code-governance owners from `.github/CODEOWNERS`.
+
+These are reviewer suggestions, not permission to request reviews or block a PR
+by themselves. If a physics-changing PR lacks the needed scientific review or
+sign-off, report that separately under the scientific evidence audit.
 
 ## Change Classification
 
@@ -107,7 +128,7 @@ The `Verdict`, `Size gate`, and per-finding `[severity]` tags are the fields a
 consuming skill (e.g. `fix-issue` step 5) branches on; keep them explicit.
 
 ### Suggested Reviewers
-@reviewer (module:name)
+- @reviewer (source: CODEOWNERS or review panel; reason: changed area)
 ```
 
 ## Approval Options

--- a/.claude/skills/audit-pr/references/review-checklist.md
+++ b/.claude/skills/audit-pr/references/review-checklist.md
@@ -210,17 +210,21 @@ PR can be merged when ALL of:
 
 | Module Label | Files | Reviewers |
 |--------------|-------|-----------|
-| `module:stebbs` | `suews_phys_stebbs*` | @yiqing1021, @denisehertwig |
-| `module:rslprof` | `suews_phys_rslprof*` | @vitorlavor, @suegrimmond |
-| `module:spartacus` | `suews_phys_spartacus*` | @suegrimmond, @yiqing1021 |
-| `module:biogenco2` | `suews_phys_biogen*` | @havum, @ljarvi |
-| `module:snow` | `suews_phys_snow*` | @havum, @ljarvi |
-| `module:ehc` | `suews_phys_ehc*` | @sunt05 |
-| `module:anohm` | `suews_phys_anohm*` | @sunt05 |
-| `module:ohm` | `suews_phys_ohm*` | Seeking reviewer |
-| `module:estm` | `suews_phys_estm*` | Seeking reviewer |
-| `module:lumps` | `suews_phys_lumps*` | Seeking reviewer |
-| `module:narp` | `suews_phys_narp*` | Seeking reviewer |
-| `module:evap` | `suews_phys_evap*` | Seeking reviewer |
-| `module:waterdist` | `suews_phys_waterdist*` | Seeking reviewer |
-| Overall | General PRs | @sunt05, @MatthewPaskin, @dayantur |
+| `2-module:stebbs` | `suews_phys_stebbs*` | @yiqing1021, @denisehertwig |
+| `2-module:rslprof` | `suews_phys_rslprof*` | @vitorlavor, @suegrimmond |
+| `2-module:spartacus` | `suews_phys_spartacus*`, `suews_type_spartacus*`, `spartacus-surface/` | @suegrimmond, @yiqing1021, @vitorlavor |
+| `2-module:biogenco2` | `suews_phys_biogen*` | @havum, @ljarvi |
+| `2-module:snow` | `suews_phys_snow*` | @havum, @ljarvi |
+| `2-module:ehc` | `suews_phys_ehc*` | @sunt05 |
+| `2-module:anohm` | `suews_phys_anohm*` | @sunt05 |
+| `2-module:ohm` | `suews_phys_ohm*` | @sunt05, @suegrimmond |
+| `2-module:estm` | `suews_phys_estm*` | @sunt05, @suegrimmond |
+| `2-module:lumps` | `suews_phys_lumps*` | @sunt05, @suegrimmond |
+| `2-module:narp` | `suews_phys_narp*` | @sunt05, @suegrimmond |
+| `2-module:evap` | `suews_phys_evap*` | @sunt05, @suegrimmond |
+| `2-module:waterdist` | `suews_phys_waterdist*` | @sunt05, @suegrimmond |
+| Overall | General PRs | @sunt05, @MatthewPaskin |
+
+Use `.github/CODEOWNERS` as the operational source for suggested reviewers in
+the audit summary, and use `dev-ref/REVIEW_PROCESS.md` as the maintained human
+explanation of why those reviewers are suggested.

--- a/.claude/skills/audit-pr/references/workflow-steps.md
+++ b/.claude/skills/audit-pr/references/workflow-steps.md
@@ -20,16 +20,34 @@ Apply lint-code checks. See `style-checks.md`.
 
 **Only for physics changes** (`suews_phys_*.f95`).
 
-### Module Reviewers
+### Suggested Reviewers
+
+Reviewer suggestions are advisory metadata in the audit summary. Derive them
+from changed files, `.github/CODEOWNERS`, and `dev-ref/REVIEW_PROCESS.md`;
+do not request reviews or post comments without explicit approval.
+
+For changed paths:
+
+1. Match the path against `.github/CODEOWNERS`.
+2. For physics modules, cross-check the table below and the maintained panel in
+   `dev-ref/REVIEW_PROCESS.md`.
+3. If the module is not listed with named reviewers, suggest the default
+   scientific review owners: @sunt05, @suegrimmond.
+4. For coding style, linting, naming conventions, issue triage, or review
+   process changes, suggest @sunt05 and @suegrimmond.
+
+### Module Reviewer Reference
 
 | File Pattern | Module | Reviewers |
 |--------------|--------|-----------|
-| `suews_phys_stebbs` | module:stebbs | @yiqing1021, @denisehertwig |
-| `suews_phys_rslprof` | module:rslprof | @vitorlavor, @suegrimmond |
-| `suews_phys_spartacus` | module:spartacus | @suegrimmond, @yiqing1021 |
-| `suews_phys_snow` | module:snow | @havum, @ljarvi |
-| `suews_phys_ehc` | module:ehc | @sunt05 |
-| `suews_phys_anohm` | module:anohm | @sunt05 |
+| `suews_phys_stebbs` | `2-module:stebbs` | @yiqing1021, @denisehertwig |
+| `suews_phys_rslprof` | `2-module:rslprof` | @vitorlavor, @suegrimmond |
+| `suews_phys_spartacus`, `suews_type_spartacus`, `spartacus-surface/` | `2-module:spartacus` | @suegrimmond, @yiqing1021, @vitorlavor |
+| `suews_phys_biogenco2` | `2-module:biogenco2` | @havum, @ljarvi |
+| `suews_phys_snow` | `2-module:snow` | @havum, @ljarvi |
+| `suews_phys_ehc` | `2-module:ehc` | @sunt05 |
+| `suews_phys_anohm` | `2-module:anohm` | @sunt05 |
+| Other `suews_phys_*` files | Matching `2-module:*` | @sunt05, @suegrimmond |
 | General | Overall | @sunt05, @MatthewPaskin |
 
 ### Validation Checks

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,32 @@
 # CODEOWNERS file for SUEWS
 # This file defines who should review changes to specific parts of the codebase
 
+# Governance, review process, and coding style
+/dev-ref/REVIEW_PROCESS.md @sunt05 @suegrimmond
+/dev-ref/ISSUE_TRIAGE.md @sunt05 @suegrimmond
+/dev-ref/CODING_GUIDELINES.md @sunt05 @suegrimmond
+/dev-ref/FORTRAN_NAMING_CONVENTIONS.md @sunt05 @suegrimmond
+/.claude/skills/audit-pr/ @sunt05 @suegrimmond
+/.claude/rules/ @sunt05 @suegrimmond
+/scripts/lint/ @sunt05 @suegrimmond
+/.ruff.toml @sunt05 @suegrimmond
+/pyproject.toml @sunt05 @suegrimmond
+
+# Default scientific review owner for physics modules without a named panel.
+# More specific entries below override this default.
+/src/suews/src/suews_phys_*.f95 @sunt05 @suegrimmond
+
+# Named scientific review panel members by physics module.
+/src/suews/src/suews_phys_stebbs.f95 @yiqing1021 @denisehertwig
+/src/suews/src/suews_phys_rslprof.f95 @vitorlavor @suegrimmond
+/src/suews/src/suews_phys_spartacus.f95 @suegrimmond @yiqing1021 @vitorlavor
+/src/suews/src/suews_type_spartacus.f95 @suegrimmond @yiqing1021 @vitorlavor
+/src/suews/ext_lib/spartacus-surface/ @suegrimmond @yiqing1021 @vitorlavor
+/src/suews/src/suews_phys_biogenco2.f95 @havum @ljarvi
+/src/suews/src/suews_phys_snow.f95 @havum @ljarvi
+/src/suews/src/suews_phys_ehc.f95 @sunt05
+/src/suews/src/suews_phys_anohm.f95 @sunt05
+
 # Workflow files require admin review
 /.github/workflows/ @sunt05
 /.github/actions/ @sunt05

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /dev-ref/ISSUE_TRIAGE.md @sunt05 @suegrimmond
 /dev-ref/CODING_GUIDELINES.md @sunt05 @suegrimmond
 /dev-ref/FORTRAN_NAMING_CONVENTIONS.md @sunt05 @suegrimmond
+/.github/CODEOWNERS @sunt05 @suegrimmond
 /.claude/skills/audit-pr/ @sunt05 @suegrimmond
 /.claude/rules/ @sunt05 @suegrimmond
 /scripts/lint/ @sunt05 @suegrimmond

--- a/dev-ref/REVIEW_PROCESS.md
+++ b/dev-ref/REVIEW_PROCESS.md
@@ -1,67 +1,102 @@
-# SUEWS Scientific Review Process
+# SUEWS Review and Governance Process
 
 ## Overview
 
-This document outlines the scientific review process for SUEWS pull requests to ensure changes maintain physical validity and scientific correctness.
+This document outlines how SUEWS connects issue triage, PR review, scientific
+review, and code-governance ownership. The goal is to preserve the existing
+review panel while making ownership visible to GitHub's review and assignment
+flow.
 
-## Review Panel
+## Review and Governance Panels
 
-The SUEWS review panel consists of domain experts responsible for validating changes based on specific modules:
+The SUEWS review panel consists of domain experts responsible for validating
+module-specific scientific changes. The code-governance panel owns review
+process, coding style, issue-triage conventions, and default ownership when a
+module does not yet have named reviewers.
 
-### Current Panel Members
+### Scientific Review Panel
 
 | Module | Label | Reviewers |
 |--------|-------|-----------|
-| STEBBS | [`module:stebbs`](https://github.com/UMEP-dev/SUEWS/labels/module%3Astebbs) | @yiqing1021, @denisehertwig |
-| RSL Profiles | [`module:rslprof`](https://github.com/UMEP-dev/SUEWS/labels/module%3Arslprof) | @vitorlavor, @suegrimmond |
-| SPARTACUS | [`module:spartacus`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aspartacus) | @suegrimmond, @yiqing1021 |
-| Biogenic CO2 | [`module:biogenco2`](https://github.com/UMEP-dev/SUEWS/labels/module%3Abiogenco2) | @havum, @ljarvi |
-| Snow | [`module:snow`](https://github.com/UMEP-dev/SUEWS/labels/module%3Asnow) | @havum, @ljarvi |
-| EHC | [`module:ehc`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aehc) | @sunt05 |
-| AnOHM | [`module:anohm`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aanohm) | @sunt05 |
-| Overall | General PRs | @sunt05, @MatthewPaskin, @dayantur |
+| STEBBS | [`2-module:stebbs`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Astebbs) | @yiqing1021, @denisehertwig |
+| RSL Profiles | [`2-module:rslprof`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Arslprof) | @vitorlavor, @suegrimmond |
+| SPARTACUS | [`2-module:spartacus`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aspartacus) | @suegrimmond, @yiqing1021, @vitorlavor |
+| Biogenic CO2 | [`2-module:biogenco2`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Abiogenco2) | @havum, @ljarvi |
+| Snow | [`2-module:snow`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Asnow) | @havum, @ljarvi |
+| EHC | [`2-module:ehc`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aehc) | @sunt05 |
+| AnOHM | [`2-module:anohm`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aanohm) | @sunt05 |
+| Overall | General PRs | @sunt05, @MatthewPaskin |
 
-### Modules Seeking Reviewers
+### Default Scientific Review Coverage
 
-- Atmospheric stability ([`module:atmmoiststab`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aatmmoiststab))
-- Evaporation ([`module:evap`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aevap))
-- Water distribution ([`module:waterdist`](https://github.com/UMEP-dev/SUEWS/labels/module%3Awaterdist))
-- Anthropogenic heat ([`module:anthro`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aanthro))
-- OHM ([`module:ohm`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aohm))
-- ESTM ([`module:estm`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aestm))
-- LUMPS ([`module:lumps`](https://github.com/UMEP-dev/SUEWS/labels/module%3Alumps))
-- NARP ([`module:narp`](https://github.com/UMEP-dev/SUEWS/labels/module%3Anarp))
-- SOLWEIG ([`module:solweig`](https://github.com/UMEP-dev/SUEWS/labels/module%3Asolweig))
-- BEERS ([`module:beers`](https://github.com/UMEP-dev/SUEWS/labels/module%3Abeers))
-- Resistance ([`module:resist`](https://github.com/UMEP-dev/SUEWS/labels/module%3Aresist))
-- BLUEWS ([`module:bluews`](https://github.com/UMEP-dev/SUEWS/labels/module%3Abluews))
-- Daily state ([`module:dailystate`](https://github.com/UMEP-dev/SUEWS/labels/module%3Adailystate))
+Modules without named domain reviewers are routed to @sunt05 and @suegrimmond
+by default until the panel appoints module-specific reviewers:
+
+- Atmospheric stability ([`2-module:atmmoiststab`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aatmmoiststab))
+- Evaporation ([`2-module:evap`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aevap))
+- Water distribution ([`2-module:waterdist`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Awaterdist))
+- Anthropogenic heat ([`2-module:anthro`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aanthro))
+- OHM ([`2-module:ohm`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aohm))
+- ESTM ([`2-module:estm`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aestm))
+- LUMPS ([`2-module:lumps`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Alumps))
+- NARP ([`2-module:narp`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Anarp))
+- SOLWEIG ([`2-module:solweig`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Asolweig))
+- BEERS ([`2-module:beers`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Abeers))
+- Resistance ([`2-module:resist`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Aresist))
+- BLUEWS ([`2-module:bluews`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Abluews))
+- Daily state ([`2-module:dailystate`](https://github.com/UMEP-dev/SUEWS/labels/2-module%3Adailystate))
+
+### Code Governance Panel
+
+| Area | Owners |
+|------|--------|
+| Review process and issue triage | @sunt05, @suegrimmond |
+| Coding style, linting, and naming conventions | @sunt05, @suegrimmond |
+| GitHub workflow administration | @sunt05 |
 
 ## Review Workflow
 
-### 1. Initial Triage
+### 1. Issue Triage
+
+When an issue is opened, maintainers apply the MECE label system described in
+[`ISSUE_TRIAGE.md`](ISSUE_TRIAGE.md):
+
+- Type labels: `1-bug`, `1-feature`, `1-question`
+- Area labels: `2-module:*`, `2-infra:*`, `2-doc:*`, `2-meta:*`
+- Priority labels: `3-P0`, `3-P1`, `3-P2`
+- Status labels: `4-ready`, `4-in-progress`, `4-needs-science`, `4-needs-deps`
+
+Assignees are set only when someone is expected to drive the issue. For module
+issues that need scientific input, use the relevant `2-module:*` label and
+`4-needs-science`, then route the discussion to the panel owner listed above.
+
+### 2. PR Triage
 
 When a PR is opened, maintainers perform initial triage:
-- Assess if changes affect model physics or scientific calculations
-- Determine which modules are impacted
-- Apply appropriate labels:
-  - Module labels (e.g., `module:stebbs`, `module:rslprof`, `module:biogenco2`)
-  - Note: Physics impact is documented in PR description instead of labels
 
-### 2. Scientific Review Request
+1. Assess whether changes affect model physics, scientific calculations, coding
+   style, process, or infrastructure.
+2. Determine which labels and ownership areas apply.
+3. Use `.github/CODEOWNERS` to request review from the relevant panel members.
+4. Document physics impact and scientific rationale in the PR description or PR
+   comments, rather than creating one-off labels for every review state.
+
+### 3. Scientific Review Request
 
 For PRs requiring scientific validation:
-1. Tag relevant domain expert(s) based on module labels
-2. Provide context about what specifically needs review
-3. Track review status in PR comments
+
+1. Apply the relevant `2-module:*` label.
+2. Request review from the domain expert(s) identified by `.github/CODEOWNERS`.
+3. Provide context about what specifically needs review.
+4. Track review status in PR comments and GitHub's review system.
 
 Example comment:
 ```
-@yiqing1021 @denisehertwig - This PR modifies module:stebbs temperature calculations. 
+@yiqing1021 @denisehertwig - This PR modifies 2-module:stebbs temperature calculations.
 Please review for scientific validity, particularly the changes to surface temperature iteration in suews_phys_stebbs.f95.
 ```
 
-### 3. Review Process
+### 4. Review Process
 
 Domain experts should:
 1. **Verify Physical Validity**
@@ -84,14 +119,14 @@ Domain experts should:
    - Note any concerns or limitations
    - Suggest improvements if needed
 
-### 4. Approval
+### 5. Approval
 
 When satisfied with scientific validity:
 1. Domain expert approves the PR
 2. Comment with approval rationale
 3. PR can proceed to merge
 
-### 5. Merge Criteria
+### 6. Merge Criteria
 
 PRs can be merged when:
 - All CI tests pass
@@ -112,31 +147,33 @@ Special attention for PRs using AI tools (e.g., Claude Code):
 ## Label Reference
 
 ### Module Labels (Physics - suews_phys_*)
-Module labels remain unchanged and are used to identify which physics components are affected:
-- `module:ohm` - Objective Hysteresis Model
-- `module:anohm` - Analytical OHM
-- `module:ehc` - Explicit Heat Conduction
-- `module:estm` - Element Surface Temperature Method
-- `module:stebbs` - Surface Temperature Energy Balance
-- `module:lumps` - LUMPS energy balance
-- `module:narp` - Net All-wave Radiation Parameterization
-- `module:spartacus` - SPARTACUS radiation
-- `module:solweig` - Solar and longwave radiation
-- `module:beers` - Building radiation
-- `module:evap` - Evaporation processes
-- `module:waterdist` - Water distribution
-- `module:bluews` - Building water balance
-- `module:snow` - Snow processes
-- `module:atmmoiststab` - Atmospheric stability
-- `module:resist` - Resistance calculations
-- `module:rslprof` - RSL profiles
-- `module:anthro` - Anthropogenic heat
-- `module:biogenco2` - Biogenic CO2
-- `module:dailystate` - Daily state updates
+Module labels identify which physics components are affected:
+
+- `2-module:ohm` - Objective Hysteresis Model
+- `2-module:anohm` - Analytical OHM
+- `2-module:ehc` - Explicit Heat Conduction
+- `2-module:estm` - Element Surface Temperature Method
+- `2-module:stebbs` - Surface Temperature Energy Balance
+- `2-module:lumps` - LUMPS energy balance
+- `2-module:narp` - Net All-wave Radiation Parameterization
+- `2-module:spartacus` - SPARTACUS radiation
+- `2-module:solweig` - Solar and longwave radiation
+- `2-module:beers` - Building radiation
+- `2-module:evap` - Evaporation processes
+- `2-module:waterdist` - Water distribution
+- `2-module:bluews` - Building water balance
+- `2-module:snow` - Snow processes
+- `2-module:atmmoiststab` - Atmospheric stability
+- `2-module:resist` - Resistance calculations
+- `2-module:rslprof` - RSL profiles
+- `2-module:anthro` - Anthropogenic heat
+- `2-module:biogenco2` - Biogenic CO2
+- `2-module:dailystate` - Daily state updates
 
 ### Simplified Label System
 Following the simplified labeling approach, PRs use:
 - Module labels (as above) to identify affected components
+- Ownership and review requests are routed through `.github/CODEOWNERS`
 - Review status is tracked in PR comments and GitHub's review system
 - Physics impacts are documented in PR descriptions rather than labels
 


### PR DESCRIPTION
## Summary

- record the current SUEWS scientific review panel and code-governance panel in `dev-ref/REVIEW_PROCESS.md`
- add CODEOWNERS routing for review-process, style/linting, named physics modules, and default scientific-review ownership
- wire the audit-pr skill to surface suggested reviewers from CODEOWNERS and the review panel mapping

## Notes

This preserves the existing review-panel assignments, adds @vitorlavor to SPARTACUS ownership, removes @dayantur from the general review panel, and routes modules without named reviewers to @sunt05 and @suegrimmond by default.

When this PR closes GH536, the review-panel bootstrap is complete at this point. If new panel entries are needed later, or if an updated governance model is agreed, that should be tracked in a new issue rather than keeping GH536 open indefinitely.

Closes #536

## Validation

- `git diff --check`
- `make test-smoke` initially failed because `python` was not on PATH
- `make test-smoke PYTHON=python3` reached pytest but imported a stale system `supy`
- `uv venv && source .venv/bin/activate && make dev && make test-smoke` passed: 12 passed, 1759 deselected, 34 warnings
