### PR TITLE
Trim nightly API-test matrix and refresh testing docs

### DIFF
--- a/.claude/rules/ci/conventions.md
+++ b/.claude/rules/ci/conventions.md
@@ -266,7 +266,25 @@ Always: PR_PLATFORMS (3), BOOKEND (2), test tier **standard**. No path-based dif
 
 ### Nightly schedule / tag push
 
-Always: FULL_PLATFORMS (4), ALL_PYTHON (6), test tier **all**.
+Always: FULL_PLATFORMS (4), ALL_PYTHON (3, clamped to the `>=3.12` floor --
+cp312/cp313/cp314), test tier **all**.
+
+**Nightly-only api-test platform trim (run 28990965739, 9 Jul 2026):** the
+nightly `api cross-CPython` job (`test_api_cross_python`) uses a separate
+platform matrix output, `api_buildplat`, distinct from the wheel-build job's
+`buildplat`. On the nightly schedule `api_buildplat` = `NIGHTLY_API_PLATFORMS`
+= FULL_PLATFORMS minus `macos-15-intel`; every other trigger (PR, merge queue,
+tag push, workflow_dispatch) sets `api_buildplat` equal to `buildplat`. This
+closes a runner-scarcity gap: in run 28990965739 the
+`api cross-CPython / cp314-macosx x86_64` job alone waited ~3h54m for a scarce
+`macos-15-intel` runner, stretching the nightly's wall clock to 4h39m while
+every other job (including the wheel build on the same runner class) finished
+within minutes. Wheel builds and physics tests still run on macOS Intel
+nightly -- `buildplat` is untouched, so Intel wheels keep shipping and the
+physics axis keeps covering that platform. Only the nightly api-test coverage
+on that runner is dropped; tag/release builds keep `api_buildplat` =
+`buildplat` = FULL_PLATFORMS, so Intel api coverage is retained at release
+time.
 
 ### Manual dispatch (`workflow_dispatch`)
 
@@ -323,8 +341,15 @@ The merge queue deliberately uses a reduced matrix rather than the full matrix. 
 
 **Safety net:**
 
-- **Nightly builds** (2 AM UTC) run the full matrix with all tests. Any platform-specific regression that slips through the merge queue is caught within 24 hours.
-- **Tag releases** also run the full matrix before publishing to PyPI.
+- **Nightly builds** (2 AM UTC) run the full wheel-build matrix (all 4
+  platforms, including macOS Intel) with all tests. Any platform-specific
+  regression that slips through the merge queue is caught within 24 hours.
+  Exception: the nightly api cross-CPython tests skip `macos-15-intel`
+  (runner scarcity -- see "Nightly schedule / tag push" above); the physics
+  axis and the wheel build itself still cover macOS Intel nightly, so this
+  only narrows the api-surface safety net on that one platform.
+- **Tag releases** also run the full matrix before publishing to PyPI,
+  including api tests on macOS Intel (`api_buildplat` = `buildplat` there).
 - If a nightly fails, the issue is visible in the Actions tab and can be addressed before the next release.
 
 **When to reconsider:** If a platform-specific bug reaches master via the merge queue and causes user impact before the nightly catches it, consider either adding macOS Intel to PR_PLATFORMS (increases merge queue from 6 to 8 jobs) or running the full matrix on merge queue for fortran-touching changes only.

--- a/.github/scripts/determine-matrix.sh
+++ b/.github/scripts/determine-matrix.sh
@@ -2,7 +2,7 @@
 # Determine the cibuildwheel build matrix based on trigger type and change detection.
 #
 # Called from build-publish_to_pypi.yml determine_matrix job.
-# Writes buildplat, python, api_python, test_tier to GITHUB_OUTPUT.
+# Writes buildplat, api_buildplat, python, api_python, test_tier to GITHUB_OUTPUT.
 #
 # "python" is the cibuildwheel build matrix (the abi3 floor derived from
 # pyproject's requires-python — emits one abi3 wheel per platform). Physics
@@ -12,6 +12,12 @@
 # the api marker covers the Python wrapper surface (pandas/numpy/pydantic,
 # CLI, SUEWSSimulation) and needs full (platform x Python) coverage
 # (BOOKEND for PRs, ALL for nightly/tag).
