### PR TITLE
Complete durable CI test metrics

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: 'Whether this is a TestPyPI build (adds notice to README)'
     required: false
     default: 'false'
+  metrics_host_dir:
+    description: 'Host directory persisted across cibuildwheel containers for CI metrics'
+    required: true
 
 runs:
   using: 'composite'
@@ -59,7 +62,9 @@ runs:
 
     - name: Prepare cache directories
       shell: bash
-      run: mkdir -p .cargo-cache .rust-target-cache .pip-cache
+      env:
+        METRICS_HOST_DIR: ${{ inputs.metrics_host_dir }}
+      run: mkdir -p .cargo-cache .rust-target-cache .pip-cache "$METRICS_HOST_DIR"
 
     - name: Cache Rust/Cargo dependencies
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -108,8 +113,9 @@ runs:
           --volume ${{ github.workspace }}/.cargo-cache:/cargo-cache
           --volume ${{ github.workspace }}/.rust-target-cache:/rust-target-cache
           --volume ${{ github.workspace }}/.pip-cache:/pip-cache
+          --volume ${{ inputs.metrics_host_dir }}:/ci-metrics
         # CIBW_ENABLE: ${{ inputs.python == 'cp314' && 'cp314' || '' }}
-        CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+        CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS RUNNER_ARCH GITHUB_JOB
         # Use manylinux_2_28 for Python 3.13+ (newer dependencies require it), manylinux2014 for 3.12 (older Linux compatibility)
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ (inputs.python == 'cp313' || inputs.python == 'cp314') && 'manylinux_2_28' || 'manylinux2014' }}
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ (inputs.python == 'cp313' || inputs.python == 'cp314') && 'manylinux_2_28' || 'manylinux2014' }}
@@ -124,6 +130,9 @@ runs:
           CARGO_HOME=${{ github.workspace }}/.cargo-cache
           CARGO_TARGET_DIR=${{ github.workspace }}/.rust-target-cache
           SUEWS_KNOWLEDGE_GIT_SHA=${{ github.sha }}
+          SUEWS_CI_PHASES='${{ inputs.metrics_host_dir }}/physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-phases.json'
+          SUEWS_CI_METRICS_DIR='${{ inputs.metrics_host_dir }}'
+          SUEWS_CI_METRICS_NAME=physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
         # Platform-specific: Linux Fortran compiler and Rust toolchain settings
         # NOTE: CIBW_ENVIRONMENT_{PLATFORM} replaces (not merges with) CIBW_ENVIRONMENT,
         # so PIP_PREFER_BINARY and PIP_CACHE_DIR must be repeated here.
@@ -136,22 +145,31 @@ runs:
           CARGO_HOME=/cargo-cache
           CARGO_TARGET_DIR=/rust-target-cache
           SUEWS_KNOWLEDGE_GIT_SHA=${{ github.sha }}
+          SUEWS_CI_PHASES=/ci-metrics/physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-phases.json
+          SUEWS_CI_METRICS_DIR=/ci-metrics
+          SUEWS_CI_METRICS_NAME=physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
           PATH="/cargo-cache/bin:$PATH"
         CIBW_BEFORE_ALL_LINUX: >
+          python "{package}/scripts/suews/ci_phase_metrics.py" start toolchain_setup &&
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip setuptools wheel &&
+          python "{package}/scripts/suews/ci_phase_metrics.py" stop toolchain_setup
         CIBW_BEFORE_ALL_MACOS: >
+          python "{package}/scripts/suews/ci_phase_metrics.py" start toolchain_setup &&
           brew install gfortran &&
           brew unlink gfortran &&
-          brew link gfortran
+          brew link gfortran &&
+          python "{package}/scripts/suews/ci_phase_metrics.py" stop toolchain_setup
         # Windows MSYS2/pacman setup with two workarounds:
         # 1. Core package updates (pacman, msys2-runtime) terminate bash.exe via taskkill - use Windows-level
         #    error suppression (|| ver >nul) since bash can't execute || true when forcibly killed
         # 2. Mirror timeouts cause "Operation too slow" errors - use --disable-download-timeout + retry
         CIBW_BEFORE_ALL_WINDOWS: >
+          python "{package}/scripts/suews/ci_phase_metrics.py" start toolchain_setup &&
           (C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm --disable-download-timeout" || ver >nul) &&
           C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm --disable-download-timeout" &&
-          C:\msys64\usr\bin\bash.exe -lc "for i in 1 2 3; do pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-gcc-fortran mingw-w64-ucrt-x86_64-binutils mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-openblas && break || { echo Retry $i/3 && sleep 15; }; done"
+          C:\msys64\usr\bin\bash.exe -lc "for i in 1 2 3; do pacman -S --needed --noconfirm --disable-download-timeout mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-gcc-fortran mingw-w64-ucrt-x86_64-binutils mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-openblas && break || { echo Retry $i/3 && sleep 15; }; done" &&
+          python "{package}/scripts/suews/ci_phase_metrics.py" stop toolchain_setup
         # Platform-specific: Windows compiler and toolchain settings
         # NOTE: CIBW_ENVIRONMENT_{PLATFORM} replaces (not merges with) CIBW_ENVIRONMENT,
         # so CARGO_HOME/CARGO_TARGET_DIR, PIP_PREFER_BINARY, and PIP_CACHE_DIR
@@ -171,7 +189,13 @@ runs:
           CARGO_HOME='${{ github.workspace }}/.cargo-cache'
           CARGO_TARGET_DIR='${{ github.workspace }}/.rust-target-cache'
           SUEWS_KNOWLEDGE_GIT_SHA='${{ github.sha }}'
+          SUEWS_CI_PHASES='${{ inputs.metrics_host_dir }}\physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-phases.json'
+          SUEWS_CI_METRICS_DIR='${{ inputs.metrics_host_dir }}'
+          SUEWS_CI_METRICS_NAME=physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
+        CIBW_BEFORE_BUILD: >
+          python "{package}/scripts/suews/ci_phase_metrics.py" start build
         CIBW_BEFORE_BUILD_WINDOWS: >
+          python "{package}/scripts/suews/ci_phase_metrics.py" start build &&
           echo Creating setjmp compatibility library... &&
           echo int _setjmpex(void* buf) { extern int __intrinsic_setjmpex(void*); return __intrinsic_setjmpex(buf); } > setjmp_compat.c &&
           C:\msys64\ucrt64\bin\gcc.exe -c setjmp_compat.c -o setjmp_compat.o &&
@@ -188,7 +212,20 @@ runs:
           where gcc &&
           gcc --version &&
           pip install delvewheel
-        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+        CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+          python scripts/suews/ci_phase_metrics.py transition build repair &&
+          auditwheel repair -w {dest_dir} {wheel} &&
+          python scripts/suews/ci_phase_metrics.py stop repair
+        CIBW_REPAIR_WHEEL_COMMAND_MACOS: >-
+          python scripts/suews/ci_phase_metrics.py transition build repair &&
+          delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} &&
+          python scripts/suews/ci_phase_metrics.py stop repair
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+          python scripts/suews/ci_phase_metrics.py transition build repair &&
+          delvewheel repair -w {dest_dir} {wheel} &&
+          python scripts/suews/ci_phase_metrics.py stop repair
+        CIBW_BEFORE_TEST: >-
+          python "{package}/scripts/suews/ci_phase_metrics.py" start install
         # Pin the scheduler stack so distribution behaviour cannot drift between
         # CI runs. Re-benchmark the fixed-worker candidates before updating.
         CIBW_TEST_REQUIRES: pytest==9.1.1 pytest-xdist==3.8.0
@@ -215,6 +252,30 @@ runs:
               inputs.test_tier == 'all' && '-m physics' ||
               '-m physics' }}
         MACOSX_DEPLOYMENT_TARGET: '15.0'
