### PR TITLE
Prune dead test blocks and consolidate duplicate sample runs

### DIFF
--- a/test/core/test_supy.py
+++ b/test/core/test_supy.py
@@ -29,9 +29,6 @@ test_data_dir = Path(__file__).parent.parent / "fixtures" / "data_test"
 
 # Note: sample_output.pkl testing has been moved to test_sample_output.py
 
-# Enable all tests on all platforms and Python versions
-flag_full_test = True
-
 # Note: Sample data loading moved to individual test methods to avoid test interference
 # This prevents caching issues when tests run in sequence
 
@@ -326,44 +323,6 @@ class TestSuPy(TestCase):
 
         print("Version tracking works correctly through checkpoint save/load/run cycle")
 
-    # # test if single-tstep and multi-tstep modes can produce the same SUEWS results
-    # @skipUnless(flag_full_test, "Full test is not required.")
-    # def test_is_supy_euqal_mode(self):
-    #     print("\n========================================")
-    #     print("Testing if single-tstep and multi-tstep modes can produce the same SUEWS results...")
-    #     df_state_init, df_forcing_tstep = sp.load_SampleData()
-    #     df_forcing_part = df_forcing_tstep.iloc[: 12*8]
-
-    # # single-step results
-    # df_output_s, df_state_s = sp.run_supy(
-    #     df_forcing_part, df_state_init, save_state=True
-    # )
-    # df_res_s = (
-    #     df_output_s.loc[:, list_grp_test]
-    #     .fillna(-999.0)
-    #     .sort_index(axis=1)
-    #     .round(6)
-    #     .applymap(lambda x: -999.0 if np.abs(x) > 3e4 else x)
-    # )
-
-    # df_state_init, df_forcing_tstep = sp.load_SampleData()
-    # # multi-step results
-    # df_output_m, df_state_m = sp.run_supy(
-    #     df_forcing_part, df_state_init, save_state=False
-    # )
-    # df_res_m = (
-    #     df_output_m.loc[:, list_grp_test]
-    #     .fillna(-999.0)
-    #     .sort_index(axis=1)
-    #     .round(6)
-    #     .applymap(lambda x: -999.0 if np.abs(x) > 3e4 else x)
-    # )
-    # # print(df_res_m.iloc[:3, 86], df_res_s.iloc[:3, 86])
-    # pd.testing.assert_frame_equal(
-    #     left=df_res_s,
-    #     right=df_res_m,
-    # )
-
     # test saving output files working
     def test_is_supy_save_working(self):
         print("\n========================================")
@@ -396,33 +355,6 @@ class TestSuPy(TestCase):
             print(f"Running time: {t_end - t_start:.2f} s for {n_grid} grids")
             sys.stdout = sys.__stdout__
             print("Captured:\n", capturedOutput.getvalue())
-
-    # TODO: disable this test for now - need to recover in the future
-    # # test saving output files working
-    # @skipUnless(flag_full_test, "Full test is not required.")
-    # def test_is_checking_complete(self):
-    #     print("\n========================================")
-    #     print("Testing if checking-complete is working...")
-    #     df_state_init, df_forcing_tstep = sp.load_SampleData()
-    #     dict_rules = sp._check.dict_rules_indiv
-
-    #     # variables in loaded dataframe
-    #     set_var_df_init = set(df_state_init.columns.get_level_values("var"))
-
-    #     # variables in dict_rules
-    #     set_var_dict_rules = set(list(dict_rules.keys()))
-
-    #     # common variables
-    #     set_var_common = set_var_df_init.intersection(set_var_dict_rules)
-
-    #     # test if common variables are all those in `df_state_init`
-    #     test_common_all = set_var_df_init == set_var_common
-    #     if not test_common_all:
-    #         print("Variables not in `dict_rules` but in `df_state_init`:")
-    #         print(set_var_df_init.difference(set_var_common))
-    #         print("Variables not in `df_state_init` but in `dict_rules`:")
-    #         print(set_var_common.difference(set_var_df_init))
-    #     self.assertTrue(test_common_all)
 
     # test ERA5 forcing generation
     def test_gen_forcing(self):
@@ -492,20 +424,18 @@ class TestSuPy(TestCase):
         print("\n========================================")
         print("Testing if dailystate are written out correctly...")
 
