### PR TITLE
Add parallel multi-grid tutorial

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -138,6 +138,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "docs/source/tutorials/tutorial_05_results_analysis.py" = ["D205", "D400"]
 "docs/source/tutorials/tutorial_06_external_coupling.py" = ["D205", "D301", "D400"]
 "docs/source/tutorials/tutorial_07_attribution.py" = ["D205", "D400"]
+"docs/source/tutorials/tutorial_08_parallel_multi_grid.py" = ["D205", "D400"]
 "docs/table.py" = ["D412"]
 "get_ver_git.py" = ["D103", "D400", "D406", "D407"]
 "scripts/lint/audit_docstrings.py" = ["D103"]

--- a/docs/source/tutorials/tutorial_04_impact_studies.py
+++ b/docs/source/tutorials/tutorial_04_impact_studies.py
@@ -40,7 +40,9 @@ sim = SUEWSSimulation.from_sample_data()
 forcing_sliced = sim.forcing["2012-01":"2012-03"].iloc[1:]
 
 print("Sample data loaded using SUEWSSimulation.from_sample_data()")
-print(f"Simulation period: {forcing_sliced.df.index[0]} to {forcing_sliced.df.index[-1]}")
+print(
+    f"Simulation period: {forcing_sliced.df.index[0]} to {forcing_sliced.df.index[-1]}"
+)
 
 # %%
 # Part 1: Surface Properties - Albedo Study
@@ -111,7 +113,9 @@ print(f"Completed {n_albedo} albedo simulations")
 # Examine the temperature response to albedo changes using the OOP output interface.
 
 # Combine T2 results from all scenarios
-dict_T2 = {alb: output.SUEWS.T2.droplevel("grid") for alb, output in dict_outputs.items()}
+dict_T2 = {
+    alb: output.SUEWS.T2.droplevel("grid") for alb, output in dict_outputs.items()
+}
 df_T2_all = pd.concat(dict_T2, axis=1, names=["albedo"])
 
 # Select last month for analysis
@@ -178,9 +182,11 @@ plt.tight_layout()
 #
 # .. note::
 #
-#    For larger studies, these simulations could be run in parallel using
-#    ``concurrent.futures.ThreadPoolExecutor``. We use a simple loop here
-#    for clarity.
+#    A loop over scenarios is the right tool when each scenario uses
+#    different forcing. When the *same* forcing applies across many sites
+#    (e.g. land-cover ensembles), populate ``config.sites`` instead and run
+#    the multi-site simulation with ``sim.run(n_jobs=-1)`` -- see
+#    :doc:`tutorial_08_parallel_multi_grid`.
 
 # Temperature offsets to test
 n_climate = 3
@@ -206,7 +212,9 @@ for temp_offset in list_temp_offset:
     list_outputs.append((temp_offset, output))
 
 print(f"Completed {n_climate} climate scenarios")
-print(f"Temperature offsets: {list_temp_offset[0]:.1f} to {list_temp_offset[-1]:.1f} deg C")
+print(
+    f"Temperature offsets: {list_temp_offset[0]:.1f} to {list_temp_offset[-1]:.1f} deg C"
+)
 
 # %%
 # Combine and Analyse Climate Results
@@ -249,7 +257,9 @@ df_temp_diff_stats.plot(ax=ax, marker="o")
 ax.set_ylabel(r"$\Delta T_2$ ($^\circ$C)")
 ax.set_xlabel(r"$\Delta T_{a}$ ($^\circ$C)")
 ax.set_aspect("equal")
-ax.set_title(f"Temperature Response to Background Climate Change ({last_month_climate})")
+ax.set_title(
+    f"Temperature Response to Background Climate Change ({last_month_climate})"
+)
 ax.legend(title="Statistic")
 plt.tight_layout()
 

--- a/docs/source/tutorials/tutorial_05_results_analysis.py
+++ b/docs/source/tutorials/tutorial_05_results_analysis.py
@@ -56,7 +56,7 @@ qh = output.get_variable("QH", group="SUEWS")
 print(f"QH shape: {qh.shape}")
 
 # Method 2: Direct MultiIndex access on raw DataFrame
-qn = results[("SUEWS", "QN")]
+qn = results["SUEWS", "QN"]
 print(f"QN shape: {qn.shape}")
 
 # List available groups and variables
