### PR TITLE
Remove stale native-state test ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ rebuild-meson:
 # - test-qgis: UMEP/QGIS compatibility tests (Windows + Python 3.12 target)
 test:
 	@echo "Running standard tests (excluding slow tests)..."
-	@echo "NOTE: Slow tests (e.g., Fortran state persistence ~3-4 min) are skipped."
+	@echo "NOTE: Long-running regression tests are skipped."
 	@echo "      Run 'make test-all' for comprehensive testing."
 	@echo ""
 	$(PYTHON) -m pytest test -m "not slow and not qgis" -v --tb=short --durations=10

--- a/dev-ref/CODING_GUIDELINES.md
+++ b/dev-ref/CODING_GUIDELINES.md
@@ -392,6 +392,14 @@ python -m pytest test -v                   # Run in suite
 Only the API-surface probe is prioritised via `conftest.py` so import failures fail fast.
 All other tests retain their declared collection order.
 Native simulation calls must own fresh state, while continuation tests pass prior state explicitly; tests must not rely on suite ordering for isolation.
+The removed workaround had moved every `test/core/test_sample_output.py` item plus the public API-equivalence nodes `TestPublicAPIEquivalence` and `test_functional_matches_oop`; executable collection evidence for that bounded set lives in `test/test_api_surface.py`.
+
+### 5.11 Native Mutable-State Inventory
+
+- `src/suews_bridge/src/lib.rs` exposes the active Rust entry points, and `src/suews_bridge/c_api/driver.f95::suews_cal_multitsteps_c` materialises `SUEWS_TIMER`, `SUEWS_CONFIG`, `SUEWS_SITE`, and `SUEWS_STATE` as call-local values.
+- `src/suews/src/suews_ctrl_error.f95::module_ctrl_error_state` retains the fatal-error flag, code, and message with `SAVE`; `suews_cal_multitsteps_c` calls `reset_supy_error()` at every driver entry.
+- `src/suews/src/suews_phys_anohm.f95` still contains `SAVE` declarations, but AnOHM is disabled and remains outside the active bridge path.
+  Removing or explicitly owning that state is a reactivation gate for AnOHM, not a claim that the current tree contains no `SAVE` state.
 
 ## Version Control Practices
 

--- a/dev-ref/CODING_GUIDELINES.md
+++ b/dev-ref/CODING_GUIDELINES.md
@@ -389,11 +389,9 @@ python -m pytest test -v                   # Run in suite
 
 ### 5.10 Test Execution Order
 
-Critical tests run first via `conftest.py`:
-- Sample output validation
-- Benchmark tests
-- Core functionality
-This ensures fundamental features are tested before complex scenarios.
+Only the API-surface probe is prioritised via `conftest.py` so import failures fail fast.
+All other tests retain their declared collection order.
+Native simulation calls must own fresh state, while continuation tests pass prior state explicitly; tests must not rely on suite ordering for isolation.
 
 ## Version Control Practices
 

--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ This directory contains the test suite for SUEWS/SuPy, organised by functionalit
 
 ### Core Tests (`core/`)
 Essential core functionality tests including:
-- **test_sample_output.py** - Tolerance-based validation (runs first in CI fast-fail)
-- **test_fortran_state_persistence.py** - Ensures Fortran state isolation between runs
+- **test_sample_output.py** - Tolerance-based reference-output validation
+- **test_fortran_state_persistence.py** - Exercises native-state isolation across an in-process order matrix
 - **test_floating_point_stability.py** - Numerical stability and reproducibility tests
 - **test_suews_simulation.py** - High-level API interface tests
 - **test_supy.py** - Comprehensive test suite (runs during wheel building)
@@ -163,7 +163,10 @@ Subset runs (`pytest test/core/test_x.py`) are unaffected.
 
 ## Test Order
 
-The test suite uses `conftest.py` to ensure `test_sample_output.py` runs first. This is necessary because the Fortran model maintains internal state between test runs, and running this benchmark test first ensures consistent results.
+The test suite only prioritises `test_api_surface.py` so broken imports fail fast.
+All other tests retain their declared collection order.
+Fresh native simulation calls own fresh state; continuation is explicit through the state returned by the previous call.
+`test_fortran_state_persistence.py` exercises the A->B, B->A, A->A and B->B order matrix at that boundary.
 
 ## Adding New Tests
 

--- a/test/README.md
+++ b/test/README.md
@@ -166,7 +166,8 @@ Subset runs (`pytest test/core/test_x.py`) are unaffected.
 The test suite only prioritises `test_api_surface.py` so broken imports fail fast.
 All other tests retain their declared collection order.
 Fresh native simulation calls own fresh state; continuation is explicit through the state returned by the previous call.