+# "api_buildplat" is the platform matrix consumed by test-api-cross-python
+# (the wheel-build job keeps plain "buildplat"). Identical to "buildplat" on
+# every branch except the nightly schedule, where it drops macos-15-intel
+# (see NIGHTLY_API_PLATFORMS below) -- macOS Intel wheels are still built and
+# release-gated, only nightly api-test coverage on that runner class is
+# dropped.
 #
 # Required environment variables:
 #   EVENT_NAME           -- github.event_name
@@ -53,6 +59,17 @@ FULL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-15-intel", "m
 PR_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-15", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
 MINIMAL_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"]]'
 
+# Nightly-only api-test preset: FULL_PLATFORMS minus macos-15-intel. Run
+# 28990965739 (9 Jul 2026) showed the nightly `api cross-CPython` job on
+# macos-15-intel waiting ~3h54m for a scarce macOS Intel runner while every
+# other job finished within a few minutes -- wall clock 4h39m for a run that
+# should take well under an hour. macOS Intel wheels are still built and
+# release-gated (see FULL_PLATFORMS above); only the nightly api-test
+# coverage on that platform is dropped, since it is a declining platform
+# already excluded from PR/merge-queue via PR_PLATFORMS. See api_buildplat
+# below.
+NIGHTLY_API_PLATFORMS='[["ubuntu-latest", "manylinux", "x86_64"], ["macos-15", "macosx", "arm64"], ["windows-2025", "win", "AMD64"]]'
+
 # Python version policy.
 #
 # The full candidate CPython window is authored here; its lower edge is then
@@ -93,14 +110,17 @@ if [[ "${EVENT_NAME}" == "pull_request" ]] && [[ "${IS_DRAFT}" == "true" ]]; the
   if [[ "${FORTRAN_CHANGED}" == "true" ]] || [[ "${RUST_CHANGED}" == "true" ]]; then
     echo "Draft PR with fortran/rust changes - reduced platforms, core tests"
     echo "buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
+    echo "api_buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
     echo "test_tier=core" >> "$GITHUB_OUTPUT"
   elif [[ "${BUILD_CHANGED}" == "true" ]]; then
     echo "Draft PR with build-system changes - reduced platforms, cfg tests"
     echo "buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
+    echo "api_buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
     echo "test_tier=cfg" >> "$GITHUB_OUTPUT"
   else
     echo "Draft PR with python/util/ci/tests changes - minimal platform, smoke tests"
     echo "buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
+    echo "api_buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
     echo "test_tier=smoke" >> "$GITHUB_OUTPUT"
   fi
   echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
@@ -110,12 +130,15 @@ elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
   if [[ "$NEEDS_MULTIPLATFORM" == "true" ]]; then
     echo "Ready PR with fortran/build changes - reduced platforms, standard tests"
     echo "buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
+    echo "api_buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
   elif [[ "${PYTHON_CHANGED}" == "true" ]] || [[ "${UTIL_CHANGED}" == "true" ]]; then
     echo "Ready PR with python/util changes - minimal platform, standard tests"
     echo "buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
+    echo "api_buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
   else
     echo "Ready PR with ci/tests-only changes - minimal platform, smoke tests"
     echo "buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
+    echo "api_buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
     TIER=smoke
   fi
   # gh#1576: a physics-change PR runs the full physics tier (incl. slow) so an
@@ -140,12 +163,14 @@ elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
     echo "Merge queue validation - reduced platforms, standard tests"
   fi
   echo "buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
+  echo "api_buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
   echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
   echo "test_tier=$MERGE_TIER" >> "$GITHUB_OUTPUT"
 
 elif [[ "${EVENT_NAME}" == "schedule" ]]; then
-  echo "Nightly - full matrix, all tests"
+  echo "Nightly - full matrix, all tests (api tests skip macos-15-intel; see NIGHTLY_API_PLATFORMS)"
   echo "buildplat=$FULL_PLATFORMS" >> "$GITHUB_OUTPUT"
