### PR TITLE
Use same-timestep displacement height for MacDonald z0m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ EXAMPLES:
 
 ## 2026
 
+### 13 Jul 2026
+
+- [bugfix] Fixed MacDonald (1998) momentum roughness using a stale displacement height (#1615)
+  - Under `roughness_length_momentum: macdonald` (`RoughLenMomMethod=3`), `z0m` was computed from the persistent `zdm` state, which still held the previous timestep's plan-area-blended displacement height (and zero on the first timestep), instead of the MacDonald displacement height computed alongside it. `z0m` was therefore inflated several-fold and the scheme did not reproduce MacDonald (1998) as published.
+  - Users of this option will see `z0m` drop by roughly a factor of 2 to 4, depending on plan area index, with knock-on changes to aerodynamic resistance and the near-surface diagnostics. Other roughness options are unaffected, as are all reference outputs.
+
 ### 9 Jul 2026
 
 - [feature][experimental] Added the `dyohm_building` storage-heat option (#1601)

--- a/src/suews/src/suews_phys_resist.f95
+++ b/src/suews/src/suews_phys_resist.f95
@@ -659,7 +659,9 @@ CONTAINS
                   zdm_zh = 0.7*Zh
                ELSEIF (RoughLenMomMethod == 3) THEN !MacDonald 1998
                   zdm_zh = (1 + 4.43**(-sfr_surf(BldgSurf))*(sfr_surf(BldgSurf) - 1))*Zh
-                  z0m_zh = ((1 - zdm/Zh)*EXP(-(0.5*1.0*1.2/0.4**2*(1 - zdm/Zh)*FAI)**(-0.5)))*Zh
+                  ! #1615: z0m must use the zdm_zh computed above, not the persistent `zdm`
+                  ! state (which still holds the previous timestep's PAI-blended value here)
+                  z0m_zh = ((1 - zdm_zh/Zh)*EXP(-(0.5*1.0*1.2/0.4**2*(1 - zdm_zh/Zh)*FAI)**(-0.5)))*Zh
                ELSEIF (RoughLenMomMethod == 4) THEN ! lambdaP dependent as in Fig.1a of G&O (1999)
                   ! these are derived using digitalised points
                   zdm_zh = (-0.182 + 0.722*sigmoid(-1.16 + 3.89*PAI) + 0.493*sigmoid(-5.17 + 32.7*PAI))*Zh

--- a/test/physics/test_macdonald_roughness.py
+++ b/test/physics/test_macdonald_roughness.py
@@ -1,0 +1,133 @@
+"""Regression tests for the MacDonald (1998) momentum-roughness option (gh#1615).
+
+`RoughLenMomMethod = 3` must derive `z0m` from the MacDonald displacement height
+computed in the same timestep, not from the persistent `zdm` state field (which
+carries the previous timestep's plan-area-blended value, and zero on the first
+timestep).
+
+The site used here has no trees, so PAI, Zh, FAI and the building plan-area
+fraction are all constant over the run and the MacDonald relations can be
+asserted in closed form.
+"""
+
+import pathlib
+
+import numpy as np
+import pytest
+import yaml
+
+import supy as sp
+from supy.data_model import SUEWSConfig
+
+pytestmark = [pytest.mark.physics, pytest.mark.core]
+
+# Roughness lengths of the non-roughness (zh = 0) surfaces, mirroring the
+# PARAMETER values in suews_phys_resist.f95.
+Z0M_PAVED = 0.003
+Z0M_GRASS = 0.02
+Z0M_BSOIL = 0.002
+Z0M_WATER = 0.0005
+
+# MacDonald (1998) coefficients, as used in suews_phys_resist.f95.
+MACDONALD_A = 4.43
+DRAG_COEFFICIENT = 1.2
+BETA = 1.0
+VON_KARMAN = 0.4
+
+N_STEPS = 288 * 3  # three days at the 5-min sample resolution
+
+
+def _tree_free_macdonald_config(tmp_path):
+    """Sample config with MacDonald roughness and no tree cover.
+
+    Zeroing the deciduous fraction removes the phenology feedback on porosity,
+    so Zh, FAI and PAI stay constant and the closed-form check below is exact.
+    """
+    src = pathlib.Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+    raw = yaml.safe_load(src.read_text())
+
+    raw["model"]["physics"]["roughness_length_momentum"] = "macdonald"
+
+    land_cover = raw["sites"][0]["properties"]["land_cover"]
+    # Move the deciduous fraction into grass, keeping the fractions summing to 1.
+    land_cover["grass"]["sfr"]["value"] += land_cover["dectr"]["sfr"]["value"]
+    land_cover["dectr"]["sfr"]["value"] = 0.0
+    land_cover["evetr"]["sfr"]["value"] = 0.0
+
+    path = tmp_path / "config_macdonald.yml"
+    path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    return path, land_cover
+
+
+def _expected_z0m_zdm(land_cover):
+    """MacDonald z0m and zdm, plus the surface-blended values SUEWS reports."""
+    sfr = {
+        name: land_cover[name]["sfr"]["value"] for name in land_cover if name != "ref"
+    }
+    height_building = land_cover["bldgs"]["bldgh"]["value"]
+    # With FAImethod = 0 the provided frontal-area index is used as given; with
+    # buildings as the only roughness elements it is the whole of FAI.
+    fai = land_cover["bldgs"]["faibldg"]["value"]
+
+    # Buildings are the only roughness elements, so PAI and Zh follow directly.
+    plan_area_index = sfr["bldgs"]
+    lambda_p = sfr["bldgs"]
+    zh = height_building
+
+    # MacDonald displacement height, then roughness length from that same value.
+    zdm_over_zh = 1 + MACDONALD_A ** (-lambda_p) * (lambda_p - 1)
+    zdm_zh = zdm_over_zh * zh
+    exponent = (
+        0.5 * BETA * DRAG_COEFFICIENT / VON_KARMAN**2 * (1 - zdm_over_zh) * fai
+    ) ** (-0.5)
+    z0m_zh = (1 - zdm_over_zh) * np.exp(-exponent) * zh
+
+    # SUEWS blends the roughness elements with the zh = 0 surfaces by plan area.
+    z0m_non_rough = (
+        Z0M_PAVED * sfr["paved"]
+        + Z0M_GRASS * sfr["grass"]
+        + Z0M_BSOIL * sfr["bsoil"]
+        + Z0M_WATER * sfr["water"]
+    )
+    z0m = plan_area_index * z0m_zh + z0m_non_rough
+    zdm = plan_area_index * zdm_zh  # zdm_zh0 is zero for the non-rough surfaces
+    return z0m, zdm
+
+
+@pytest.fixture(scope="module")
+def macdonald_run(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("macdonald")
+    config_path, land_cover = _tree_free_macdonald_config(tmp_path)
+
+    df_state = SUEWSConfig.from_yaml(str(config_path)).to_df_state()
+    _, df_forcing = sp.load_SampleData()
+    df_output, _ = sp.run_supy(df_forcing.iloc[:N_STEPS], df_state)
+
+    return df_output.loc[:, "SUEWS"], land_cover
+
+
+def test_z0m_matches_macdonald_closed_form(macdonald_run):
+    """z0m must follow MacDonald (1998) using this timestep's displacement height.
+
+    Before gh#1615 the roughness length was computed from the persistent `zdm`
+    state, which is smaller than the MacDonald displacement height (it is blended
+    down by the non-roughness plan area), inflating z0m several-fold.
+    """
+    df_output, land_cover = macdonald_run
+    z0m_expected, zdm_expected = _expected_z0m_zdm(land_cover)
+
+    assert df_output["zdm"].to_numpy() == pytest.approx(zdm_expected, rel=1e-6)
+    assert df_output["z0m"].to_numpy() == pytest.approx(z0m_expected, rel=1e-6)
+
+
+def test_z0m_is_not_contaminated_by_initial_state(macdonald_run):
+    """The first timestep must not see the zero-initialised `zdm` state.
+
+    With the bug, `zdm` is still 0 on the first timestep, so (1 - zdm/Zh) = 1 and
+    z0m takes its maximum possible value before dropping once the state fills in.
+    """
+    df_output, _ = macdonald_run
+    z0m = df_output["z0m"].to_numpy()
+
+    assert z0m[0] == pytest.approx(z0m[1], rel=1e-9)
+    assert np.ptp(z0m) == pytest.approx(0.0, abs=1e-9)

--- a/test/physics/test_macdonald_roughness.py
+++ b/test/physics/test_macdonald_roughness.py
@@ -19,7 +19,7 @@ import yaml
 import supy as sp
 from supy.data_model import SUEWSConfig
 
-pytestmark = [pytest.mark.physics, pytest.mark.core]
+pytestmark = pytest.mark.physics
 
 # Roughness lengths of the non-roughness (zh = 0) surfaces, mirroring the
 # PARAMETER values in suews_phys_resist.f95.
@@ -47,6 +47,9 @@ def _tree_free_macdonald_config(tmp_path):
     raw = yaml.safe_load(src.read_text())
 
     raw["model"]["physics"]["roughness_length_momentum"] = "macdonald"
+    # Pin the FAI source: the closed form below uses the provided FAIBldg as-is,
+    # which only holds for FAImethod = 0. Do not rely on the sample default.
+    raw["model"]["physics"]["frontal_area_index"] = "observed"
 
     land_cover = raw["sites"][0]["properties"]["land_cover"]
     # Move the deciduous fraction into grass, keeping the fractions summing to 1.
@@ -106,6 +109,7 @@ def macdonald_run(tmp_path_factory):
     return df_output.loc[:, "SUEWS"], land_cover
 
 
+@pytest.mark.core
 def test_z0m_matches_macdonald_closed_form(macdonald_run):
     """z0m must follow MacDonald (1998) using this timestep's displacement height.
 
@@ -120,11 +124,14 @@ def test_z0m_matches_macdonald_closed_form(macdonald_run):
     assert df_output["z0m"].to_numpy() == pytest.approx(z0m_expected, rel=1e-6)
 
 
+@pytest.mark.core
 def test_z0m_is_not_contaminated_by_initial_state(macdonald_run):
-    """The first timestep must not see the zero-initialised `zdm` state.
+    """z0m must be constant here: the site morphology never changes.
 
-    With the bug, `zdm` is still 0 on the first timestep, so (1 - zdm/Zh) = 1 and
-    z0m takes its maximum possible value before dropping once the state fills in.
+    With the bug, `zdm` is still zero when the model starts, so (1 - zdm/Zh) = 1
+    and z0m takes its maximum possible value before settling once the state fills
+    in. That start-up transient survives the output averaging, so a flat z0m
+    series is enough to pin it.
     """
     df_output, _ = macdonald_run
     z0m = df_output["z0m"].to_numpy()

--- a/test/physics/test_macdonald_roughness.py
+++ b/test/physics/test_macdonald_roughness.py
@@ -44,7 +44,7 @@ def _tree_free_macdonald_config(tmp_path):
     so Zh, FAI and PAI stay constant and the closed-form check below is exact.
     """
     src = pathlib.Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
-    raw = yaml.safe_load(src.read_text())
+    raw = yaml.safe_load(src.read_text(encoding="utf-8"))
 
     raw["model"]["physics"]["roughness_length_momentum"] = "macdonald"
     # Pin the FAI source: the closed form below uses the provided FAIBldg as-is,
@@ -58,7 +58,7 @@ def _tree_free_macdonald_config(tmp_path):
     land_cover["evetr"]["sfr"]["value"] = 0.0
 
     path = tmp_path / "config_macdonald.yml"
-    path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return path, land_cover
 
 


### PR DESCRIPTION
## Summary

The MacDonald (1998) branch of `RoughLenMomMethod = 3` computed `z0m` from the persistent `zdm` state field instead of the `zdm_zh` it had just computed on the line above. At the point of use, `zdm` still holds the *previous* timestep's plan-area-blended displacement height (and zero on the very first timestep), so `z0m` was inflated several-fold relative to published MacDonald.

The fix is one identifier: use `zdm_zh` in the `z0m_zh` expression.

Fixes #1615

## Scientific evidence

**Quantities changed:** `z0m` [m] under `RoughLenMomMethod = 3` only, and everything downstream of it (`RA` [s m-1], `U10` [m s-1], `T2` [degC], `QH` [W m-2]).

**Mechanism:** MacDonald gives `z0m/Zh = (1 - zd/Zh) * exp[-(0.5*beta*Cd/k^2 * (1 - zd/Zh) * FAI)^(-0.5)]`, where `zd` must be the MacDonald displacement height computed for the roughness elements (`zdm_zh`). The code instead passed the *blended* `zdm` state, which is scaled down by the plan-area index (`zdm = PAI * zdm_zh`, since the non-roughness surfaces contribute zero displacement). For the sample site (PAI = 0.40, Zh = 21.2 m) that means `zd` = 5.49 m rather than 13.7 m, so the prefactor `(1 - zd/Zh)` was 0.74 instead of 0.35 -- and it enters the exponential term as well, compounding the error. Net effect: `z0m` roughly 3.7x too large. A smaller `z0m` means less drag, hence a higher `U10` and a higher aerodynamic resistance.

Sample config with `roughness_length_momentum: macdonald`, 14 days at 5-min resolution (all other settings unchanged):

| Output | Before | After | Expected? |
|--------|--------|-------|-----------|
| `z0m`, first timestep [m] | 2.886 | 0.488 | Yes. Before, `zdm` state is still 0, so the prefactor is 1 and `z0m` takes its maximum possible value -- a pure initialisation artefact. After, there is no discontinuity. |
| `z0m`, steady [m] | 1.860 | 0.499 | Yes. Correct MacDonald `zd` (13.7 m) is much larger than the blended one (5.49 m), so the correct `z0m` is smaller. Factor 3.7 matches the closed form. |
| `zdm`, steady [m] | 5.487 | 5.487 | Yes -- unchanged. `zdm` was already computed correctly; only its use inside `z0m` was wrong. |
| `RA`, mean [s m-1] | 61.8 | 63.2 | Yes. A smoother surface mixes less efficiently, so aerodynamic resistance rises. |
| `U10`, mean [m s-1] | 0.421 | 0.687 | Yes. Less drag, so more wind survives to 10 m. |
| `QH`, mean [W m-2] | 57.9 | 58.6 | Small, as expected -- `RA` shifts by ~2%. |

The new test asserts the MacDonald closed form exactly (`rel=1e-6`) on a tree-free site, where `PAI`, `Zh`, `FAI` and the building plan-area fraction are all static, so both `z0m` and `zdm` can be predicted analytically with no phenology feedback. Both new tests fail against the unfixed code and pass against the fix.

**Reference fixtures refreshed in this PR:** none expected, and none needed. Every vendored reference config (`test/fixtures/benchmark1/*.yml`, `test/fixtures/data_test/stebbs_test/sample_config.yml`, and `sample_config.yml` itself) uses `roughness_length_momentum = 1` (fixed), so no reference output moves. The full `-m physics` tier (including `slow`) confirms this: 125 passed, 1 skipped, 0 failed.

**Domain owner sign-off:** @sunt05 (momentum roughness / `suews_phys_resist.f95` -- no separately named owner).

## Validation

- `make test-smoke` -- 26 passed, 1 skipped.
- `pytest -m physics` (full tier, includes `slow`) -- 125 passed, 1 skipped, 0 failed.
- `pytest test/physics/test_macdonald_roughness.py` -- 2 passed against the fix; both fail against the unfixed code (verified by reverting the Fortran, rebuilding, and re-running).
- `ruff check` / `ruff format` clean on the new test.

## Known limitations

This changes results for every existing `RoughLenMomMethod = 3` run. It is a correctness fix rather than a tuning change -- the previous numbers were not MacDonald (1998) as published -- but it should be released deliberately, with a version note, since users' `z0m` will drop by roughly a factor of 2 to 4 depending on their plan-area index.
