### PR TITLE
Make site-derived output filenames cross-platform safe

### DIFF
--- a/src/supy/_filename.py
+++ b/src/supy/_filename.py
@@ -1,0 +1,118 @@
+"""Prepare user-provided identifiers for use in output filenames.
+
+User identifiers such as site names are concatenated into output filenames
+SUEWS writes. Some characters that are perfectly legal in a name are unsafe
+in a filename on at least one supported platform, and using them silently
+corrupts or loses output:
+
+- On Windows/NTFS a colon is the Alternate Data Stream (ADS) separator, so a
+  site named ``grid no: 0`` makes SUEWS write to ``df_state_grid no: 0.csv``,
+  which creates a 0-byte visible file ``df_state_grid no`` with the real data
+  hidden in the stream ``...:$DATA``. The stream is invisible to ``dir``,
+  Explorer, and normal file-reading code, so the run looks like it produced
+  empty output.
+- The wider unsafe set on Windows also includes ``* ? " < > |``, ASCII control
+  characters, trailing dots or spaces, and reserved device names including
+  ``CON``, ``NUL``, ``COM1``..``COM9``, their superscript-number variants,
+  and the equivalent ``LPT`` names.
+- On POSIX only ``/`` (and NUL) are unsafe, but we sanitise the full Windows
+  set on every platform so a configuration produces the same filenames
+  everywhere.
+
+`safe_filename_component` handles these invalid-name cases consistently on
+every supported platform. See gh#1619.
+"""
+
+import re
+import warnings
+
+# Characters that are unsafe in a filename component on Windows (a superset of
+# POSIX, which forbids only "/" and NUL). ASCII control characters (0x00-0x1f)
+# are unsafe on all platforms.
+_UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+# Windows reserved device names (case-insensitive), which cannot be used as a
+# filename even with an extension appended.
+_RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
+    | {f"COM{suffix}" for suffix in "123456789¹²³"}
+    | {f"LPT{suffix}" for suffix in "123456789¹²³"}
+)
+
+_REPLACEMENT = "_"
+
+
+def safe_filename_component(name: str) -> str:
+    """Return a filesystem-safe token for use inside an output filename.
+
+    Parameters
+    ----------
+    name : str
+        The identifier to make safe (e.g. a site name). Non-string input is
+        coerced with ``str()``.
+
+    Returns
+    -------
+    str
+        A token with known cross-platform invalid filename forms removed. An
+        empty input is returned unchanged (an empty string is the "no site
+        identifier" signal, which the filename builders handle).
+
+    Examples
+    --------
+    >>> safe_filename_component("grid no: 0")
+    'grid no_ 0'
+    >>> safe_filename_component("")
+    ''
+    >>> safe_filename_component("NUL")
+    'NUL_'
+    """
+    text = str(name)
+    # An empty identifier means "no site prefix"; preserve that signal.
+    if not text:
+        return ""
+    # Replace reserved characters with an underscore.
+    safe = _UNSAFE_CHARS.sub(_REPLACEMENT, text)
+    # Windows silently strips trailing dots and spaces from filenames, which
+    # would change the name behind the user's back; drop them ourselves so the
+    # token is stable across platforms.
+    safe = safe.rstrip(" .")
+    # A name made only of trailing dots/spaces sanitises to nothing; fall back
+    # rather than silently dropping the user's identifier.
+    if not safe:
+        return "site"
+    # Windows reserves device names even when followed by an extension
+    # (``CON.txt`` is still reserved). Add the marker before the first dot so
+    # the filename stem itself is safe.
+    stem, separator, suffix = safe.partition(".")
+    if stem.rstrip(" ").upper() in _RESERVED_NAMES:
+        safe = f"{stem}{_REPLACEMENT}{separator}{suffix}"
+    return safe
+
+
+def prepare_filename_component(name: str, description: str) -> str:
+    """Return a safe filename token and warn when the input is adjusted.
+
+    Parameters
+    ----------
+    name : str
+        User-provided identifier to prepare for filename construction.
+    description : str
+        Human-readable field description for the warning message.
+
+    Returns
+    -------
+    str
+        Filesystem-safe token produced by :func:`safe_filename_component`.
+    """
+    original = str(name)
+    safe = safe_filename_component(original)
+    if safe != original:
+        warnings.warn(
+            f"{description} {original!a} contains characters that are "
+            "unsafe in filenames; output files will use "
+            f"{safe!a} instead.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return safe

--- a/src/supy/_save.py
+++ b/src/supy/_save.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import f90nml
 import pandas as pd
@@ -606,6 +606,7 @@ def save_df_output_parquet(
     path_dir_save: Path = Path("."),
     save_tstep=False,
     save_state: bool = True,
+    site_metadata: Optional[str] = None,
 ) -> list:
     """Save supy output to Parquet format.
 
@@ -623,6 +624,9 @@ def save_df_output_parquet(
         Directory to save Parquet file
     save_tstep : bool, optional
         Whether to save at simulation timestep resolution
+    site_metadata : str, optional
+        Original site identifier to record in metadata when ``site`` is a
+        filesystem-safe filename token. Defaults to ``site``.
 
     Returns
     -------
@@ -670,7 +674,7 @@ def save_df_output_parquet(
 
     # Save with metadata
     metadata = {
-        "site": site,
+        "site": site if site_metadata is None else site_metadata,
         "output_frequency_s": freq_s,
         "save_tstep": save_tstep,
         "creation_time": pd.Timestamp.now().isoformat(),

--- a/src/supy/_save.py
+++ b/src/supy/_save.py
@@ -5,10 +5,9 @@ import f90nml
 import pandas as pd
 
 # import ray
-
 from ._env import logger_supy
 from ._load import load_SUEWS_dict_ModConfig
-from ._post import resample_output, df_var as df_var_out
+from ._post import df_var as df_var_out, resample_output
 
 
 def gen_df_save(df_grid_group: pd.DataFrame) -> pd.DataFrame:

--- a/src/supy/_supy_module.py
+++ b/src/supy/_supy_module.py
@@ -33,6 +33,7 @@ from ._check import (
     check_state,
 )
 from ._env import logger_supy, trv_supy_module
+from ._filename import prepare_filename_component
 from ._load import (
     load_df_state,
     load_InitialCond_grid_df,
@@ -958,6 +959,16 @@ def _save_supy(
             path_runcontrol
         )
 
+    # Make the site identifier safe to embed in output filenames on every
+    # platform (gh#1619). The site name is concatenated verbatim into every
+    # filename below; a character such as a colon is the NTFS Alternate Data
+    # Stream separator on Windows and would silently write output into a hidden
+    # stream instead of a normal file. This common multi-file save boundary
+    # covers txt, state csv, InitialConditions nml, and Parquet. The modern OOP
+    # save methods apply the same helper before constructing checkpoint names.
+    site_metadata = str(site)
+    site = prepare_filename_component(site_metadata, "Site name")
+
     # Handle output configuration if provided
     # output_format = "txt"  # default - MP: Moved as argument
     output_groups = None  # default will be handled in save_df_output
@@ -978,8 +989,6 @@ def _save_supy(
                 output_groups = output_config.groups
         elif isinstance(output_config, str):
             # Legacy string format - issue deprecation warning
-            import warnings
-
             warnings.warn(
                 "The 'output_file' parameter as a string is deprecated and was never used. "
                 "Please use the new OutputControl block or remove this parameter. "
@@ -1018,6 +1027,7 @@ def _save_supy(
             path_dir_save,
             save_tstep,
             save_state=save_state,
+            site_metadata=site_metadata,
         )
     else:
         # Save as text files (existing behavior)

--- a/src/supy/_supy_module.py
+++ b/src/supy/_supy_module.py
@@ -19,8 +19,8 @@ import os
 from pathlib import Path
 import sys
 import time
-import warnings
 from typing import Optional
+import warnings
 
 import numpy as np
 import pandas
@@ -736,8 +736,8 @@ def _run_supy(
     logger_supy.info(f"No. of grids: {n_grid}")
 
     # Build config from DataFrame state
-    from .data_model.core import SUEWSConfig
     from ._run_rust import run_suews_rust_chunked
+    from .data_model.core import SUEWSConfig
     from .util._forcing import convert_observed_soil_moisture
 
     config = SUEWSConfig.from_df_state(df_state_init)

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -3,6 +3,7 @@ py.install_sources(
         '__init__.py',
         '_check.py',
         '_env.py',
+        '_filename.py',
         '_load.py',
         '_misc.py',
         '_post.py',

--- a/src/supy/suews_output.py
+++ b/src/supy/suews_output.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 
+from ._filename import safe_filename_component
 from .suews_checkpoint import SUEWSCheckpoint
 
 
@@ -482,6 +483,8 @@ class SUEWSOutput:
             except AttributeError:
                 pass
 
+        site_filename = safe_filename_component(site)
+
         list_path_save = _save_supy(
             df_output=self._df_output,
             df_state_final=self._df_state_final,
@@ -495,7 +498,9 @@ class SUEWSOutput:
 
         if self._checkpoint is not None:
             checkpoint_name = (
-                f"{site}_SUEWS_checkpoint.json" if site else "SUEWS_checkpoint.json"
+                f"{site_filename}_SUEWS_checkpoint.json"
+                if site_filename
+                else "SUEWS_checkpoint.json"
             )
             checkpoint_path = self._checkpoint.to_file(path / checkpoint_name)
             list_path_save.append(checkpoint_path)

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 
 from ._check import check_forcing
 from ._env import logger_supy
+from ._filename import safe_filename_component
 from ._run_rust import _check_rust_available, run_suews_rust_chunked
 
 # Import SuPy components directly
@@ -889,6 +890,7 @@ class SUEWSSimulation:
             # Get site name from first site
             if hasattr(self._config, "sites") and len(self._config.sites) > 0:
                 site = self._config.sites[0].name
+        site_filename = safe_filename_component(site)
         if "format" in save_kwargs:  # TODO: When yaml format working, make elif
             output_format = save_kwargs["format"]
 
@@ -907,7 +909,9 @@ class SUEWSSimulation:
 
         if self._checkpoint is not None:
             checkpoint_name = (
-                f"{site}_SUEWS_checkpoint.json" if site else "SUEWS_checkpoint.json"
+                f"{site_filename}_SUEWS_checkpoint.json"
+                if site_filename
+                else "SUEWS_checkpoint.json"
             )
             checkpoint_path = self._checkpoint.to_file(output_path / checkpoint_name)
             list_path_save.append(checkpoint_path)

--- a/test/io_tests/test_save_supy.py
+++ b/test/io_tests/test_save_supy.py
@@ -1,16 +1,20 @@
 """Test save_supy functionality with various output configurations."""
 
-import pytest
-import pandas as pd
-import numpy as np
 from pathlib import Path
 import tempfile
-import shutil
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
 import supy as sp
+from supy._filename import safe_filename_component
 from supy._supy_module import _save_supy
 from supy.data_model.core import SUEWSConfig
 from supy.data_model.core.model import OutputControl, OutputFormat
+from supy.suews_checkpoint import SUEWSCheckpoint
 from supy.suews_output import SUEWSOutput
+from supy.suews_sim import SUEWSSimulation
 
 pytestmark = pytest.mark.api
 
@@ -213,3 +217,188 @@ class TestSaveSuPy:
             assert parquet_files, (
                 "An explicit format='parquet' must override config format=txt"
             )
+
+    def test_output_save_uses_safe_site_name_for_checkpoint(self, sample_output):
+        """The modern API must apply one safe token to every saved artifact."""
+        df_output, df_state_final = sample_output
+        output_control = OutputControl(format=OutputFormat.PARQUET)
+        config = SimpleNamespace(
+            model=SimpleNamespace(control=SimpleNamespace(output=output_control)),
+            sites=[SimpleNamespace(name="grid no: 0")],
+        )
+        checkpoint = SUEWSCheckpoint.from_grid_states({0: {}})
+        output = SUEWSOutput(
+            df_output=df_output,
+            df_state_final=df_state_final,
+            config=config,
+            checkpoint=checkpoint,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.warns(
+                UserWarning,
+                match="output files will use 'grid no_ 0' instead",
+            ):
+                list_files = output.save(path=tmpdir)
+
+            names = {Path(path).name for path in list_files}
+            assert "grid no_ 0_SUEWS_checkpoint.json" in names
+            assert all(":" not in name for name in names)
+            path_metadata = next(
+                Path(path)
+                for path in list_files
+                if Path(path).name.endswith("_SUEWS_metadata.parquet")
+            )
+            assert pd.read_parquet(path_metadata).loc[0, "site"] == "grid no: 0"
+
+    def test_simulation_save_uses_safe_site_name_for_checkpoint(self, sample_output):
+        """The simulation API must apply the safe token to every artifact."""
+        df_output, df_state_final = sample_output
+        output_control = OutputControl(format=OutputFormat.PARQUET)
+        config = SimpleNamespace(
+            model=SimpleNamespace(control=SimpleNamespace(output=output_control)),
+            sites=[SimpleNamespace(name="grid no: 0")],
+        )
+        simulation = SUEWSSimulation.__new__(SUEWSSimulation)
+        simulation._run_completed = True
+        simulation._df_output = df_output
+        simulation._df_state_final = df_state_final
+        simulation._checkpoint = SUEWSCheckpoint.from_grid_states({0: {}})
+        simulation._config = config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.warns(
+                UserWarning,
+                match="output files will use 'grid no_ 0' instead",
+            ):
+                list_files = simulation.save(tmpdir, format="parquet")
+
+            names = {Path(path).name for path in list_files}
+            assert "grid no_ 0_SUEWS_checkpoint.json" in names
+            assert all(":" not in name for name in names)
+            path_metadata = next(
+                Path(path)
+                for path in list_files
+                if Path(path).name.endswith("_SUEWS_metadata.parquet")
+            )
+            assert pd.read_parquet(path_metadata).loc[0, "site"] == "grid no: 0"
+
+    def test_legacy_save_preserves_original_site_in_parquet_metadata(
+        self, sample_output
+    ):
+        """The legacy API must not replace the semantic site identifier."""
+        df_output, df_state_final = sample_output
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.warns(UserWarning):
+                list_files = sp.save_supy(
+                    df_output,
+                    df_state_final,
+                    path_dir_save=tmpdir,
+                    site="grid no: 0",
+                    output_config=OutputControl(format=OutputFormat.PARQUET),
+                )
+
+            path_metadata = next(
+                Path(path)
+                for path in list_files
+                if Path(path).name.endswith("_SUEWS_metadata.parquet")
+            )
+            assert pd.read_parquet(path_metadata).loc[0, "site"] == "grid no: 0"
+
+    def test_save_sanitises_unsafe_site_name(self, sample_output):
+        """A site name with filename-unsafe characters must not leak into paths.
+
+        A colon in the site name is the NTFS Alternate Data Stream separator on
+        Windows, which silently writes output into a hidden stream instead of a
+        normal file (gh#1619). The saved paths must therefore be free of the
+        unsafe characters and every file must have real content, on any OS.
+        """
+        df_output, df_state_final = sample_output
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.warns(
+                UserWarning,
+                match="output files will use 'grid no_ 0' instead",
+            ):
+                list_files = sp.save_supy(
+                    df_output,
+                    df_state_final,
+                    path_dir_save=tmpdir,
+                    site="grid no: 0",
+                )
+
+            assert list_files, "No files were created"
+            for path in list_files:
+                name = Path(path).name
+                # None of the Windows-unsafe characters may reach the filename.
+                for ch in ':<>"/\\|?*':
+                    assert ch not in name, (
+                        f"Unsafe character {ch!r} leaked into filename {name!r}"
+                    )
+                # The sanitised site token must still be present as a prefix.
+                assert "grid no_ 0" in name, (
+                    f"Sanitised site token missing from {name!r}"
+                )
+                # And the file must actually hold data, not be a 0-byte stub
+                # (the failure mode when data lands in an alternate stream).
+                assert Path(path).stat().st_size > 0, f"{name!r} is empty"
+
+
+class TestSafeFilenameComponent:
+    """Unit tests for the filesystem-safety helper (gh#1619)."""
+
+    def test_colon_replaced(self):
+        # The reporter's case: a colon must not survive into the token.
+        assert ":" not in safe_filename_component("grid no: 0")
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["a<b", "a>b", "a:b", 'a"b', "a/b", "a\\b", "a|b", "a?b", "a*b", "a\x01b"],
+    )
+    def test_all_unsafe_chars_replaced(self, raw):
+        result = safe_filename_component(raw)
+        for ch in '<>:"/\\|?*':
+            assert ch not in result
+        assert "\x01" not in result
+
+    def test_empty_is_preserved(self):
+        # An empty identifier means "no site prefix" and must stay empty.
+        assert safe_filename_component("") == ""
+
+    def test_degenerate_name_uses_fallback(self):
+        # A name that reduces to nothing (only dots/spaces, which are stripped)
+        # must fall back rather than vanish.
+        assert safe_filename_component(". .") == "site"
+        assert safe_filename_component("  ") == "site"
+
+    def test_unsafe_chars_become_underscores_not_fallback(self):
+        # Unsafe characters are replaced (not stripped), so a name of them is a
+        # valid non-empty token and does not trigger the fallback.
+        assert safe_filename_component("///") == "___"
+
+    def test_trailing_dot_and_space_stripped(self):
+        # Windows silently strips these; we strip them ourselves for stability.
+        assert safe_filename_component("site .") == "site"
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("CON", "CON_"),
+            ("nul", "nul_"),
+            ("Com1", "Com1_"),
+            ("LPT9", "LPT9_"),
+            ("CON.txt", "CON_.txt"),
+            ("COM¹", "COM¹_"),
+            ("LPT³.tar.gz", "LPT³_.tar.gz"),
+            ("CONIN$.txt", "CONIN$_.txt"),
+            ("CON .txt", "CON _.txt"),
+        ],
+    )
+    def test_reserved_device_names_guarded(self, name, expected):
+        result = safe_filename_component(name)
+        assert result == expected
+
+    def test_safe_name_unchanged(self):
+        # A name that is already safe must pass through untouched.
+        assert safe_filename_component("KCL_London") == "KCL_London"


### PR DESCRIPTION
## Summary

- add a shared cross-platform filename-component sanitiser for user-provided site identifiers
- apply the sanitised token consistently to text, state, initial-condition, Parquet, and checkpoint filenames while preserving the original site identifier in Parquet metadata
- cover legacy and object-oriented save paths, Windows-unsafe characters, trailing dots/spaces, and reserved device names

Closes #1619.

## Validation

- uv run pytest test/io_tests/test_save_supy.py -q (37 passed)
- source .venv/bin/activate && make test-smoke (26 passed, 1 skipped)