-        # Create simulation with sample data
-        sim = SUEWSSimulation.from_sample_data()
-
-        # Run for 10 days
+        # Run for 10 days via the shared cached functional-API run (verified
+        # equivalent to SUEWSSimulation.from_sample_data().run() for this
+        # window - see task-4-report.md).
         n_days = 10
-        end_index = TIMESTEPS_PER_DAY * n_days - 1  # 0-indexed
-        results = sim.run(end_date=sim.forcing.index[end_index])
+        df_output, df_state_final = self._sample_run(TIMESTEPS_PER_DAY * n_days)
 
         # Check that DailyState exists in output
-        groups = results.columns.get_level_values("group").unique()
+        groups = df_output.columns.get_level_values("group").unique()
         self.assertIn("DailyState", groups, "DailyState should be in output groups")
 
         # Use xs() for robust MultiIndex column access across platforms
-        df_dailystate = results.xs("DailyState", level="group", axis=1)
+        df_dailystate = df_output.xs("DailyState", level="group", axis=1)
 
         # More robust check: Count rows that have at least one non-NaN value
         # This avoids issues with dropna() behavior across pandas versions
@@ -550,22 +480,21 @@ class TestSuPy(TestCase):
         print("\n========================================")
         print("Testing if water balance is closed...")
 
-        # Create simulation with sample data
-        sim = SUEWSSimulation.from_sample_data()
-
-        # Run for 100 days
+        # Run for 100 days via the shared cached functional-API run (verified
+        # equivalent to SUEWSSimulation.from_sample_data().run() for this
+        # window - see task-4-report.md).
         n_days = 100
-        end_index = TIMESTEPS_PER_DAY * n_days - 1  # 0-indexed
-        results = sim.run(end_date=sim.forcing.index[end_index])
+        df_output, df_state_final = self._sample_run(TIMESTEPS_PER_DAY * n_days)
 
         # Get soilstore from debug output
-        df_soilstore = results.loc[1, "debug"].filter(regex="^ss_.*_next$")
-        ser_sfr_surf = sim._df_state_init.sfr_surf.iloc[0]
+        df_soilstore = df_output.loc[1, "debug"].filter(regex="^ss_.*_next$")
+        df_state_init, _ = self._sample_data
+        ser_sfr_surf = df_state_init.sfr_surf.iloc[0]
         ser_soilstore = df_soilstore.dot(ser_sfr_surf.values)
 
         # Get water balance