@@ -85,7 +85,8 @@ def get_var(out, name, group="SUEWS"):
         if n_grids != 1:
             raise ValueError(
                 f"Expected single-grid output, but found {n_grids} grids. "
-                "Use MultiIndex indexing directly for multi-grid runs."
+                "Use MultiIndex indexing directly for multi-grid runs "
+                "(see tutorial_08_parallel_multi_grid for a worked example)."
             )
         ser = ser.droplevel("grid")
     return ser
@@ -113,10 +114,20 @@ print("Annual Energy Balance Statistics (W/m2):")
 print(energy_df.describe().round(1))
 
 # Seasonal means using meteorological seasons (month-based grouping)
-season_map = {12: "Winter (DJF)", 1: "Winter (DJF)", 2: "Winter (DJF)",
-              3: "Spring (MAM)", 4: "Spring (MAM)", 5: "Spring (MAM)",
-              6: "Summer (JJA)", 7: "Summer (JJA)", 8: "Summer (JJA)",
-              9: "Autumn (SON)", 10: "Autumn (SON)", 11: "Autumn (SON)"}
+season_map = {
+    12: "Winter (DJF)",
+    1: "Winter (DJF)",
+    2: "Winter (DJF)",
+    3: "Spring (MAM)",
+    4: "Spring (MAM)",
+    5: "Spring (MAM)",
+    6: "Summer (JJA)",
+    7: "Summer (JJA)",
+    8: "Summer (JJA)",
+    9: "Autumn (SON)",
+    10: "Autumn (SON)",
+    11: "Autumn (SON)",
+}
 season_order = ["Winter (DJF)", "Spring (MAM)", "Summer (JJA)", "Autumn (SON)"]
 seasonal = energy_df.groupby(energy_df.index.month.map(season_map)).mean()
 seasonal = seasonal.loc[[s for s in season_order if s in seasonal.index]]
@@ -164,7 +175,13 @@ print(f"    Runoff:        {runoff.sum():.1f}")
 print(f"    Drainage:      {drainage.sum():.1f}")
 print(f"  Storage change:  {storage_change.sum():.1f}")
 
-water_residual = (rain.sum() + irr.sum()) - evap.sum() - runoff.sum() - drainage.sum() - storage_change.sum()
+water_residual = (
+    (rain.sum() + irr.sum())
+    - evap.sum()
+    - runoff.sum()
+    - drainage.sum()
+    - storage_change.sum()
+)
 print(f"  Residual:        {water_residual:.1f}")
 
 # %%
@@ -278,8 +295,24 @@ ax.set_xlabel("Hour of Day")
 ax.set_ylabel("Tsurf - T2 (degC)")
 ax.set_title("Surface-Air Temperature Difference")
 ax.axhline(y=0, color="r", linestyle="--", alpha=0.5)
-ax.fill_between(delta_t_hourly.index, 0, delta_t_hourly.values, where=delta_t_hourly.values > 0, alpha=0.3, color="red", label="Surface warmer")
-ax.fill_between(delta_t_hourly.index, 0, delta_t_hourly.values, where=delta_t_hourly.values < 0, alpha=0.3, color="blue", label="Air warmer")
+ax.fill_between(
+    delta_t_hourly.index,
+    0,
+    delta_t_hourly.values,
+    where=delta_t_hourly.values > 0,
+    alpha=0.3,
+    color="red",
+    label="Surface warmer",
+)
+ax.fill_between(
+    delta_t_hourly.index,
+    0,
+    delta_t_hourly.values,
+    where=delta_t_hourly.values < 0,
+    alpha=0.3,
+    color="blue",
+    label="Air warmer",
+)
 ax.legend()
 
 plt.tight_layout()
@@ -375,7 +408,7 @@ for key, val in stats_t2.items():
 def validation_scatter(observed, modelled, variable_name, units="", ax=None):
     """Create validation scatter plot with statistics."""
     if ax is None:
-        fig, ax = plt.subplots(figsize=(8, 8))
+        _fig, ax = plt.subplots(figsize=(8, 8))
 
     obs, mod = observed.align(modelled, join="inner")
     obs = obs.dropna()
@@ -390,12 +423,31 @@ def validation_scatter(observed, modelled, variable_name, units="", ax=None):
 
     # Regression line
     slope, intercept = np.polyfit(obs, mod, 1)
-    ax.plot(lims, [slope * x + intercept for x in lims], "r-", label=f"Fit: y = {slope:.2f}x + {intercept:.2f}", linewidth=2)
+    ax.plot(
+        lims,
+        [slope * x + intercept for x in lims],
+        "r-",
+        label=f"Fit: y = {slope:.2f}x + {intercept:.2f}",
+        linewidth=2,
+    )
 
     # Statistics annotation
     stats_dict = validation_statistics(observed, modelled)
