### PR TITLE
Balance fixed-worker physics test scheduling

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -189,19 +189,24 @@ runs:
           gcc --version &&
           pip install delvewheel
         CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
-        CIBW_TEST_REQUIRES: pytest pytest-xdist
+        # Pin the scheduler stack so distribution behaviour cannot drift between
+        # CI runs. Re-benchmark the fixed-worker candidates before updating.
+        CIBW_TEST_REQUIRES: pytest==9.1.1 pytest-xdist==3.8.0
         # Test tiers: choose subset based on path detection and trigger.
         # gh#1300: physics tests are binary-determined, so one run per
         # (OS, arch) on the build Python is sufficient. API tests (Python
         # wrapper surface) run separately per (platform x Python) via
         # test-api-cross-python-reusable.yml.
         # Always include --durations=10 to show slowest tests in output.
+        # Keep the runner-detected worker budget: GitHub-hosted CPU capacity is
+        # the constraint, so adding workers can increase contention. Work
+        # stealing balances long simulation tests across the existing workers.
         # After pytest, enforce bridge-manifest coverage of public Fortran types.
         # Uses run_ci_tests.py wrapper to avoid shell-level && chaining,
         # which breaks on Windows cmd.exe with quoted marker expressions.
         CIBW_TEST_COMMAND: >-
           python {project}/scripts/suews/run_ci_tests.py {project}