+  echo "api_buildplat=$NIGHTLY_API_PLATFORMS" >> "$GITHUB_OUTPUT"
   echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
   echo "test_tier=all" >> "$GITHUB_OUTPUT"
   API_PYTHON="$ALL_PYTHON"
@@ -155,17 +180,20 @@ elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
     full)
       echo "Manual dispatch: full matrix"
       echo "buildplat=$FULL_PLATFORMS" >> "$GITHUB_OUTPUT"
+      echo "api_buildplat=$FULL_PLATFORMS" >> "$GITHUB_OUTPUT"
       echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
       API_PYTHON="$ALL_PYTHON"
       ;;
     pr)
       echo "Manual dispatch: PR-style reduced matrix"
       echo "buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
+      echo "api_buildplat=$PR_PLATFORMS" >> "$GITHUB_OUTPUT"
       echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
       ;;
     minimal)
       echo "Manual dispatch: minimal matrix"
       echo "buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
+      echo "api_buildplat=$MINIMAL_PLATFORMS" >> "$GITHUB_OUTPUT"
       echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
       ;;
     custom)
@@ -197,6 +225,7 @@ elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
       fi
 
       echo "buildplat=$PLATFORMS" >> "$GITHUB_OUTPUT"
+      echo "api_buildplat=$PLATFORMS" >> "$GITHUB_OUTPUT"
       echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
       API_PYTHON="$TEST_PYS"
       ;;
@@ -204,9 +233,11 @@ elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
   echo "test_tier=${INPUT_TEST_TIER}" >> "$GITHUB_OUTPUT"
 
 else
-  # Tag pushes - full matrix for releases
+  # Tag pushes - full matrix for releases (Intel api coverage retained: releases
+  # stay fully gated, unlike the nightly api_buildplat trim above)
   echo "Tag release - full matrix, all tests"
   echo "buildplat=$FULL_PLATFORMS" >> "$GITHUB_OUTPUT"
+  echo "api_buildplat=$FULL_PLATFORMS" >> "$GITHUB_OUTPUT"
   echo "python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
   echo "test_tier=all" >> "$GITHUB_OUTPUT"
   API_PYTHON="$ALL_PYTHON"

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -474,7 +474,12 @@ jobs:
     if: always() && needs.build_wheels.result == 'success'
     uses: ./.github/workflows/test-api-cross-python-reusable.yml
     with:
-      buildplat_json: ${{ needs.determine_matrix.outputs.api_buildplat }}
+      # Fall back to the full buildplat when api_buildplat is empty: the
+      # determine_matrix job runs determine-matrix.sh from the BASE branch
+      # (trusted-script design), so a PR that introduces or extends the
+      # api_buildplat output would otherwise hand this job an empty matrix
+      # until the script change lands on master.
+      buildplat_json: ${{ needs.determine_matrix.outputs.api_buildplat || needs.determine_matrix.outputs.buildplat }}
       api_python_json: ${{ needs.determine_matrix.outputs.api_python }}
       test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
 

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -275,6 +275,7 @@ jobs:
     if: always() && (needs.detect-changes.result == 'success' || needs.detect-changes.result == 'skipped')
     outputs:
       buildplat: ${{ steps.set-matrix.outputs.buildplat }}
+      api_buildplat: ${{ steps.set-matrix.outputs.api_buildplat }}
       python: ${{ steps.set-matrix.outputs.python }}
       api_python: ${{ steps.set-matrix.outputs.api_python }}
       test_tier: ${{ steps.set-matrix.outputs.test_tier }}
@@ -473,7 +474,7 @@ jobs:
     if: always() && needs.build_wheels.result == 'success'
     uses: ./.github/workflows/test-api-cross-python-reusable.yml
     with:
