### PR TITLE
Add machine-readable metrics for API test jobs

### DIFF
--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -95,6 +95,7 @@ jobs:
         shell: bash
         env:
           MARKER_EXPR: ${{ steps.marker.outputs.expr }}
+          SUEWS_CI_METRICS: ci-metrics/api-${{ matrix.python_version }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}.json
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest
@@ -102,4 +103,14 @@ jobs:
           # Run in one process. xdist duplicates every session fixture per
           # worker; the API lane contains simulation outputs large enough to
           # exhaust hosted-runner memory even with two workers.
-          python -m pytest test -m "$MARKER_EXPR" -v --tb=short --durations=25
+          python -m pytest -p scripts.suews.pytest_ci_metrics test \
+            -m "$MARKER_EXPR" -v --tb=short --durations=25
+
+      - name: Upload API test metrics
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: ci-metrics-api-${{ matrix.python_version }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
+          path: ci-metrics/*.json
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/suews/README.md
+++ b/scripts/suews/README.md
@@ -2,6 +2,45 @@
 
 This directory contains utility scripts for development and maintenance.
 
+## Pytest CI metrics
+
+**Plugin**: `pytest_ci_metrics.py`
+
+The API test workflow loads this standalone pytest plugin to publish a compact
+machine-readable artefact and append the same run's headline measurements to
+the GitHub Actions step summary. The plugin observes pytest hooks only: it does
+not perform a second collection or test pass.
+
+Set `SUEWS_CI_METRICS` to the JSON output path and load the plugin explicitly:
+
+```bash
+SUEWS_CI_METRICS=ci-metrics.json \
+  python -m pytest -p scripts.suews.pytest_ci_metrics test
+```
+
+When `GITHUB_STEP_SUMMARY` is set, the plugin also appends a Markdown summary.
+
+### Schema version 1
+
+The top-level JSON fields are:
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | Integer contract version, currently `1` |
+| `generated_at` | UTC timestamp at artefact creation |
+| `environment` | Python and GitHub runner/job identity when available |
+| `result` | Pytest exit code |
+| `phases` | Collection, test-loop and whole-session durations in seconds |
+| `inventory` | Collected node count and SHA-256 of sorted node IDs |
+| `execution` | Effective worker count and whether xdist was active |
+| `warnings` | Counts grouped by warning category and message, with stable SHA-256 fingerprints |
+
+The node fingerprint makes two CI cells directly comparable without storing
+the full collection in every artefact. Warning fingerprints deliberately omit
+source paths and line numbers so unchanged warnings remain grouped after code
+moves. Per-worker assignments, resource-tree peaks and workflow dependency-path
+analysis remain follow-up layers under issue #1623.
+
 ## Naming Convention Checker
 
 **Script**: `check_naming_conventions.py`

--- a/scripts/suews/pytest_ci_metrics.py
+++ b/scripts/suews/pytest_ci_metrics.py
@@ -1,0 +1,239 @@
+"""Low-overhead, machine-readable metrics for SUEWS pytest jobs.
+
+Load this module as a pytest plugin and set ``SUEWS_CI_METRICS`` to the output
+path. The plugin performs no additional collection or test execution: it only
+records timestamps and data already exposed by pytest hooks.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import time
+from typing import Any
+import warnings
+
+import pytest
+
+SCHEMA_VERSION = 1
+SUMMARY_WARNING_LIMIT = 10
+
+
+@dataclass
+class _MetricsState:
+    """Mutable measurements for one pytest controller process."""
+
+    session_started: float = 0.0
+    collection_seconds: float = 0.0
+    tests_seconds: float = 0.0
+    node_ids: list[str] = field(default_factory=list)
+    warning_counts: Counter[tuple[str, str]] = field(default_factory=Counter)
+    effective_worker_count: int = 1
+    uses_xdist: bool = False
+
+    def reset(self) -> None:
+        """Clear measurements when pytest is invoked again in one process."""
+        self.session_started = time.perf_counter()
+        self.collection_seconds = 0.0
+        self.tests_seconds = 0.0
+        self.node_ids.clear()
+        self.warning_counts.clear()
+        self.effective_worker_count = 1
+        self.uses_xdist = False
+
+
+_STATE = _MetricsState()
+
+
+def _normalise_node_ids(node_ids: list[str]) -> list[str]:
+    """Return stable, sorted node IDs without duplicates."""
+    return sorted(set(node_ids))
+
+
+def _inventory(node_ids: list[str]) -> dict[str, Any]:
+    """Build the stable test-coverage fingerprint."""
+    normalised = _normalise_node_ids(node_ids)
+    digest = hashlib.sha256("\n".join(normalised).encode()).hexdigest()
+    return {
+        "node_count": len(normalised),
+        "node_id_sha256": digest,
+    }
+
+
+def _warning_records(
+    counts: Counter[tuple[str, str]],
+) -> list[dict[str, Any]]:
+    """Group warnings by category and message with a stable fingerprint."""
+    records = []
+    for (category, message), count in sorted(counts.items()):
+        fingerprint = hashlib.sha256(f"{category}\n{message}".encode()).hexdigest()
+        records.append({
+            "category": category,
+            "count": count,
+            "fingerprint": fingerprint,
+            "message": message,
+        })
+    return records
+
+
+def _metrics(exit_code: int, session_seconds: float) -> dict[str, Any]:
+    """Serialise the current controller measurements."""
+
+    def duration(seconds: float) -> dict[str, float]:
+        return {"duration_seconds": round(seconds, 6)}
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "environment": {
+            "github_job": os.environ.get("GITHUB_JOB"),
+            "python": platform.python_version(),
+            "runner_arch": os.environ.get("RUNNER_ARCH"),
+            "runner_os": os.environ.get("RUNNER_OS"),
+        },
+        "result": {"exit_code": exit_code},
+        "phases": {
+            "collection": duration(_STATE.collection_seconds),
+            "session": duration(session_seconds),
+            "tests": duration(_STATE.tests_seconds),
+        },
+        "inventory": _inventory(_STATE.node_ids),
+        "execution": {
+            "effective_worker_count": _STATE.effective_worker_count,
+            "xdist": _STATE.uses_xdist,
+        },
+        "warnings": _warning_records(_STATE.warning_counts),
+    }
+
+
+def _write_json(path: Path, metrics: dict[str, Any]) -> None:
+    """Write the artefact atomically so failed writes cannot leave partial JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    temporary_path.write_text(
+        json.dumps(metrics, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary_path.replace(path)
+
+
+def _append_step_summary(path: Path, metrics: dict[str, Any]) -> None:
+    """Append a compact human view to the GitHub Actions step summary."""
+    phases = metrics["phases"]
+    inventory = metrics["inventory"]
+    execution = metrics["execution"]
+    warning_records = metrics["warnings"]
+    lines = [
+        "## Pytest CI metrics",
+        "",
+        "| Measurement | Value |",
+        "|---|---:|",
+        f"| Collected tests | {inventory['node_count']} |",
+        f"| Effective workers | {execution['effective_worker_count']} |",
+        f"| Collection | {phases['collection']['duration_seconds']:.3f} s |",
+        f"| Tests | {phases['tests']['duration_seconds']:.3f} s |",
+        f"| Session | {phases['session']['duration_seconds']:.3f} s |",
+        "",
+        f"Coverage fingerprint: `{inventory['node_id_sha256']}`",
+        "",
+        "### Grouped warnings",
+        "",
+    ]
+    if warning_records:
+        ordered_warnings = sorted(
+            warning_records,
+            key=lambda record: (-record["count"], record["fingerprint"]),
+        )
+        lines.extend(
+            f"- {record['count']} x {record['category']}: {record['message']} "
+            f"(`{record['fingerprint'][:12]}`)"
+            for record in ordered_warnings[:SUMMARY_WARNING_LIMIT]
+        )
+        hidden_count = len(ordered_warnings) - SUMMARY_WARNING_LIMIT
+        if hidden_count > 0:
+            lines.append(
+                f"- {hidden_count} additional warning fingerprints are in the JSON artefact."
+            )
+    else:
+        lines.append("No warnings recorded.")
+    lines.append("")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines))
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Reset state and start the whole-session timer."""
+    _STATE.reset()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_collection(session: pytest.Session):
+    """Measure collection without issuing an additional collection pass."""
+    started = time.perf_counter()
+    yield
+    _STATE.collection_seconds += time.perf_counter() - started
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    """Capture node IDs for serial pytest runs."""
+    if session.items:
+        _STATE.node_ids = [item.nodeid for item in session.items]
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_xdist_setupnodes(config: pytest.Config, specs: list[Any]) -> None:
+    """Capture the resolved worker count, including ``-n auto`` runs."""
+    _STATE.uses_xdist = True
+    _STATE.effective_worker_count = len(specs)
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_xdist_node_collection_finished(node: Any, ids: list[str]) -> None:
+    """Capture the common xdist inventory reported by the first worker."""
+    if not _STATE.node_ids:
+        _STATE.node_ids = list(ids)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtestloop(session: pytest.Session):
+    """Measure the test phase around pytest's existing run loop."""
+    started = time.perf_counter()
+    yield
+    _STATE.tests_seconds += time.perf_counter() - started
+
+
+def pytest_warning_recorded(
+    warning_message: warnings.WarningMessage,
+    when: str,
+    nodeid: str,
+    location: tuple[str, int, str] | None,
+) -> None:
+    """Group warnings by their stable category and message."""
+    del when, nodeid, location
+    category = warning_message.category.__name__
+    _STATE.warning_counts[category, str(warning_message.message)] += 1
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Write the requested artefact once, from the controller process only."""
+    if hasattr(session.config, "workerinput"):
+        return
+    output = os.environ.get("SUEWS_CI_METRICS")
+    if not output:
+        return
+
+    session_seconds = max(0.0, time.perf_counter() - _STATE.session_started)
+    metrics = _metrics(int(exitstatus), session_seconds)
+    _write_json(Path(output), metrics)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        _append_step_summary(Path(summary), metrics)

--- a/test/core/test_pytest_ci_metrics.py
+++ b/test/core/test_pytest_ci_metrics.py
@@ -1,0 +1,96 @@
+"""Contract tests for the standalone pytest CI metrics plugin."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.api
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.smoke
+def test_plugin_writes_parseable_metrics_and_step_summary(tmp_path: Path) -> None:
+    """A pytest run records its stable inventory, timings, workers and warnings."""
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text(
+        """\
+import warnings
+
+
+def test_pass():
+    assert True
+
+
+def test_warn():
+    warnings.warn("group me", UserWarning)
+""",
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "ci-metrics.json"
+    summary_path = tmp_path / "step-summary.md"
+    env = os.environ.copy()
+    env.update({
+        "GITHUB_STEP_SUMMARY": str(summary_path),
+        "PYTHONPATH": os.pathsep.join(
+            part for part in (str(PROJECT_ROOT), env.get("PYTHONPATH", "")) if part
+        ),
+        "SUEWS_CI_METRICS": str(metrics_path),
+    })
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--confcutdir",
+            str(tmp_path),
+            "-p",
+            "scripts.suews.pytest_ci_metrics",
+            str(test_file),
+            "-q",
+        ],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    node_ids = ["test_sample.py::test_pass", "test_sample.py::test_warn"]
+    expected_hash = hashlib.sha256("\n".join(node_ids).encode()).hexdigest()
+
+    assert metrics["schema_version"] == 1
+    assert metrics["result"]["exit_code"] == 0
+    assert metrics["inventory"] == {
+        "node_count": 2,
+        "node_id_sha256": expected_hash,
+    }
+    assert metrics["execution"] == {
+        "effective_worker_count": 1,
+        "xdist": False,
+    }
+    assert set(metrics["phases"]) == {"collection", "session", "tests"}
+    assert all(phase["duration_seconds"] >= 0 for phase in metrics["phases"].values())
+    assert metrics["warnings"] == [
+        {
+            "category": "UserWarning",
+            "count": 1,
+            "fingerprint": hashlib.sha256(b"UserWarning\ngroup me").hexdigest(),
+            "message": "group me",
+        }
+    ]
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "Pytest CI metrics" in summary
+    assert expected_hash in summary
+    assert "UserWarning: group me" in summary


### PR DESCRIPTION
## Summary

- add a standalone pytest plugin that writes schema-versioned JSON with collection/test/session timings, a stable node-inventory fingerprint, effective worker count, result status, environment identity and grouped warning fingerprints
- append a compact GitHub Actions step summary and upload one uniquely named metrics artefact for every API platform/Python cell, including failed pytest runs
- document the schema and protect the contract with an isolated smoke-tier subprocess test

Refs #1623

## Scope

This is the first independently useful observability layer for #1623 and intentionally targets the serial API lane that currently dominates the workflow critical path. The plugin uses existing pytest hooks and performs no second collection or test pass. It also understands xdist's resolved worker count without changing the CI worker configuration.

The following #1623 scope remains for subsequent focused PRs:

- per-worker assignments, busy durations and finish skew
- process-tree CPU time and peak RSS with explicit unsupported-platform status
- checkout, environment, build, repair and install phase timings
- physics/wheel-job artefact transport from cibuildwheel containers
- post-run queue, execution, dependency-barrier and workflow critical-path analysis
- hosted-run measurement of the 2% overhead budget

## Hosted evidence

[PR run 29435659064](https://github.com/UMEP-dev/SUEWS/actions/runs/29435659064) passed on the current head and uploaded both API metrics artefacts. Each JSON file parsed against schema version 1, reported one effective worker and contained the same eight-node coverage fingerprint (`36fb14bc48ce92aa3fb1405ca07a7a171fa1b06f1f657b2247c6ed00fe668af2`).

| Python | Collection | Tests | Session | Warning groups |
|---|---:|---:|---:|---:|
| 3.12.13 | 5.36 s | 22.69 s | 28.06 s | 1 |
| 3.14.6 | 3.99 s | 24.68 s | 28.67 s | 1 |

## Validation

- test-first contract: observed the expected missing-plugin failure before implementation
- `python -m pytest test/core/test_pytest_ci_metrics.py -q` - 1 passed
- manual xdist contract with `-n 2` - 2 passed; artefact reported two effective workers and the expected node hash
- `ruff check scripts/suews/pytest_ci_metrics.py test/core/test_pytest_ci_metrics.py` - passed
- `ruff format --check scripts/suews/pytest_ci_metrics.py test/core/test_pytest_ci_metrics.py` - passed
- `python scripts/lint/check_test_markers.py .` - passed (118 direct, 5 auto-applied)
- workflow YAML parse - passed
- `make test-smoke` - 27 passed, 1 skipped
- `make test` - 1,740 passed, 8 skipped
