### PR TITLE
Gate supy resample on saving against check if output frequency matches model timestep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ EXAMPLES:
 
 ## 2026
 
-### 2 Jul 2026
+### 8 Jul 2026
 
 - [change][experimental] Skip output resampling when it is a no-op (#1599)
   - Saving multi-year sub-hourly runs spent ~80% of the time resampling even when the requested output frequency already matched the model timestep. `resample_output` now returns the frame unchanged (byte-identical) when the data is already at the target frequency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ EXAMPLES:
 
 ## 2026
 
+### 2 Jul 2026
+
+- [change][experimental] Skip output resampling when it is a no-op (#1599)
+  - Saving multi-year sub-hourly runs spent ~80% of the time resampling even when the requested output frequency already matched the model timestep. `resample_output` now returns the frame unchanged (byte-identical) when the data is already at the target frequency.
+  - The guard lives inside `resample_output`, so every caller benefits (`save_supy`, `SUEWSOutput.resample`, the TMY/EPW generator), and uses `pandas.infer_freq` so an irregular index is never falsely treated as a match.
+
 ### 29 Jun 2026
 
 - [bugfix] Capped `pandas<3` on the manylinux2014 matrix to stop a numpy/pandas ABI segfault

--- a/src/supy/_post.py
+++ b/src/supy/_post.py
@@ -165,6 +165,45 @@ def pack_df_output_block(dict_output_block, df_forcing_block):
 
 
 # resample supy output
+def _index_freq_matches(df_output, freq):
+    """Return True when ``df_output`` is already at the target frequency ``freq``.
+
+    Uses :func:`pandas.infer_freq`, which returns ``None`` for an irregular or
+    ambiguous index; such an index therefore never matches and always falls
+    through to a real resample (avoiding the false positives a median-of-diffs
+    reconstruction could produce). ``freq`` may be a pandas offset alias
+    (e.g. ``"h"``, ``"5min"``) or a :class:`pandas.Timedelta` (as passed by the
+    save path).
+
+    Parameters
+    ----------
+    df_output : pandas.DataFrame
+        Output frame with a ``datetime`` index level.
+    freq : str or pandas.Timedelta
+        Target resampling frequency.
+
+    Returns
+    -------
+    bool
+        True only when the index cadence is regular and equal to ``freq``.
+    """
+    level = "datetime" if "datetime" in df_output.index.names else -1
+    idx_dt = df_output.index.get_level_values(level).unique().sort_values()
+    if len(idx_dt) < 3:
+        # infer_freq needs at least three timestamps to determine a cadence.
+        return False
+    inferred = pd.infer_freq(idx_dt)
+    if inferred is None:
+        return False
+    to_offset = pd.tseries.frequencies.to_offset
+    try:
+        return pd.Timedelta(to_offset(inferred)) == pd.Timedelta(to_offset(freq))
+    except ValueError:
+        # Non-fixed frequencies (e.g. month-end) cannot become a Timedelta;
+        # compare the offsets directly instead.
+        return to_offset(inferred) == to_offset(freq)
+
+
 def resample_output(df_output, freq="60min", dict_aggm=dict_var_aggm, _internal=False):
     """Resample SUEWS simulation output to a different temporal frequency.
 
@@ -271,6 +310,11 @@ def resample_output(df_output, freq="60min", dict_aggm=dict_var_aggm, _internal=
         from ._supy_module import _warn_functional_deprecation
 
         _warn_functional_deprecation("resample_output")
+
+    # Skip resampling entirely when the data is already at the requested
+    # frequency
+    if _index_freq_matches(df_output, freq):
+        return df_output
 
     # Helper function to resample a group with specified parameters
     def _resample_group(df_group, freq, label, dict_aggm_group, group_name=None):

--- a/src/supy/_save.py
+++ b/src/supy/_save.py
@@ -266,8 +266,15 @@ def save_df_output(
         df_save_no_daily = df_save
 
     # resample `df_output` at `freq_save` (excluding DailyState)
+    # Only apply when the target freq differs from the run's native timestep
     if len(df_save_no_daily.columns) > 0:
-        df_rsmp = resample_output(df_save_no_daily, freq_save, _internal=True)
+        level = "datetime" if "datetime" in df_save_no_daily.index.names else -1
+        dt = df_save_no_daily.index.get_level_values(level).unique().sort_values()
+        src_freq = dt.to_series().diff().dropna().median()
+        if freq_save == src_freq:
+            df_rsmp = df_save_no_daily
+        else:
+            df_rsmp = resample_output(df_save_no_daily, freq_save, _internal=True)
     else:
         df_rsmp = None
 

--- a/src/supy/_save.py
+++ b/src/supy/_save.py
@@ -266,15 +266,8 @@ def save_df_output(
         df_save_no_daily = df_save
 
     # resample `df_output` at `freq_save` (excluding DailyState)
-    # Only apply when the target freq differs from the run's native timestep
     if len(df_save_no_daily.columns) > 0:
-        level = "datetime" if "datetime" in df_save_no_daily.index.names else -1
-        dt = df_save_no_daily.index.get_level_values(level).unique().sort_values()
-        src_freq = dt.to_series().diff().dropna().median()
-        if freq_save == src_freq:
-            df_rsmp = df_save_no_daily
-        else:
-            df_rsmp = resample_output(df_save_no_daily, freq_save, _internal=True)
+        df_rsmp = resample_output(df_save_no_daily, freq_save, _internal=True)
     else:
         df_rsmp = None
 

--- a/test/io_tests/test_resample_output.py
+++ b/test/io_tests/test_resample_output.py
@@ -38,6 +38,46 @@ class TestResampleOutput:
         assert isinstance(output_resampled, sp.SUEWSOutput)
         assert not output_resampled.df.empty
 
+    def test_resample_native_freq_skips_and_is_identical(self):
+        """At the run's native frequency resample_output is a no-op (gh#1599).
+
+        The save path calls resample_output with the model timestep as the
+        target; when the data already has that cadence, resampling must be
+        skipped and the frame returned unchanged (byte-identical), not rebuilt.
+        """
+        df_state_init, df_forcing = sp.load_SampleData()
+        df_output, _ = sp.run_supy(df_forcing.iloc[:48], df_state_init)
+
+        # native cadence of the run (5 min for the sample data)
+        idx_dt = df_output.index.get_level_values("datetime").unique().sort_values()
+        native_freq = pd.infer_freq(idx_dt)
+        assert native_freq is not None
+
+        # both a string alias and the equivalent Timedelta (as the save path
+        # passes) must be recognised and skipped
+        to_offset = pd.tseries.frequencies.to_offset
+        for freq in (native_freq, pd.Timedelta(to_offset(native_freq))):
+            result = resample_output(df_output, freq=freq, _internal=True)
+            assert result is df_output  # skipped -> same object, no work done
+            pd.testing.assert_frame_equal(result, df_output)  # byte-identical
+
+    def test_resample_irregular_index_not_skipped(self):
+        """An irregular index must not be treated as a frequency match (gh#1599).
+
+        infer_freq returns None for irregular cadence, so the guard falls
+        through to a real resample rather than a false-positive skip (which a
+        median-of-diffs reconstruction could wrongly trigger).
+        """
+        from supy._post import _index_freq_matches
+
+        df_state_init, df_forcing = sp.load_SampleData()
+        df_output, _ = sp.run_supy(df_forcing.iloc[:48], df_state_init)
+        # drop interior rows to break the regular 5-min cadence
+        df_irregular = df_output.drop(df_output.index[[10, 25]])
+
+        assert _index_freq_matches(df_output, "5min") is True
+        assert _index_freq_matches(df_irregular, "5min") is False
+
     @analyze_dailystate_nan  # Add NaN analysis even when test passes
     @debug_on_ci
     @capture_test_artifacts("dailystate_resample")


### PR DESCRIPTION
When saving model output through SuPy, multiple years of data at 5 minute time steps can take up to 15 minutes to save. If the goal frequency of the output files matches the model timestep then resampling is wasted resources and time, taking up 80% of the full time to save.