-    stats_text = f"n = {stats_dict['n']}\n" f"$R^2$ = {stats_dict['r2']:.3f}\n" f"RMSE = {stats_dict['rmse']:.2f}\n" f"Bias = {stats_dict['bias']:.2f}"
-    ax.text(0.05, 0.95, stats_text, transform=ax.transAxes, verticalalignment="top", fontsize=10, bbox=dict(boxstyle="round", facecolor="wheat", alpha=0.8))
+    stats_text = (
+        f"n = {stats_dict['n']}\n"
+        f"$R^2$ = {stats_dict['r2']:.3f}\n"
+        f"RMSE = {stats_dict['rmse']:.2f}\n"
+        f"Bias = {stats_dict['bias']:.2f}"
+    )
+    ax.text(
+        0.05,
+        0.95,
+        stats_text,
+        transform=ax.transAxes,
+        verticalalignment="top",
+        fontsize=10,
+        bbox={"boxstyle": "round", "facecolor": "wheat", "alpha": 0.8},
+    )
 
     ax.set_xlabel(f"Observed {variable_name} ({units})")
     ax.set_ylabel(f"Modelled {variable_name} ({units})")
@@ -421,7 +473,7 @@ export_vars = ["QN", "QH", "QE", "QS", "T2", "RH2"]
 export_df = get_vars(output, export_vars)
 # export_df.to_csv('suews_output.csv')  # Uncomment to save
 print(f"Export DataFrame shape: {export_df.shape}")
-print(f"Ready to save with: export_df.to_csv('suews_output.csv')")
+print("Ready to save with: export_df.to_csv('suews_output.csv')")
 
 # Save typed checkpoint for restart runs
 checkpoint = output.checkpoint

