### PR TITLE
Remove issue shorthand from user-facing docs

### DIFF
--- a/.claude/rules/docs/conventions.md
+++ b/.claude/rules/docs/conventions.md
@@ -111,6 +111,12 @@ cd docs && make livehtml     # Live-reload development server
 - **Code blocks**: Always specify language (`python`, `bash`, `fortran`, `yaml`)
 - **Cross-references**: `:ref:` for sections, `:doc:` for documents, `:option:` for parameters
 - **British English**: organise, analyse, colour, behaviour
+- **User-facing issue references**: Do not put GitHub issue/PR shorthand such
+  as `gh#1372`, `GH#1372`, `issue #1372`, or `PR #1372` in page titles,
+  section headings, option descriptions, or explanatory prose. Use descriptive
+  reader-facing wording instead. Keep issue numbers in GitHub discussions,
+  changelogs where a formal PR link is part of release metadata, or internal
+  maintainer notes such as `.claude/rules/**`.
 
 ### API References (Classes and Methods)
 

--- a/docs/source/_ext/input_domain.py
+++ b/docs/source/_ext/input_domain.py
@@ -3,8 +3,6 @@ Sphinx extension for SUEWS input configuration options.
 
 This creates a separate namespace for input configuration options,
 preventing collisions with output variable directives in the documentation.
-
-See GitHub issue #1031 for context.
 """
 
 from sphinx import addnodes

--- a/docs/source/_ext/output_domain.py
+++ b/docs/source/_ext/output_domain.py
@@ -3,8 +3,6 @@ Sphinx extension for SUEWS output variables.
 
 This creates a separate namespace for output variables,
 preventing collisions with YAML configuration options in the documentation.
-
-See GitHub issue #1031 for context.
 """
 
 from sphinx import addnodes

--- a/docs/source/api/python-cli-equivalents/run.rst
+++ b/docs/source/api/python-cli-equivalents/run.rst
@@ -22,7 +22,7 @@ CLI Command
 
 .. note::
    The CLI command currently only supports the deprecated namelist format.
-   YAML support is being added - see `Issue #834 <https://github.com/UMEP-dev/SUEWS/issues/834>`_.
+   YAML support is still being added.
 
    For YAML configurations, use the Python API below.
 

