### PR TITLE
Fix RSL canopy-top profile discontinuity

### DIFF
--- a/src/suews/src/suews_phys_rslprof.f95
+++ b/src/suews/src/suews_phys_rslprof.f95
@@ -232,10 +232,11 @@ CONTAINS
 
       ! Upper half: half canyon to canyon top
       dz_can = zH_RSL - zarray(10)
-      DO i = 11, nz_can
+      DO i = 11, nz_can - 1
          zarray(i) = zarray(i - 1) + dz_can*.5
          dz_can = zH_RSL - zarray(i)
       END DO
+      zarray(nz_can) = zH_RSL
 
       ! Above canopy: levels nz_can+1 to nz
       zarray(nz) = zMeas

--- a/test/physics/test_rslprof.py
+++ b/test/physics/test_rslprof.py
@@ -60,6 +60,20 @@ class TestWindProfiles:
         df_output_rsl, _ = sp.run_supy(df_forcing_short, df_state_init)
         assert not df_output_rsl.empty, "RSL failed to run"
 
+    def test_rsl_grid_includes_exact_canopy_top(self, sample_data):
+        """Regression test for GH#296: RSL level 20 is the canopy top."""
+        df_state_init, df_forcing = sample_data
+        df_state = df_state_init.iloc[[0]].copy()
+
+        df_state.loc[:, ("rslmethod", "0")] = 1
+        df_state.loc[:, ("bldgh", "0")] = 40.0
+
+        df_output, _ = sp.run_supy(df_forcing.iloc[:1], df_state, save_state=False)
+        rsl = df_output.xs("RSL", axis=1, level=0).iloc[0]
+
+        assert rsl["flag_RSL"] == 1
+        assert rsl["z_20"] == pytest.approx(rsl["zH_RSL"], abs=1e-9)
+
     @pytest.mark.parametrize(
         "zh,z0m_in,zdm_in",
         [


### PR DESCRIPTION
## Summary
- Pin RSL grid level 20 to the exact canopy-top height `zH_RSL`.
- Add a GH296 regression test for `z_20 == zH_RSL`.

Closes #296.

## Impact check
I compared `origin/master` with this branch using the sample forcing for 288 timesteps, with `rslmethod=1` and `bldgh=40.0`.

| Quantity | `origin/master` | This branch | Max absolute change |
| --- | ---: | ---: | ---: |
| first-step `z_20` | 39.426100394652 m | 39.445360824742 m | 0.019260430090 m |
| first-step `zH_RSL` | 39.445360824742 m | 39.445360824742 m | 0 |
| RSL `z_20`, all timesteps | - | - | 0.019260431840 m |
| RSL `U_20`, all timesteps | - | - | 0.007332088676 m s-1 |
| RSL `T_20`, all timesteps | - | - | 0.000169724626 degC |
| RSL `q_20`, all timesteps | - | - | 0.000164947957 g kg-1 |
| SUEWS `QN` / `QS` | - | - | 0 / 0 W m-2 |
| SUEWS `QH` / `QE` / `QF` | - | - | 3.28e-05 / 5.00e-06 / 3.78e-05 W m-2 |
| SUEWS `U10` / `T2` / `RH2` | - | - | 8.28e-04 m s-1 / 6.74e-05 degC / 6.70e-04 % |
| SUEWS/debug `RS` | - | - | 0.019802914458 s m-1 |

The substantive change is localised to the RSL canopy-top profile anchor. The small changes in diagnostic near-surface values are consistent with removing the roughly 1.9 cm mismatch between level 20 and `zH_RSL`; core net/storage radiation outputs were unchanged in this sample check.

Note: the RSL output metadata wording around level 21 is left unchanged in this PR, because changing `src/supy/data_model/output/` triggers the schema audit even for cosmetic derived-output text.

## Validation
- `make dev`
- `python -m pytest test/physics/test_rslprof.py::TestWindProfiles::test_rsl_grid_includes_exact_canopy_top -q`
- `python -m pytest test/physics/test_rslprof.py -q`
- `python -m pytest test/data_model/test_output_models.py -q`
- `make test-smoke`