-`test_fortran_state_persistence.py` exercises the A->B, B->A, A->A and B->B order matrix at that boundary.
+The removed workaround had protected every `test_sample_output.py` item plus `TestPublicAPIEquivalence` and `test_functional_matches_oop`; `test_api_surface.py` now checks the real bounded node set retains requested order.
+`test_fortran_state_persistence.py` gives A and B independently clean process references, then exercises A->B, B->A, A->A and B->B as separate test items with both calls in each transition sharing one process.
 
 ## Adding New Tests
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -270,40 +270,22 @@ def pytest_configure():
 
 
 def pytest_collection_modifyitems(items):
-    """Order tests to catch import breakages first, then protect Fortran state.
+    """Run the import-surface probe first and preserve all other test order.
 
-    Test ordering:
-    1. test_api_surface.py (meta validation - catches broken imports immediately)
-    2. test_sample_output.py (reference output - needs completely clean Fortran state)
-    3. API equivalence tests (need clean state, but less critical than sample output)
-    4. All other tests
+    Native simulation calls own fresh state at the Rust/Fortran boundary.  Tests
+    that need continuation pass the previous state explicitly, so reference and
+    API-equivalence tests no longer need collection-order protection.
     """
     api_surface_tests = []
-    sample_output_tests = []
-    api_equivalence_tests = []
     other_tests = []
 
     for item in items:
         if "test_api_surface" in str(item.fspath):
             api_surface_tests.append(item)
-        elif "test_sample_output" in str(item.fspath) or "core/test_sample_output" in str(
-            item.fspath
-        ):
-            sample_output_tests.append(item)
-        elif (
-            "test_functional_matches_oop" in item.nodeid
-            or "TestPublicAPIEquivalence" in item.nodeid
-        ):
-            api_equivalence_tests.append(item)
         else:
             other_tests.append(item)
 
-    items[:] = (
-        api_surface_tests
-        + sample_output_tests
-        + api_equivalence_tests
-        + other_tests
-    )
+    items[:] = api_surface_tests + other_tests
 
 
 # =============================================================================

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -275,6 +275,11 @@ def pytest_collection_modifyitems(items):
     Native simulation calls own fresh state at the Rust/Fortran boundary.  Tests
     that need continuation pass the previous state explicitly, so reference and
     API-equivalence tests no longer need collection-order protection.
+
+    The removed workaround moved every ``test_sample_output.py`` item plus
+    ``TestPublicAPIEquivalence`` and ``test_functional_matches_oop`` nodes.  The
+    bounded real-node set has an executable collection regression in
+    ``test_api_surface.py``.
     """
     api_surface_tests = []
     other_tests = []

--- a/test/core/test_fortran_state_persistence.py
+++ b/test/core/test_fortran_state_persistence.py
@@ -1,13 +1,16 @@
 """Exercise the native simulation boundary in different in-process orders.
 
-Fresh ``run_suews`` calls own a fresh model state.  Continuation is explicit and
-uses ``run_suews_with_state`` with the state returned by an earlier call.  This
-test protects that lifecycle contract without relying on pytest collection order.
+Each reference case runs in its own fresh Python process.  Every transition
+still makes both native calls in one process, so retained Fortran state cannot
+hide behind pytest process isolation or collection order.
 """
 
 from copy import deepcopy
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 from conftest import SHORT_RUN_STEPS
 import numpy as np
@@ -15,16 +18,49 @@ import pytest
 
 from supy import SUEWSSimulation
 from supy._run_rust import (  # noqa: PLC2701 - test the native boundary directly.
-    _load_rust_module,
     _prepare_forcing_block,
 )
 
 pytestmark = pytest.mark.physics
 
+_RESULT_PREFIX = "__SUEWS_NATIVE_RESULT__"
+_NATIVE_SEQUENCE_RUNNER = f"""
+import json
+import os
+import sys
+import uuid
+
+from supy._run_rust import _load_rust_module
+
+payload = json.load(sys.stdin)
+rust_module = _load_rust_module()
+results = []
+for case_name in payload["sequence"]:
+    output_flat, state_json, actual_len = rust_module.run_suews(
+        payload["config_json_by_case"][case_name],
+        payload["forcing_flat"],
+        payload["len_sim"],
+    )
+    results.append(
+        {{
+            "actual_len": actual_len,
+            "output_flat": output_flat,
+            "state_json": state_json,
+        }}
+    )
+
+result = {{
+    "pid": os.getpid(),
+    "process_token": uuid.uuid4().hex,
+    "results": results,
+}}
+sys.stdout.write("{_RESULT_PREFIX}" + json.dumps(result))
+"""
+
 
 @pytest.fixture(scope="module")