--- a/docs/source/assets/refs/refs-SUEWS.bib
+++ b/docs/source/assets/refs/refs-SUEWS.bib
@@ -1,5 +1,5 @@
 @comment{
-   SUEWS publications -- topic taxonomy (GH#1310)
+   SUEWS publications -- topic taxonomy
 
    Every entry MUST carry `keywords = {<slug>[, <slug>...]}` with at least
    one slug from the controlled vocabulary below. Slugs are lowercase,

--- a/docs/source/assets/refs/refs-community.bib
+++ b/docs/source/assets/refs/refs-community.bib
@@ -1,5 +1,5 @@
 @comment{
-   SUEWS publications -- topic taxonomy (GH#1310)
+   SUEWS publications -- topic taxonomy
 
    Every entry MUST carry `keywords = {<slug>[, <slug>...]}` with at least
    one slug from the controlled vocabulary below. Slugs are lowercase,
@@ -28,7 +28,7 @@
 % 2. Add your BibTeX entry below
 % 3. Include a comment above your entry describing how SUEWS was used in your work
 
-% Example entry from issue #80
+% Example entry
 % Used SUEWS for urban climate modelling
 @article{panagiotakis2021,
   title     = {Evaluation of nature-based solutions implementation scenarios, using urban surface modelling},

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -286,8 +286,8 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
-    "input_domain",  # Custom domain for input configuration options (see GH#1031)
-    "output_domain",  # Custom domain for output variables (see GH#1031)
+    "input_domain",  # Custom domain for input configuration options
+    "output_domain",  # Custom domain for output variables
     "publications_topic_annotate",  # Tags bibliography <li>s with keyword classes for the client-side topic filter
 
     "sphinx_design",  # For collapsible sections, tabs, and dropdowns in YAML config reference

--- a/docs/source/contributing/schema/schema-developer.rst
+++ b/docs/source/contributing/schema/schema-developer.rst
@@ -20,7 +20,7 @@ Schema Versioning Basics
   is the single source of truth for compatibility:
   ``is_schema_compatible(old, current)`` returns ``True`` iff
   ``(old, current)`` has a registered handler (or the labels match).
-  There is no separate compatibility table (gh#1304).
+  There is no separate compatibility table.
 
 When a Schema Bump Is Required
 ------------------------------

--- a/docs/source/contributing/schema/schema_cli.rst
+++ b/docs/source/contributing/schema/schema_cli.rst
@@ -258,7 +258,7 @@ Using in CI/CD
 Future Integration with suews-wizard
 ------------------------------------
 
-The ``suews schema`` CLI is designed to integrate seamlessly with the upcoming ``suews-wizard`` (issue #544):
+The ``suews schema`` CLI is designed to integrate seamlessly with the upcoming ``suews-wizard``:
 
 - The wizard will use the validation logic to ensure created configurations are valid
 - Migration utilities can be called from within the wizard for upgrading existing configs

--- a/docs/source/contributing/schema/schema_versioning.rst
+++ b/docs/source/contributing/schema/schema_versioning.rst
@@ -97,7 +97,7 @@ static compatibility table: a version is compatible with the current
 one if and only if it equals the current version or a
 ``(config_version, current_version)`` handler is registered. Adding a
 handler is what makes the previous schema compatible; there is no
-separate table to update (gh#1304).
+separate table to update.
 
 The three outcomes users see:
 

--- a/docs/source/inputs/forcing-data.rst
+++ b/docs/source/inputs/forcing-data.rst
@@ -119,8 +119,8 @@ Where:
 
 .. _named_column_forcing:
 
-Named-column forcing files (gh#1372)
-------------------------------------
+Named-column forcing files
+--------------------------
 
 Since schema 2026.5, SUEWS reads forcing files by **column name**,
 not by column position. The header line is required and its content is

--- a/docs/source/inputs/tables/schema.json
+++ b/docs/source/inputs/tables/schema.json
@@ -3878,7 +3878,7 @@
       "type": "object"
     },
     "FAIMethod": {
-      "description": "Method for calculating frontal area index (FAI) - the ratio of frontal area to plan area.\n\n0: OBSERVED - Use FAI values provided in site parameters (FAIBldg, FAIEveTree, FAIDecTree)\n1: MODELLED - Calculate FAI using simple scheme based on surface fractions and heights (see issue #192)",
+      "description": "Method for calculating frontal area index (FAI) - the ratio of frontal area to plan area.\n\n0: OBSERVED - Use FAI values provided in site parameters (FAIBldg, FAIEveTree, FAIDecTree)\n1: MODELLED - Calculate FAI using simple scheme based on surface fractions and heights",
       "enum": [
         0,
         1
@@ -3887,7 +3887,7 @@
       "type": "integer"
     },
     "ForcingControl": {
-      "description": "Configuration block for meteorological forcing input.\n\nCreated in gh#1372 so future forcing-related fields (sub-hourly\ndisaggregation, gh#1373; resampling policy; etc.) have a stable\nhome rather than accreting flat ``forcing_*`` siblings under\n:class:`ModelControl`.",
+      "description": "Configuration block for meteorological forcing input.\n\nGroups forcing-related fields, such as sub-hourly disaggregation and\nresampling policy, under a stable home rather than accreting flat\n``forcing_*`` siblings under :class:`ModelControl`.",
       "properties": {
         "file": {
           "anyOf": [
@@ -7418,7 +7418,7 @@
             }
           ],
           "default": 0,
-          "description": "Method for calculating frontal area index (FAI) - the ratio of frontal area to plan area. Options: 0 (OBSERVED) = Use FAI values provided in site parameters (FAIBldg, FAIEveTree, FAIDecTree); 1 (MODELLED) = Calculate FAI using simple scheme based on surface fractions and heights (see issue #192)",
+          "description": "Method for calculating frontal area index (FAI) - the ratio of frontal area to plan area. Options: 0 (OBSERVED) = Use FAI values provided in site parameters (FAIBldg, FAIEveTree, FAIDecTree); 1 (MODELLED) = Calculate FAI using simple scheme based on surface fractions and heights",
           "title": "Frontal Area Index",
           "unit": "dimensionless"
         },
@@ -7486,7 +7486,7 @@
           "depends_on": [
             "storage_heat"
           ],
-          "description": "STEBBS physics switches (gh#1456): master toggle (enabled + parameters), capacitance method, setpoint method, and the same-albedo / same-emissivity wall/roof switches.",
+          "description": "STEBBS physics switches: master toggle (enabled + parameters), capacitance method, setpoint method, and the same-albedo / same-emissivity wall/roof switches.",
           "note": "When storage_heat selects STEBBS (7), this block enables and parameterises the STEBBS contribution to storage heat.",
           "provides_to": [
             "stebbs.capacitance"
@@ -7659,7 +7659,7 @@
       "type": "integer"
     },
     "OutputControl": {
-      "description": "Configuration block for model output files.\n\nRenamed from ``OutputConfig`` and lifted out of the legacy\n``Union[str, OutputConfig]`` ``output_file`` field in gh#1372 follow-up,\nso the ``model.control`` surface is uniform with the new ``forcing:``\nsub-object. The legacy string form (silently ignored since 2025.10.15)\nis dropped.",
+      "description": "Configuration block for model output files.\n\nRenamed from ``OutputConfig`` and lifted out of the legacy\n``Union[str, OutputConfig]`` ``output_file`` field so the\n``model.control`` surface is uniform with the new ``forcing:`` sub-object.\nThe legacy string form (silently ignored since 2025.10.15) is dropped.",
       "properties": {
         "format": {
           "$ref": "#/$defs/OutputFormat",
@@ -7988,7 +7988,7 @@
       "type": "object"
     },
     "RCMethod": {
-      "description": "Method to determine the two weighting factors (wall_outer_heat_capacity_fraction and roof_outer_heat_capacity_fraction) splitting heat capacity of building envelope into two nodes in STEBBS.\n\nExposed on the YAML / data-model surface as ``stebbs.capacitance`` (the\nfield formerly named ``outer_cap_fraction``, gh#1456). The ``rcmethod``\nDataFrame column the Fortran bridge reads is unchanged.\n\n0: DEFAULT - Default value of 0.5 is used\n1: PROVIDED - Use user defined value (wall_outer_heat_capacity_fraction and roof_outer_heat_capacity_fraction) between 0 and 1\n2: PARAMETERISE - Use building material thermal property to parameterise the weighting factor",
+      "description": "Method to determine the two weighting factors (wall_outer_heat_capacity_fraction and roof_outer_heat_capacity_fraction) splitting heat capacity of building envelope into two nodes in STEBBS.\n\nExposed on the YAML / data-model surface as ``stebbs.capacitance`` (the\nfield formerly named ``outer_cap_fraction``). The ``rcmethod``\nDataFrame column the Fortran bridge reads is unchanged.\n\n0: DEFAULT - Default value of 0.5 is used\n1: PROVIDED - Use user defined value (wall_outer_heat_capacity_fraction and roof_outer_heat_capacity_fraction) between 0 and 1\n2: PARAMETERISE - Use building material thermal property to parameterise the weighting factor",
       "enum": [
         0,
         1,
@@ -10270,7 +10270,7 @@
       "type": "integer"
     },
     "StebbsParameterSource": {
-      "description": "Source of STEBBS parameters when STEBBS is enabled (``stebbs.enabled=true``).\n\nOnly consulted when STEBBS is enabled; ignored otherwise. The values equal\nthe non-zero ``StebbsMethod`` codes so the composed ``stebbsmethod`` column\nis simply ``int(parameters)`` whenever STEBBS is enabled (gh#1456).\n\n1: DEFAULT - STEBBS uses default parameters\n2: PROVIDED - STEBBS uses user-specified parameters",
+      "description": "Source of STEBBS parameters when STEBBS is enabled (``stebbs.enabled=true``).\n\nOnly consulted when STEBBS is enabled; ignored otherwise. The values equal\nthe non-zero ``StebbsMethod`` codes so the composed ``stebbsmethod`` column\nis simply ``int(parameters)`` whenever STEBBS is enabled.\n\n1: DEFAULT - STEBBS uses default parameters\n2: PROVIDED - STEBBS uses user-specified parameters",
       "enum": [
         1,
         2
@@ -10279,7 +10279,7 @@
       "type": "integer"
     },
     "StebbsPhysics": {
-      "description": "STEBBS (Surface Temperature Energy Balance Based Scheme) physics switches.\n\nGroups the six STEBBS-scoped method switches that previously sat flat on\n``model.physics`` (gh#1456). The master on/off toggle is split into\n``enabled`` (bool) and ``parameters`` (StebbsParameterSource); the two\ncompose back to the single legacy ``stebbsmethod`` integer column on\n``ModelPhysics.to_df_state`` and are decomposed on ``from_df_state``. The\nDataFrame / Fortran column names are unchanged.",
+      "description": "STEBBS (Surface Temperature Energy Balance Based Scheme) physics switches.\n\nGroups the six STEBBS-scoped method switches that previously sat flat on\n``model.physics``. The master on/off toggle is split into\n``enabled`` (bool) and ``parameters`` (StebbsParameterSource); the two\ncompose back to the single legacy ``stebbsmethod`` integer column on\n``ModelPhysics.to_df_state`` and are decomposed on ``from_df_state``. The\nDataFrame / Fortran column names are unchanged.",
       "properties": {
         "enabled": {
           "anyOf": [
@@ -13117,7 +13117,7 @@
     }
   },
   "additionalProperties": true,
-  "description": "JSON Schema for SUEWS YAML configuration files. Schema version 2026.6.dev1. Development schema for the SPARTACUS direct/diffuse benchmark work: adds the model.physics.kdown_split_method selector with model.physics.kdown_split_method.constant.sw_dn_direct_frac for constant splits, forest-column SPARTACUS stream and vegetation-region controls, and the optional vertical_layers.veg_ext extinction override. Existing 2026.5 YAMLs remain compatible through a no-op migration because all new inputs have defaults and legacy sites[*].properties.spartacus.sw_dn_direct_frac input is migrated.",
+  "description": "JSON Schema for SUEWS YAML configuration files. Schema version 2026.6.dev1. Development schema for the SPARTACUS direct/diffuse benchmark work: adds the model.physics.kdown_split_method selector with model.physics.kdown_split_method.constant.sw_dn_direct_frac for constant splits, forest-column SPARTACUS stream and vegetation-region controls, and the optional vertical_layers.veg_ext extinction override. Existing 2026.5 YAMLs remain compatible through a no-op migration because all new inputs have defaults and legacy sites[*].properties.spartacus.sw_dn_direct_frac input remains accepted at parse time and is copied into the model-owned value.",
   "properties": {
     "name": {
       "default": "sample config",

--- a/docs/source/inputs/transition_guide.rst
+++ b/docs/source/inputs/transition_guide.rst
@@ -391,8 +391,8 @@ Troubleshooting
    - Check the debug directory to identify which conversion step failed
    - Report issues with the specific version transition that failed
 
-Nested Physics Sub-Options (accept-only, gh#972)
--------------------------------------------------
+Nested Physics Sub-Options
+--------------------------
 
 Three ``model.physics`` fields accept a family-tagged nested form
 alongside the existing flat ``{value: N}`` shape:

--- a/docs/source/inputs/yaml/index.rst
+++ b/docs/source/inputs/yaml/index.rst
@@ -282,7 +282,7 @@ Urban Site Configuration
 Tips for Success
 ----------------
 
-1. **Start with the sample**: Always begin with ``sample_config.yml`` and modify it — configs that omit physics-required blocks (``conductance``, per-surface ``lai``, tree ``fai_*``/``height_*``, ``bldgs.bldgh``/``faibldg``) raise a :class:`ValueError` at load (gh#1333)
+1. **Start with the sample**: Always begin with ``sample_config.yml`` and modify it; configs that omit physics-required blocks (``conductance``, per-surface ``lai``, tree ``fai_*``/``height_*``, ``bldgs.bldgh``/``faibldg``) raise a :class:`ValueError` at load time.
 2. **Validate early**: Run validation before long simulations
 3. **Check the report**: Understand what the validator changed
 4. **Use meaningful names**: Help yourself remember what each simulation is for

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -257,7 +257,6 @@ The same plugin works across the Codex CLI, the Codex Desktop App
 
 A Model Context Protocol (MCP) server for SUEWS is in development and will
 provide a universal install path across MCP-aware tools (Cursor, Gemini CLI,
-Goose, JetBrains Junie, etc.). Tracking issue:
-`gh#1364 <https://github.com/UMEP-dev/SUEWS/issues/1364>`_. Until that lands,
-MCP-only users can clone the repository and point their MCP client at the
-bundled CLI surface manually.
+Goose, JetBrains Junie, etc.). Until that support is available, MCP-only users
+can clone the repository and point their MCP client at the bundled CLI surface
+manually.

--- a/docs/source/version-history/v2026.4.3.rst
+++ b/docs/source/version-history/v2026.4.3.rst
@@ -100,6 +100,6 @@ This release delivers a major backend migration to Rust FFI, RSL physics refinem
 
 - f90wrap is no longer supported; the Rust FFI bridge is the sole simulation backend. (:pr:`1209`)
 - Deprecated ``env.yml`` and conda/mamba build pathway. (:pr:`1163`)
-- YAML schema bumped ``2025.12 -> 2026.1 -> 2026.4`` (retrospectively via gh#1304). Breaking field-level changes include ``DeepSoilTemperature`` -> ``AnnualMeanAirTemperature`` (:pr:`1240`), removal of ``MinimumVolumeOfDHWinUse`` / ``MaximumVolumeOfDHWinUse`` (:pr:`1242`), and STEBBS setpoint scalar/profile split gated on ``model.physics.setpointmethod`` (:pr:`1261`). Migration handlers cover the full chain; run ``suews-schema migrate your_config.yml`` to upgrade existing YAMLs. See :ref:`transition_guide` for the user-facing upgrade summary.
+- YAML schema bumped ``2025.12 -> 2026.1 -> 2026.4`` after the schema compatibility audit. Breaking field-level changes include ``DeepSoilTemperature`` -> ``AnnualMeanAirTemperature`` (:pr:`1240`), removal of ``MinimumVolumeOfDHWinUse`` / ``MaximumVolumeOfDHWinUse`` (:pr:`1242`), and STEBBS setpoint scalar/profile split gated on ``model.physics.setpointmethod`` (:pr:`1261`). Migration handlers cover the full chain; run ``suews-schema migrate your_config.yml`` to upgrade existing YAMLs. See :ref:`transition_guide` for the user-facing upgrade summary.
 
 For complete details, see the `CHANGELOG <https://github.com/UMEP-dev/SUEWS/blob/master/CHANGELOG.md>`_.

--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -612,10 +612,10 @@ Migration Process
 
 .. code-block:: bash
 
-   # Convert legacy table inputs to modern YAML (pending issue #581)
+   # Convert legacy table inputs to modern YAML (under development)
    suews-convert to-yaml -i legacy_input_dir/ -o modern_config.yml
    
-   # Note: This feature is under development (see issue #581)
+   # Note: This feature is under development
    # For now, use the SUEWSSimulation class with existing table inputs or YAML files
 
 **Testing Your Migration:**

--- a/src/supy/_supy_module.py
+++ b/src/supy/_supy_module.py
@@ -80,7 +80,6 @@ def _warn_functional_deprecation(name: str) -> None:
     procedural API in this module is end-user-facing, not a developer-only
     surface, so ``FutureWarning`` is the right Python-level signal — see
     https://docs.python.org/3/library/warnings.html#warning-categories.
-    Tracked under gh#1370 (Phase 2: visibility).
     """
     replacement = _FUNCTIONAL_DEPRECATIONS.get(name, "the object-oriented API")
     warnings.warn(

--- a/src/supy/data_model/core/model.py
+++ b/src/supy/data_model/core/model.py
@@ -482,7 +482,7 @@ class FAIMethod(Enum):
     Method for calculating frontal area index (FAI) - the ratio of frontal area to plan area.
 
     0: OBSERVED - Use FAI values provided in site parameters (FAIBldg, FAIEveTree, FAIDecTree)
-    1: MODELLED - Calculate FAI using simple scheme based on surface fractions and heights (see issue #192)
+    1: MODELLED - Calculate FAI using simple scheme based on surface fractions and heights
     """
 
     OBSERVED = 0  # Use FAI values from site parameters
@@ -558,7 +558,7 @@ class StebbsMethod(Enum):
     column the Fortran bridge reads). On the YAML / data-model surface this
     tri-state is split into ``stebbs.enabled`` (bool) and ``stebbs.parameters``
     (StebbsParameterSource); the two compose back to this integer code via
-    ``to_df_state`` / decompose on ``from_df_state`` (gh#1456).
+    ``to_df_state`` / decompose on ``from_df_state``.
     """
 
     NONE = 0
@@ -578,7 +578,7 @@ class StebbsParameterSource(Enum):
 
     Only consulted when STEBBS is enabled; ignored otherwise. The values equal
     the non-zero ``StebbsMethod`` codes so the composed ``stebbsmethod`` column
-    is simply ``int(parameters)`` whenever STEBBS is enabled (gh#1456).
+    is simply ``int(parameters)`` whenever STEBBS is enabled.
 
     1: DEFAULT - STEBBS uses default parameters
     2: PROVIDED - STEBBS uses user-specified parameters
@@ -599,7 +599,7 @@ class RCMethod(Enum):
     Method to determine the two weighting factors (wall_outer_heat_capacity_fraction and roof_outer_heat_capacity_fraction) splitting heat capacity of building envelope into two nodes in STEBBS.
 
     Exposed on the YAML / data-model surface as ``stebbs.capacitance`` (the
-    field formerly named ``outer_cap_fraction``, gh#1456). The ``rcmethod``
+    field formerly named ``outer_cap_fraction``). The ``rcmethod``
     DataFrame column the Fortran bridge reads is unchanged.
 
     0: DEFAULT - Default value of 0.5 is used
@@ -779,7 +779,7 @@ class StebbsPhysics(BaseModel):
     STEBBS (Surface Temperature Energy Balance Based Scheme) physics switches.
 
     Groups the six STEBBS-scoped method switches that previously sat flat on
-    ``model.physics`` (gh#1456). The master on/off toggle is split into
+    ``model.physics``. The master on/off toggle is split into
     ``enabled`` (bool) and ``parameters`` (StebbsParameterSource); the two
     compose back to the single legacy ``stebbsmethod`` integer column on
     ``ModelPhysics.to_df_state`` and are decomposed on ``from_df_state``. The
@@ -1068,8 +1068,8 @@ class ModelPhysics(BaseModel):
     stebbs: StebbsPhysics = Field(
         default_factory=StebbsPhysics,
         description=(
-            "STEBBS physics switches (gh#1456): master toggle (enabled + "
-            "parameters), capacitance method, setpoint method, and the "
+            "STEBBS physics switches: master toggle (enabled + parameters), "
+            "capacitance method, setpoint method, and the "
             "same-albedo / same-emissivity wall/roof switches."
         ),
         json_schema_extra={
@@ -1287,10 +1287,9 @@ class OutputControl(BaseModel):
     """Configuration block for model output files.
 
     Renamed from ``OutputConfig`` and lifted out of the legacy
-    ``Union[str, OutputConfig]`` ``output_file`` field in gh#1372 follow-up,
-    so the ``model.control`` surface is uniform with the new ``forcing:``
-    sub-object. The legacy string form (silently ignored since 2025.10.15)
-    is dropped.
+    ``Union[str, OutputConfig]`` ``output_file`` field so the
+    ``model.control`` surface is uniform with the new ``forcing:`` sub-object.
+    The legacy string form (silently ignored since 2025.10.15) is dropped.
     """
 
     model_config = ConfigDict(title="Output Control")
@@ -1317,9 +1316,8 @@ class OutputControl(BaseModel):
         """Deprecated alias for ``OutputControl.dir``.
 
         External Python consumers (UMEP postprocessor, etc.) that still
-        read ``config.model.control.output_file.path`` keep working
-        through the gh#1372 migration window. Scheduled for removal in
-        2026.6.
+        read ``config.model.control.output_file.path`` keep working through the
+        migration window. Scheduled for removal in 2026.6.
         """
         import warnings
 
@@ -1347,10 +1345,9 @@ class OutputControl(BaseModel):
 class ForcingControl(BaseModel):
     """Configuration block for meteorological forcing input.
 
-    Created in gh#1372 so future forcing-related fields (sub-hourly
-    disaggregation, gh#1373; resampling policy; etc.) have a stable
-    home rather than accreting flat ``forcing_*`` siblings under
-    :class:`ModelControl`.
+    Groups forcing-related fields, such as sub-hourly disaggregation and
+    resampling policy, under a stable home rather than accreting flat
+    ``forcing_*`` siblings under :class:`ModelControl`.
     """
 
     model_config = ConfigDict(title="Forcing Control")
@@ -1500,8 +1497,8 @@ class ModelControl(BaseModel):
         """Deprecated alias for ``model.control.output``.
 
         External Python consumers (UMEP postprocessor, etc.) that still
-        read ``config.model.control.output_file`` keep working through
-        the gh#1372 migration window. Scheduled for removal in 2026.6.
+        read ``config.model.control.output_file`` keep working through the
+        migration window. Scheduled for removal in 2026.6.
         """
         import warnings
 

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -113,15 +113,14 @@ class SUEWSSimulation:
         Parameters
         ----------
         config : str, Path, dict, or SUEWSConfig
-            Configuration source:
-            - Path to YAML file
-            - Dictionary with parameters: a full configuration dict when no
-              config is loaded yet, or a partial update merged onto the
-              existing config. Either way the result is re-validated through
-              ``SUEWSConfig``, so enum/RefValue coercion and range checks
-              apply exactly as for YAML input. Unknown keys raise
-              ``ValueError``; list values replace the existing list.
-            - SUEWSConfig object
+            Configuration source. Pass a path to a YAML file, a
+            ``SUEWSConfig`` object, or a dictionary with parameters. A
+            dictionary is treated as a full configuration when no config is
+            loaded yet, or as a partial update merged onto the existing config.
+            Either way the result is re-validated through ``SUEWSConfig``, so
+            enum/RefValue coercion and range checks apply exactly as for YAML
+            input. Unknown keys raise ``ValueError``; list values replace the
+            existing list.
         auto_load_forcing : bool, optional
             If True (default), automatically load forcing data specified in the
             config file. If False, forcing must be loaded explicitly using
@@ -169,8 +168,8 @@ class SUEWSSimulation:
             if self._config is None:
                 # No existing config: treat the dict as a full configuration
                 # and build it through the validated SUEWSConfig path
-                # (gh#1530). Partial dicts are only meaningful as updates to
-                # an existing configuration.
+                # Partial dicts are only meaningful as updates to an existing
+                # configuration.
                 candidate = SUEWSConfig.from_dict(config)
                 if not candidate.sites:
                     raise ValueError(
@@ -189,7 +188,7 @@ class SUEWSSimulation:
             else:
                 # Merge the partial update onto the existing config, then
                 # re-validate the whole configuration so enum coercion,
-                # RefValue wrapping, and range checks all apply (gh#1530).
+                # RefValue wrapping, and range checks all apply.
                 # The merged dict is the user's effective input (original
                 # explicitly-set fields plus this update), so from_dict's
                 # default raw snapshot of it is the correct record for
@@ -217,7 +216,7 @@ class SUEWSSimulation:
         Returns a plain dict ready for re-validation through
         ``SUEWSConfig.from_dict``; the configuration is never mutated in
         place, so enum coercion, RefValue wrapping, and range checks always
-        apply to the merged result (gh#1530).
+        apply to the merged result.
 
         Merge semantics:
         - dicts merge recursively into model-backed nodes; unknown field
@@ -251,7 +250,7 @@ class SUEWSSimulation:
             ``stability``, the ``output_file``/``forcing_file`` lifts)
             through each model's before-validators. Partial updates must
             accept the same forms, so the patch is run through the same
-            machinery before the unknown-key check (gh#1530 follow-up).
+            machinery before the unknown-key check.
             """
             decorators = getattr(model_cls, "__pydantic_decorators__", None)
             if decorators is None:
@@ -423,8 +422,7 @@ class SUEWSSimulation:
         rejected with a clear error otherwise. Unlike file loading, no column
         renaming or unit conversion is applied to in-memory inputs; build them
         with :func:`supy.util.read_forcing` or
-        :meth:`supy.SUEWSForcing.from_file` to guarantee that contract
-        (gh#1537).
+        :meth:`supy.SUEWSForcing.from_file` to guarantee that contract.
 
         Examples
         --------
@@ -735,7 +733,7 @@ class SUEWSSimulation:
             physics = getattr(self._config.model, "physics", None)
             if physics is not None and hasattr(physics, "model_dump"):
                 physics_dict = physics.model_dump(mode="python")
-            # Cross-check physics path against forcing columns (gh#1372).
+            # Cross-check physics path against forcing columns.
             # Helper is silent on success; raises ValueError on mismatch.
             if physics is not None:
                 from .data_model.core.forcing_validation import (

--- a/src/supy/util/_era5.py
+++ b/src/supy/util/_era5.py
@@ -280,7 +280,7 @@ def safe_stdout_stderr():
 
     # Replace None streams with devnull. Force UTF-8 so libraries that emit
     # Unicode (e.g. tqdm progress bars) don't crash on Windows, whose default
-    # cp1252 codec cannot encode them (see gh#1097, gh#902).
+    # cp1252 codec cannot encode them.
     devnull = open(os.devnull, "w", encoding="utf-8")
     try:
         if stdout_was_none:


### PR DESCRIPTION
## Summary
- remove GitHub issue shorthand from user-facing documentation headings, prose, schema descriptions, and rendered API/source-view text
- add a documentation convention that keeps issue and PR shorthand out of user-facing docs
- regenerate the committed YAML schema artifact after source description cleanup

## Validation
- `rg -n -i "gh#[0-9]+|GH#[0-9]+|issue #[0-9]+|Issue #[0-9]+|pending issue #[0-9]+|PR #[0-9]+" docs/source docs/build/html` (no matches)
- `git diff --check`
- `uv run --extra docs --reinstall-package supy make -C docs html` (passes; existing docs warnings remain)
- `uv run --extra dev --reinstall-package supy make test-smoke` (passes: 12 passed, 1760 deselected)