--- a/docs/source/tutorials/tutorial_08_parallel_multi_grid.py
+++ b/docs/source/tutorials/tutorial_08_parallel_multi_grid.py
@@ -1,0 +1,243 @@
+"""
+Parallel Multi-Grid Execution
+=============================
+
+Run several SUEWS grid cells in one simulation, with parallelism controlled by
+``n_jobs``.
+
+Many urban-climate workflows need more than one site at a time: comparing
+neighbourhoods that differ in land cover, evaluating scenarios over a city's
+grid cells, or producing a small sensitivity ensemble. SUEWS handles this
+natively. A configuration with multiple sites is dispatched through the
+Rust/Rayon bridge; you supply the sites, call ``sim.run(n_jobs=...)``, and
+choose whether to use the default thread pool, serial execution, or a capped
+number of worker threads.
+
+This tutorial covers two things:
+
+- Part 1 -- a four-site ensemble that varies surface composition, run in one
+  ``sim.run(n_jobs=-1)`` call.
+- Part 2 -- a short timing appendix measuring wall-clock time at
+  N = 1, 4, 8, 16 grids, so you can calibrate expectations on your own
+  machine.
+
+**API approach**: This tutorial uses the :class:`~supy.SUEWSSimulation` OOP
+interface. The bundled sample data contains one site, so the tutorial copies
+that site configuration into a small multi-grid ensemble and assigns each copy
+a unique ``gridiv``. Real multi-grid workflows use the same shape: one entry in
+``config.sites`` per grid cell.
+"""
+
+# %%
+# Setup
+# -----
+#
+# Start from the bundled sample dataset, then build a small multi-site
+# configuration by copying the sample site. The shared sample forcing is reused
+# for all four sites.
+
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from supy import SUEWSSimulation
+
+
+def make_multi_site_simulation(n_sites: int) -> SUEWSSimulation:
+    """Create an N-site sample simulation with unique names and grid IDs."""
+    if n_sites < 1:
+        raise ValueError("n_sites must be at least 1")
+
+    base = SUEWSSimulation.from_sample_data()
+    config = base.config.model_copy(deep=True)
+    template_site = config.sites[0]
+
+    sites = []
+    for idx in range(n_sites):
+        site = template_site.model_copy(deep=True)
+        site.name = f"KCL_{idx + 1:02d}"
+        site.gridiv = idx + 1
+        sites.append(site)
+
+    config.sites = sites
+
+    sim = SUEWSSimulation(config)
+    sim.update_forcing(base.forcing.df.copy())
+    return sim
+
+
+sim = make_multi_site_simulation(4)
+
+# Slice the forcing to the first month for a fast tutorial run.
+forcing_one_month = sim.forcing.df["2012-01":"2012-01"].iloc[1:]
+sim.update_forcing(forcing_one_month)
+
+print(f"Configured {len(sim.config.sites)} sites:")
+for site in sim.config.sites:
+    print(f"  name={site.name}  gridiv={site.gridiv}")
+
+# %%
+# Part 1: Four-Site Land-Cover Ensemble
+# -------------------------------------
+#
+# Vary surface composition across the four sites to build a small land-cover
+# gradient: from a paved-dominated site through to a grass-dominated one. This
+# stands in for comparing four neighbourhoods or four idealised land-cover
+# archetypes.
+
+# Each row is (paved, bldgs, grass) for one site; the remaining surface
+# fractions are zeroed for clarity. The four mixes span concrete-heavy through
+# to vegetation-heavy.
+land_cover_mix = [
+    (0.80, 0.10, 0.10),  # KCL_01: heavily paved
+    (0.50, 0.30, 0.20),  # KCL_02: mixed urban
+    (0.30, 0.20, 0.50),  # KCL_03: greener
+    (0.10, 0.10, 0.80),  # KCL_04: grass-dominated
+]
+
+for site, (paved, bldgs, grass) in zip(sim.config.sites, land_cover_mix):
+    lc = site.properties.land_cover
+    lc.paved.sfr = paved
+    lc.bldgs.sfr = bldgs
+    lc.grass.sfr = grass
+    lc.evetr.sfr = 0.0
+    lc.dectr.sfr = 0.0
+    lc.bsoil.sfr = 0.0
+    lc.water.sfr = 0.0
+
+# %%
+# Run All Four Sites in One Call
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# A single ``sim.run(n_jobs=-1)`` dispatches all four sites using the
+# Rust/Rayon default thread pool. The forcing is cloned per thread so writes
+# from the Fortran kernel stay isolated. Use ``n_jobs=1`` for a serial run, or
+# a positive value such as ``n_jobs=4`` to cap the Rayon worker count.
+
+output = sim.run(n_jobs=-1)
+
+print(f"Output grids: {output.grids}")
+print(
+    f"Output shape: {output.df.shape}  # rows = grids x timesteps, columns = variables"
+)
+
+# %%
+# Plot Per-Site Air Temperature
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# ``output.SUEWS.T2`` returns a Series with a ``(grid, datetime)`` MultiIndex.
+# ``unstack`` gives one column per grid, which plots cleanly.
+
+df_t2 = output.SUEWS.T2.unstack(level="grid")
+df_t2.columns = [
+    f"{site.name} ({pv:.0%} paved, {gr:.0%} grass)"
+    for site, (pv, _, gr) in zip(sim.config.sites, land_cover_mix)
+]
+
+# Daily mean for readability on a one-month plot.
+df_t2_daily = df_t2.resample("1D").mean()
+
+fig, ax = plt.subplots(figsize=(9, 5))
+df_t2_daily.plot(ax=ax)
+ax.set_ylabel(r"Daily mean $T_2$ ($^\circ$C)")
+ax.set_xlabel("Date")
+ax.set_title("Air temperature across a four-site land-cover ensemble")
+ax.legend(title="Site", loc="best", fontsize=9)
+ax.grid(alpha=0.3)
+plt.tight_layout()
+
+# sphinx_gallery_thumbnail_number = 1
+
+# %%
+# The grass-dominated site (``KCL_04``) is consistently cooler than the
+# paved-dominated site (``KCL_01``) by daytime evapotranspiration: the same
+# contrast you would get from running four single-site simulations in a loop,
+# but without the loop.
+
+# %%
+# Part 2: Timing Appendix
+# -----------------------
+#
+# How much faster is multi-site execution as the number of grids grows? We time
+# the same forcing window at N = 1, 4, 8, 16 sites. The exact numbers depend on
+# your machine's core count and what else it is doing; the shape of the curve is
+# what matters.
+#
+# Each iteration recreates the simulation so the timing reflects a clean
+# end-to-end run rather than an in-place re-execution.
+
+
+def time_run(n_sites: int, n_steps: int = 576, n_jobs: int = -1) -> float:
+    """Measure wall-clock seconds for a fresh N-site run."""
+    sim_n = make_multi_site_simulation(n_sites)
+    forcing_short = sim_n.forcing.df.iloc[1 : n_steps + 1]  # about two days
+    sim_n.update_forcing(forcing_short)
+
+    t0 = time.perf_counter()
+    sim_n.run(n_jobs=n_jobs)
+    return time.perf_counter() - t0
+
+
+grid_counts = [1, 4, 8, 16]
+wall_seconds = [time_run(n, n_jobs=-1) for n in grid_counts]
+
+for n, elapsed in zip(grid_counts, wall_seconds):
+    print(
+        f"  N={n:>3d} grids, n_jobs=-1: {elapsed:6.2f}s  ({n / elapsed:5.1f} grids/s)"
+    )
+
+# %%
+# Plot Wall-Clock vs Grid Count
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+fig, ax = plt.subplots(figsize=(7, 5))
+ax.plot(grid_counts, wall_seconds, marker="o")
+ax.set_xlabel("Number of grids")
+ax.set_ylabel("Wall-clock time (s)")
+ax.set_title("Multi-grid execution time (2-day forcing)")
+ax.set_xscale("log", base=2)
+ax.set_xticks(grid_counts)
+ax.set_xticklabels([str(n) for n in grid_counts])
+ax.grid(alpha=0.3, which="both")
+
+# Reference: linear scaling from the N=1 baseline.
+linear_ref = np.array(wall_seconds[0]) * np.array(grid_counts)
+ax.plot(
+    grid_counts,
+    linear_ref,
+    linestyle="--",
+    alpha=0.5,
+    label="serial scaling (N x baseline)",
+)
+ax.legend()
+plt.tight_layout()
+
+# %%
+# On a typical multi-core laptop the curve sits well below the dashed
+# linear-scaling reference: doubling the grid count costs noticeably less than
+# double the wall-clock time, up to roughly your physical core count. Beyond
+# that the gains taper off as threads compete for cores.
+
+# %%
+# Caveats
+# -------
+#
+# A few things to keep in mind when scaling up:
+#
+# 1. **Memory scales with grid count**. The forcing array is cloned per thread
+#    because the Fortran kernel mutates it in place, so peak memory use grows
+#    roughly linearly with the number of sites in flight.
+# 2. **Each site needs its own config entry**. ``config.sites`` is the unit of
+#    parallelism: one entry per grid, with a unique ``gridiv``.
+# 3. **``n_jobs`` controls the per-call worker policy**. ``n_jobs=-1`` uses the
+#    Rust/Rayon default and is the normal choice for production runs.
+#    ``n_jobs=1`` forces serial execution for debugging or benchmarking, while
+#    values greater than 1 cap the Rayon worker count.
+#
+# **Next steps**:
+#
+# - :doc:`tutorial_04_impact_studies` -- scenario sweeps that combine naturally
+#   with multi-site setups.
+# - :doc:`tutorial_05_results_analysis` -- MultiIndex result handling (the
+#   ``unstack(level="grid")`` pattern used here).