-        df_water = results.SUEWS[["Rain", "Irr", "Evap", "RO", "State"]].assign(
-            SoilStore=ser_soilstore, TotalStore=ser_soilstore + results.SUEWS.State
+        df_water = df_output.SUEWS[["Rain", "Irr", "Evap", "RO", "State"]].assign(
+            SoilStore=ser_soilstore, TotalStore=ser_soilstore + df_output.SUEWS.State
         )
 
         # ===============================

--- a/test/physics/test_core_physics.py
+++ b/test/physics/test_core_physics.py
@@ -34,13 +34,25 @@ pytestmark = [pytest.mark.physics, pytest.mark.core]
 class TestPhysicalValidation(TestCase):
     """Test physical validity of SUEWS outputs."""
 
+    @pytest.fixture(autouse=True, scope="class")
     @classmethod
-    def setUpClass(cls):
-        """Run the shared weekly simulation once for all physical checks."""
-        cls.df_state_init, cls.df_forcing = sp.load_SampleData()
-        cls.df_forcing_week = cls.df_forcing.iloc[: TIMESTEPS_PER_DAY * 7]
-        cls.df_output, cls.df_state_final = sp.run_supy(
-            cls.df_forcing_week, cls.df_state_init
+    def _sample_fixtures(cls, request, sample_data_loaded, sample_run_cached):
+        """Bridge session-scoped sample fixtures onto this unittest.TestCase.
+
+        Runs the shared weekly window once via the cached functional-API
+        factory (``sample_run_cached``, see conftest.py) instead of calling
+        ``run_supy`` directly in ``setUpClass``.
+
+        ``@classmethod``: a class-scoped fixture runs once per class, not
+        once per test instance, so it must set attributes on ``cls`` rather
+        than being bound as an instance method (pytest deprecates the
+        instance-method form; see PytestRemovedIn10Warning).
+        """
+        df_state_init, df_forcing = sample_data_loaded
+        request.cls.df_state_init = df_state_init
+        request.cls.df_forcing_week = df_forcing.iloc[: TIMESTEPS_PER_DAY * 7].copy()
+        request.cls.df_output, request.cls.df_state_final = sample_run_cached(
+            TIMESTEPS_PER_DAY * 7
         )
 
     def test_physical_bounds(self):
@@ -406,6 +418,18 @@ class TestPhysicalValidation(TestCase):
 class TestNumericalStability(TestCase):
     """Test numerical stability under various conditions."""
 
+    @pytest.fixture(autouse=True, scope="class")
+    @classmethod
+    def _sample_fixtures(cls, request, sample_data_loaded):
+        """Bridge the shared sample-data load onto this unittest.TestCase.
+
+        These tests mutate forcing (zero/extreme conditions) and must run
+        their own ``run_supy`` call per scenario, so only the read-only
+        ``(df_state_init, df_forcing)`` load is shared via
+        ``sample_data_loaded`` - not the cached run factory (see conftest.py).
+        """
+        request.cls._sample_data = sample_data_loaded
+
     def test_zero_forcing_stability(self):
         """
         Test model stability with zero/minimal forcing.
@@ -422,8 +446,8 @@ class TestNumericalStability(TestCase):
 
         This tests numerical stability and proper initialization.
         """
-        # Create minimal forcing
-        df_state_init, df_forcing = sp.load_SampleData()
+        # Shared sample data (session-scoped); copy since we mutate below.
+        df_state_init, df_forcing = self._sample_data
 
         # Create zero forcing (except mandatory fields)
         df_zero = df_forcing.iloc[:TIMESTEPS_PER_DAY].copy()  # One day
@@ -446,7 +470,7 @@ class TestNumericalStability(TestCase):
 
         # Model should run without crashing
         try:
-            df_output, df_state = sp.run_supy(df_zero, df_state_init)
+            df_output, df_state = sp.run_supy(df_zero, df_state_init.copy())
             success = True
         except Exception as e:
             success = False
@@ -493,7 +517,8 @@ class TestNumericalStability(TestCase):
         This ensures the model can handle diverse climates without
         special case handling or artificial limits.
         """
-        df_state_init, df_forcing = sp.load_SampleData()
+        # Shared sample data (session-scoped); copy since we mutate below.
+        df_state_init, df_forcing = self._sample_data
 
         # Test hot conditions
         df_hot = df_forcing.iloc[:TIMESTEPS_PER_DAY].copy()
@@ -501,7 +526,7 @@ class TestNumericalStability(TestCase):
         df_hot["RH"] = 20  # Low humidity
 
         try:
-            df_out_hot, _ = sp.run_supy(df_hot, df_state_init)
+            df_out_hot, _ = sp.run_supy(df_hot, df_state_init.copy())
             hot_success = True
         except:
             hot_success = False
@@ -514,7 +539,7 @@ class TestNumericalStability(TestCase):
         df_cold["RH"] = 80  # High humidity
 
         try:
-            df_out_cold, _ = sp.run_supy(df_cold, df_state_init)
+            df_out_cold, _ = sp.run_supy(df_cold, df_state_init.copy())
             cold_success = True
         except:
             cold_success = False


### PR DESCRIPTION
## Summary

Third PR in the CI test-efficiency series (follows #1603, #1604; context: #911).

- Delete two fully commented-out test bodies in `test_supy.py` (`test_is_supy_euqal_mode`, `test_is_checking_complete`) and the `flag_full_test` flag that only they referenced.
- Convert `test_core_physics.py` to the shared session fixtures: `TestPhysicalValidation` consumes the cached 7-day sample run (same window as its old `setUpClass` run); `TestNumericalStability` shares the sample-data load but keeps its own runs (it mutates forcing), with defensive copies added on the now-shared state frame.
- Convert `test_water_balance_closed` and `test_dailystate_meaningful` to the cached factory after proving output equivalence (rtol=1e-10, identical) between their old OOP runs and the shared functional runs over the same windows.
- Deliberately NOT converted: `test_library_cli_parity` — its standalone 3-day run and a full-year-sliced run differ measurably (~0.026 on Obukhov-length columns; spin-up state), so substituting a shared run would change what the parity test sees. Documented rather than forced.

## Validation

- Converted files pass alone and together (serial, editable install); smoke tier green full-tree; no assertion weakened, no live test deleted, markers unchanged.
- Three-file verification command: 92.8s -> 84.6s locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)