-          -v --tb=short --durations=10 -n auto --dist loadscope
+          -v --tb=short --durations=10 -n auto --maxprocesses=4 --dist worksteal
           ${{ inputs.test_tier == 'smoke' && '-m "physics and smoke and not slow"' ||
               inputs.test_tier == 'core' && '-m "physics and (smoke or core) and not slow"' ||
               inputs.test_tier == 'cfg' && '-m "physics and (smoke or cfg) and not slow"' ||

--- a/test/core/test_cli_validation.py
+++ b/test/core/test_cli_validation.py
@@ -142,7 +142,7 @@ def test_validate_produces_meaningful_output(suews_validate_exe, tmp_path):
 
 
 @pytest.mark.cfg
-@pytest.mark.smoke
+@pytest.mark.slow
 def test_validate_second_run_not_truncated(suews_validate_exe, tmp_path):
     """Repeated validation runs should not truncate reports or updated YAML files."""
     yaml_path = tmp_path / "yaml_setup.yml"
@@ -210,7 +210,6 @@ def test_validate_second_run_not_truncated(suews_validate_exe, tmp_path):
 
 
 @pytest.mark.cfg
-@pytest.mark.smoke
 def test_validate_issue_1097_fixture(suews_validate_exe, tmp_path):
     """The issue #1097 fixture should still yield non-empty, meaningful outputs."""
     fixture = Path(__file__).parent / "data" / "issue_1097" / "yaml_setup.yml"
@@ -245,7 +244,6 @@ def test_validate_issue_1097_fixture(suews_validate_exe, tmp_path):
 
 
 @pytest.mark.cfg
-@pytest.mark.smoke
 def test_validate_windows_paths(suews_validate_exe, tmp_path):
     """Windows-style paths should produce meaningful reports on every platform."""
     yaml_path = tmp_path / "windows_paths.yml"

--- a/test/core/test_ehc_regression.py
+++ b/test/core/test_ehc_regression.py
@@ -8,9 +8,7 @@ import supy as sp
 
 pytestmark = [
     pytest.mark.physics,
-    pytest.mark.core,
     pytest.mark.rust,
-    pytest.mark.smoke,
 ]
 
 
@@ -145,6 +143,7 @@ def _run_short_spartacus_ehc_with_building_cp(rho_cp):
     return output.df[("SUEWS", "QS")].to_numpy()
 
 
+@pytest.mark.core
 def test_ehc_lumped_storage_is_sensitive_to_surface_rho_cp():
     low_cp_qs = _run_short_ehc_with_surface_cp(1.0e6)
     high_cp_qs = _run_short_ehc_with_surface_cp(4.0e6)
@@ -153,6 +152,7 @@ def test_ehc_lumped_storage_is_sensitive_to_surface_rho_cp():
     assert np.max(np.abs(high_cp_qs - low_cp_qs)) > 1.0
 
 
+@pytest.mark.smoke
 def test_ehc_lumped_storage_skips_invalid_surface_without_zeroing_grid():
     qs = _run_short_ehc_with_surface_cp(1.0e6, surface_rho_cp={"bldgs": 0.0})
 
@@ -238,6 +238,7 @@ def test_ehc_direct_air_qf_mode_changes_lumped_storage_response(monkeypatch):
     assert np.max(np.abs(direct_air_qf_qs - default_qs)) > 0.1
 
 
+@pytest.mark.core
 def test_ehc_direct_air_qf_mode_changes_coupled_qe_response(monkeypatch):
     monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", raising=False)
@@ -429,6 +430,7 @@ def test_ehc_restore_best_iteration_path_runs(monkeypatch):
     assert np.max(np.abs(qs)) > 1.0
 
 
+@pytest.mark.core
 def test_ehc_spartacus_facet_storage_is_sensitive_to_building_rho_cp():
     low_cp_qs = _run_short_spartacus_ehc_with_building_cp(1.0e6)
     high_cp_qs = _run_short_spartacus_ehc_with_building_cp(4.0e6)


### PR DESCRIPTION
## Summary

- cap pytest-xdist at four workers while retaining automatic runner detection
- switch the physics lane from `loadscope` to `worksteal` and pin pytest 9.1.1 / pytest-xdist 3.8.0
- keep one EHC smoke sentinel, four smoke-or-core EHC checks, and all 18 EHC regressions in standard/full physics
- move the three-run CLI truncation regression to `slow` and keep the single-run fixture/path checks in `cfg`

This change works within the existing GitHub-hosted CPU and memory budget. It does not add workers.

## Directional scheduler evidence

A local macOS A-B-B-A comparison used the same environment, test selection and fixed four-worker cap. Both schedulers collected the same 127 nodes (`sha256:11c615130a5056b38c3d4dc312037fd95a67568e7960ea892ac208130465882c`) and every run finished with 127 passed / 1 skipped.

| Scheduler | Pytest times | Median | Median max RSS | Median peak footprint |
| --- | --- | ---: | ---: | ---: |
| `loadscope` | 148.59s, 149.57s | 149.08s | 1114 MiB | 98.33 MiB |
| `worksteal` | 114.30s, 121.61s | 117.96s | 1152 MiB | 98.92 MiB |

The directional median improvement is 20.9%. `loadscope` placed all 18 EHC tests on one worker; `worksteal` distributed them 4/6/3/5 across the four workers. Median max RSS increased by 3.4%, while the macOS peak-footprint metric increased by 0.6%.

These local results are directional, not a substitute for a same-job hosted comparison. PR CI validates the selected configuration and correctness only.

## Marker inventory

| File | Before | After |
| --- | --- | --- |
| EHC smoke / core-or-smoke / standard | 18 / 18 / 18 | 1 / 4 / 18 |
| CLI smoke / cfg-not-slow / all | 5 / 5 / 5 | 2 / 4 / 5 |

## Validation

- EHC regression file: 18 passed
- CLI validation file with installed entry point: 5 passed
- `make test-smoke`: 6 passed, 1 skipped
- full `-m physics` tier with worksteal and four workers: 133 passed, 1 skipped
- `make test`: 1738 passed, 8 skipped, 68 deselected
- workflow YAML/static scheduler contract: passed
- marker-axis lint: passed
- pinned pytest/xdist dependency resolution: passed

## Remaining acceptance

Keep #1626 open until a single Linux hosted job runs the incumbent and challenger in ABBA order against one wheel, recording worker finish skew and hosted peak RSS. The CI metrics work in #1623 can provide the durable measurement surface.

Refs #1626