### PR DESCRIPTION
## Summary

- Add a Sphinx Gallery tutorial for Rust/Rayon parallel multi-grid execution using the current `SUEWSSimulation.run(n_jobs=...)` API.
- Build the multi-site sample ensemble from the existing single-site sample config, avoiding the stale `from_sample_data(n_sites=...)` helper that never landed on `master`.
- Cross-link the new worked example from the impact-studies and results-analysis tutorials, and add the matching Ruff docstring exception for tutorial 08.

Closes #1315

## Validation

- `ruff format --check .ruff.toml docs/source/tutorials/tutorial_04_impact_studies.py docs/source/tutorials/tutorial_05_results_analysis.py docs/source/tutorials/tutorial_08_parallel_multi_grid.py && ruff check .ruff.toml docs/source/tutorials/tutorial_04_impact_studies.py docs/source/tutorials/tutorial_05_results_analysis.py docs/source/tutorials/tutorial_08_parallel_multi_grid.py`
- `.venv/bin/python docs/source/tutorials/tutorial_08_parallel_multi_grid.py`
- `. .venv/bin/activate && make test-smoke`
- `. .venv/bin/activate && make -C docs html SPHINXOPTS='--keep-going -D sphinx_gallery_conf.filename_pattern=tutorial_08_parallel_multi_grid.py'`

Note: a stricter docs build with `-W` still fails on pre-existing repository warnings; the targeted build without `-W` succeeds and Sphinx Gallery recognises `tutorial_08_parallel_multi_grid.py`.