-def native_run_cases():
-    """Return two distinct inputs for repeated native-boundary calls."""
+def native_run_payload():
+    """Return two physically distinct inputs for native-boundary calls."""
     path_config = (
         Path(__file__).resolve().parents[2]
         / "src"
@@ -36,60 +72,123 @@ def native_run_cases():
     dict_config_a = simulation.config.model_dump(exclude_none=True, mode="json")
     dict_config_b = deepcopy(dict_config_a)
 
-    # Make B physically distinct from A while retaining the same dimensions and
-    # forcing.  A large albedo contrast ensures the matrix is not a vacuous
-    # comparison between two aliases of the same input.
+    # A large albedo contrast ensures A and B cannot be aliases whose identical
+    # outputs would make the order matrix pass vacuously.
     dict_config_b["sites"][0]["properties"]["land_cover"]["paved"]["alb"]["value"] = 0.8
 
     df_forcing = simulation.forcing.df.iloc[:SHORT_RUN_STEPS]
     forcing_flat = _prepare_forcing_block(df_forcing).ravel(order="C").tolist()
-    return (
-        _load_rust_module(),
-        {
+    return {
+        "config_json_by_case": {
             "A": json.dumps(dict_config_a),
             "B": json.dumps(dict_config_b),
         },
-        forcing_flat,
-        len(df_forcing),
-    )
+        "forcing_flat": forcing_flat,
+        "len_sim": len(df_forcing),
+    }
 
 
-def _run_native_case(native_run_cases, case_name):
-    """Run one fresh native simulation and return output plus final state."""
-    rust_module, dict_config_json, forcing_flat, len_sim = native_run_cases
-    output_flat, state_json, actual_len = rust_module.run_suews(
-        dict_config_json[case_name], forcing_flat, len_sim
+def _run_native_sequence(native_run_payload, sequence):
+    """Run a sequence of native calls together in one fresh Python process."""
+    dict_payload = {**native_run_payload, "sequence": list(sequence)}
+    result = subprocess.run(
+        [sys.executable, "-c", _NATIVE_SEQUENCE_RUNNER],
+        input=json.dumps(dict_payload),
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=False,
+        cwd=Path(__file__).resolve().parents[2],
     )
-    assert actual_len == len_sim
-    return np.asarray(output_flat), state_json
+    if result.returncode != 0:
+        pytest.fail(
+            "native sequence subprocess failed: "
+            f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+        )
+
+    result_line = next(
+        (
+            line
+            for line in reversed(result.stdout.splitlines())
+            if line.startswith(_RESULT_PREFIX)
+        ),
+        None,
+    )
+    assert result_line is not None, result.stdout
+    dict_result = json.loads(result_line.removeprefix(_RESULT_PREFIX))
+    assert len(dict_result["results"]) == len(sequence)
+    for dict_case_result in dict_result["results"]:
+        assert dict_case_result["actual_len"] == native_run_payload["len_sim"]
+    return dict_result
+
+
+@pytest.fixture(scope="module")
+def clean_native_references(native_run_payload):
+    """Run A and B separately so neither can contaminate the other reference."""
+    dict_reference = {}
+    for case_name in ("A", "B"):
+        dict_run = _run_native_sequence(native_run_payload, (case_name,))
+        dict_case_result = dict_run["results"][0]
+        dict_reference[case_name] = {
+            "output": np.asarray(dict_case_result["output_flat"]),
+            "state": dict_case_result["state_json"],
+            "pid": dict_run["pid"],
+            "process_token": dict_run["process_token"],
+        }
+    return dict_reference
 
 
 @pytest.mark.core
-def test_native_state_isolated_across_order_matrix(native_run_cases):
-    """Each case is independent of whether A or B ran immediately before it."""
-    dict_reference = {
-        case_name: _run_native_case(native_run_cases, case_name)
-        for case_name in ("A", "B")
-    }
-    output_a = dict_reference["A"][0]
-    output_b = dict_reference["B"][0]
+def test_native_references_use_independent_processes(clean_native_references):
+    """Reject the old A-then-B reference scheme in the pytest process."""
+    list_pid = [dict_case["pid"] for dict_case in clean_native_references.values()]
+    list_process_token = [
+        dict_case["process_token"] for dict_case in clean_native_references.values()
+    ]
+
+    assert all(pid != os.getpid() for pid in list_pid)
+    assert len(set(list_pid)) == len(list_pid)
+    assert len(set(list_process_token)) == len(list_process_token)
+
+
+@pytest.mark.core
+def test_native_reference_cases_are_physically_distinct(clean_native_references):
+    """A and B need at least one real finite output difference."""
+    output_a = clean_native_references["A"]["output"]
+    output_b = clean_native_references["B"]["output"]
     finite_difference = (
         np.isfinite(output_a) & np.isfinite(output_b) & (output_a != output_b)
     )
-    assert np.any(finite_difference), "A and B need a real finite output difference"
+    assert np.any(finite_difference)
 
-    for first_case, second_case in (("A", "B"), ("B", "A"), ("A", "A"), ("B", "B")):
-        _run_native_case(native_run_cases, first_case)
-        output_observed, state_observed = _run_native_case(
-            native_run_cases, second_case
-        )
-        output_expected, state_expected = dict_reference[second_case]
 
+@pytest.mark.core
+@pytest.mark.parametrize(
+    ("first_case", "second_case"),
+    (("A", "B"), ("B", "A"), ("A", "A"), ("B", "B")),
+    ids=("A-to-B", "B-to-A", "A-to-A", "B-to-B"),
+)
+def test_native_state_isolated_across_order(
+    native_run_payload,
+    clean_native_references,
+    first_case,
+    second_case,
+):
+    """Both calls match clean references when run consecutively in one process."""
+    tuple_sequence = (first_case, second_case)
+    dict_run = _run_native_sequence(native_run_payload, tuple_sequence)
+    set_reference_token = {
+        dict_case["process_token"] for dict_case in clean_native_references.values()
+    }
+    assert dict_run["process_token"] not in set_reference_token
+
+    for case_name, dict_observed in zip(tuple_sequence, dict_run["results"]):
+        dict_expected = clean_native_references[case_name]
         np.testing.assert_array_equal(
-            output_observed,
-            output_expected,
+            np.asarray(dict_observed["output_flat"]),
+            dict_expected["output"],
             err_msg=f"native output leaked across {first_case}->{second_case}",
         )
-        assert state_observed == state_expected, (
+        assert dict_observed["state_json"] == dict_expected["state"], (
             f"native final state leaked across {first_case}->{second_case}"
         )

--- a/test/core/test_fortran_state_persistence.py
+++ b/test/core/test_fortran_state_persistence.py
@@ -1,245 +1,95 @@
-#!/usr/bin/env python3
-"""
-Test Fortran State Persistence Within Same Python Process
+"""Exercise the native simulation boundary in different in-process orders.
 
-This test suite verifies that Fortran state does not persist between multiple
-calls to sp.run_supy() within the same Python process. State persistence would
-indicate uninitialized variables or improper state reset mechanisms.
-
-These tests take ~3.6 minutes total but provide comprehensive state isolation validation.
-
-Based on user correction: "you need to test running the fortran multiple times
-within the same python script. Not calling the test 3 separate times. A new
-python kernel will reset both python and fortran states."
+Fresh ``run_suews`` calls own a fresh model state.  Continuation is explicit and
+uses ``run_suews_with_state`` with the state returned by an earlier call.  This
+test protects that lifecycle contract without relying on pytest collection order.
 """
 
-import logging
+from copy import deepcopy
+import json
 from pathlib import Path
-from unittest import TestCase
 
-from conftest import TIMESTEPS_PER_DAY
-
+from conftest import SHORT_RUN_STEPS
+import numpy as np
 import pytest
-import supy as sp
+
+from supy import SUEWSSimulation
+from supy._run_rust import (  # noqa: PLC2701 - test the native boundary directly.
+    _load_rust_module,
+    _prepare_forcing_block,
+)
 
 pytestmark = pytest.mark.physics
 
-# Suppress logging to get clean output
-logging.getLogger("SuPy").setLevel(logging.CRITICAL)
+
+@pytest.fixture(scope="module")
+def native_run_cases():
+    """Return two distinct inputs for repeated native-boundary calls."""
+    path_config = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "supy"
+        / "sample_data"
+        / "sample_config.yml"
+    )
+    simulation = SUEWSSimulation(str(path_config))
+    dict_config_a = simulation.config.model_dump(exclude_none=True, mode="json")
+    dict_config_b = deepcopy(dict_config_a)
+
+    # Make B physically distinct from A while retaining the same dimensions and
+    # forcing.  A large albedo contrast ensures the matrix is not a vacuous
+    # comparison between two aliases of the same input.
+    dict_config_b["sites"][0]["properties"]["land_cover"]["paved"]["alb"]["value"] = 0.8
+
+    df_forcing = simulation.forcing.df.iloc[:SHORT_RUN_STEPS]
+    forcing_flat = _prepare_forcing_block(df_forcing).ravel(order="C").tolist()
+    return (
+        _load_rust_module(),
+        {
+            "A": json.dumps(dict_config_a),
+            "B": json.dumps(dict_config_b),
+        },
+        forcing_flat,
+        len(df_forcing),
+    )
 
 
-@pytest.mark.slow
-class TestFortranStatePersistence(TestCase):
-    """Test suite for Fortran state persistence issues."""
+def _run_native_case(native_run_cases, case_name):
+    """Run one fresh native simulation and return output plus final state."""
+    rust_module, dict_config_json, forcing_flat, len_sim = native_run_cases
+    output_flat, state_json, actual_len = rust_module.run_suews(
+        dict_config_json[case_name], forcing_flat, len_sim
+    )
+    assert actual_len == len_sim
+    return np.asarray(output_flat), state_json
 
-    def setUp(self):
-        """Set up test environment."""
-        # Clear any cached data from previous tests
-        import functools
-        import gc
 
-        # Clear all LRU caches in the supy module
-        for obj in gc.get_objects():
-            if isinstance(obj, functools._lru_cache_wrapper):
-                try:
-                    obj.cache_clear()
-                except:
-                    pass
+@pytest.mark.core
+def test_native_state_isolated_across_order_matrix(native_run_cases):
+    """Fresh calls produce their isolated baseline in A/B and repeat orders."""
+    dict_baseline = {
+        case_name: _run_native_case(native_run_cases, case_name)
+        for case_name in ("A", "B")
+    }
+    output_a = dict_baseline["A"][0]
+    output_b = dict_baseline["B"][0]
+    finite_difference = (
+        np.isfinite(output_a) & np.isfinite(output_b) & (output_a != output_b)
+    )
+    assert np.any(finite_difference), "A and B need a real finite output difference"
 
-        # More aggressive cache clearing for supy._load module
-        try:
-            import supy._load
-
-            # Clear specific caches in _load module
-            for attr_name in dir(supy._load):
-                attr = getattr(supy._load, attr_name)
-                if hasattr(attr, "cache_clear"):
-                    attr.cache_clear()
-        except:
-            pass
-
-    def run_sample_year(self):
-        """Run the sample year simulation that shows pollution effects."""
-        trv_sample_data = Path(sp.__file__).parent / "sample_data"
-        path_config_default = trv_sample_data / "sample_config.yml"
-
-        df_state_init = sp.init_supy(path_config_default, force_reload=True)
-        df_forcing_tstep = sp.load_forcing_grid(
-            path_config_default, df_state_init.index[0], df_state_init=df_state_init
+    for first_case, second_case in (("A", "B"), ("B", "A"), ("A", "A"), ("B", "B")):
+        _run_native_case(native_run_cases, first_case)
+        output_observed, state_observed = _run_native_case(
+            native_run_cases, second_case
         )
+        output_expected, state_expected = dict_baseline[second_case]
 
-        # Run one year
-        df_forcing_part = df_forcing_tstep.iloc[: TIMESTEPS_PER_DAY * 366]
-        df_output, df_state = sp.run_supy(df_forcing_part, df_state_init)
-
-        return df_output.SUEWS["QE"].values[286]
-
-    def run_benchmark_test(self):
-        """Run the benchmark test that causes pollution."""
-        p_config = Path("test/fixtures/benchmark1/benchmark1.yml")
-        if p_config.exists():
-            df_state_init = sp.init_supy(p_config, force_reload=True)
-            df_forcing_tstep = sp.load_forcing_grid(
-                p_config, df_state_init.index[0], df_state_init=df_state_init
-            )
-            df_output, df_state = sp.run_supy(df_forcing_tstep, df_state_init)
-            return True
-        return False
-
-    def run_short_benchmark(self):
-        """Run a short version of benchmark test to minimize execution time."""
-        p_config = Path("test/fixtures/benchmark1/benchmark1.yml")
-        if p_config.exists():
-            df_state_init = sp.init_supy(p_config, force_reload=True)
-            df_forcing_tstep = sp.load_forcing_grid(
-                p_config, df_state_init.index[0], df_state_init=df_state_init
-            )
-            # Just run first day to minimize time
-            df_forcing_part = df_forcing_tstep.iloc[:TIMESTEPS_PER_DAY]
-            df_output, df_state = sp.run_supy(df_forcing_part, df_state_init)
-            return True
-        return False
-
-    def test_fortran_state_persistence(self):
-        """
-        Test if Fortran state persists between multiple calls in the same Python process.
-
-        This test passes if no difference is found between runs, fails if pollution is detected.
-        Runtime: ~68 seconds
-        """
-        print("\n" + "=" * 70)
-        print("FORTRAN STATE PERSISTENCE TEST")
-        print("=" * 70)
-
-        print("\n1. Clean baseline run...")
-        clean_qe = self.run_sample_year()
-        print(f"   Clean QE at timestep 286: {clean_qe:.6f}")
-
-        print("\n2. Running benchmark test (potential polluter)...")
-        benchmark_success = self.run_benchmark_test()
-        print(f"   Benchmark completed: {benchmark_success}")
-
-        print("\n3. Sample year run after benchmark (same Python process)...")
-        polluted_qe = self.run_sample_year()
-        print(f"   Polluted QE at timestep 286: {polluted_qe:.6f}")
-
-        diff = abs(clean_qe - polluted_qe)
-        print("\n*** RESULTS ***")
-        print(f"Difference: {diff:.6f}")
-
-        if diff > 1e-6:
-            print("*** FORTRAN STATE PERSISTENCE DETECTED ***")
-            print("The problem persists within the same Python process.")
-            print(
-                "This indicates Fortran module variables are not being reset between calls."
-            )
-            self.fail(f"Fortran state persistence detected: QE difference = {diff:.6f}")
-        else:
-            print("*** NO FORTRAN STATE PERSISTENCE ***")
-            print("The problem does not occur within the same Python process.")
-            print("Test PASSED: No state pollution detected.")
-
-    def test_multiple_consecutive_runs(self):
-        """
-        Test multiple consecutive runs to see if pollution accumulates.
-
-        Runtime: ~109 seconds
-        """
-        print("\n" + "=" * 70)
-        print("MULTIPLE CONSECUTIVE RUNS TEST")
-        print("=" * 70)
-
-        print("\n1. Initial clean run...")
-        baseline_qe = self.run_sample_year()
-        print(f"   Baseline QE: {baseline_qe:.6f}")
-
-        results = [baseline_qe]
-
-        # Run multiple polluter-target cycles
-        for i in range(3):
-            print(f"\n{i + 2}. Cycle {i + 1}: Polluter + Target...")
-
-            # Short polluter run
-            self.run_short_benchmark()
-
-            # Target run
-            cycle_qe = self.run_sample_year()
-            results.append(cycle_qe)
-
-            diff_from_baseline = abs(baseline_qe - cycle_qe)
-            print(
-                f"   Cycle {i + 1} QE: {cycle_qe:.6f} (diff from baseline: {diff_from_baseline:.6f})"
-            )
-
-        print("\n*** CONSECUTIVE RUNS RESULTS ***")
-        print(f"Baseline:  {results[0]:.6f}")
-        for i, qe in enumerate(results[1:], 1):
-            diff = abs(results[0] - qe)
-            print(f"Cycle {i}:   {qe:.6f} (diff: {diff:.6f})")
-
-        # Check if pollution is consistent or accumulating
-        diffs = [abs(results[0] - qe) for qe in results[1:]]
-        max_diff = max(diffs)
-        min_diff = min(diffs)
-
-        if max_diff > 1e-6:
-            print("\n*** POLLUTION CONFIRMED ***")
-            print(f"Max difference: {max_diff:.6f}")
-            print(f"Min difference: {min_diff:.6f}")
-
-            if max_diff - min_diff < 1e-8:
-                print("*** CONSISTENT POLLUTION - Same difference each time ***")
-                print("This suggests deterministic Fortran state pollution.")
-            else:
-                print("*** VARIABLE POLLUTION - Different differences ***")
-                print("This suggests accumulating or variable state pollution.")
-
-            self.fail(
-                f"Multiple consecutive runs show pollution: max diff = {max_diff:.6f}"
-            )
-        else:
-            print("*** NO POLLUTION DETECTED ***")
-            print("Test PASSED: No pollution in consecutive runs.")
-
-    def test_minimal_reproduction(self):
-        """
-        Create minimal reproduction case.
-
-        Runtime: ~42 seconds
-        """
-        print("\n" + "=" * 70)
-        print("MINIMAL REPRODUCTION TEST")
-        print("=" * 70)
-
-        print("\n1. Minimal clean run...")
-        clean_qe = self.run_sample_year()
-        print(f"   Clean QE: {clean_qe:.6f}")
-
-        print("\n2. Minimal polluter (just first day of benchmark)...")
-        success = self.run_short_benchmark()
-        print(f"   Short benchmark success: {success}")
-
-        print("\n3. Minimal target run...")
-        polluted_qe = self.run_sample_year()
-        print(f"   Polluted QE: {polluted_qe:.6f}")
-
-        diff = abs(clean_qe - polluted_qe)
-        print("\n*** MINIMAL REPRODUCTION RESULTS ***")
-        print(f"Difference: {diff:.6f}")
-
-        if diff > 1e-6:
-            print("*** MINIMAL REPRODUCTION SUCCESSFUL ***")
-            print("Even a short benchmark run causes pollution.")
-            self.fail(
-                f"Minimal reproduction shows pollution: QE difference = {diff:.6f}"
-            )
-        else:
-            print("*** MINIMAL REPRODUCTION PASSED ***")
-            print("Short benchmark run does not cause pollution.")
-            print("Test PASSED: No state pollution detected in minimal case.")
-
-
-if __name__ == "__main__":
-    import unittest
-
-    unittest.main()
+        np.testing.assert_array_equal(
+            output_observed,
+            output_expected,
+            err_msg=f"native output leaked across {first_case}->{second_case}",
+        )
+        assert state_observed == state_expected, (
+            f"native final state leaked across {first_case}->{second_case}"
+        )

--- a/test/core/test_fortran_state_persistence.py
+++ b/test/core/test_fortran_state_persistence.py
@@ -66,13 +66,13 @@ def _run_native_case(native_run_cases, case_name):
 
 @pytest.mark.core
 def test_native_state_isolated_across_order_matrix(native_run_cases):
-    """Fresh calls produce their isolated baseline in A/B and repeat orders."""
-    dict_baseline = {
+    """Each case is independent of whether A or B ran immediately before it."""
+    dict_reference = {
         case_name: _run_native_case(native_run_cases, case_name)
         for case_name in ("A", "B")
     }
-    output_a = dict_baseline["A"][0]
-    output_b = dict_baseline["B"][0]
+    output_a = dict_reference["A"][0]
+    output_b = dict_reference["B"][0]
     finite_difference = (
         np.isfinite(output_a) & np.isfinite(output_b) & (output_a != output_b)
     )
@@ -83,7 +83,7 @@ def test_native_state_isolated_across_order_matrix(native_run_cases):
         output_observed, state_observed = _run_native_case(
             native_run_cases, second_case
         )
-        output_expected, state_expected = dict_baseline[second_case]
+        output_expected, state_expected = dict_reference[second_case]
 
         np.testing.assert_array_equal(
             output_observed,

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -18,8 +18,8 @@ optimizations, and library implementations. Rather than pursuing bit-for-bit
 reproducibility, this test ensures results remain within scientifically
 acceptable bounds.
 
-This test runs first in CI/CD to provide fast feedback before expensive
-wheel building operations.
+This test is independent of collection order and can run alongside other
+physics validation.
 """
 
 import os

--- a/test/test_api_surface.py
+++ b/test/test_api_surface.py
@@ -16,6 +16,12 @@ import pytest
 
 pytestmark = pytest.mark.api
 
+_HISTORIC_NATIVE_ORDER_NODEIDS = (
+    "test/core/test_public_api_wrappers.py::TestPublicAPIEquivalence::test_functional_matches_oop",
+    "test/core/test_sample_output.py::TestSampleOutput::test_library_cli_parity",
+    "test/core/test_sample_output.py::TestSampleOutput::test_sample_output_validation",
+)
+
 
 class _CollectedItem:
     """Minimal pytest item surface used to exercise collection ordering."""
@@ -46,6 +52,32 @@ def test_collection_preserves_native_test_relative_order():
         "sample",
         "TestPublicAPIEquivalence::test_functional_matches_oop",
     ]
+
+
+@pytest.mark.core
+def test_historic_native_nodes_retain_requested_collection_order():
+    """Collect the exact nodes formerly moved by the native-state workaround."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            *_HISTORIC_NATIVE_ORDER_NODEIDS,
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    list_collected_nodeid = [
+        line
+        for line in result.stdout.splitlines()
+        if line in _HISTORIC_NATIVE_ORDER_NODEIDS
+    ]
+    assert list_collected_nodeid == list(_HISTORIC_NATIVE_ORDER_NODEIDS)
 
 
 # Files to skip when scanning for imports

--- a/test/test_api_surface.py
+++ b/test/test_api_surface.py
@@ -11,9 +11,42 @@ from pathlib import Path
 import subprocess
 import sys
 
+import conftest as suite_conftest
 import pytest
 
 pytestmark = pytest.mark.api
+
+
+class _CollectedItem:
+    """Minimal pytest item surface used to exercise collection ordering."""
+
+    def __init__(self, path, nodeid):
+        self.fspath = Path(path)
+        self.nodeid = nodeid
+
+
+@pytest.mark.core
+def test_collection_preserves_native_test_relative_order():
+    """Only the import-surface probe may move ahead of declared test order."""
+    items = [
+        _CollectedItem("test/physics/test_other.py", "other"),
+        _CollectedItem("test/core/test_sample_output.py", "sample"),
+        _CollectedItem(
+            "test/core/test_public_api_wrappers.py",
+            "TestPublicAPIEquivalence::test_functional_matches_oop",
+        ),
+        _CollectedItem("test/test_api_surface.py", "api_surface"),
+    ]
+
+    suite_conftest.pytest_collection_modifyitems(items)
+
+    assert [item.nodeid for item in items] == [
+        "api_surface",
+        "other",
+        "sample",
+        "TestPublicAPIEquivalence::test_functional_matches_oop",
+    ]
+
 
 # Files to skip when scanning for imports
 _SKIP_FILES = {"conftest.py", "debug_utils.py", "__init__.py"}

--- a/test/test_api_surface.py
+++ b/test/test_api_surface.py
@@ -16,10 +16,19 @@ import pytest
 
 pytestmark = pytest.mark.api
 
-_HISTORIC_NATIVE_ORDER_NODEIDS = (
-    "test/core/test_public_api_wrappers.py::TestPublicAPIEquivalence::test_functional_matches_oop",
+_HISTORIC_API_EQUIVALENCE_NODEID = (
+    "test/core/test_public_api_wrappers.py::TestPublicAPIEquivalence::"
+    "test_functional_matches_oop"
+)
+_HISTORIC_SAMPLE_OUTPUT_NODEIDS = (
     "test/core/test_sample_output.py::TestSampleOutput::test_library_cli_parity",
     "test/core/test_sample_output.py::TestSampleOutput::test_sample_output_validation",
+    "test/core/test_sample_output.py::TestSTEBBSOutput::"
+    "test_stebbs_building_energy_outputs",
+)
+_HISTORIC_NATIVE_ORDER_NODEIDS = (
+    _HISTORIC_API_EQUIVALENCE_NODEID,
+    *_HISTORIC_SAMPLE_OUTPUT_NODEIDS,
 )
 
 
@@ -64,11 +73,13 @@ def test_historic_native_nodes_retain_requested_collection_order():
             "pytest",
             "--collect-only",
             "-q",
-            *_HISTORIC_NATIVE_ORDER_NODEIDS,
+            _HISTORIC_API_EQUIVALENCE_NODEID,
+            "test/core/test_sample_output.py",
         ],
         cwd=Path(__file__).resolve().parents[1],
         text=True,
         capture_output=True,
+        timeout=60,
         check=False,
     )
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- Replace the documented 3.6-minute legacy full-year state suite with direct 24-step native-boundary order regressions.
- Stop moving sample-output and API-equivalence tests ahead of normal collection order; only the import-surface probe remains fail-fast.
- Bound the removed workaround to its complete historical node set and document the remaining native mutable-state inventory.

## Design

The current Rust/Fortran adapter materialises timer, configuration, site, and model state as call-local values, and resets the retained fatal-error state at entry.
Fresh `run_suews` calls therefore own fresh state, while continuation remains opt-in through `run_suews_with_state` and the returned JSON state.
A new reset API would duplicate that ownership boundary, so this change adds executable evidence at the boundary instead of production reset code.

A and B are physically distinct configurations.
Their clean references are generated in two separate fresh Python processes, so one reference cannot contaminate the other.
A->B, B->A, A->A, and B->B are separate parameterised pytest items; each transition launches a fresh process and performs both native calls consecutively inside that one process.
Both calls and their final JSON states must match the corresponding independently clean reference.

The collection regression executes the exact previously protected set in the requested order:

- `TestPublicAPIEquivalence::test_functional_matches_oop`
- `TestSampleOutput::test_library_cli_parity`
- `TestSampleOutput::test_sample_output_validation`
- `TestSTEBBSOutput::test_stebbs_building_energy_outputs`

The regression collects the whole `test_sample_output.py` file and compares every collected node against the explicit historical list, so another file-level omission cannot pass silently.
The collect-only subprocess has a 60-second timeout.

## Test-first evidence

Against the old same-process A-then-B reference scheme, the new isolation regression observed both references in PID 22355 and failed the distinct-process assertion: 1 failed in 2.53s.
After introducing independent reference processes, the focused regression is green.

## Validation

- Explicit local fixed-cap worksteal run, `pytest -n 2 --dist worksteal -vv test/core/test_fortran_state_persistence.py`: 6 passed in 59.36s.
  `gw0` ran B->A and A->A; `gw1` ran A->B and B->B plus the reference checks.
- Exact four-node historical execution set in API-first requested order: 4 passed in 1m50.69s.
- Complete bounded-set collection regression: 1 passed in 10.74s.
- `make test-smoke`: 26 passed, 1 skipped, 1,792 deselected in 3m50s.
- Prior full local suite on the same native-state implementation, before the bounded-list-only follow-up: 1,747 passed, 8 skipped, 64 deselected in 20m27s on one worker.
- Current-head hosted physics-full run [29442975771](https://github.com/UMEP-dev/SUEWS/actions/runs/29442975771): Linux Python 3.12 used `-n auto --maxprocesses=4 --dist worksteal -m physics`, created 4/4 workers, and passed 136 tests with 1 skip in 5m18s.
  All six native-state tests, including A->B, B->A, A->A, and B->B, executed and passed under the hosted scheduler; this run assigned them to `gw2`.
- Hosted wheel build passed in 10m11s; cross-CPython API jobs passed in 15m27s and 14m35s; final PR build validation passed.
- Ruff formatting and targeted lint, docstring checks, test-marker audit, pathlib encoding audit, dependency audit, and `git diff --check` pass.

## Native mutable-state inventory

- Active bridge calls materialise `SUEWS_TIMER`, `SUEWS_CONFIG`, `SUEWS_SITE`, and `SUEWS_STATE` locally.
- `module_ctrl_error_state` retains fatal-error fields with `SAVE`, but the C adapter calls `reset_supy_error()` at each entry.
- AnOHM retains `SAVE` declarations but is disabled and outside the active bridge path; explicit ownership or removal is required before reactivation.

## Residual scope

Current-head GitHub Actions are green against the merged fixed-cap worksteal scheduler from #1630.
This PR does not claim that the tree contains no `SAVE` state and does not refactor inactive AnOHM state.

Refs #1624