-      buildplat_json: ${{ needs.determine_matrix.outputs.buildplat }}
+      buildplat_json: ${{ needs.determine_matrix.outputs.api_buildplat }}
       api_python_json: ${{ needs.determine_matrix.outputs.api_python }}
       test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
 

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -99,4 +99,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist
           python -m pip install wheelhouse/*.whl
-          python -m pytest test -m "$MARKER_EXPR" -v --tb=short --durations=25 -n auto --dist loadscope
+          # -n 2 (not auto): each xdist worker holds its own session-scoped
+          # sample-run caches (test/conftest.py), and 4 workers OOM-killed
+          # 16 GB Linux runners ("runner has received a shutdown signal" at a
+          # reproducible suite position) and swap-crawled 7 GB macOS runners.
+          # Two workers keep most of the wall-time win at half the footprint.
+          python -m pytest test -m "$MARKER_EXPR" -v --tb=short --durations=25 -n 2 --dist loadscope

--- a/dev-ref/MERGE_QUEUE.md
+++ b/dev-ref/MERGE_QUEUE.md
@@ -28,7 +28,8 @@ merge_group:
 
 ### Validation Matrix
 - **Platforms**: Linux (manylinux) + ARM Mac + Windows
-- **Python versions**: 3.9 and 3.14 (bookend versions)
+- **Python versions**: 3.12 and 3.14 (bookend versions -- 3.12 is the
+  `requires-python` floor per gh#1553, not 3.9)
 - **Test tier**: `standard` (more thorough than PR smoke tests)
 
 ### Gate Job
@@ -186,10 +187,15 @@ gh pr edit <FAILING_PR_NUMBER> --remove-from-merge-queue
 
 | Event | Platforms | Python Versions | Test Tier |
 |-------|-----------|-----------------|-----------|
-| Draft PR | manylinux only | 3.9, 3.14 | smoke |
-| Ready PR | Linux, ARM Mac, Win | 3.9, 3.14 | standard |
-| **Merge Queue** | Linux, ARM Mac, Win | 3.9, 3.14 | standard |
-| Nightly/Release | All (incl. x86 Mac) | 3.9-3.14 | all |
+| Draft PR | manylinux only | 3.12, 3.14 | smoke |
+| Ready PR | Linux, ARM Mac, Win | 3.12, 3.14 | standard |
+| **Merge Queue** | Linux, ARM Mac, Win | 3.12, 3.14 | standard |
+| Nightly | All (incl. x86 Mac) for the wheel build; api tests skip x86 Mac (runner scarcity -- see run 28990965739) | 3.12-3.14 | all |
+| Release (tag push) | All (incl. x86 Mac), api tests included | 3.12-3.14 | all |
+
+Python versions are the `requires-python` floor (3.12) plus the newest
+supported CPython (3.14); the candidate window is clamped in
+`.github/scripts/determine-matrix.sh` and tracks `pyproject.toml` (gh#1553).
 
 ### Path-Based Skipping
 
@@ -200,9 +206,16 @@ Documentation-only PRs skip builds even in merge queue:
 
 ### UMEP Validation
 
-Merge queue includes UMEP variant testing:
-- Windows Python 3.12 only (QGIS 3.40 LTR compatibility)
+UMEP/QGIS tests (the `qgis` tier) do **not** run in the merge queue. The
+merge queue's `standard` test tier explicitly excludes them
+(`api and not slow and not qgis`); `qgis`-tier tests run only under the
+`all` tier -- nightly schedule, tag push, or manual dispatch (`full`):
+- Windows Python 3.12 only (current QGIS 3 LTR / QGIS 4 runtime)
 - Validates NumPy 1.x compatibility
+
+A platform-specific UMEP/QGIS regression is therefore caught by the nightly
+build, not the merge queue -- see "Safety net" in
+`.claude/rules/ci/conventions.md`.
 
 ## Workflow Integration
 

--- a/dev-ref/testing/TESTING_GUIDELINES.md
+++ b/dev-ref/testing/TESTING_GUIDELINES.md
@@ -143,21 +143,76 @@ test/physics/
 
 ## 5. pytest Markers and Configuration
 
-### Standard Markers
+### Two-Axis Marker System (gh#1300)
+
+Markers sit on two orthogonal axes, declared in `pyproject.toml` (see
+`.claude/rules/tests/patterns.md` for the full authoring guide):
+
+- **Nature axis** -- what the test actually exercises. Every test file must
+  declare exactly one (or, rarely, both) at module level via `pytestmark`:
+  - `physics` -- numerical/binary correctness; sufficient to run once per
+    `(OS, arch)` on the canonical build Python (the compiled artefact
+    determines the result, not the interpreter).
+  - `api` -- Python wrapper correctness (pandas/numpy/pydantic, CLI,
+    `SUEWSSimulation`); run across `(platform x Python)` because the
+    dependency surface varies per interpreter.
+- **Tier axis** -- how fast/expensive the test is, applied as a per-test
+  decorator on top of the nature marker:
+  - `smoke` -- minimal wheel validation (~6 tests, ~60s)
+  - `smoke_bridge` -- bridge-loading subset run across `cp312..cp3xx` after a
+    single abi3 build
+  - `core` -- core physics and logic tests (Fortran, driver)
+  - `cfg` -- config/schema validation tests
+  - `util` -- utility function tests (non-critical)
+  - `rust` -- Rust bridge backend tests (requires `suews_bridge` built with
+    the `physics` feature)
+  - `slow` -- tests taking >30s individually
+  - `qgis` -- UMEP plugin integration tests in `test/umep/`, targeting
+    Windows + Python 3.12 (current QGIS 3 LTR / QGIS 4 runtime); auto-applied
+    by `test/umep/conftest.py`, stays out of normal PR/merge-queue tiers
+
 ```python
-# pyproject.toml
+# pyproject.toml (abbreviated -- see pyproject.toml for the authoritative list)
 [tool.pytest.ini_options]
 markers = [
-    "essential: Core tests that must pass (Tier 1)",
-    "critical: Critical functionality tests (Tier 1)",
-    "smoke: Basic smoke tests (Tier 1)",
-    "extended: Extended validation tests (Tier 2)",
-    "integration: Integration tests (Tier 2+)",
-    "slow: Tests that take > 10 seconds (Tier 3)",
-    "performance: Performance benchmarks (Tier 3)",
-    "platform: Platform-specific tests (Tier 4)",
+    # Nature axis
+    "physics: Numerical/binary correctness; sufficient to run once per (OS, arch) on the canonical Python",
+    "api: Python wrapper correctness; run across (platform x Python) because pandas/numpy/pydantic surface varies",
+    # Tier axis
+    "smoke: Minimal wheel validation (~6 tests, ~60s)",
+    "smoke_bridge: Bridge-loading subset run across cp312..cp3xx after a single abi3 build",
+    "core: Core physics & logic tests (Fortran, driver)",
+    "rust: Rust bridge backend tests (requires suews_bridge with physics feature)",
+    "util: Utility function tests (non-critical)",
+    "cfg: Config/schema validation tests",
+    "slow: Tests taking >30s individually",
+    "qgis: UMEP plugin integration tests in test/umep/ (Windows + Python 3.12 target)",
 ]
 ```
+
+A CI expression composes the two axes, e.g. `-m "api and smoke"` or
+`-m "physics and not slow"`. A static lint
+(`scripts/lint/check_test_markers.py`) plus a `pytest_collection_finish` hook
+in `test/conftest.py` fail any PR that adds a test file without a nature
+marker.
+
+### Tier -> CI Mapping
+
+Tier names map onto CI wall-clock budgets and the events that run them (see
+`.claude/rules/ci/conventions.md` "Test Tier Definitions" and "Test Tier
+Assignment by Event" for the authoritative mapping):
+
+| Tier | Approx. duration | Runs on |
+|------|-------------------|---------|
+| `smoke` | ~60s | Draft PRs (python/util/ci/tests-only changes), ready PRs (ci/tests-only) |
+| `core` / `cfg` | ~2-3 min | Draft PRs (fortran/rust -> core; build-system -> cfg) |
+| `standard` | ~5-10 min | Ready PRs, merge queue |
+| `physics-full` | physics axis widens to include `slow`; api axis stays `standard` | Ready PR / merge queue when the PR carries `0-physics:change` (gh#1576) |
+| `all` | ~15-30 min | Nightly schedule, tag push, manual dispatch (`full`) |
+
+`qgis`-tier tests run only under the `all` tier (nightly/release/manual
+`full`); every other tier expression explicitly excludes them
+(`and not qgis`), so they never gate a PR or the merge queue.
 
 ## 6. Coverage Standards
 
@@ -195,16 +250,45 @@ def test_urban_canyon_radiation(self):
 ## 8. CI Test Tier Principles
 
 ### Tier Structure
-- **Tier 1 (PR)**: < 5 minutes, essential correctness
-- **Tier 2 (Merge)**: < 15 minutes, extended validation
-- **Tier 3 (Nightly)**: < 2 hours, comprehensive
-- **Tier 4 (Weekly)**: < 4 hours, platform matrix
+
+CI tiers are driven by the two-axis marker system in Section 5, not a
+separate taxonomy. The `determine_matrix` job in
+`.github/workflows/build-publish_to_pypi.yml` assigns a tier per event; see
+`.claude/rules/ci/conventions.md` ("Test Tier Definitions" and "Test Tier
+Assignment by Event") for the authoritative mapping:
+
+- **Draft PR**: `smoke`, `core`, or `cfg` depending on what changed -- fastest
+  feedback (~60s-3 min)
+- **Ready PR / merge queue**: `standard` (all non-`slow` tests, ~5-10 min), or
+  `physics-full` when the PR carries `0-physics:change` (gh#1576)
+- **Nightly / tag push / manual dispatch (`full`)**: `all` -- the complete
+  suite including `slow` and `qgis` (~15-30 min)
 
 ### Test Selection Criteria for PR
 - Fast (< 10 seconds per test)
 - Focused (test one functionality)
 - Stable (no flaky failures)
 - Critical (block merging if fail)
+
+### Session-Scoped Sample Fixtures (Required for Sample Runs)
+
+Tests that need the bundled sample simulation should use the session-scoped
+fixtures in `test/conftest.py` rather than building or running a fresh
+`SUEWSSimulation` per test:
+
+- `sample_data_loaded` -- the bundled `(df_state_init, df_forcing)`, loaded
+  once per session (read-only; `.copy()` before mutating)
+- `completed_sample_sim` -- a `SUEWSSimulation` built from the sample YAML
+  with `.run()` already called (read-only; do not `.reset()`, mutate, or
+  re-run)
+- `sample_run_cached` -- a session-scoped factory memoising functional-API
+  (`supy.run_supy`) sample runs by forcing window
+
+Use these for any test that only *reads* a completed run's config, forcing,
+state, or output. Tests exercising running, mutation, or lifecycle behaviour
+(reset, checkpoint continuation, chunking, parallelism, before/after-run
+state) must still construct and run their own instance -- see each fixture's
+docstring in `test/conftest.py` for the full contract.
 
 ---
 


### PR DESCRIPTION
## Summary

Final PR in the CI test-efficiency series (follows #1603, #1604; context: #911).

- **Nightly matrix**: the API cross-CPython test job gets its own platform matrix output (`api_buildplat`). On the nightly schedule it excludes `macos-15-intel` — in the 9 Jul nightly (run 28990965739) that job alone queued ~3h54m for a scarce Intel-mac runner, stretching the nightly to 4h39m. Wheel builds and physics tests still run on Intel nightly, and tag/release builds keep full Intel API coverage, so Intel wheels remain fully release-gated. All 13 code paths in `determine-matrix.sh` were simulated to confirm every `buildplat` write has a matching `api_buildplat`.
- **Docs**: `dev-ref/testing/TESTING_GUIDELINES.md` still described a marker taxonomy (`essential`/`critical`/`extended`/...) that no longer exists — replaced with the actual two-axis system (physics/api nature axis + smoke/core/cfg/slow/... tiers) and the current tier-to-CI mapping, plus a pointer to the session-scoped sample fixtures as the pattern for tests needing sample runs. `dev-ref/MERGE_QUEUE.md` bookend claims corrected to the cp312/cp314 floor (gh#1553 follow-through).

## Validation

- `bash -n` on the matrix script; YAML parse on the workflow; per-event simulation outputs recorded for schedule, draft/ready PRs, merge queue, tag push, and all workflow_dispatch matrix configs.
- Doc claims cross-checked against `pyproject.toml` markers and current workflow behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)