+
+    - name: Finalise wheel CI metrics
+      if: always()
+      shell: bash
+      env:
+        SUEWS_CI_PHASES: ${{ inputs.metrics_host_dir }}/physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-phases.json
+        PYTEST_METRICS: ${{ inputs.metrics_host_dir }}/physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-pytest.json
+        WHEEL_METRICS: ${{ inputs.metrics_host_dir }}/physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-wheel-job.json
+        PHYSICS_JOB_NAME: physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
+      run: >-
+        python scripts/suews/ci_phase_metrics.py
+        --state "$SUEWS_CI_PHASES" finalise
+        --pytest "$PYTEST_METRICS"
+        --output "$WHEEL_METRICS"
+        --job-name "$PHYSICS_JOB_NAME"
+
+    - name: Upload wheel CI metrics
+      if: always()
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      with:
+        name: ci-metrics-physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
+        path: ${{ inputs.metrics_host_dir }}/*.json
+        if-no-files-found: error
+        retention-days: 14
 
     - name: Upload wheels
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/ci-metrics-needs.json
+++ b/.github/ci-metrics-needs.json
@@ -1,0 +1,31 @@
+{
+  "API cross-CPython tests / *": [
+    "Determine build matrix",
+    "Build standard wheels / *"
+  ],
+  "Build MCP package": [
+    "Create nightly tag for scheduled builds",
+    "Detect code changes",
+    "Verify tag is on master"
+  ],
+  "Build standard wheels / *": [
+    "Create nightly tag for scheduled builds",
+    "Detect code changes",
+    "Determine build matrix",
+    "Verify tag is on master"
+  ],
+  "Determine build matrix": [
+    "Detect code changes"
+  ],
+  "Post CI summary comment": [
+    "Detect code changes",
+    "Determine build matrix"
+  ],
+  "PR build validation": [
+    "API cross-CPython tests / *",
+    "Build MCP package",
+    "Build standard wheels / *",
+    "Check pytest marker axis",
+    "Detect code changes"
+  ]
+}

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -75,8 +75,11 @@ pyproject:
 ci:
   # CI workflows and build tooling
   - '.github/path-filters.yml'
+  - '.github/ci-metrics-needs.json'
   - '.github/workflows/build-publish_to_pypi.yml'
+  - '.github/workflows/build-wheels-reusable.yml'
   - '.github/workflows/cibuildwheel-debug.yml'
+  - '.github/workflows/ci-metrics-overhead.yml'
   - '.github/actions/build-suews/**'
   - '.github/scripts/**'
   - 'Makefile'

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -81,6 +81,8 @@ jobs:
           persist-credentials: false
       - name: Build current SUEWS (Fortran + Rust) + install supy
         uses: ./.github/actions/build-suews
+        with:
+          metrics_host_dir: ${{ runner.temp }}/suews-ci-metrics
       - name: Install benchmark requirements
         # The benchmark stats are vendored under benchmark/ (bench_stats.py); only
         # stdlib + numpy/pandas are needed at run time.

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -431,7 +431,7 @@ jobs:
       buildplat_json: ${{ needs.determine_matrix.outputs.buildplat }}
       python_json: ${{ needs.determine_matrix.outputs.python }}
       test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
-      is_testpypi_build: ${{ github.event_name == 'schedule' || (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev')) }}
+      is_testpypi_build: ${{ (github.event_name == 'schedule' || (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev'))) && 'true' || 'false' }}
 
   build_mcp:
     name: Build MCP package
@@ -540,6 +540,52 @@ jobs:
           CHECK_MARKERS_RESULT: ${{ needs.check_test_markers.result }}
           NEEDS_BUILD: ${{ needs.detect-changes.outputs.needs-build }}
         run: bash .github/scripts/pr-gate.sh
+
+  ci_observability:
+    name: CI observability summary
+    runs-on: ubuntu-latest
+    needs: [pr-gate]
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: |
+            .github/ci-metrics-needs.json
+            scripts/suews/analyse_ci_run.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download workflow and Jobs REST data
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          mkdir -p ci-metrics-workflow
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" > ci-metrics-workflow/run.json
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100" > ci-metrics-workflow/jobs.json
+
+      - name: Analyse declared workflow critical path
+        shell: bash
+        run: >-
+          python scripts/suews/analyse_ci_run.py
+          --run-json ci-metrics-workflow/run.json
+          --jobs-json ci-metrics-workflow/jobs.json
+          --needs-json .github/ci-metrics-needs.json
+          --target-job "PR build validation"
+          --output ci-metrics-workflow/workflow-ci-metrics.json
+          --summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload workflow CI metrics
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: ci-metrics-workflow-${{ github.run_id }}
+          path: ci-metrics-workflow/*.json
+          if-no-files-found: error
+          retention-days: 14
 
   deploy_testpypi:
     name: Publish to TestPyPI

--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -41,11 +41,30 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Start checkout phase timing
+        shell: bash
+        env:
+          SUEWS_CI_PHASES: ${{ runner.temp }}/suews-ci-metrics/physics-${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}-phases.json
+        run: >-
+          python -c "import json, os, time; from pathlib import Path;
+          path = Path(os.environ['SUEWS_CI_PHASES']);
+          path.parent.mkdir(parents=True, exist_ok=True);
+          payload = {'schema_version': 1, 'phases': {'checkout':
+          {'source': 'runner-step-wall-clock', 'started_at_epoch_seconds': time.time(),
+          'status': 'running'}}};
+          path.write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8')"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           submodules: recursive
           persist-credentials: false
+
+      - name: Stop checkout phase timing
+        shell: bash
+        env:
+          SUEWS_CI_PHASES: ${{ runner.temp }}/suews-ci-metrics/physics-${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}-phases.json
+        run: python scripts/suews/ci_phase_metrics.py stop checkout
 
       - name: Build SUEWS wheels
         uses: ./.github/actions/build-suews
@@ -56,3 +75,4 @@ jobs:
           python: ${{ matrix.python }}
           test_tier: ${{ inputs.test_tier }}
           is_testpypi_build: ${{ inputs.is_testpypi_build }}
+          metrics_host_dir: ${{ runner.temp }}/suews-ci-metrics

--- a/.github/workflows/ci-metrics-overhead.yml
+++ b/.github/workflows/ci-metrics-overhead.yml
@@ -1,0 +1,104 @@
+name: CI metrics overhead check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-metrics-overhead-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  default_branch_guard:
+    name: Require default branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check dispatched ref
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+            echo "::error::Dispatch this evidence workflow from the default branch."
+            exit 1
+          fi
+
+  build_wheel:
+    name: Build controlled wheel
+    needs: [default_branch_guard]
+    uses: ./.github/workflows/build-wheels-reusable.yml
+    with:
+      buildplat_json: '[["ubuntu-latest","manylinux","x86_64"]]'
+      python_json: '["cp312"]'
+      test_tier: smoke
+
+  paired_overhead:
+    name: Same-job metrics off/on comparison
+    runs-on: ubuntu-latest
+    needs: [build_wheel]
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Download the single controlled wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cp312-manylinux-x86_64
+          path: wheelhouse/
+
+      - name: Verify exactly one downloaded wheel
+        id: wheel
+        shell: bash
+        run: |
+          wheels=(wheelhouse/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ] || [ ! -f "${wheels[0]}" ]; then
+            echo "::error::Expected exactly one downloaded wheel; found ${#wheels[@]}."
+            exit 1
+          fi
+          echo "path=${wheels[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Install the wheel and pinned pytest scheduler
+        shell: bash
+        env:
+          CONTROLLED_WHEEL: ${{ steps.wheel.outputs.path }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0
+          python -m pip install "$CONTROLLED_WHEEL"
+
+      - name: Run fixed-worker metrics off/on/on/off trials
+        shell: bash
+        env:
+          CONTROLLED_WHEEL: ${{ steps.wheel.outputs.path }}
+        run: >-
+          python scripts/suews/benchmark_ci_metrics.py
+          --output-dir ci-metrics-overhead
+          --threshold-percent 2
+          --worker-count 4
+          --scheduler worksteal
+          --source-sha "${{ github.sha }}"
+          --wheel "$CONTROLLED_WHEEL"
+          -- python -m pytest test
+          -m "physics and not slow"
+          -q --tb=short
+          -n 4 --maxprocesses=4 --dist worksteal
+
+      - name: Upload raw trials and comparison manifest
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: ci-metrics-overhead-${{ github.run_id }}
+          path: ci-metrics-overhead/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -98,7 +98,7 @@ jobs:
           SUEWS_CI_METRICS: ci-metrics/api-${{ matrix.python_version }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}.json
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0
           python -m pip install wheelhouse/*.whl
           # Run in one process. xdist duplicates every session fixture per
           # worker; the API lane contains simulation outputs large enough to

--- a/scripts/suews/README.md
+++ b/scripts/suews/README.md
@@ -6,10 +6,10 @@ This directory contains utility scripts for development and maintenance.
 
 **Plugin**: `pytest_ci_metrics.py`
 
-The API test workflow loads this standalone pytest plugin to publish a compact
-machine-readable artefact and append the same run's headline measurements to
-the GitHub Actions step summary. The plugin observes pytest hooks only: it does
-not perform a second collection or test pass.
+The API and physics test workflows load this standalone pytest plugin to
+publish a compact machine-readable artefact and append the same run's headline
+measurements to the GitHub Actions step summary. The plugin observes pytest
+hooks only: it does not perform a second collection or test pass.
 
 Set `SUEWS_CI_METRICS` to the JSON output path and load the plugin explicitly:
 
@@ -20,26 +20,99 @@ SUEWS_CI_METRICS=ci-metrics.json \
 
 When `GITHUB_STEP_SUMMARY` is set, the plugin also appends a Markdown summary.
 
-### Schema version 1
+### Pytest schema version 2
 
-The top-level JSON fields are:
+Schema version 2 retains the version 1 top-level fields and adds execution,
+resource and warning details. It intentionally changes warning fingerprints
+to hash normalised rather than raw text, so consumers must check
+`schema_version` before interpreting fingerprints. The deterministic consumer
+fixture is `test/fixtures/ci_metrics/schema-v2-xdist.json`.
 
 | Field | Meaning |
 |---|---|
-| `schema_version` | Integer contract version, currently `1` |
+| `schema_version` | Integer contract version, currently `2` |
 | `generated_at` | UTC timestamp at artefact creation |
 | `environment` | Python and GitHub runner/job identity when available |
-| `result` | Pytest exit code |
-| `phases` | Collection, test-loop and whole-session durations in seconds |
+| `result` | Pytest exit code and stable passed/failed/skipped/xfailed/xpassed counts |
+| `phases` | Collection, test-loop and whole-session wall durations in seconds |
 | `inventory` | Collected node count and SHA-256 of sorted node IDs |
-| `execution` | Effective worker count and whether xdist was active |
-| `warnings` | Counts grouped by warning category and message, with stable SHA-256 fingerprints |
+| `execution` | Effective worker count, xdist flag and worker timeline |
+| `resources` | Process-tree CPU seconds and peak resident bytes with availability metadata |
+| `warnings` | Counts grouped by normalised warning fingerprint, retaining one raw sample message |
 
-The node fingerprint makes two CI cells directly comparable without storing
-the full collection in every artefact. Warning fingerprints deliberately omit
-source paths and line numbers so unchanged warnings remain grouped after code
-moves. Per-worker assignments, resource-tree peaks and workflow dependency-path
-analysis remain follow-up layers under issue #1623.
+For xdist, each `execution.workers` record contains the assigned node IDs,
+their count/hash, `busy_duration_seconds` and `finished_at_seconds`.
+Assignment means a node ID observed in that worker's pytest reports. Busy time
+is the sum of setup, call and teardown report durations. Finish time is the
+arrival of the worker's last test report, relative to the controller's
+test-loop start; it is not worker shutdown time. The execution object reports
+latest-minus-earliest finish skew and latest-minus-median tail. A serial run
+deliberately has `workers: []`, `xdist: false` and effective worker count 1.
+
+Linux resource measurement samples the controller process and its descendants
+through procfs every 0.25 seconds by default. CPU values retain the last
+observed cumulative total for an exited child. Peak RSS is the largest sampled
+sum of resident bytes across the live tree. `sample_count`, interval, status,
+method and reason are always explicit. Short-lived processes between samples
+can be missed, and procfs access/exit races are ignored safely. macOS and
+Windows records are explicitly unavailable rather than reported as zero.
+
+Warning grouping replaces workspace/temp roots, memory addresses and UUIDs in
+the fingerprint input. The first unmodified message remains in `message` for
+diagnosis, and the grouped representation is in `normalised_message`. Other
+numbers and paths are preserved so scientifically different warnings do not
+collapse together.
+
+### Wheel-job phase evidence
+
+Physics wheel jobs publish three files under one
+`ci-metrics-physics-<python>-<platform>-<arch>` artefact:
+
+- the schema version 2 pytest JSON;
+- raw cross-process phase boundaries;
+- a `wheel-job-ci-metrics` JSON combining checkout, toolchain setup, build,
+  repair, install, collection, tests and session durations.
+
+Checkout is timed around `actions/checkout`. The other build phases use
+cibuildwheel's before-all, before-build, repair and before-test/test-command
+boundaries. Linux writes through an explicit host-mounted metrics directory;
+macOS and Windows write to the host directory directly. Missing boundaries
+remain `unavailable` with a reason and can never look like measured zeroes.
+
+### Workflow critical-path view
+
+`analyse_ci_run.py` consumes the GitHub Actions run and Jobs REST payloads plus
+`.github/ci-metrics-needs.json`. It resolves the explicit `PR build validation`
+target, expands declared matrix dependencies and follows the latest-finishing
+predecessor through each fan-in. The output separates:
+
+- orchestration hand-off: dependency barrier to job creation;
+- runner queue: Jobs REST `created_at` to `started_at`;
+- execution: `started_at` to `completed_at`;
+- dependency fan-in spread: earliest to latest predecessor completion.
+
+The later `CI observability summary` job is excluded from the gate path. Step
+durations remain available in the workflow JSON, but they do not substitute
+for the explicit wheel-job phase artefact.
+
+Checkout, setup and install times vary with GitHub cache/network/service load
+and are execution-phase load, not proof of a pytest scheduling improvement.
+Compare scheduler candidates in the same job with the same wheel, inventory,
+worker cap and alternating order.
+
+### Controlled overhead evidence
+
+The manual `CI metrics overhead check` workflow runs only from the default
+branch. It verifies and installs one Linux wheel once, records the source SHA
+and wheel SHA-256, and runs the standard non-slow physics selection in
+the fixed order metrics-off/on/on/off. Every run uses four workers,
+`--maxprocesses=4`, work stealing, a unique base temporary directory and no
+pytest cache. It uploads four raw JSON files, captured logs and a comparison
+manifest. The median measured test-phase overhead must be no more than 2%.
+
+This manual same-job result is the acceptance evidence. Ordinary PR runs and
+unrelated historical runs cannot establish the overhead bound because GitHub
+host load is uncontrolled.
 
 ## Naming Convention Checker
 

--- a/scripts/suews/analyse_ci_run.py
+++ b/scripts/suews/analyse_ci_run.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Build a queue, execution and dependency-path view from Actions Jobs REST data."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from fnmatch import fnmatchcase
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_EXCLUDED_JOB_PATTERNS = ("CI observability summary",)
+
+
+def _timestamp(value: str) -> datetime:
+    """Parse a GitHub UTC timestamp."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _seconds(start: datetime, end: datetime) -> float:
+    """Return a non-negative duration rounded for stable JSON."""
+    return round(max(0.0, (end - start).total_seconds()), 6)
+
+
+def _matching_jobs(
+    jobs: list[dict[str, Any]],
+    pattern: str,
+) -> list[dict[str, Any]]:
+    """Resolve one declared-needs display-name pattern, including matrix children."""
+    return [job for job in jobs if fnmatchcase(job["name"], pattern)]
+
+
+def _dependency_patterns(
+    job_name: str,
+    declared_needs: dict[str, list[str]],
+) -> list[str]:
+    """Return all dependency patterns declared for a matching job pattern."""
+    patterns = []
+    for target_pattern, dependencies in declared_needs.items():
+        if fnmatchcase(job_name, target_pattern):
+            patterns.extend(dependencies)
+    return patterns
+
+
+def _prepare_jobs(
+    jobs_payload: dict[str, Any],
+    excluded_job_patterns: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    """Filter completed non-summary jobs and parse their timestamps."""
+    jobs = []
+    for raw_job in jobs_payload.get("jobs", []):
+        if any(
+            fnmatchcase(raw_job["name"], pattern) for pattern in excluded_job_patterns
+        ):
+            continue
+        if (
+            raw_job.get("status") != "completed"
+            or raw_job.get("conclusion") == "skipped"
+        ):
+            continue
+        if not all(
+            raw_job.get(field) for field in ("created_at", "started_at", "completed_at")
+        ):
+            continue
+        job = dict(raw_job)
+        job["_created"] = _timestamp(raw_job["created_at"])
+        job["_started"] = _timestamp(raw_job["started_at"])
+        job["_completed"] = _timestamp(raw_job["completed_at"])
+        jobs.append(job)
+    return jobs
+
+
+def _resolve_dependencies(
+    jobs: list[dict[str, Any]],
+    declared_needs: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    """Expand declared display-name patterns, including every matrix child."""
+    dependencies = {}
+    for job in jobs:
+        resolved = []
+        for pattern in _dependency_patterns(job["name"], declared_needs):
+            resolved.extend(
+                candidate["name"] for candidate in _matching_jobs(jobs, pattern)
+            )
+        dependencies[job["name"]] = sorted(set(resolved) - {job["name"]})
+    return dependencies
+
+
+def _step_records(job: dict[str, Any]) -> list[dict[str, Any]]:
+    """Reduce Actions step timestamps to named execution durations."""
+    records = []
+    for step in job.get("steps") or []:
+        if not step.get("started_at") or not step.get("completed_at"):
+            continue
+        records.append({
+            "duration_seconds": _seconds(
+                _timestamp(step["started_at"]),
+                _timestamp(step["completed_at"]),
+            ),
+            "name": step["name"],
+        })
+    return records
+
+
+def _job_record(
+    job: dict[str, Any],
+    dependencies: list[str],
+    jobs_by_name: dict[str, dict[str, Any]],
+    run_created: datetime,
+) -> dict[str, Any]:
+    """Build one queue/execution/fan-in record."""
+    dependency_jobs = [
+        jobs_by_name[name] for name in dependencies if name in jobs_by_name
+    ]
+    barrier = max(
+        (dependency["_completed"] for dependency in dependency_jobs),
+        default=run_created,
+    )
+    earliest_dependency = min(
+        (dependency["_completed"] for dependency in dependency_jobs),
+        default=barrier,
+    )
+    critical_predecessor = (
+        max(dependency_jobs, key=lambda dependency: dependency["_completed"])["name"]
+        if dependency_jobs
+        else None
+    )
+    return {
+        "completed_at": job["completed_at"],
+        "conclusion": job.get("conclusion"),
+        "created_at": job["created_at"],
+        "critical_predecessor": critical_predecessor,
+        "declared_dependencies": dependencies,
+        "execution_seconds": _seconds(job["_started"], job["_completed"]),
+        "fan_in_spread_seconds": _seconds(earliest_dependency, barrier),
+        "name": job["name"],
+        "orchestration_delay_seconds": _seconds(barrier, job["_created"]),
+        "ready_offset_seconds": _seconds(run_created, barrier),
+        "runner_queue_seconds": _seconds(job["_created"], job["_started"]),
+        "started_at": job["started_at"],
+        "steps": _step_records(job),
+    }
+
+
+def _trace_critical_path(
+    records_by_name: dict[str, dict[str, Any]],
+    target_name: str,
+) -> tuple[float, list[str]]:
+    """Follow the latest-finishing predecessor through the declared DAG."""
+    memo: dict[str, tuple[float, list[str]]] = {}
+
+    def visit(job_name: str, visiting: set[str]) -> tuple[float, list[str]]:
+        if job_name in memo:
+            return memo[job_name]
+        if job_name in visiting:
+            raise ValueError(f"Cycle in declared needs at {job_name}")
+        visiting.add(job_name)
+        record = records_by_name[job_name]
+        own_duration = sum(
+            record[field]
+            for field in (
+                "orchestration_delay_seconds",
+                "runner_queue_seconds",
+                "execution_seconds",
+            )
+        )
+        parent = record["critical_predecessor"]
+        if parent in records_by_name:
+            parent_duration, parent_path = visit(parent, visiting)
+        else:
+            parent_duration, parent_path = 0.0, []
+        visiting.remove(job_name)
+        result = round(parent_duration + own_duration, 6), [*parent_path, job_name]
+        memo[job_name] = result
+        return result
+
+    return visit(target_name, set())
+
+
+def analyse_run(
+    run: dict[str, Any],
+    jobs_payload: dict[str, Any],
+    *,
+    declared_needs: dict[str, list[str]] | None = None,
+    excluded_job_patterns: tuple[str, ...] = DEFAULT_EXCLUDED_JOB_PATTERNS,
+    target_job_pattern: str = "PR build validation",
+) -> dict[str, Any]:
+    """Separate dependency barriers, runner queues and execution on a declared DAG."""
+    run_created = _timestamp(run["created_at"])
+    jobs = _prepare_jobs(jobs_payload, excluded_job_patterns)
+    dependencies = _resolve_dependencies(jobs, declared_needs or {})
+    jobs_by_name = {job["name"]: job for job in jobs}
+    records_by_name = {
+        job["name"]: _job_record(
+            job,
+            dependencies[job["name"]],
+            jobs_by_name,
+            run_created,
+        )
+        for job in jobs
+    }
+
+    target_jobs = [job for job in jobs if fnmatchcase(job["name"], target_job_pattern)]
+    if len(target_jobs) != 1:
+        raise ValueError(
+            f"Expected one completed target matching {target_job_pattern!r}; "
+            f"found {len(target_jobs)}."
+        )
+    gate_job = target_jobs[0]
+    path_duration, path_names = _trace_critical_path(records_by_name, gate_job["name"])
+    path_records = [records_by_name[name] for name in path_names]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "workflow": {
+            "event": run.get("event"),
+            "gate_completed_at": gate_job["completed_at"],
+            "head_sha": run.get("head_sha"),
+            "id": run.get("id"),
+            "created_at": run["created_at"],
+            "elapsed_seconds": _seconds(run_created, gate_job["_completed"]),
+        },
+        "observed_critical_path": {
+            "max_fan_in_spread_seconds": round(
+                max(
+                    (record["fan_in_spread_seconds"] for record in path_records),
+                    default=0.0,
+                ),
+                6,
+            ),
+            "duration_seconds": path_duration,
+            "execution_seconds": round(
+                sum(record["execution_seconds"] for record in path_records),
+                6,
+            ),
+            "job_names": path_names,
+            "orchestration_delay_seconds": round(
+                sum(record["orchestration_delay_seconds"] for record in path_records),
+                6,
+            ),
+            "runner_queue_seconds": round(
+                sum(record["runner_queue_seconds"] for record in path_records),
+                6,
+            ),
+            "target_job": path_names[-1] if path_names else None,
+        },
+        "jobs": sorted(
+            records_by_name.values(), key=lambda record: record["created_at"]
+        ),
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _append_summary(path: Path, metrics: dict[str, Any]) -> None:
+    """Append a concise workflow critical-path view to a step summary."""
+    critical = metrics["observed_critical_path"]
+    lines = [
+        "## Workflow CI observability",
+        "",
+        f"Observed declared-needs path: `{' -> '.join(critical['job_names']) or 'none'}`",
+        "",
+        "| Critical-path component | Duration |",
+        "|---|---:|",
+        f"| Orchestration hand-off | {critical['orchestration_delay_seconds']:.1f} s |",
+        f"| Runner queue | {critical['runner_queue_seconds']:.1f} s |",
+        f"| Job execution | {critical['execution_seconds']:.1f} s |",
+        f"| Total | {critical['duration_seconds']:.1f} s |",
+        "",
+        f"Maximum dependency fan-in spread on this path: {critical['max_fan_in_spread_seconds']:.1f} s.",
+        "",
+        "Queue is `created_at -> started_at`; execution is `started_at -> completed_at`.",
+        "The summary job itself is excluded from the gate path.",
+        "",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines))
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-json", type=Path, required=True)
+    parser.add_argument("--jobs-json", type=Path, required=True)
+    parser.add_argument("--needs-json", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument("--target-job", default="PR build validation")
+    return parser
+
+
+def main() -> int:
+    """Run the workflow analysis CLI."""
+    args = _parser().parse_args()
+    run = json.loads(args.run_json.read_text(encoding="utf-8"))
+    jobs = json.loads(args.jobs_json.read_text(encoding="utf-8"))
+    needs = json.loads(args.needs_json.read_text(encoding="utf-8"))
+    metrics = analyse_run(
+        run,
+        jobs,
+        declared_needs=needs,
+        target_job_pattern=args.target_job,
+    )
+    _write_json(args.output, metrics)
+    if args.summary:
+        _append_summary(args.summary, metrics)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/suews/benchmark_ci_metrics.py
+++ b/scripts/suews/benchmark_ci_metrics.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Run a same-job metrics-off/on/on/off pytest overhead comparison."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+from statistics import median
+import subprocess
+import sys
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def compute_overhead(
+    baseline_seconds: list[float],
+    instrumented_seconds: list[float],
+    threshold_percent: float,
+) -> dict[str, Any]:
+    """Reduce paired durations to a median percentage overhead decision."""
+    if not baseline_seconds or not instrumented_seconds:
+        raise ValueError("Both baseline and instrumented trials are required.")
+    baseline_median = median(baseline_seconds)
+    instrumented_median = median(instrumented_seconds)
+    if baseline_median <= 0:
+        raise ValueError("Baseline median must be positive.")
+    overhead = ((instrumented_median / baseline_median) - 1.0) * 100.0
+    return {
+        "baseline_median_seconds": round(baseline_median, 6),
+        "instrumented_median_seconds": round(instrumented_median, 6),
+        "overhead_percent": round(overhead, 6),
+        "passed": overhead <= threshold_percent,
+        "threshold_percent": threshold_percent,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def file_sha256(path: Path) -> str:
+    """Hash the exact wheel installed for the paired run."""
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _run_trial(
+    command: list[str],
+    output_dir: Path,
+    mode: str,
+    suffix: str,
+) -> dict[str, Any]:
+    """Run one isolated control or instrumented pytest process."""
+    output_path = output_dir / f"metrics-{mode}-{suffix}.json"
+    env = os.environ.copy()
+    env.pop("GITHUB_STEP_SUMMARY", None)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(PROJECT_ROOT), env.get("PYTHONPATH", "")) if part
+    )
+    if mode == "on":
+        env["SUEWS_CI_METRICS"] = str(output_path)
+        env.pop("SUEWS_CI_PHASE_TIMER", None)
+        plugin = "scripts.suews.pytest_ci_metrics"
+    else:
+        env["SUEWS_CI_PHASE_TIMER"] = str(output_path)
+        env.pop("SUEWS_CI_METRICS", None)
+        plugin = "scripts.suews.pytest_phase_timer"
+    basetemp = output_dir / f"basetemp-{mode}-{suffix}"
+    completed = subprocess.run(
+        [
+            *command,
+            "--basetemp",
+            str(basetemp),
+            "-p",
+            "no:cacheprovider",
+            "-p",
+            plugin,
+        ],
+        cwd=PROJECT_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    (output_dir / f"metrics-{mode}-{suffix}.stdout.txt").write_text(
+        completed.stdout,
+        encoding="utf-8",
+    )
+    (output_dir / f"metrics-{mode}-{suffix}.stderr.txt").write_text(
+        completed.stderr,
+        encoding="utf-8",
+    )
+    if not output_path.exists():
+        raise RuntimeError(
+            f"{mode}-{suffix} produced no metrics (pytest exit {completed.returncode})"
+        )
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    if completed.returncode != 0 or payload["result"]["exit_code"] != 0:
+        raise RuntimeError(f"{mode}-{suffix} pytest failed; inspect captured logs")
+    return {
+        "file": output_path.name,
+        "inventory": payload["inventory"],
+        "mode": mode,
+        "tests_seconds": payload["phases"]["tests"]["duration_seconds"],
+    }
+
+
+def _option_value(command: list[str], option: str) -> str | None:
+    """Read either ``--option value`` or ``--option=value`` from a command."""
+    for index, argument in enumerate(command):
+        if argument == option and index + 1 < len(command):
+            return command[index + 1]
+        if argument.startswith(option + "="):
+            return argument.split("=", 1)[1]
+        if option == "-n" and argument.startswith("-n") and argument != "-n":
+            return argument[2:]
+    return None
+
+
+def validate_command(command: list[str], worker_count: int, scheduler: str) -> None:
+    """Require the command to enact the declared fixed scheduler contract."""
+    if not 1 <= worker_count <= 4:
+        raise ValueError("The controlled harness requires between 1 and 4 workers.")
+    actual_workers = _option_value(command, "-n")
+    actual_cap = _option_value(command, "--maxprocesses")
+    actual_scheduler = _option_value(command, "--dist")
+    if actual_workers != str(worker_count):
+        raise ValueError("The pytest -n value must equal --worker-count.")
+    if actual_cap != str(worker_count):
+        raise ValueError("pytest --maxprocesses must equal --worker-count.")
+    if actual_scheduler != scheduler:
+        raise ValueError("The pytest --dist value must equal --scheduler.")
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--threshold-percent", type=float, default=2.0)
+    parser.add_argument("--worker-count", type=int, required=True)
+    parser.add_argument("--scheduler", required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--wheel", type=Path, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main() -> int:
+    """Execute four alternating trials and write the comparison manifest."""
+    args = _parser().parse_args()
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise SystemExit("A pytest command is required after --.")
+    if args.threshold_percent < 0:
+        raise SystemExit("--threshold-percent must be non-negative.")
+    if not args.wheel.is_file():
+        raise SystemExit(f"Wheel not found: {args.wheel}")
+    try:
+        validate_command(command, args.worker_count, args.scheduler)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    order = (("off", "a"), ("on", "a"), ("on", "b"), ("off", "b"))
+    runs = [
+        _run_trial(command, args.output_dir, mode, suffix) for mode, suffix in order
+    ]
+    inventories = {
+        (run["inventory"]["node_count"], run["inventory"]["node_id_sha256"])
+        for run in runs
+    }
+    if len(inventories) != 1:
+        raise RuntimeError("Overhead trials collected different test inventories.")
+    comparison = compute_overhead(
+        [run["tests_seconds"] for run in runs if run["mode"] == "off"],
+        [run["tests_seconds"] for run in runs if run["mode"] == "on"],
+        args.threshold_percent,
+    )
+    manifest = {
+        "schema_version": 1,
+        "command": command,
+        "comparison": comparison,
+        "inventory": runs[0]["inventory"],
+        "order": [f"{mode}-{suffix}" for mode, suffix in order],
+        "provenance": {
+            "source_sha": args.source_sha,
+            "wheel_name": args.wheel.name,
+            "wheel_sha256": file_sha256(args.wheel),
+        },
+        "runs": runs,
+        "scheduler": {
+            "distribution": args.scheduler,
+            "worker_count": args.worker_count,
+        },
+    }
+    _write_json(args.output_dir / "comparison-manifest.json", manifest)
+    json.dump(manifest, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0 if comparison["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/suews/ci_phase_metrics.py
+++ b/scripts/suews/ci_phase_metrics.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Record cibuildwheel phase boundaries and combine them with pytest metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any
+
+SCHEMA_VERSION = 1
+REQUIRED_WHEEL_PHASES = ("checkout", "toolchain_setup", "build", "repair", "install")
+PYTEST_PHASES = ("collection", "tests", "session")
+
+
+def _read_state(path: Path) -> dict[str, Any]:
+    """Read a phase state file or return an empty state."""
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "phases": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON atomically across phase subprocesses."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def start_phase(
+    path: Path,
+    phase: str,
+    *,
+    now: float | None = None,
+    source: str = "cibuildwheel-hook-wall-clock",
+) -> None:
+    """Record the start boundary for one phase."""
+    state = _read_state(path)
+    existing = state["phases"].get(phase)
+    if existing and existing.get("status") == "running":
+        raise ValueError(f"Phase {phase!r} is already running.")
+    state["phases"][phase] = {
+        "source": source,
+        "started_at_epoch_seconds": time.time() if now is None else now,
+        "status": "running",
+    }
+    _write_json(path, state)
+
+
+def stop_phase(path: Path, phase: str, *, now: float | None = None) -> None:
+    """Record the completion boundary for one running phase."""
+    state = _read_state(path)
+    record = state["phases"].get(phase)
+    if not record or record.get("status") != "running":
+        raise ValueError(f"Phase {phase!r} has no running start boundary.")
+    completed = time.time() if now is None else now
+    started = float(record["started_at_epoch_seconds"])
+    if completed < started:
+        raise ValueError(f"Phase {phase!r} completed before it started.")
+    record.update({
+        "completed_at_epoch_seconds": completed,
+        "duration_seconds": round(completed - started, 6),
+        "status": "measured",
+    })
+    _write_json(path, state)
+
+
+def transition_phase(
+    path: Path,
+    from_phase: str,
+    to_phase: str,
+    *,
+    now: float | None = None,
+    source: str = "cibuildwheel-hook-wall-clock",
+) -> None:
+    """Close one phase and open the next at the same wall-clock boundary."""
+    boundary = time.time() if now is None else now
+    stop_phase(path, from_phase, now=boundary)
+    start_phase(path, to_phase, now=boundary, source=source)
+
+
+def _measured_phase(record: dict[str, Any]) -> dict[str, Any]:
+    """Reduce internal timestamps to the published phase contract."""
+    return {
+        "available": True,
+        "duration_seconds": record["duration_seconds"],
+        "reason": None,
+        "source": record["source"],
+        "status": "measured",
+    }
+
+
+def _unavailable_phase(phase: str) -> dict[str, Any]:
+    """Publish a missing phase explicitly rather than as zero seconds."""
+    return {
+        "available": False,
+        "duration_seconds": None,
+        "reason": f"No completed {phase} boundary was recorded.",
+        "source": None,
+        "status": "unavailable",
+    }
+
+
+def read_pytest_metrics(path: Path) -> dict[str, Any]:
+    """Read pytest metrics or describe an earlier wheel-job failure."""
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "available": False,
+        "reason": "The wheel job failed before pytest metrics were written.",
+        "schema_version": None,
+        "result": None,
+        "phases": None,
+        "inventory": None,
+        "resources": None,
+    }
+
+
+def finalise_evidence(
+    state_path: Path,
+    pytest_metrics: dict[str, Any],
+    *,
+    job_name: str,
+) -> dict[str, Any]:
+    """Combine wheel boundaries and pytest schema v2 into one job artefact."""
+    state = _read_state(state_path)
+    phases = {}
+    for phase in REQUIRED_WHEEL_PHASES:
+        record = state["phases"].get(phase, {})
+        phases[phase] = (
+            _measured_phase(record)
+            if record.get("status") == "measured"
+            else _unavailable_phase(phase)
+        )
+    pytest_phases = pytest_metrics.get("phases") or {}
+    for phase in PYTEST_PHASES:
+        pytest_phase = pytest_phases.get(phase)
+        if pytest_phase and "duration_seconds" in pytest_phase:
+            phases[phase] = {
+                "available": True,
+                "duration_seconds": pytest_phase["duration_seconds"],
+                "reason": None,
+                "source": "pytest-hook",
+                "status": "measured",
+            }
+        else:
+            phases[phase] = _unavailable_phase(phase)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "wheel-job-ci-metrics",
+        "job_name": job_name,
+        "phases": phases,
+        "pytest_metrics": pytest_metrics,
+    }
+
+
+def _phase_summary_value(record: dict[str, Any]) -> str:
+    """Render a measured or explicitly unavailable phase."""
+    if record.get("available"):
+        return f"{record['duration_seconds']:.3f} s"
+    return f"unavailable ({record.get('reason', 'no reason recorded')})"
+
+
+def _resource_summary_value(record: dict[str, Any], *, bytes_value: bool) -> str:
+    """Render one resource measurement without inventing a zero."""
+    if record.get("available"):
+        value = float(record["value"])
+        if bytes_value:
+            return f"{value / (1024 * 1024):.1f} MiB"
+        return f"{value:.3f} s"
+    return str(record.get("status", "unavailable"))
+
+
+def append_step_summary(path: Path, evidence: dict[str, Any]) -> None:
+    """Append a compact host-side wheel, pytest and resource summary."""
+    phases = evidence["phases"]
+    pytest_metrics = evidence["pytest_metrics"]
+    inventory = pytest_metrics.get("inventory") or {}
+    resources = pytest_metrics.get("resources") or {}
+    cpu = resources.get("process_tree_cpu_seconds", {})
+    rss = resources.get("process_tree_peak_rss_bytes", {})
+    lines = [
+        f"## Wheel job CI metrics: {evidence['job_name']}",
+        "",
+        "| Measurement | Value |",
+        "|---|---:|",
+    ]
+    phase_labels = {
+        "checkout": "Checkout",
+        "toolchain_setup": "Toolchain Setup",
+        "build": "Build",
+        "repair": "Repair",
+        "install": "Install",
+        "collection": "Collection",
+        "tests": "Tests",
+    }
+    lines.extend(
+        f"| {label} | {_phase_summary_value(phases[phase])} |"
+        for phase, label in phase_labels.items()
+    )
+    lines.extend([
+        f"| Collected tests | {inventory.get('node_count', 'unavailable')} |",
+        f"| Process-tree CPU | {_resource_summary_value(cpu, bytes_value=False)} |",
+        f"| Process-tree peak RSS | {_resource_summary_value(rss, bytes_value=True)} |",
+        "",
+        f"Coverage fingerprint: `{inventory.get('node_id_sha256') or 'unavailable'}`",
+        "",
+    ])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines))
+
+
+def _state_path(argument: Path | None) -> Path:
+    """Resolve the CLI state path from an argument or environment."""
+    if argument is not None:
+        return argument
+    environment_path = os.environ.get("SUEWS_CI_PHASES")
+    if not environment_path:
+        raise SystemExit("Set SUEWS_CI_PHASES or pass --state.")
+    return Path(environment_path)
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state", type=Path)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    start = subparsers.add_parser("start")
+    start.add_argument("phase")
+    start.add_argument("--source", default="cibuildwheel-hook-wall-clock")
+    stop = subparsers.add_parser("stop")
+    stop.add_argument("phase")
+    transition = subparsers.add_parser("transition")
+    transition.add_argument("from_phase")
+    transition.add_argument("to_phase")
+    transition.add_argument("--source", default="cibuildwheel-hook-wall-clock")
+    finalise = subparsers.add_parser("finalise")
+    finalise.add_argument("--pytest", type=Path, required=True)
+    finalise.add_argument("--output", type=Path, required=True)
+    finalise.add_argument("--job-name", required=True)
+    return parser
+
+
+def main() -> int:
+    """Execute one phase-boundary or finalisation operation."""
+    args = _parser().parse_args()
+    state_path = _state_path(args.state)
+    if args.command == "start":
+        start_phase(state_path, args.phase, source=args.source)
+    elif args.command == "stop":
+        stop_phase(state_path, args.phase)
+    elif args.command == "transition":
+        transition_phase(
+            state_path,
+            args.from_phase,
+            args.to_phase,
+            source=args.source,
+        )
+    else:
+        pytest_metrics = read_pytest_metrics(args.pytest)
+        evidence = finalise_evidence(
+            state_path,
+            pytest_metrics,
+            job_name=args.job_name,
+        )
+        _write_json(args.output, evidence)
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            append_step_summary(Path(summary_path), evidence)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/suews/pytest_ci_metrics.py
+++ b/scripts/suews/pytest_ci_metrics.py
@@ -2,7 +2,8 @@
 
 Load this module as a pytest plugin and set ``SUEWS_CI_METRICS`` to the output
 path. The plugin performs no additional collection or test execution: it only
-records timestamps and data already exposed by pytest hooks.
+records timestamps and data already exposed by pytest hooks. On Linux, a small
+background sampler reads procfs for process-tree CPU time and peak RSS.
 """
 
 from __future__ import annotations
@@ -15,14 +16,35 @@ import json
 import os
 from pathlib import Path
 import platform
+import re
+from statistics import median
+import sys
+import tempfile
+from threading import Event, Thread
 import time
 from typing import Any
 import warnings
 
 import pytest
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 SUMMARY_WARNING_LIMIT = 10
+OUTCOME_NAMES = ("passed", "failed", "skipped", "xfailed", "xpassed")
+DEFAULT_SAMPLE_INTERVAL_SECONDS = 0.25
+_ADDRESS_RE = re.compile(r"0x[0-9a-fA-F]+")
+_UUID_RE = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-"
+    r"[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\b"
+)
+
+
+@dataclass
+class _WorkerMetrics:
+    """Measurements attributed to one xdist worker."""
+
+    node_ids: set[str] = field(default_factory=set)
+    busy_duration_seconds: float = 0.0
+    finished_at_seconds: float | None = None
 
 
 @dataclass
@@ -30,22 +52,230 @@ class _MetricsState:
     """Mutable measurements for one pytest controller process."""
 
     session_started: float = 0.0
+    test_phase_started: float = 0.0
     collection_seconds: float = 0.0
     tests_seconds: float = 0.0
     node_ids: list[str] = field(default_factory=list)
     warning_counts: Counter[tuple[str, str]] = field(default_factory=Counter)
+    warning_samples: dict[tuple[str, str], str] = field(default_factory=dict)
+    node_outcomes: dict[str, str] = field(default_factory=dict)
+    workers: dict[str, _WorkerMetrics] = field(default_factory=dict)
     effective_worker_count: int = 1
     uses_xdist: bool = False
+    resource_sampler: ProcfsSampler | None = None
 
-    def reset(self) -> None:
+    def reset(self, *, collect_resources: bool) -> None:
         """Clear measurements when pytest is invoked again in one process."""
+        if self.resource_sampler is not None:
+            self.resource_sampler.stop()
         self.session_started = time.perf_counter()
+        self.test_phase_started = 0.0
         self.collection_seconds = 0.0
         self.tests_seconds = 0.0
         self.node_ids.clear()
         self.warning_counts.clear()
+        self.warning_samples.clear()
+        self.node_outcomes.clear()
+        self.workers.clear()
         self.effective_worker_count = 1
         self.uses_xdist = False
+        self.resource_sampler = ProcfsSampler.from_environment()
+        if collect_resources:
+            self.resource_sampler.start()
+
+
+class ProcfsSampler:
+    """Sample the current process tree through Linux procfs."""
+
+    def __init__(
+        self,
+        interval_seconds: float,
+        *,
+        proc_root: Path = Path("/proc"),
+    ) -> None:
+        self.interval_seconds = interval_seconds
+        self.proc_root = proc_root
+        self.root_pid = os.getpid()
+        self.stop_event = Event()
+        self.thread: Thread | None = None
+        self.sample_count = 0
+        self.peak_rss_bytes = 0
+        self.cpu_seconds_by_process: dict[tuple[int, int], float] = {}
+        self.error_reason: str | None = None
+        self.supported = sys.platform.startswith("linux") and proc_root.is_dir()
+        self.clock_ticks = float(os.sysconf("SC_CLK_TCK")) if self.supported else 1.0
+        self.page_size = int(os.sysconf("SC_PAGE_SIZE")) if self.supported else 1
+
+    @classmethod
+    def from_environment(cls) -> ProcfsSampler:
+        """Build a sampler with a bounded user-selectable interval."""
+        raw_interval = os.environ.get("SUEWS_CI_RESOURCE_SAMPLE_INTERVAL", "")
+        try:
+            interval = (
+                float(raw_interval) if raw_interval else DEFAULT_SAMPLE_INTERVAL_SECONDS
+            )
+        except ValueError:
+            interval = DEFAULT_SAMPLE_INTERVAL_SECONDS
+        return cls(min(5.0, max(0.05, interval)))
+
+    def start(self) -> None:
+        """Start sampling when procfs is supported."""
+        if not self.supported:
+            return
+        self.thread = Thread(target=self._run, name="suews-ci-resources", daemon=True)
+        self.thread.start()
+
+    def stop(self) -> None:
+        """Stop sampling and retain the last CPU value for exited children."""
+        if self.thread is None:
+            return
+        self.stop_event.set()
+        self.thread.join(timeout=max(1.0, self.interval_seconds * 2))
+        self.thread = None
+
+    def measurements(self) -> dict[str, Any]:
+        """Return resource values with explicit support metadata."""
+        base = {
+            "sample_count": self.sample_count,
+            "sample_interval_seconds": round(self.interval_seconds, 6),
+        }
+        if not self.supported:
+            reason = "Process-tree sampling requires Linux procfs."
+            return {
+                **base,
+                "process_tree_cpu_seconds": _unavailable("seconds", reason),
+                "process_tree_peak_rss_bytes": _unavailable("bytes", reason),
+            }
+        if self.sample_count == 0:
+            reason = self.error_reason or "No readable procfs samples were captured."
+            return {
+                **base,
+                "process_tree_cpu_seconds": _unavailable(
+                    "seconds", reason, status="error"
+                ),
+                "process_tree_peak_rss_bytes": _unavailable(
+                    "bytes", reason, status="error"
+                ),
+            }
+        return {
+            **base,
+            "process_tree_cpu_seconds": _available(
+                "seconds",
+                round(sum(self.cpu_seconds_by_process.values()), 6),
+            ),
+            "process_tree_peak_rss_bytes": _available("bytes", self.peak_rss_bytes),
+        }
+
+    def _run(self) -> None:
+        """Sample immediately, then at the configured interval."""
+        while not self.stop_event.is_set():
+            try:
+                self._sample()
+            except (OSError, ValueError) as error:
+                self.error_reason = f"procfs sample failed: {type(error).__name__}"
+            self.stop_event.wait(self.interval_seconds)
+        try:
+            self._sample()
+        except (OSError, ValueError) as error:
+            self.error_reason = f"final procfs sample failed: {type(error).__name__}"
+
+    def _sample(self) -> None:
+        """Read current descendants while tolerating child exit races."""
+        pending = [self.root_pid]
+        seen: set[int] = set()
+        total_rss_bytes = 0
+        root_read = False
+        while pending:
+            pid = pending.pop()
+            if pid in seen:
+                continue
+            seen.add(pid)
+            pending.extend(_proc_children(pid, proc_root=self.proc_root))
+            process = read_proc_process(
+                pid,
+                self.clock_ticks,
+                self.page_size,
+                proc_root=self.proc_root,
+            )
+            if process is None:
+                continue
+            start_time, cpu_seconds, rss_bytes = process
+            root_read = root_read or pid == self.root_pid
+            key = (pid, start_time)
+            self.cpu_seconds_by_process[key] = max(
+                cpu_seconds,
+                self.cpu_seconds_by_process.get(key, 0.0),
+            )
+            total_rss_bytes += rss_bytes
+        if root_read:
+            self.sample_count += 1
+            self.peak_rss_bytes = max(self.peak_rss_bytes, total_rss_bytes)
+
+
+def _proc_children(pid: int, *, proc_root: Path = Path("/proc")) -> list[int]:
+    """Return direct children for a live Linux process."""
+    path = proc_root / str(pid) / "task" / str(pid) / "children"
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, PermissionError, ProcessLookupError, OSError):
+        return []
+    return [int(child) for child in content.split()] if content else []
+
+
+def read_proc_process(
+    pid: int,
+    clock_ticks: float,
+    page_size: int,
+    *,
+    proc_root: Path = Path("/proc"),
+) -> tuple[int, float, int] | None:
+    """Read start time, cumulative CPU and resident pages from procfs stat."""
+    path = proc_root / str(pid) / "stat"
+    try:
+        stat = path.read_text(encoding="utf-8")
+        fields = stat[stat.rfind(")") + 2 :].split()
+        cpu_seconds = (float(fields[11]) + float(fields[12])) / clock_ticks
+        start_time = int(fields[19])
+        rss_bytes = max(0, int(fields[21])) * page_size
+    except (
+        FileNotFoundError,
+        PermissionError,
+        ProcessLookupError,
+        OSError,
+        ValueError,
+        IndexError,
+    ):
+        return None
+    return start_time, cpu_seconds, rss_bytes
+
+
+def _available(unit: str, value: Any) -> dict[str, Any]:
+    """Build a populated resource measurement."""
+    return {
+        "available": True,
+        "method": "linux-procfs-sampling",
+        "reason": None,
+        "status": "sampled",
+        "unit": unit,
+        "value": value,
+    }
+
+
+def _unavailable(
+    unit: str,
+    reason: str,
+    *,
+    status: str = "unavailable",
+) -> dict[str, Any]:
+    """Build an explicit unavailable resource measurement."""
+    return {
+        "available": False,
+        "method": None,
+        "reason": reason,
+        "status": status,
+        "unit": unit,
+        "value": None,
+    }
 
 
 _STATE = _MetricsState()
@@ -66,20 +296,85 @@ def _inventory(node_ids: list[str]) -> dict[str, Any]:
     }
 
 
-def _warning_records(
-    counts: Counter[tuple[str, str]],
-) -> list[dict[str, Any]]:
-    """Group warnings by category and message with a stable fingerprint."""
+def _normalise_warning_message(message: str) -> str:
+    """Replace volatile path, address and UUID components before hashing."""
+    normalised = message
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        normalised = normalised.replace(workspace, "<workspace>")
+        normalised = normalised.replace(workspace.replace("/", "\\"), "<workspace>")
+
+    temp_root = tempfile.gettempdir().rstrip("/\\")
+    roots = {temp_root}
+    if temp_root.startswith("/var/"):
+        roots.add("/private" + temp_root)
+    for root in sorted(roots, key=len, reverse=True):
+        pattern = re.compile(re.escape(root) + r"[/\\](?:tmp|pytest-of-)[^/\\\s:]+")
+        normalised = pattern.sub("<temp>", normalised)
+    normalised = re.sub(
+        r"(?:/tmp|/var/tmp)[/\\](?:tmp|pytest-of-)[^/\\\s:]+",
+        "<temp>",
+        normalised,
+    )
+    normalised = re.sub(
+        r"[A-Za-z]:\\[^\s:]*\\Temp\\(?:tmp|pytest-of-)[^\\\s:]+",
+        "<temp>",
+        normalised,
+        flags=re.IGNORECASE,
+    )
+    normalised = _ADDRESS_RE.sub("0x<address>", normalised)
+    return _UUID_RE.sub("<uuid>", normalised)
+
+
+def _warning_records() -> list[dict[str, Any]]:
+    """Group warnings by category and normalised message fingerprint."""
     records = []
-    for (category, message), count in sorted(counts.items()):
-        fingerprint = hashlib.sha256(f"{category}\n{message}".encode()).hexdigest()
+    for (category, normalised_message), count in sorted(_STATE.warning_counts.items()):
+        fingerprint = hashlib.sha256(
+            f"{category}\n{normalised_message}".encode()
+        ).hexdigest()
+        key = (category, normalised_message)
         records.append({
             "category": category,
             "count": count,
             "fingerprint": fingerprint,
-            "message": message,
+            "message": _STATE.warning_samples[key],
+            "normalised_message": normalised_message,
         })
     return records
+
+
+def _outcomes() -> dict[str, int]:
+    """Return stable outcome keys, including zero-count outcomes."""
+    counts = Counter(_STATE.node_outcomes.values())
+    return {name: counts[name] for name in OUTCOME_NAMES}
+
+
+def _worker_records() -> tuple[list[dict[str, Any]], float, float]:
+    """Serialise assignments and final-test completion spread."""
+    records = []
+    finishes = []
+    for worker_id, worker in sorted(_STATE.workers.items()):
+        node_ids = sorted(worker.node_ids)
+        inventory = _inventory(node_ids)
+        finish = worker.finished_at_seconds
+        if finish is not None:
+            finishes.append(finish)
+        records.append({
+            "busy_duration_seconds": round(worker.busy_duration_seconds, 6),
+            "finished_at_seconds": None if finish is None else round(finish, 6),
+            **inventory,
+            "node_ids": node_ids,
+            "worker_id": worker_id,
+        })
+    if len(finishes) < 2:
+        return records, 0.0, 0.0
+    latest = max(finishes)
+    return (
+        records,
+        round(latest - min(finishes), 6),
+        round(latest - median(finishes), 6),
+    )
 
 
 def _metrics(exit_code: int, session_seconds: float) -> dict[str, Any]:
@@ -88,6 +383,8 @@ def _metrics(exit_code: int, session_seconds: float) -> dict[str, Any]:
     def duration(seconds: float) -> dict[str, float]:
         return {"duration_seconds": round(seconds, 6)}
 
+    workers, finish_skew, tail_over_median = _worker_records()
+    sampler = _STATE.resource_sampler or ProcfsSampler.from_environment()
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
@@ -97,7 +394,7 @@ def _metrics(exit_code: int, session_seconds: float) -> dict[str, Any]:
             "runner_arch": os.environ.get("RUNNER_ARCH"),
             "runner_os": os.environ.get("RUNNER_OS"),
         },
-        "result": {"exit_code": exit_code},
+        "result": {"exit_code": exit_code, "outcomes": _outcomes()},
         "phases": {
             "collection": duration(_STATE.collection_seconds),
             "session": duration(session_seconds),
@@ -106,9 +403,13 @@ def _metrics(exit_code: int, session_seconds: float) -> dict[str, Any]:
         "inventory": _inventory(_STATE.node_ids),
         "execution": {
             "effective_worker_count": _STATE.effective_worker_count,
+            "worker_finish_skew_seconds": finish_skew,
+            "worker_tail_over_median_seconds": tail_over_median,
+            "workers": workers,
             "xdist": _STATE.uses_xdist,
         },
-        "warnings": _warning_records(_STATE.warning_counts),
+        "resources": sampler.measurements(),
+        "warnings": _warning_records(),
     }
 
 
@@ -128,7 +429,14 @@ def _append_step_summary(path: Path, metrics: dict[str, Any]) -> None:
     phases = metrics["phases"]
     inventory = metrics["inventory"]
     execution = metrics["execution"]
+    resources = metrics["resources"]
     warning_records = metrics["warnings"]
+    cpu = resources["process_tree_cpu_seconds"]
+    rss = resources["process_tree_peak_rss_bytes"]
+    cpu_value = f"{cpu['value']:.3f} s" if cpu["available"] else cpu["status"]
+    rss_value = (
+        f"{rss['value'] / (1024 * 1024):.1f} MiB" if rss["available"] else rss["status"]
+    )
     lines = [
         "## Pytest CI metrics",
         "",
@@ -139,6 +447,9 @@ def _append_step_summary(path: Path, metrics: dict[str, Any]) -> None:
         f"| Collection | {phases['collection']['duration_seconds']:.3f} s |",
         f"| Tests | {phases['tests']['duration_seconds']:.3f} s |",
         f"| Session | {phases['session']['duration_seconds']:.3f} s |",
+        f"| Worker finish skew | {execution['worker_finish_skew_seconds']:.3f} s |",
+        f"| Process-tree CPU | {cpu_value} |",
+        f"| Process-tree peak RSS | {rss_value} |",
         "",
         f"Coverage fingerprint: `{inventory['node_id_sha256']}`",
         "",
@@ -170,8 +481,10 @@ def _append_step_summary(path: Path, metrics: dict[str, Any]) -> None:
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
-    """Reset state and start the whole-session timer."""
-    _STATE.reset()
+    """Reset state and start whole-session and resource measurements."""
+    output_requested = bool(os.environ.get("SUEWS_CI_METRICS"))
+    is_worker = hasattr(session.config, "workerinput")
+    _STATE.reset(collect_resources=output_requested and not is_worker)
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -193,6 +506,8 @@ def pytest_xdist_setupnodes(config: pytest.Config, specs: list[Any]) -> None:
     """Capture the resolved worker count, including ``-n auto`` runs."""
     _STATE.uses_xdist = True
     _STATE.effective_worker_count = len(specs)
+    for spec in specs:
+        _STATE.workers.setdefault(str(spec.id), _WorkerMetrics())
 
 
 @pytest.hookimpl(optionalhook=True)
@@ -206,8 +521,46 @@ def pytest_xdist_node_collection_finished(node: Any, ids: list[str]) -> None:
 def pytest_runtestloop(session: pytest.Session):
     """Measure the test phase around pytest's existing run loop."""
     started = time.perf_counter()
+    _STATE.test_phase_started = started
     yield
     _STATE.tests_seconds += time.perf_counter() - started
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Record outcomes and xdist assignments from existing reports."""
+    _record_outcome(report)
+    worker_id = getattr(report, "worker_id", None)
+    if worker_id is None:
+        return
+    worker = _STATE.workers.setdefault(str(worker_id), _WorkerMetrics())
+    worker.node_ids.add(report.nodeid)
+    worker.busy_duration_seconds += max(0.0, float(report.duration))
+    if _STATE.test_phase_started:
+        worker.finished_at_seconds = max(
+            0.0,
+            time.perf_counter() - _STATE.test_phase_started,
+        )
+
+
+def _record_outcome(report: pytest.TestReport) -> None:
+    """Store one terminal outcome per node, allowing teardown failures to win."""
+    if report.when == "setup":
+        if report.failed:
+            _STATE.node_outcomes[report.nodeid] = "failed"
+        elif report.skipped:
+            _STATE.node_outcomes[report.nodeid] = "skipped"
+        return
+    if report.when == "call":
+        was_xfail = hasattr(report, "wasxfail")
+        if report.skipped and was_xfail:
+            outcome = "xfailed"
+        elif report.passed and was_xfail:
+            outcome = "xpassed"
+        else:
+            outcome = report.outcome
+        _STATE.node_outcomes[report.nodeid] = outcome
+    elif report.when == "teardown" and report.failed:
+        _STATE.node_outcomes[report.nodeid] = "failed"
 
 
 def pytest_warning_recorded(
@@ -216,14 +569,21 @@ def pytest_warning_recorded(
     nodeid: str,
     location: tuple[str, int, str] | None,
 ) -> None:
-    """Group warnings by their stable category and message."""
+    """Group warnings by stable category and normalised message."""
     del when, nodeid, location
     category = warning_message.category.__name__
-    _STATE.warning_counts[category, str(warning_message.message)] += 1
+    message = str(warning_message.message)
+    normalised = _normalise_warning_message(message)
+    key = (category, normalised)
+    _STATE.warning_counts[key] += 1
+    _STATE.warning_samples.setdefault(key, message)
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """Write the requested artefact once, from the controller process only."""
+    sampler = _STATE.resource_sampler
+    if sampler is not None:
+        sampler.stop()
     if hasattr(session.config, "workerinput"):
         return
     output = os.environ.get("SUEWS_CI_METRICS")

--- a/scripts/suews/pytest_phase_timer.py
+++ b/scripts/suews/pytest_phase_timer.py
@@ -1,0 +1,93 @@
+"""Minimal pytest test-phase timer used as the metrics-off overhead control."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any
+
+import pytest
+
+
+@dataclass
+class _TimerState:
+    """Mutable controller state for the metrics-off control."""
+
+    started: float = 0.0
+    duration: float = 0.0
+    node_ids: list[str] = field(default_factory=list)
+
+    def reset(self) -> None:
+        """Clear state for a repeat invocation in one process."""
+        self.started = 0.0
+        self.duration = 0.0
+        self.node_ids.clear()
+
+
+_STATE = _TimerState()
+
+
+def _inventory(node_ids: list[str]) -> dict[str, Any]:
+    """Build the same stable inventory fields as the full plugin."""
+    normalised = sorted(set(node_ids))
+    return {
+        "node_count": len(normalised),
+        "node_id_sha256": hashlib.sha256("\n".join(normalised).encode()).hexdigest(),
+    }
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Reset module state for repeat in-process invocations."""
+    del session
+    _STATE.reset()
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    """Capture serial node IDs."""
+    if session.items:
+        _STATE.node_ids = [item.nodeid for item in session.items]
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_xdist_node_collection_finished(node: Any, ids: list[str]) -> None:
+    """Capture the common xdist inventory once."""
+    del node
+    if not _STATE.node_ids:
+        _STATE.node_ids = list(ids)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtestloop(session: pytest.Session):
+    """Measure only pytest's existing test loop."""
+    del session
+    _STATE.started = time.perf_counter()
+    yield
+    _STATE.duration += time.perf_counter() - _STATE.started
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Write one control result from the xdist controller or serial process."""
+    if hasattr(session.config, "workerinput"):
+        return
+    output = os.environ.get("SUEWS_CI_PHASE_TIMER")
+    if not output:
+        return
+    path = Path(output)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "mode": "metrics-off-control",
+        "result": {"exit_code": int(exitstatus)},
+        "phases": {"tests": {"duration_seconds": round(_STATE.duration, 6)}},
+        "inventory": _inventory(_STATE.node_ids),
+    }
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)

--- a/scripts/suews/run_ci_tests.py
+++ b/scripts/suews/run_ci_tests.py
@@ -8,8 +8,32 @@ on Windows cmd.exe when pytest marker expressions contain double quotes
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+import os
+from pathlib import Path
 import subprocess
 import sys
+
+if __package__:
+    from .ci_phase_metrics import stop_phase
+else:
+    from ci_phase_metrics import stop_phase
+
+
+def metrics_paths(
+    project_dir: Path,
+    environment: Mapping[str, str],
+) -> tuple[Path, Path]:
+    """Resolve the pytest and phase files shared with the host runner."""
+    metrics_dir = Path(
+        environment.get("SUEWS_CI_METRICS_DIR", str(project_dir / "ci-metrics"))
+    )
+    name = environment.get("SUEWS_CI_METRICS_NAME", "physics")
+    pytest_path = metrics_dir / f"{name}-pytest.json"
+    phases_path = Path(
+        environment.get("SUEWS_CI_PHASES", str(metrics_dir / f"{name}-phases.json"))
+    )
+    return pytest_path, phases_path
 
 
 def main() -> int:
@@ -17,19 +41,39 @@ def main() -> int:
         print("usage: run_ci_tests.py <project_dir> [pytest_args...]", file=sys.stderr)
         return 2
 
-    project_dir = sys.argv[1]
+    project_dir = Path(sys.argv[1]).resolve()
     pytest_args = sys.argv[2:]
+    metrics_path, phases_path = metrics_paths(project_dir, os.environ)
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    if phases_path.exists():
+        stop_phase(phases_path, "install")
+    pytest_environment = os.environ.copy()
+    pytest_environment["PYTHONPATH"] = os.pathsep.join(
+        part
+        for part in (str(project_dir), pytest_environment.get("PYTHONPATH", ""))
+        if part
+    )
+    pytest_environment["SUEWS_CI_METRICS"] = str(metrics_path)
 
     # Run pytest
     rc = subprocess.call(
-        [sys.executable, "-m", "pytest", f"{project_dir}/test"] + pytest_args,
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "scripts.suews.pytest_ci_metrics",
+            str(project_dir / "test"),
+            *pytest_args,
+        ],
+        env=pytest_environment,
     )
     if rc != 0:
         return rc
 
     # Run bridge manifest check
     rc = subprocess.call(
-        [sys.executable, f"{project_dir}/scripts/suews/check_bridge_manifest.py"],
+        [sys.executable, str(project_dir / "scripts/suews/check_bridge_manifest.py")],
     )
     return rc
 

--- a/test/core/test_ci_phase_metrics.py
+++ b/test/core/test_ci_phase_metrics.py
@@ -1,0 +1,208 @@
+"""Contracts for wheel-job phase evidence and cibuildwheel artefact transport."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.suews.ci_phase_metrics import (
+    append_step_summary,
+    finalise_evidence,
+    read_pytest_metrics,
+    start_phase,
+    stop_phase,
+)
+from scripts.suews.run_ci_tests import metrics_paths
+
+pytestmark = pytest.mark.api
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+REQUIRED_PHASES = ("checkout", "toolchain_setup", "build", "repair", "install")
+
+
+@pytest.mark.core
+def test_wheel_evidence_contains_explicit_build_and_pytest_phases(
+    tmp_path: Path,
+) -> None:
+    """A completed wheel job publishes all required phase records in one artefact."""
+    state_path = tmp_path / "phases.json"
+    boundaries = {
+        "checkout": (10.0, 14.0),
+        "toolchain_setup": (15.0, 20.0),
+        "build": (20.0, 30.0),
+        "repair": (30.0, 32.0),
+        "install": (32.0, 35.0),
+    }
+    for phase, (started, completed) in boundaries.items():
+        start_phase(state_path, phase, now=started, source="test-boundary")
+        stop_phase(state_path, phase, now=completed)
+    pytest_metrics = {
+        "schema_version": 2,
+        "phases": {
+            "collection": {"duration_seconds": 1.25},
+            "session": {"duration_seconds": 8.0},
+            "tests": {"duration_seconds": 6.5},
+        },
+        "inventory": {"node_count": 8, "node_id_sha256": "abc"},
+        "result": {"exit_code": 0, "outcomes": {"passed": 8}},
+    }
+
+    evidence = finalise_evidence(state_path, pytest_metrics, job_name="physics-cp312")
+
+    assert evidence["schema_version"] == 1
+    assert evidence["kind"] == "wheel-job-ci-metrics"
+    assert evidence["job_name"] == "physics-cp312"
+    for phase in REQUIRED_PHASES:
+        assert evidence["phases"][phase] == {
+            "available": True,
+            "duration_seconds": boundaries[phase][1] - boundaries[phase][0],
+            "reason": None,
+            "source": "test-boundary",
+            "status": "measured",
+        }
+    assert evidence["phases"]["collection"]["source"] == "pytest-hook"
+    assert evidence["phases"]["tests"]["duration_seconds"] == pytest.approx(6.5)
+    assert evidence["pytest_metrics"] == pytest_metrics
+
+
+@pytest.mark.core
+def test_missing_wheel_phase_is_explicitly_unavailable(tmp_path: Path) -> None:
+    """An absent hook can never be mistaken for a measured zero duration."""
+    state_path = tmp_path / "phases.json"
+    start_phase(state_path, "checkout", now=1.0, source="test-boundary")
+    stop_phase(state_path, "checkout", now=2.0)
+
+    evidence = finalise_evidence(
+        state_path,
+        {
+            "schema_version": 2,
+            "phases": {
+                "collection": {"duration_seconds": 0.1},
+                "session": {"duration_seconds": 0.3},
+                "tests": {"duration_seconds": 0.2},
+            },
+        },
+        job_name="incomplete",
+    )
+
+    assert evidence["phases"]["repair"] == {
+        "available": False,
+        "duration_seconds": None,
+        "reason": "No completed repair boundary was recorded.",
+        "source": None,
+        "status": "unavailable",
+    }
+
+
+@pytest.mark.core
+def test_pretest_failure_still_produces_explicit_pytest_unavailability(
+    tmp_path: Path,
+) -> None:
+    """Missing pytest JSON remains publishable evidence after an earlier failure."""
+    metrics = read_pytest_metrics(tmp_path / "missing-pytest.json")
+
+    assert metrics["available"] is False
+    assert metrics["schema_version"] is None
+    assert metrics["result"] is None
+    assert "before pytest metrics" in metrics["reason"]
+
+
+@pytest.mark.core
+def test_host_finaliser_appends_combined_wheel_job_summary(tmp_path: Path) -> None:
+    """The host summary covers build, test, resource and inventory evidence."""
+    state_path = tmp_path / "phases.json"
+    for phase, started in zip(REQUIRED_PHASES, range(5), strict=True):
+        start_phase(state_path, phase, now=float(started), source="test-boundary")
+        stop_phase(state_path, phase, now=float(started + 1))
+    evidence = finalise_evidence(
+        state_path,
+        {
+            "schema_version": 2,
+            "phases": {
+                "collection": {"duration_seconds": 0.5},
+                "session": {"duration_seconds": 9.0},
+                "tests": {"duration_seconds": 8.25},
+            },
+            "inventory": {"node_count": 4, "node_id_sha256": "abc123"},
+            "resources": {
+                "process_tree_cpu_seconds": {
+                    "available": True,
+                    "status": "sampled",
+                    "value": 12.5,
+                },
+                "process_tree_peak_rss_bytes": {
+                    "available": True,
+                    "status": "sampled",
+                    "value": 268435456,
+                },
+            },
+        },
+        job_name="physics-cp312",
+    )
+    summary_path = tmp_path / "step-summary.md"
+
+    append_step_summary(summary_path, evidence)
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "Wheel job CI metrics: physics-cp312" in summary
+    for phase in (*REQUIRED_PHASES, "collection", "tests"):
+        assert phase.replace("_", " ").title() in summary
+    assert "Process-tree CPU | 12.500 s" in summary
+    assert "Process-tree peak RSS | 256.0 MiB" in summary
+    assert "Collected tests | 4" in summary
+    assert "Coverage fingerprint: `abc123`" in summary
+
+
+@pytest.mark.core
+def test_physics_metrics_path_and_linux_transport_are_stable(tmp_path: Path) -> None:
+    """The wrapper path matches the host-mounted directory uploaded by the action."""
+    metrics_path, phases_path = metrics_paths(
+        PROJECT_ROOT,
+        {
+            "SUEWS_CI_METRICS_DIR": str(tmp_path),
+            "SUEWS_CI_METRICS_NAME": "physics-cp312-manylinux-x86_64",
+            "SUEWS_CI_PHASES": str(
+                tmp_path / "physics-cp312-manylinux-x86_64-phases.json"
+            ),
+        },
+    )
+    action = (PROJECT_ROOT / ".github/actions/build-suews/action.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert metrics_path == tmp_path / "physics-cp312-manylinux-x86_64-pytest.json"
+    assert phases_path == tmp_path / "physics-cp312-manylinux-x86_64-phases.json"
+    assert "${{ inputs.metrics_host_dir }}:/ci-metrics" in action
+    assert "SUEWS_CI_METRICS_DIR=/ci-metrics" in action
+    assert "ci-metrics-physics-${{ inputs.python }}" in action
+    assert "METRICS_HOST_DIR: ${{ inputs.metrics_host_dir }}" in action
+    assert (
+        'mkdir -p .cargo-cache .rust-target-cache .pip-cache "$METRICS_HOST_DIR"'
+        in action
+    )
+    assert "PHYSICS_JOB_NAME: physics-${{ inputs.python }}" in action
+    assert '--job-name "$PHYSICS_JOB_NAME"' in action
+    assert "CIBW_TEST_ENVIRONMENT" not in action
+    assert "start toolchain_setup" in action
+    assert "start build" in action
+    assert "transition build repair" in action
+    assert "start install" in action
+    assert "{project}/scripts/suews/ci_phase_metrics.py" not in action
+    assert action.count("if: always()") >= 2
+
+
+@pytest.mark.core
+def test_every_local_build_action_caller_passes_metrics_host_dir() -> None:
+    """Adding metrics transport cannot break a less common workflow caller."""
+    callers = []
+    for workflow in (PROJECT_ROOT / ".github/workflows").glob("*.yml"):
+        lines = workflow.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if "uses: ./.github/actions/build-suews" in line:
+                callers.append((workflow.name, index + 1))
+                nearby = "\n".join(lines[index + 1 : index + 16])
+                assert "metrics_host_dir:" in nearby, (
+                    f"{workflow.name}:{index + 1} must pass metrics_host_dir"
+                )
+    assert callers

--- a/test/core/test_ci_run_metrics.py
+++ b/test/core/test_ci_run_metrics.py
@@ -1,0 +1,248 @@
+"""Contract tests for workflow timing analysis and overhead calculations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+import re
+
+import pytest
+
+from scripts.suews.analyse_ci_run import analyse_run
+from scripts.suews.benchmark_ci_metrics import (
+    compute_overhead,
+    file_sha256,
+    validate_command,
+)
+
+pytestmark = pytest.mark.api
+
+
+@pytest.mark.core
+def test_analysis_separates_dependency_queue_and_execution_time() -> None:
+    """Workflow jobs retain distinct readiness, queue and execution durations."""
+    run = {
+        "id": 42,
+        "created_at": "2026-07-15T00:00:00Z",
+        "updated_at": "2026-07-15T00:01:54Z",
+        "event": "pull_request",
+        "head_sha": "abc123",
+    }
+    jobs = {
+        "jobs": [
+            _job("Detect", 0, 2, 10),
+            _job("Build", 10, 15, 75, steps=[("Checkout", 15, 20), ("Build", 20, 75)]),
+            _job("API", 75, 78, 108),
+            _job("Gate", 108, 109, 114),
+        ]
+    }
+
+    metrics = analyse_run(
+        run,
+        jobs,
+        declared_needs={
+            "Build": ["Detect"],
+            "API": ["Build"],
+            "Gate": ["API"],
+        },
+        target_job_pattern="Gate",
+    )
+
+    assert metrics["schema_version"] == 1
+    assert metrics["workflow"]["elapsed_seconds"] == pytest.approx(114.0)
+    assert metrics["observed_critical_path"]["job_names"] == [
+        "Detect",
+        "Build",
+        "API",
+        "Gate",
+    ]
+    assert metrics["observed_critical_path"][
+        "orchestration_delay_seconds"
+    ] == pytest.approx(0.0)
+    assert metrics["observed_critical_path"]["runner_queue_seconds"] == pytest.approx(
+        11.0
+    )
+    assert metrics["observed_critical_path"]["execution_seconds"] == pytest.approx(
+        103.0
+    )
+    by_name = {job["name"]: job for job in metrics["jobs"]}
+    assert by_name["Build"]["orchestration_delay_seconds"] == pytest.approx(0.0)
+    assert by_name["Build"]["ready_offset_seconds"] == pytest.approx(10.0)
+    assert by_name["Build"]["fan_in_spread_seconds"] == pytest.approx(0.0)
+    assert by_name["Build"]["runner_queue_seconds"] == pytest.approx(5.0)
+    assert by_name["Build"]["execution_seconds"] == pytest.approx(60.0)
+    assert by_name["Build"]["steps"] == [
+        {"duration_seconds": 5.0, "name": "Checkout"},
+        {"duration_seconds": 55.0, "name": "Build"},
+    ]
+
+
+@pytest.mark.core
+def test_analysis_follows_dependency_fan_in_and_ignores_later_non_gate_job() -> None:
+    """The latest declared predecessor, not a later summary, sets the gate path."""
+    run = {
+        "id": 43,
+        "created_at": "2026-07-15T00:00:00Z",
+        "updated_at": "2026-07-15T00:01:20Z",
+        "event": "pull_request",
+        "head_sha": "def456",
+    }
+    jobs = {
+        "jobs": [
+            _job("Build / linux", 0, 0, 20),
+            _job("Build / windows", 0, 1, 40),
+            _job("Gate", 42, 45, 55),
+            _job("Later diagnostics", 55, 56, 80),
+        ]
+    }
+
+    metrics = analyse_run(
+        run,
+        jobs,
+        declared_needs={"Gate": ["Build / *"]},
+        target_job_pattern="Gate",
+    )
+
+    gate = {job["name"]: job for job in metrics["jobs"]}["Gate"]
+    assert gate["ready_offset_seconds"] == pytest.approx(40.0)
+    assert gate["orchestration_delay_seconds"] == pytest.approx(2.0)
+    assert gate["fan_in_spread_seconds"] == pytest.approx(20.0)
+    assert gate["critical_predecessor"] == "Build / windows"
+    assert metrics["workflow"]["gate_completed_at"] == "2026-07-15T00:00:55Z"
+    assert metrics["observed_critical_path"]["job_names"] == [
+        "Build / windows",
+        "Gate",
+    ]
+
+
+@pytest.mark.core
+def test_overhead_uses_medians_and_reports_percentage() -> None:
+    """Alternating trials are reduced to a stable median overhead result."""
+    result = compute_overhead(
+        baseline_seconds=[10.0, 10.2, 9.8],
+        instrumented_seconds=[10.1, 10.3, 9.9],
+        threshold_percent=2.0,
+    )
+
+    assert result == {
+        "baseline_median_seconds": 10.0,
+        "instrumented_median_seconds": 10.1,
+        "overhead_percent": pytest.approx(1.0),
+        "passed": True,
+        "threshold_percent": 2.0,
+    }
+
+
+@pytest.mark.core
+def test_overhead_command_must_enact_declared_fixed_scheduler() -> None:
+    """Harness metadata cannot claim a scheduler the pytest command does not use."""
+    command = [
+        "python",
+        "-m",
+        "pytest",
+        "test/core/test_ehc_regression.py",
+        "-n",
+        "4",
+        "--maxprocesses=4",
+        "--dist",
+        "worksteal",
+    ]
+
+    validate_command(command, worker_count=4, scheduler="worksteal")
+    with pytest.raises(ValueError, match="--dist"):
+        validate_command(command, worker_count=4, scheduler="loadscope")
+    with pytest.raises(ValueError, match="between 1 and 4"):
+        validate_command(command, worker_count=5, scheduler="worksteal")
+
+
+@pytest.mark.core
+def test_wheel_provenance_hashes_exact_download(tmp_path: Path) -> None:
+    """The comparison manifest can identify the exact installed wheel bytes."""
+    wheel = tmp_path / "supy.whl"
+    wheel.write_bytes(b"controlled-wheel")
+
+    assert file_sha256(wheel) == (
+        "3a5e31bfeb5d9c690917610ae054fb563fb0c896704bf93dba8c7ea0202f74d1"
+    )
+
+
+@pytest.mark.core
+def test_manual_overhead_workflow_uses_realistic_fixed_capacity_contract() -> None:
+    """Post-merge overhead evidence uses the full standard physics workload."""
+    workflow = (
+        Path(__file__).resolve().parents[2]
+        / ".github/workflows/ci-metrics-overhead.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "timeout-minutes: 90" in workflow
+    assert "-- python -m pytest test" in workflow
+    assert '-m "physics and not slow"' in workflow
+    assert "-n 4 --maxprocesses=4 --dist worksteal" in workflow
+    assert '--source-sha "${{ github.sha }}"' in workflow
+    assert workflow.count("CONTROLLED_WHEEL: ${{ steps.wheel.outputs.path }}") == 2
+    assert 'python -m pip install "$CONTROLLED_WHEEL"' in workflow
+    assert '--wheel "$CONTROLLED_WHEEL"' in workflow
+
+
+@pytest.mark.core
+def test_new_ci_observability_surfaces_trigger_normal_ci() -> None:
+    """Metrics workflow/config-only changes remain inside the positive CI filter."""
+    path_filters = (
+        Path(__file__).resolve().parents[2] / ".github/path-filters.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "- '.github/workflows/ci-metrics-overhead.yml'" in path_filters
+    assert "- '.github/workflows/build-wheels-reusable.yml'" in path_filters
+    assert "- '.github/ci-metrics-needs.json'" in path_filters
+
+
+@pytest.mark.core
+def test_api_lane_installs_xdist_contract_without_parallelising_main_suite() -> None:
+    """The nested xdist contract has its plugin while API tests stay serial."""
+    workflow = (
+        Path(__file__).resolve().parents[2]
+        / ".github/workflows/test-api-cross-python-reusable.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "python -m pip install pytest==9.1.1 pytest-xdist==3.8.0" in workflow
+    main_invocation = re.search(
+        r"^[ \t]*python -m pytest -p scripts\.suews\.pytest_ci_metrics test \\\n"
+        r"[ \t]+-m \"\$MARKER_EXPR\" -v --tb=short --durations=25[ \t]*$",
+        workflow,
+        flags=re.MULTILINE,
+    )
+    assert main_invocation is not None
+    assert re.search(r"(?:^|\s)-n(?:\s|$)", main_invocation.group()) is None
+
+
+def _job(
+    name: str,
+    created: int,
+    started: int,
+    completed: int,
+    *,
+    steps: list[tuple[str, int, int]] | None = None,
+) -> dict[str, object]:
+    """Build a minimal GitHub Actions job payload relative to midnight."""
+    return {
+        "name": name,
+        "created_at": _timestamp(created),
+        "started_at": _timestamp(started),
+        "completed_at": _timestamp(completed),
+        "status": "completed",
+        "conclusion": "success",
+        "steps": [
+            {
+                "name": step_name,
+                "started_at": _timestamp(step_started),
+                "completed_at": _timestamp(step_completed),
+            }
+            for step_name, step_started, step_completed in (steps or [])
+        ],
+    }
+
+
+def _timestamp(offset_seconds: int) -> str:
+    """Return an ISO timestamp at the requested midnight offset."""
+    timestamp = datetime(2026, 7, 15, tzinfo=UTC).timestamp() + offset_seconds
+    return datetime.fromtimestamp(timestamp, tz=UTC).isoformat().replace("+00:00", "Z")

--- a/test/core/test_pytest_ci_metrics.py
+++ b/test/core/test_pytest_ci_metrics.py
@@ -8,12 +8,17 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
+from typing import Any
 
 import pytest
+
+from scripts.suews.pytest_ci_metrics import ProcfsSampler, read_proc_process
 
 pytestmark = pytest.mark.api
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_V2_FIXTURE = PROJECT_ROOT / "test/fixtures/ci_metrics/schema-v2-xdist.json"
 
 
 @pytest.mark.smoke
@@ -69,24 +74,38 @@ def test_warn():
     node_ids = ["test_sample.py::test_pass", "test_sample.py::test_warn"]
     expected_hash = hashlib.sha256("\n".join(node_ids).encode()).hexdigest()
 
-    assert metrics["schema_version"] == 1
-    assert metrics["result"]["exit_code"] == 0
+    assert metrics["schema_version"] == 2
+    assert metrics["result"] == {
+        "exit_code": 0,
+        "outcomes": {
+            "failed": 0,
+            "passed": 2,
+            "skipped": 0,
+            "xfailed": 0,
+            "xpassed": 0,
+        },
+    }
     assert metrics["inventory"] == {
         "node_count": 2,
         "node_id_sha256": expected_hash,
     }
     assert metrics["execution"] == {
         "effective_worker_count": 1,
+        "worker_finish_skew_seconds": 0.0,
+        "worker_tail_over_median_seconds": 0.0,
+        "workers": [],
         "xdist": False,
     }
     assert set(metrics["phases"]) == {"collection", "session", "tests"}
     assert all(phase["duration_seconds"] >= 0 for phase in metrics["phases"].values())
+    _assert_resource_contract(metrics["resources"])
     assert metrics["warnings"] == [
         {
             "category": "UserWarning",
             "count": 1,
             "fingerprint": hashlib.sha256(b"UserWarning\ngroup me").hexdigest(),
             "message": "group me",
+            "normalised_message": "group me",
         }
     ]
 
@@ -94,3 +113,308 @@ def test_warn():
     assert "Pytest CI metrics" in summary
     assert expected_hash in summary
     assert "UserWarning: group me" in summary
+
+
+def _assert_resource_contract(resources: dict[str, Any]) -> None:
+    """Check stable availability metadata for process-tree measurements."""
+    assert resources["sample_interval_seconds"] > 0
+    assert resources["sample_count"] >= 0
+    for name, unit in (
+        ("process_tree_cpu_seconds", "seconds"),
+        ("process_tree_peak_rss_bytes", "bytes"),
+    ):
+        measurement = resources[name]
+        assert measurement["unit"] == unit
+        assert isinstance(measurement["available"], bool)
+        if sys.platform.startswith("linux"):
+            assert resources["sample_count"] > 0
+            assert measurement["available"] is True
+            assert measurement["method"] == "linux-procfs-sampling"
+            assert measurement["reason"] is None
+            assert measurement["status"] == "sampled"
+            assert measurement["value"] >= 0
+        else:
+            assert measurement["available"] is False
+            assert measurement["value"] is None
+            assert measurement["method"] is None
+            assert measurement["reason"]
+            assert measurement["status"] == "unavailable"
+
+
+def _write_proc_process(
+    proc_root: Path,
+    pid: int,
+    *,
+    children: tuple[int, ...] = (),
+    cpu_ticks: tuple[int, int] = (0, 0),
+    rss_pages: int = 0,
+    start_time: int = 1,
+) -> None:
+    """Write the minimal stat and children files consumed by the sampler."""
+    process_root = proc_root / str(pid)
+    task_root = process_root / "task" / str(pid)
+    task_root.mkdir(parents=True, exist_ok=True)
+    fields = ["S", *("0" for _ in range(21))]
+    fields[11], fields[12] = map(str, cpu_ticks)
+    fields[19] = str(start_time)
+    fields[21] = str(rss_pages)
+    (process_root / "stat").write_text(
+        f"{pid} (worker with spaces) {' '.join(fields)}\n",
+        encoding="utf-8",
+    )
+    (task_root / "children").write_text(" ".join(map(str, children)), encoding="utf-8")
+
+
+def test_procfs_stat_parser_handles_process_names_with_spaces(tmp_path: Path) -> None:
+    """The stat parser indexes fields after the parenthesised process name."""
+    _write_proc_process(
+        tmp_path,
+        100,
+        cpu_ticks=(125, 75),
+        rss_pages=64,
+        start_time=999,
+    )
+
+    assert read_proc_process(100, 100.0, 4096, proc_root=tmp_path) == (
+        999,
+        2.0,
+        262144,
+    )
+
+
+def test_procfs_sampler_aggregates_tree_and_retains_exited_child_cpu(
+    tmp_path: Path,
+) -> None:
+    """One sample aggregates descendants and keeps final cumulative child CPU."""
+    _write_proc_process(
+        tmp_path,
+        100,
+        children=(101, 102),
+        cpu_ticks=(100, 0),
+        rss_pages=10,
+        start_time=1000,
+    )
+    _write_proc_process(
+        tmp_path,
+        101,
+        children=(103,),
+        cpu_ticks=(50, 0),
+        rss_pages=20,
+        start_time=1001,
+    )
+    _write_proc_process(
+        tmp_path,
+        102,
+        cpu_ticks=(25, 0),
+        rss_pages=30,
+        start_time=1002,
+    )
+    _write_proc_process(
+        tmp_path,
+        103,
+        cpu_ticks=(75, 0),
+        rss_pages=40,
+        start_time=1003,
+    )
+    sampler = ProcfsSampler(0.25, proc_root=tmp_path)
+    sampler.supported = True
+    sampler.root_pid = 100
+    sampler.clock_ticks = 100.0
+    sampler.page_size = 4096
+
+    sampler._sample()
+
+    first = sampler.measurements()
+    assert first["sample_count"] == 1
+    assert first["process_tree_cpu_seconds"]["value"] == pytest.approx(2.5)
+    assert first["process_tree_peak_rss_bytes"]["value"] == 100 * 4096
+
+    (tmp_path / "101/task/101/children").write_text("", encoding="utf-8")
+    _write_proc_process(
+        tmp_path,
+        100,
+        children=(101, 102),
+        cpu_ticks=(200, 0),
+        rss_pages=10,
+        start_time=1000,
+    )
+    sampler._sample()
+
+    second = sampler.measurements()
+    assert second["sample_count"] == 2
+    assert second["process_tree_cpu_seconds"]["value"] == pytest.approx(3.5)
+    assert second["process_tree_peak_rss_bytes"]["value"] == 100 * 4096
+
+
+def test_xdist_records_assignments_busy_duration_and_finish_skew(
+    tmp_path: Path,
+) -> None:
+    """The controller records every xdist node on its assigned worker."""
+    test_file = tmp_path / "test_parallel.py"
+    test_file.write_text(
+        """\
+import time
+
+import pytest
+
+
+@pytest.mark.parametrize("case", range(8))
+def test_parallel(case):
+    time.sleep(0.01)
+    assert case >= 0
+""",
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "ci-metrics-xdist.json"
+    env = os.environ.copy()
+    env.update({
+        "PYTHONPATH": os.pathsep.join(
+            part for part in (str(PROJECT_ROOT), env.get("PYTHONPATH", "")) if part
+        ),
+        "SUEWS_CI_METRICS": str(metrics_path),
+    })
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--confcutdir",
+            str(tmp_path),
+            "-p",
+            "scripts.suews.pytest_ci_metrics",
+            str(test_file),
+            "-q",
+            "-n",
+            "2",
+            "--dist",
+            "worksteal",
+        ],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    workers = metrics["execution"]["workers"]
+    assigned_node_ids = {
+        node_id for worker in workers for node_id in worker["node_ids"]
+    }
+
+    assert metrics["schema_version"] == 2
+    assert metrics["execution"]["xdist"] is True
+    assert metrics["execution"]["effective_worker_count"] == 2
+    assert {worker["worker_id"] for worker in workers} == {"gw0", "gw1"}
+    assert len(assigned_node_ids) == 8
+    assert all(worker["node_count"] == len(worker["node_ids"]) for worker in workers)
+    assert all(
+        worker["node_id_sha256"]
+        == hashlib.sha256("\n".join(sorted(worker["node_ids"])).encode()).hexdigest()
+        for worker in workers
+    )
+    assert all(worker["busy_duration_seconds"] > 0 for worker in workers)
+    assert all(worker["finished_at_seconds"] >= 0 for worker in workers)
+    assert metrics["execution"]["worker_finish_skew_seconds"] >= 0
+    assert metrics["execution"]["worker_tail_over_median_seconds"] >= 0
+    assert metrics["result"]["outcomes"]["passed"] == 8
+
+
+def _warning_test_source(temp_root: str) -> str:
+    """Build importable warning tests for paths containing Python escapes."""
+    warning_a = (
+        f"missing {temp_root}/tmp-alpha/forcing.csv at "
+        "0x123abc for 123e4567-e89b-12d3-a456-426614174000"
+    )
+    warning_b = (
+        f"missing {temp_root}/tmp-beta/forcing.csv at "
+        "0x987def for 123e4567-e89b-12d3-a456-426614174999"
+    )
+    return f"""\
+import warnings
+
+
+def test_warning_a():
+    warnings.warn(
+        {warning_a!r},
+        UserWarning,
+    )
+
+
+def test_warning_b():
+    warnings.warn(
+        {warning_b!r},
+        UserWarning,
+    )
+"""
+
+
+def test_warning_fixture_source_quotes_windows_backslashes() -> None:
+    """A Windows temporary path remains a valid generated Python literal."""
+    source = _warning_test_source(r"C:\Users\runneradmin\AppData\Local\Temp")
+
+    compile(source, "<generated-warning-test>", "exec")
+    assert r"C:\\Users\\runneradmin" in source
+
+
+def test_warning_fingerprint_normalises_only_volatile_components(
+    tmp_path: Path,
+) -> None:
+    """Temporary roots, UUIDs and addresses do not fragment warning groups."""
+    test_file = tmp_path / "test_warnings.py"
+    test_file.write_text(_warning_test_source(tempfile.gettempdir()), encoding="utf-8")
+    metrics_path = tmp_path / "warning-metrics.json"
+    env = os.environ.copy()
+    env.update({
+        "PYTHONPATH": os.pathsep.join(
+            part for part in (str(PROJECT_ROOT), env.get("PYTHONPATH", "")) if part
+        ),
+        "SUEWS_CI_METRICS": str(metrics_path),
+    })
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--confcutdir",
+            str(tmp_path),
+            "-p",
+            "scripts.suews.pytest_ci_metrics",
+            str(test_file),
+            "-q",
+        ],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    warnings = json.loads(metrics_path.read_text(encoding="utf-8"))["warnings"]
+    assert len(warnings) == 1
+    assert warnings[0]["count"] == 2
+    assert warnings[0]["normalised_message"] == (
+        "missing <temp>/forcing.csv at 0x<address> for <uuid>"
+    )
+    assert "tmp-alpha" in warnings[0]["message"]
+
+
+def test_schema_v2_xdist_fixture_is_a_deterministic_consumer_contract() -> None:
+    """Schedulers can consume the checked-in provider fixture without live pytest."""
+    metrics = json.loads(SCHEMA_V2_FIXTURE.read_text(encoding="utf-8"))
+    workers = metrics["execution"]["workers"]
+
+    assert metrics["schema_version"] == 2
+    assert metrics["inventory"]["node_count"] == sum(
+        worker["node_count"] for worker in workers
+    )
+    assert all(
+        worker["node_id_sha256"]
+        == hashlib.sha256("\n".join(worker["node_ids"]).encode()).hexdigest()
+        for worker in workers
+    )
+    assert metrics["resources"]["sample_count"] > 0

--- a/test/fixtures/ci_metrics/schema-v2-xdist.json
+++ b/test/fixtures/ci_metrics/schema-v2-xdist.json
@@ -1,0 +1,94 @@
+{
+  "environment": {
+    "github_job": "build",
+    "python": "3.12.11",
+    "runner_arch": "X64",
+    "runner_os": "Linux"
+  },
+  "execution": {
+    "effective_worker_count": 2,
+    "worker_finish_skew_seconds": 0.75,
+    "worker_tail_over_median_seconds": 0.375,
+    "workers": [
+      {
+        "busy_duration_seconds": 7.25,
+        "finished_at_seconds": 8.25,
+        "node_count": 2,
+        "node_id_sha256": "22c09a963a193eaeb1718055645dc9250fa5607647580a1df6d73abc731ba36c",
+        "node_ids": [
+          "test/a.py::test_a",
+          "test/c.py::test_c"
+        ],
+        "worker_id": "gw0"
+      },
+      {
+        "busy_duration_seconds": 6.75,
+        "finished_at_seconds": 7.5,
+        "node_count": 2,
+        "node_id_sha256": "d1b76cd9f60fc21f129c64a27ea91f292750433576d060e409513b458facecf7",
+        "node_ids": [
+          "test/b.py::test_b",
+          "test/d.py::test_d"
+        ],
+        "worker_id": "gw1"
+      }
+    ],
+    "xdist": true
+  },
+  "generated_at": "2026-07-15T20:00:00Z",
+  "inventory": {
+    "node_count": 4,
+    "node_id_sha256": "9a67c523b5b7cb165dcb6962dd9e4f8fb7d13fc1d7b079e33a611ed09ad0a3cb"
+  },
+  "phases": {
+    "collection": {
+      "duration_seconds": 0.5
+    },
+    "session": {
+      "duration_seconds": 9.0
+    },
+    "tests": {
+      "duration_seconds": 8.25
+    }
+  },
+  "resources": {
+    "process_tree_cpu_seconds": {
+      "available": true,
+      "method": "linux-procfs-sampling",
+      "reason": null,
+      "status": "sampled",
+      "unit": "seconds",
+      "value": 12.5
+    },
+    "process_tree_peak_rss_bytes": {
+      "available": true,
+      "method": "linux-procfs-sampling",
+      "reason": null,
+      "status": "sampled",
+      "unit": "bytes",
+      "value": 268435456
+    },
+    "sample_count": 36,
+    "sample_interval_seconds": 0.25
+  },
+  "result": {
+    "exit_code": 0,
+    "outcomes": {
+      "failed": 0,
+      "passed": 4,
+      "skipped": 0,
+      "xfailed": 0,
+      "xpassed": 0
+    }
+  },
+  "schema_version": 2,
+  "warnings": [
+    {
+      "category": "UserWarning",
+      "count": 2,
+      "fingerprint": "2e07cfad92624957fcaac1da9015f99b45dcfd135d54bb6107286bef780268ec",
+      "message": "missing /tmp/tmp-a/forcing.csv",
+      "normalised_message": "missing <temp>/forcing.csv"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Extend the pytest metrics contract to schema v2 with xdist assignments, per-worker durations and finish skew, stable warning fingerprints, and explicit Linux process-tree CPU/peak RSS availability.
- Preserve wheel-job phase evidence across checkout, toolchain setup, build, repair, install, collection, and tests, including failure-safe artefact upload and a concise host-side step summary.
- Add declared-needs workflow critical-path analysis that separates orchestration, runner queue, execution, and dependency fan-in spread.
- Add a default-branch-only same-job metrics-off/on/on/off workflow for the final <=2% overhead evidence.
- Keep GitHub-hosted capacity fixed at four workers with work stealing; this change does not increase worker count.

## Validation

- `make dev` passed.
- `make test-smoke` passed: 7 passed, 1 skipped, 1830 deselected in 50.11 seconds.
- `make test` passed: 1759 passed, 8 skipped, 65 deselected in 1353.23 seconds.
- Focused CI metrics contracts passed: 19 passed.
- Ruff format/check, action pin validation, marker validation, pathlib encoding validation, YAML parsing, actionlint v1.7.12, and `git diff --check` passed.

## Hosted evidence

PR CI must confirm the hosted Linux resource records, wheel phase artefacts, and workflow critical-path artefact.
The controlled <=2% overhead workflow can only produce acceptance evidence from the default branch after merge, so issue #1623 remains open.

Refs #1623