### PR TITLE
Improve SPARTACUS fraction mismatch guidance

### DIFF
--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -2603,28 +2603,60 @@ class SUEWSConfig(BaseModel):
 
         tol = 1e-6
 
+        def _fraction_mismatch_message(
+            left_label: str,
+            left_value: float,
+            right_label: str,
+            right_value: float,
+            guidance: str,
+        ) -> str:
+            difference = abs(float(left_value) - float(right_value))
+            return (
+                f"{site_name}: {left_label} ({left_value}) does not match "
+                f"{right_label} ({right_value}); absolute difference is "
+                f"{difference:.6g}, tolerance is {tol:g}. {guidance}"
+            )
+
         # Buildings: surface fraction vs first SPARTACUS layer
         if (
             isinstance(building_frac, (list, tuple))
             and len(building_frac) > 0
             and bldgs_sfr is not None
+            and not np.isclose(bldgs_sfr, building_frac[0], atol=tol, rtol=0.0)
         ):
-            if not np.isclose(bldgs_sfr, building_frac[0], atol=tol):
-                issues.append(
-                    f"{site_name}: bldgs.sfr ({bldgs_sfr}) does not match "
-                    f"vertical_layers.building_frac[0] ({building_frac[0]})"
+            issues.append(
+                _fraction_mismatch_message(
+                    "land_cover.bldgs.sfr",
+                    bldgs_sfr,
+                    "vertical_layers.building_frac[0]",
+                    building_frac[0],
+                    (
+                        "Both fields represent the grid building plan "
+                        "fraction for the lowest SPARTACUS layer; reconcile "
+                        "the land-cover and 3D morphology inputs before "
+                        "running SUEWS."
+                    ),
                 )
+            )
 
         # Vegetation: sum of fractions vs first veg_frac entry
         if (
             isinstance(veg_frac, (list, tuple))
             and len(veg_frac) > 0
+            and not np.isclose(veg_sfr, veg_frac[0], atol=tol, rtol=0.0)
         ):
-            if not np.isclose(veg_sfr, veg_frac[0], atol=tol):
-                issues.append(
-                    f"{site_name}: evetr.sfr + dectr.sfr ({veg_sfr}) does not match "
-                    f"vertical_layers.veg_frac[0] ({veg_frac[0]})"
+            issues.append(
+                _fraction_mismatch_message(
+                    "land_cover.evetr.sfr + land_cover.dectr.sfr",
+                    veg_sfr,
+                    "vertical_layers.veg_frac[0]",
+                    veg_frac[0],
+                    (
+                        "These fields must describe a consistent vegetation "
+                        "fraction for the SPARTACUS layer geometry."
+                    ),
                 )
+            )
 
         return issues
     

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -2091,21 +2091,22 @@ def test_validate_spartacus_building_height_stebbs_off():
 def test_validate_spartacus_sfr_mismatch_bldgs_frac():
     cfg = SUEWSConfig.model_construct()
     _force_set(cfg, "model", SimpleNamespace(physics=SimpleNamespace(net_radiation=1001)))
-    bldgs = SimpleNamespace(sfr=0.6)  
+    bldgs = SimpleNamespace(sfr=0.184)
     lc = SimpleNamespace(bldgs=bldgs, evetr=None, dectr=None)
     vertical_layers = SimpleNamespace(
-        building_frac=[0.3],  
+        building_frac=[0.153],
         veg_frac=[0.0],
     )
     props = SimpleNamespace(land_cover=lc, vertical_layers=vertical_layers)
     site = DummySite(properties=props, name="TestSite")
     msgs = cfg._validate_spartacus_sfr(site, 0)
-    assert msgs  
-    assert any(
-        "bldgs.sfr (0.6) does not match vertical_layers.building_frac[0] (0.3)"
-        in m
-        for m in msgs
-    )
+    assert msgs
+    message = msgs[0]
+    assert "land_cover.bldgs.sfr (0.184)" in message
+    assert "vertical_layers.building_frac[0] (0.153)" in message
+    assert "absolute difference is 0.031" in message
+    assert "tolerance is 1e-06" in message
+    assert "reconcile the land-cover and 3D morphology inputs" in message
 
 def test_validate_spartacus_sfr_consistent_values():
     cfg = SUEWSConfig.model_construct()
@@ -2145,7 +2146,8 @@ def test_validate_spartacus_sfr_mismatch_veg_frac():
     msgs = cfg._validate_spartacus_sfr(site, 0)
     assert msgs
     assert any(
-        "evetr.sfr + dectr.sfr (0.4) does not match vertical_layers.veg_frac[0] (0.1)"
+        "land_cover.evetr.sfr + land_cover.dectr.sfr (0.4) does not match "
+        "vertical_layers.veg_frac[0] (0.1)"
         in m
         for m in msgs
     )


### PR DESCRIPTION
## Summary

- clarify the SPARTACUS surface-fraction mismatch messages so they show both conflicting fields, both values, absolute difference, tolerance, and next action
- add regression coverage using the reported Gothenburg-style building-fraction mismatch (`0.184` vs `0.153`)
- preserve the existing hard validation behaviour; this PR improves the validator UX without automatically reconciling user GIS inputs

Fixes #1596

## Validation

- `source .venv/bin/activate && python -m pytest test/data_model/test_validation.py::test_validate_spartacus_sfr_mismatch_bldgs_frac test/data_model/test_validation.py::test_validate_spartacus_sfr_consistent_values test/data_model/test_validation.py::test_validate_spartacus_sfr_mismatch_veg_frac -q`
- `git diff --check`

## Notes

`ruff check src/supy/data_model/core/config.py test/data_model/test_validation.py` still reports pre-existing lint debt across these files, so this PR does not attempt unrelated style cleanup.
