### PR TITLE
Add hosted pytest scheduler ABBA benchmark

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -76,6 +76,7 @@ ci:
   # CI workflows and build tooling
   - '.github/path-filters.yml'
   - '.github/ci-metrics-needs.json'
+  - '.github/workflows/benchmark-pytest-scheduler.yml'
   - '.github/workflows/build-publish_to_pypi.yml'
   - '.github/workflows/build-wheels-reusable.yml'
   - '.github/workflows/cibuildwheel-debug.yml'

--- a/.github/workflows/benchmark-pytest-scheduler.yml
+++ b/.github/workflows/benchmark-pytest-scheduler.yml
@@ -1,0 +1,207 @@
+# Matched hosted comparison for gh#1626. This is intentionally manual: normal
+# pull requests must not pay for four full physics runs.
+name: Hosted pytest scheduler ABBA
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Successful Build and Publish workflow run containing the Linux cp312 wheel
+        required: true
+        type: string
+      expected_sha:
+        description: Exact 40-character source SHA built by source_run_id
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: hosted-pytest-scheduler-abba
+  cancel-in-progress: false
+
+jobs:
+  compare:
+    name: One-runner loadscope/worksteal ABBA
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Verify successful source run and SHA
+        id: source
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "source_run_id must be a positive integer" >&2
+            exit 2
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" > "$RUNNER_TEMP/source-run.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import re
+
+          source_run_id = os.environ["SOURCE_RUN_ID"]
+          expected_sha = os.environ["EXPECTED_SHA"]
+          if not source_run_id.isdigit() or int(source_run_id) <= 0:
+              raise SystemExit("source_run_id must be a positive integer")
+          if re.fullmatch(r"[0-9a-f]{40}", expected_sha) is None:
+              raise SystemExit("expected_sha must be a lowercase 40-character hex digest")
+          payload = json.loads(
+              (Path(os.environ["RUNNER_TEMP"]) / "source-run.json").read_text(encoding="utf-8")
+          )
+          if payload.get("conclusion") != "success":
+              raise SystemExit("source workflow run did not conclude successfully")
+          if payload.get("path") != ".github/workflows/build-publish_to_pypi.yml":
+              raise SystemExit("source_run_id is not the Build and Publish workflow")
+          if payload.get("head_sha") != expected_sha:
+              raise SystemExit("source workflow SHA does not match expected_sha")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"sha={expected_sha}\n")
+          PY
+
+      - name: Checkout the exact built source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Download the exact Linux wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cp312-manylinux-x86_64
+          path: wheelhouse
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Resolve the single downloaded wheel
+        id: wheel
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          wheels = sorted(Path("wheelhouse").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected exactly one wheel, found {len(wheels)}")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"path={wheels[0].resolve()}\n")
+          PY
+
+      - name: Install the one wheel and pinned scheduler stack
+        shell: bash
+        env:
+          WHEEL_PATH: ${{ steps.wheel.outputs.path }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0
+          python -m pip install "$WHEEL_PATH"
+
+      - name: A1 - loadscope
+        continue-on-error: true
+        shell: bash
+        env:
+          SUEWS_CI_METRICS: scheduler-abba/loadscope-a.json
+        run: >-
+          python -m pytest -p scripts.suews.pytest_ci_metrics test
+          -m "physics and not slow" -v --tb=short --durations=10
+          -n auto --maxprocesses=4 --dist loadscope
+          -p no:cacheprovider --basetemp="$RUNNER_TEMP/pytest-loadscope-a"
+
+      - name: B1 - worksteal
+        continue-on-error: true
+        shell: bash
+        env:
+          SUEWS_CI_METRICS: scheduler-abba/worksteal-a.json
+        run: >-
+          python -m pytest -p scripts.suews.pytest_ci_metrics test
+          -m "physics and not slow" -v --tb=short --durations=10
+          -n auto --maxprocesses=4 --dist worksteal
+          -p no:cacheprovider --basetemp="$RUNNER_TEMP/pytest-worksteal-a"
+
+      - name: B2 - worksteal
+        continue-on-error: true
+        shell: bash
+        env:
+          SUEWS_CI_METRICS: scheduler-abba/worksteal-b.json
+        run: >-
+          python -m pytest -p scripts.suews.pytest_ci_metrics test
+          -m "physics and not slow" -v --tb=short --durations=10
+          -n auto --maxprocesses=4 --dist worksteal
+          -p no:cacheprovider --basetemp="$RUNNER_TEMP/pytest-worksteal-b"
+
+      - name: A2 - loadscope
+        continue-on-error: true
+        shell: bash
+        env:
+          SUEWS_CI_METRICS: scheduler-abba/loadscope-b.json
+        run: >-
+          python -m pytest -p scripts.suews.pytest_ci_metrics test
+          -m "physics and not slow" -v --tb=short --durations=10
+          -n auto --maxprocesses=4 --dist loadscope
+          -p no:cacheprovider --basetemp="$RUNNER_TEMP/pytest-loadscope-b"
+
+      - name: Record runner memory capacity
+        if: always()
+        id: memory
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          fields = {}
+          for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+              key, value = line.split(":", maxsplit=1)
+              fields[key] = value.strip()
+          total_kib = int(fields["MemTotal"].split()[0])
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"bytes={total_kib * 1024}\n")
+          PY
+
+      - name: Compare matched ABBA evidence
+        if: always()
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          RUNNER_MEMORY_BYTES: ${{ steps.memory.outputs.bytes }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          WHEEL_PATH: ${{ steps.wheel.outputs.path }}
+        run: >-
+          python scripts/suews/compare_scheduler_runs.py
+          scheduler-abba/loadscope-a.json
+          scheduler-abba/worksteal-a.json
+          scheduler-abba/worksteal-b.json
+          scheduler-abba/loadscope-b.json
+          --runner-memory-bytes "$RUNNER_MEMORY_BYTES"
+          --source-run-id "$SOURCE_RUN_ID"
+          --source-sha "$SOURCE_SHA"
+          --expected-source-sha "$EXPECTED_SHA"
+          --wheel "$WHEEL_PATH"
+          --max-median-session-regression-fraction 0.05
+          --output scheduler-abba/comparison.json
+          --summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw trials and decision manifest
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: hosted-pytest-scheduler-abba-${{ github.run_id }}
+          path: scheduler-abba/
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/suews/README.md
+++ b/scripts/suews/README.md
@@ -114,6 +114,42 @@ This manual same-job result is the acceptance evidence. Ordinary PR runs and
 unrelated historical runs cannot establish the overhead bound because GitHub
 host load is uncontrolled.
 
+## Hosted pytest scheduler comparison
+
+**Workflow**: `Hosted pytest scheduler ABBA`
+
+The manual workflow compares `loadscope` and `worksteal` without changing the
+fixed GitHub-hosted worker budget. It downloads one successful
+`cp312-manylinux-x86_64` wheel, checks out the exact SHA that produced it, and
+runs the same `physics and not slow` nodes four times in A/B/B/A order:
+
+1. `loadscope`
+2. `worksteal`
+3. `worksteal`
+4. `loadscope`
+
+Every trial uses `-n auto --maxprocesses=4`, a fresh `--basetemp`, and a
+disabled pytest cache provider. The workflow is `workflow_dispatch` only so
+ordinary pull requests never pay for four full physics runs. Dispatch requires
+the ID of a successful Build and Publish workflow run and its exact source SHA.
+
+`compare_scheduler_runs.py` consumes the four schema-v2 metrics artefacts. It
+fails closed when node inventories, outcomes or effective worker counts differ;
+when any worker assignment or timing fingerprint is inconsistent; or when the
+hosted run does not resolve exactly four workers. `worksteal` is accepted only
+when both its median finish spread and its median tail over the worker median
+are strictly lower than `loadscope`, and its median session duration is no more
+than 5% above `loadscope`. The median-session limit is configurable through the
+comparison CLI, while the hosted workflow fixes it at 5% so dispatches cannot
+silently weaken the decision rule.
+
+The memory gate uses the maximum process-tree RSS observed in either replicate,
+not only the median. By default it requires at least 20% headroom against the
+runner's measured `/proc/meminfo` capacity and limits the challenger's maximum
+peak-RSS regression to 10%. The uploaded decision manifest records session and
+test-phase medians, worker-tail deltas, median and maximum RSS, source SHA, and
+the SHA-256 of the exact downloaded wheel.
+
 ## Naming Convention Checker
 
 **Script**: `check_naming_conventions.py`

--- a/scripts/suews/compare_scheduler_runs.py
+++ b/scripts/suews/compare_scheduler_runs.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""Compare matched loadscope/worksteal pytest runs in ABBA order."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+from statistics import median
+import sys
+from typing import Any
+
+ABBA_ORDER = ("loadscope", "worksteal", "worksteal", "loadscope")
+MAX_WORKERS = 4
+OUTCOME_NAMES = {"passed", "failed", "skipped", "xfailed", "xpassed"}
+DEFAULT_MAX_MEDIAN_SESSION_REGRESSION_FRACTION = 0.05
+DEFAULT_MAX_PEAK_RSS_REGRESSION_FRACTION = 0.10
+DEFAULT_MIN_MEMORY_HEADROOM_FRACTION = 0.20
+LINUX_WHEEL_ARTIFACT = "cp312-manylinux-x86_64"
+
+
+class ComparisonError(ValueError):
+    """Raised when matched scheduler evidence violates its contract."""
+
+
+def _sha256_node_ids(node_ids: list[str]) -> str:
+    """Return the provider's stable hash for sorted node IDs."""
+    return hashlib.sha256("\n".join(sorted(node_ids)).encode()).hexdigest()
+
+
+def _delta(challenger: float, incumbent: float) -> dict[str, float | None]:
+    """Return absolute and relative challenger-minus-incumbent changes."""
+    difference = challenger - incumbent
+    relative = difference / incumbent if incumbent else None
+    return {"absolute": difference, "fraction": relative}
+
+
+def _finite_nonnegative(path: Path, label: str, value: Any) -> float:
+    """Require one numeric measurement to be finite and non-negative."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+    ):
+        raise ComparisonError(f"{path}: {label} must be finite and non-negative")
+    return float(value)
+
+
+def _validate_provenance(provenance: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Validate the source run and exact Linux wheel identity when supplied."""
+    if provenance is None:
+        return None
+    required = {
+        "source_run_id",
+        "source_sha",
+        "expected_source_sha",
+        "wheel_artifact_name",
+        "wheel_sha256",
+    }
+    if set(provenance) != required:
+        raise ComparisonError("complete hosted provenance is required")
+    if isinstance(provenance["source_run_id"], bool) or not isinstance(
+        provenance["source_run_id"], int
+    ):
+        raise ComparisonError("source run ID must be a positive integer")
+    if provenance["source_run_id"] <= 0:
+        raise ComparisonError("source run ID must be a positive integer")
+    if not re.fullmatch(r"[0-9a-f]{40}", provenance["source_sha"]):
+        raise ComparisonError("source SHA must be a lowercase 40-character hex digest")
+    if provenance["source_sha"] != provenance["expected_source_sha"]:
+        raise ComparisonError(
+            "source SHA mismatch between successful run and dispatch input"
+        )
+    if provenance["wheel_artifact_name"] != LINUX_WHEEL_ARTIFACT:
+        raise ComparisonError(f"wheel artifact must be {LINUX_WHEEL_ARTIFACT}")
+    if not re.fullmatch(r"[0-9a-f]{64}", provenance["wheel_sha256"]):
+        raise ComparisonError(
+            "wheel SHA-256 must be a lowercase 64-character hex digest"
+        )
+    return dict(provenance)
+
+
+def _read_metrics(path: Path) -> dict[str, Any]:
+    """Read one schema-v2 pytest metrics artefact."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ComparisonError(f"cannot read metrics artefact {path}: {exc}") from exc
+    if payload.get("schema_version") != 2:
+        raise ComparisonError(f"{path}: expected metrics schema_version 2")
+    return payload
+
+
+def _validate_workers(path: Path, workers: list[dict[str, Any]]) -> list[str]:
+    """Validate per-worker node fingerprints and timing measurements."""
+    worker_ids = [worker["worker_id"] for worker in workers]
+    if len(worker_ids) != len(set(worker_ids)):
+        raise ComparisonError(f"{path}: duplicate worker IDs")
+
+    node_ids = []
+    for worker in workers:
+        assigned = worker["node_ids"]
+        worker_id = worker["worker_id"]
+        if worker["node_count"] != len(assigned):
+            raise ComparisonError(f"{path}: worker {worker_id} node count mismatch")
+        if worker["node_id_sha256"] != _sha256_node_ids(assigned):
+            raise ComparisonError(
+                f"{path}: worker {worker_id} assignment fingerprint mismatch"
+            )
+        _finite_nonnegative(
+            path, f"worker {worker_id} busy duration", worker["busy_duration_seconds"]
+        )
+        _finite_nonnegative(
+            path, f"worker {worker_id} finish time", worker["finished_at_seconds"]
+        )
+        node_ids.extend(assigned)
+    return node_ids
+
+
+def _validate_inventory(path: Path, inventory: dict[str, Any]) -> None:
+    """Validate the stable collected-node fingerprint."""
+    node_count = inventory["node_count"]
+    if (
+        isinstance(node_count, bool)
+        or not isinstance(node_count, int)
+        or node_count <= 0
+    ):
+        raise ComparisonError(f"{path}: inventory node count must be positive")
+    if re.fullmatch(r"[0-9a-f]{64}", inventory["node_id_sha256"]) is None:
+        raise ComparisonError(f"{path}: inventory node hash must be SHA-256")
+
+
+def _validate_result(
+    path: Path,
+    result: dict[str, Any],
+    inventory: dict[str, Any],
+) -> dict[str, int]:
+    """Validate one successful and complete pytest outcome ledger."""
+    exit_code = result["exit_code"]
+    if isinstance(exit_code, bool) or not isinstance(exit_code, int) or exit_code != 0:
+        raise ComparisonError(f"{path}: pytest exit code is {exit_code}")
+    outcomes = result["outcomes"]
+    if set(outcomes) != OUTCOME_NAMES or any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 0
+        for value in outcomes.values()
+    ):
+        raise ComparisonError(f"{path}: complete outcome counts are required")
+    if sum(outcomes.values()) != inventory["node_count"]:
+        raise ComparisonError(f"{path}: outcome total does not match inventory")
+    if outcomes["failed"] != 0:
+        raise ComparisonError(f"{path}: successful exit cannot contain failed outcomes")
+    return outcomes
+
+
+def _validate_execution(
+    path: Path,
+    execution: dict[str, Any],
+    inventory: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate the resolved worker budget, assignments and finish tail."""
+    workers = execution["workers"]
+    worker_count = execution["effective_worker_count"]
+    if execution["xdist"] is not True:
+        raise ComparisonError(f"{path}: xdist must be active")
+    if (
+        isinstance(worker_count, bool)
+        or not isinstance(worker_count, int)
+        or not 1 <= worker_count <= MAX_WORKERS
+    ):
+        raise ComparisonError(
+            f"{path}: effective worker count must be between 1 and {MAX_WORKERS}"
+        )
+    if len(workers) != worker_count:
+        raise ComparisonError(f"{path}: worker records do not match effective count")
+    node_ids = _validate_workers(path, workers)
+    if len(node_ids) != len(set(node_ids)):
+        raise ComparisonError(f"{path}: worker assignments contain duplicate node IDs")
+    if len(node_ids) != inventory["node_count"]:
+        raise ComparisonError(f"{path}: worker assignments do not cover the inventory")
+    if _sha256_node_ids(node_ids) != inventory["node_id_sha256"]:
+        raise ComparisonError(
+            f"{path}: worker assignment hash does not match inventory"
+        )
+
+    finish_times = [float(worker["finished_at_seconds"]) for worker in workers]
+    finish_spread = _finite_nonnegative(
+        path, "finish skew", execution["worker_finish_skew_seconds"]
+    )
+    tail = _finite_nonnegative(
+        path, "tail over median", execution["worker_tail_over_median_seconds"]
+    )
+    if not math.isclose(
+        finish_spread, max(finish_times) - min(finish_times), abs_tol=1e-6
+    ):
+        raise ComparisonError(f"{path}: finish skew does not match worker finish times")
+    if not math.isclose(tail, max(finish_times) - median(finish_times), abs_tol=1e-6):
+        raise ComparisonError(
+            f"{path}: tail over median does not match worker finish times"
+        )
+    return {
+        "worker_count": worker_count,
+        "finish_spread_seconds": finish_spread,
+        "tail_over_median_seconds": tail,
+        "workers": workers,
+    }
+
+
+def _validate_resources(path: Path, resources: dict[str, Any]) -> float:
+    """Validate Linux process-tree sampling and return peak RSS bytes."""
+    resource = resources["process_tree_peak_rss_bytes"]
+    if not resource["available"] or resource["unit"] != "bytes":
+        raise ComparisonError(
+            f"{path}: process-tree peak RSS is unavailable or not bytes"
+        )
+    if (
+        resource.get("status") != "sampled"
+        or resource.get("method") != "linux-procfs-sampling"
+    ):
+        raise ComparisonError(
+            f"{path}: process-tree peak RSS availability metadata is invalid"
+        )
+    peak_rss_bytes = _finite_nonnegative(path, "peak RSS", resource["value"])
+    if peak_rss_bytes == 0:
+        raise ComparisonError(f"{path}: peak RSS must be greater than zero")
+    sample_count = resources["sample_count"]
+    if (
+        isinstance(sample_count, bool)
+        or not isinstance(sample_count, int)
+        or sample_count <= 0
+    ):
+        raise ComparisonError(f"{path}: resource sample count must be positive")
+    sample_interval = _finite_nonnegative(
+        path,
+        "resource sample interval",
+        resources["sample_interval_seconds"],
+    )
+    if sample_interval == 0:
+        raise ComparisonError(f"{path}: resource sample interval must be positive")
+    return peak_rss_bytes
+
+
+def _run_summary_payload(path: Path, scheduler: str) -> dict[str, Any]:
+    """Validate and compact one scheduler trial."""
+    payload = _read_metrics(path)
+    inventory = payload["inventory"]
+    _validate_inventory(path, inventory)
+    outcomes = _validate_result(path, payload["result"], inventory)
+    execution = _validate_execution(path, payload["execution"], inventory)
+    wall_seconds = _finite_nonnegative(
+        path,
+        "session duration",
+        payload["phases"]["session"]["duration_seconds"],
+    )
+    test_seconds = _finite_nonnegative(
+        path,
+        "test duration",
+        payload["phases"]["tests"]["duration_seconds"],
+    )
+    peak_rss_bytes = _validate_resources(path, payload["resources"])
+    workers = execution["workers"]
+
+    return {
+        "path": str(path),
+        "scheduler": scheduler,
+        "wall_seconds": wall_seconds,
+        "test_seconds": test_seconds,
+        "finish_skew_seconds": execution["finish_spread_seconds"],
+        "tail_over_median_seconds": execution["tail_over_median_seconds"],
+        "peak_rss_bytes": peak_rss_bytes,
+        "worker_count": execution["worker_count"],
+        "inventory": inventory,
+        "outcomes": outcomes,
+        "workers": [
+            {
+                "worker_id": worker["worker_id"],
+                "node_count": worker["node_count"],
+                "node_id_sha256": worker["node_id_sha256"],
+                "busy_duration_seconds": worker["busy_duration_seconds"],
+                "finished_at_seconds": worker["finished_at_seconds"],
+            }
+            for worker in workers
+        ],
+    }
+
+
+def _run_summary(path: Path, scheduler: str) -> dict[str, Any]:
+    """Convert malformed provider data into one contract-level error type."""
+    try:
+        return _run_summary_payload(path, scheduler)
+    except ComparisonError:
+        raise
+    except (KeyError, TypeError, ValueError, IndexError) as exc:
+        raise ComparisonError(f"{path}: malformed schema-v2 metrics: {exc}") from exc
+
+
+def compare_abba(
+    paths: Sequence[Path],
+    *,
+    runner_memory_bytes: int,
+    expected_worker_count: int | None = None,
+    max_median_session_regression_fraction: float = (
+        DEFAULT_MAX_MEDIAN_SESSION_REGRESSION_FRACTION
+    ),
+    max_peak_rss_regression_fraction: float = DEFAULT_MAX_PEAK_RSS_REGRESSION_FRACTION,
+    min_memory_headroom_fraction: float = DEFAULT_MIN_MEMORY_HEADROOM_FRACTION,
+    provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Compare two loadscope and two worksteal trials on one runner."""
+    if len(paths) != len(ABBA_ORDER):
+        raise ComparisonError("ABBA comparison requires exactly four metrics files")
+    if runner_memory_bytes <= 0:
+        raise ComparisonError("runner memory must be positive")
+    if (
+        expected_worker_count is not None
+        and not 1 <= expected_worker_count <= MAX_WORKERS
+    ):
+        raise ComparisonError(
+            f"expected worker count must be between 1 and {MAX_WORKERS}"
+        )
+    if not 0 <= max_peak_rss_regression_fraction <= 1:
+        raise ComparisonError(
+            "peak RSS regression fraction must be between zero and one"
+        )
+    if not 0 <= max_median_session_regression_fraction <= 1:
+        raise ComparisonError(
+            "median session regression fraction must be between zero and one"
+        )
+    if not 0 <= min_memory_headroom_fraction < 1:
+        raise ComparisonError(
+            "memory headroom fraction must be at least zero and below one"
+        )
+    validated_provenance = _validate_provenance(provenance)
+
+    runs = [
+        _run_summary(Path(path), scheduler)
+        for path, scheduler in zip(paths, ABBA_ORDER, strict=True)
+    ]
+    first = runs[0]
+    if any(run["inventory"] != first["inventory"] for run in runs[1:]):
+        raise ComparisonError("inventory mismatch across ABBA trials")
+    if any(run["outcomes"] != first["outcomes"] for run in runs[1:]):
+        raise ComparisonError("outcome mismatch across ABBA trials")
+    if any(run["worker_count"] != first["worker_count"] for run in runs[1:]):
+        raise ComparisonError("worker count mismatch across ABBA trials")
+    if (
+        expected_worker_count is not None
+        and first["worker_count"] != expected_worker_count
+    ):
+        raise ComparisonError(
+            f"expected {expected_worker_count} effective workers, got {first['worker_count']}"
+        )
+    grouped = {
+        scheduler: [run for run in runs if run["scheduler"] == scheduler]
+        for scheduler in ("loadscope", "worksteal")
+    }
+    schedulers = {
+        scheduler: {
+            "median_session_seconds": median(run["wall_seconds"] for run in trials),
+            "median_test_seconds": median(run["test_seconds"] for run in trials),
+            "median_finish_spread_seconds": median(
+                run["finish_skew_seconds"] for run in trials
+            ),
+            "median_tail_over_median_seconds": median(
+                run["tail_over_median_seconds"] for run in trials
+            ),
+            "median_peak_rss_bytes": median(run["peak_rss_bytes"] for run in trials),
+            "max_peak_rss_bytes": max(run["peak_rss_bytes"] for run in trials),
+        }
+        for scheduler, trials in grouped.items()
+    }
+    loadscope = schedulers["loadscope"]
+    worksteal = schedulers["worksteal"]
+    if not (
+        worksteal["median_finish_spread_seconds"]
+        < loadscope["median_finish_spread_seconds"]
+        and worksteal["median_tail_over_median_seconds"]
+        < loadscope["median_tail_over_median_seconds"]
+    ):
+        raise ComparisonError(
+            "worksteal requires strictly lower median finish spread and tail"
+        )
+    maximum_worksteal_session_seconds = loadscope["median_session_seconds"] * (
+        1 + max_median_session_regression_fraction
+    )
+    if worksteal["median_session_seconds"] > maximum_worksteal_session_seconds:
+        raise ComparisonError(
+            "worksteal median session regression exceeds the safety threshold"
+        )
+    highest_peak_rss = max(run["peak_rss_bytes"] for run in runs)
+    memory_headroom_bytes = runner_memory_bytes - highest_peak_rss
+    memory_headroom_fraction = memory_headroom_bytes / runner_memory_bytes
+    if memory_headroom_fraction < min_memory_headroom_fraction:
+        raise ComparisonError(
+            "memory headroom is below the configured hosted-runner safety threshold"
+        )
+    peak_rss_delta = _delta(
+        worksteal["max_peak_rss_bytes"],
+        loadscope["max_peak_rss_bytes"],
+    )
+    if peak_rss_delta["fraction"] is None or (
+        peak_rss_delta["fraction"] > max_peak_rss_regression_fraction
+    ):
+        raise ComparisonError(
+            "worksteal peak RSS regression exceeds the safety threshold"
+        )
+
+    deltas = {
+        "median_session_seconds": _delta(
+            worksteal["median_session_seconds"], loadscope["median_session_seconds"]
+        ),
+        "median_test_seconds": _delta(
+            worksteal["median_test_seconds"], loadscope["median_test_seconds"]
+        ),
+        "median_finish_spread_seconds": _delta(
+            worksteal["median_finish_spread_seconds"],
+            loadscope["median_finish_spread_seconds"],
+        ),
+        "median_tail_over_median_seconds": _delta(
+            worksteal["median_tail_over_median_seconds"],
+            loadscope["median_tail_over_median_seconds"],
+        ),
+        "max_peak_rss_bytes": peak_rss_delta,
+    }
+    return {
+        "schema_version": 1,
+        "order": list(ABBA_ORDER),
+        "selected_scheduler": "worksteal",
+        "provenance": validated_provenance,
+        "invariants": {
+            "effective_worker_count": first["worker_count"],
+            "inventory": first["inventory"],
+            "outcomes": first["outcomes"],
+            "runner_memory_bytes": runner_memory_bytes,
+        },
+        "schedulers": schedulers,
+        "deltas": deltas,
+        "session_guardrail": {
+            "loadscope_median_seconds": loadscope["median_session_seconds"],
+            "worksteal_median_seconds": worksteal["median_session_seconds"],
+            "maximum_worksteal_seconds": maximum_worksteal_session_seconds,
+            "maximum_regression_fraction": max_median_session_regression_fraction,
+            "passed": True,
+        },
+        "memory_guardrail": {
+            "runner_capacity_bytes": runner_memory_bytes,
+            "highest_peak_rss_bytes": highest_peak_rss,
+            "headroom_bytes": memory_headroom_bytes,
+            "headroom_fraction": memory_headroom_fraction,
+            "minimum_headroom_fraction": min_memory_headroom_fraction,
+            "maximum_peak_rss_regression_fraction": max_peak_rss_regression_fraction,
+            "passed": True,
+        },
+        "runs": runs,
+    }
+
+
+def _wheel_sha256(path: Path) -> str:
+    """Fingerprint the exact wheel installed for all four trials."""
+    digest = hashlib.sha256()
+    with path.open("rb") as wheel:
+        for chunk in iter(lambda: wheel.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    """Write one deterministic decision manifest."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _append_summary(path: Path, manifest: dict[str, Any]) -> None:
+    """Append the hosted scheduler decision to a GitHub step summary."""
+    lines = ["## Hosted scheduler ABBA", ""]
+    if manifest["status"] != "passed":
+        lines.extend([f"Result: failed - {manifest['error']}", ""])
+    else:
+        loadscope = manifest["schedulers"]["loadscope"]
+        worksteal = manifest["schedulers"]["worksteal"]
+        memory = manifest["memory_guardrail"]
+        session = manifest["session_guardrail"]
+        lines.extend([
+            "Result: worksteal accepted under the fixed four-worker budget.",
+            "",
+            "| Measurement | loadscope | worksteal |",
+            "|---|---:|---:|",
+            f"| Median session | {loadscope['median_session_seconds']:.3f} s | {worksteal['median_session_seconds']:.3f} s |",
+            f"| Median test phase | {loadscope['median_test_seconds']:.3f} s | {worksteal['median_test_seconds']:.3f} s |",
+            f"| Median finish spread | {loadscope['median_finish_spread_seconds']:.3f} s | {worksteal['median_finish_spread_seconds']:.3f} s |",
+            f"| Median tail over worker median | {loadscope['median_tail_over_median_seconds']:.3f} s | {worksteal['median_tail_over_median_seconds']:.3f} s |",
+            f"| Maximum process-tree peak RSS | {loadscope['max_peak_rss_bytes']} B | {worksteal['max_peak_rss_bytes']} B |",
+            "",
+            f"Runner memory headroom: {memory['headroom_fraction']:.1%}.",
+            f"Median session regression limit: {session['maximum_regression_fraction']:.1%}.",
+            f"Source SHA: `{manifest['provenance']['source_sha']}`.",
+            f"Wheel SHA-256: `{manifest['provenance']['wheel_sha256']}`.",
+            "",
+        ])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines))
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the hosted-comparison command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("metrics", nargs=4, type=Path, metavar="METRICS")
+    parser.add_argument("--runner-memory-bytes", required=True, type=int)
+    parser.add_argument("--source-run-id", required=True, type=int)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--expected-source-sha", required=True)
+    parser.add_argument("--wheel", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument(
+        "--max-median-session-regression-fraction",
+        type=float,
+        default=DEFAULT_MAX_MEDIAN_SESSION_REGRESSION_FRACTION,
+    )
+    parser.add_argument(
+        "--max-peak-rss-regression-fraction",
+        type=float,
+        default=DEFAULT_MAX_PEAK_RSS_REGRESSION_FRACTION,
+    )
+    parser.add_argument(
+        "--min-memory-headroom-fraction",
+        type=float,
+        default=DEFAULT_MIN_MEMORY_HEADROOM_FRACTION,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the fail-closed hosted ABBA comparison."""
+    args = _parser().parse_args(argv)
+    provenance = {
+        "source_run_id": args.source_run_id,
+        "source_sha": args.source_sha,
+        "expected_source_sha": args.expected_source_sha,
+        "wheel_artifact_name": LINUX_WHEEL_ARTIFACT,
+        "wheel_sha256": "",
+    }
+    try:
+        provenance["wheel_sha256"] = _wheel_sha256(args.wheel)
+        manifest = compare_abba(
+            args.metrics,
+            runner_memory_bytes=args.runner_memory_bytes,
+            expected_worker_count=MAX_WORKERS,
+            max_median_session_regression_fraction=(
+                args.max_median_session_regression_fraction
+            ),
+            max_peak_rss_regression_fraction=args.max_peak_rss_regression_fraction,
+            min_memory_headroom_fraction=args.min_memory_headroom_fraction,
+            provenance=provenance,
+        )
+        manifest["status"] = "passed"
+        exit_code = 0
+    except (ComparisonError, OSError) as exc:
+        manifest = {
+            "schema_version": 1,
+            "status": "failed",
+            "error": str(exc),
+            "provenance": provenance,
+        }
+        exit_code = 1
+    _write_manifest(args.output, manifest)
+    if args.summary:
+        _append_summary(args.summary, manifest)
+    if exit_code:
+        print(manifest["error"], file=sys.stderr)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/core/test_scheduler_benchmark.py
+++ b/test/core/test_scheduler_benchmark.py
@@ -1,0 +1,711 @@
+"""Contract tests for matched hosted scheduler comparisons."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from statistics import median
+
+import pytest
+
+from scripts.suews.compare_scheduler_runs import ComparisonError, compare_abba, main
+
+pytestmark = pytest.mark.api
+
+SCHEMA_V2_XDIST_FIXTURE = (
+    Path(__file__).parents[1] / "fixtures/ci_metrics/schema-v2-xdist.json"
+)
+
+
+def _metrics(
+    path: Path,
+    *,
+    wall_seconds: float,
+    finish_skew_seconds: float,
+    peak_rss_bytes: int,
+    node_ids: tuple[str, str] = ("test/a.py::test_a", "test/b.py::test_b"),
+    skipped: int = 0,
+    worker_count: int = 2,
+) -> Path:
+    """Write one schema-v2 metrics fixture with a complete worker inventory."""
+    workers = []
+    for index in range(worker_count):
+        assigned = [node_ids[index]] if index < len(node_ids) else []
+        workers.append({
+            "worker_id": f"gw{index}",
+            "node_count": len(assigned),
+            "node_id_sha256": hashlib.sha256("\n".join(assigned).encode()).hexdigest(),
+            "node_ids": assigned,
+            "busy_duration_seconds": 8.0 - min(index, 1),
+            "finished_at_seconds": 9.0 + finish_skew_seconds if index == 0 else 9.0,
+        })
+    payload = {
+        "schema_version": 2,
+        "result": {
+            "exit_code": 0,
+            "outcomes": {
+                "passed": 2 - skipped,
+                "failed": 0,
+                "skipped": skipped,
+                "xfailed": 0,
+                "xpassed": 0,
+            },
+        },
+        "phases": {
+            "collection": {"duration_seconds": 1.0},
+            "tests": {"duration_seconds": wall_seconds - 1.0},
+            "session": {"duration_seconds": wall_seconds},
+        },
+        "inventory": {
+            "node_count": len(node_ids),
+            "node_id_sha256": hashlib.sha256("\n".join(node_ids).encode()).hexdigest(),
+        },
+        "execution": {
+            "xdist": True,
+            "effective_worker_count": len(workers),
+            "workers": workers,
+            "worker_finish_skew_seconds": finish_skew_seconds,
+            "worker_tail_over_median_seconds": (
+                max(worker["finished_at_seconds"] for worker in workers)
+                - median(worker["finished_at_seconds"] for worker in workers)
+            ),
+        },
+        "resources": {
+            "process_tree_cpu_seconds": {
+                "available": True,
+                "status": "sampled",
+                "value": 15.0,
+                "unit": "seconds",
+                "method": "linux-procfs-sampling",
+                "reason": None,
+            },
+            "process_tree_peak_rss_bytes": {
+                "available": True,
+                "status": "sampled",
+                "value": peak_rss_bytes,
+                "unit": "bytes",
+                "method": "linux-procfs-sampling",
+                "reason": None,
+            },
+            "sample_count": 100,
+            "sample_interval_seconds": 0.1,
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_compare_abba_accepts_merged_schema_v2_provider_fixture(
+    tmp_path: Path,
+) -> None:
+    """The comparator consumes the exact schema-v2 xdist provider contract."""
+    trials = [
+        ("loadscope-a", 12.0, 4.0, 300_000_000),
+        ("worksteal-a", 10.0, 1.0, 290_000_000),
+        ("worksteal-b", 10.2, 1.2, 295_000_000),
+        ("loadscope-b", 12.2, 4.2, 305_000_000),
+    ]
+    paths = []
+    for name, session_seconds, finish_skew_seconds, peak_rss_bytes in trials:
+        payload = json.loads(SCHEMA_V2_XDIST_FIXTURE.read_text(encoding="utf-8"))
+        payload["phases"]["session"]["duration_seconds"] = session_seconds
+        payload["phases"]["tests"]["duration_seconds"] = session_seconds - 0.5
+        payload["execution"]["workers"][0]["finished_at_seconds"] = (
+            8.0 + finish_skew_seconds
+        )
+        payload["execution"]["workers"][1]["finished_at_seconds"] = 8.0
+        payload["execution"]["worker_finish_skew_seconds"] = finish_skew_seconds
+        payload["execution"]["worker_tail_over_median_seconds"] = (
+            finish_skew_seconds / 2
+        )
+        payload["resources"]["process_tree_peak_rss_bytes"]["value"] = peak_rss_bytes
+        path = tmp_path / f"{name}.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        paths.append(path)
+
+    comparison = compare_abba(paths, runner_memory_bytes=2_000_000_000)
+
+    provider_fixture = json.loads(SCHEMA_V2_XDIST_FIXTURE.read_text(encoding="utf-8"))
+    assert comparison["selected_scheduler"] == "worksteal"
+    assert comparison["invariants"]["inventory"] == provider_fixture["inventory"]
+    assert comparison["invariants"]["effective_worker_count"] == 2
+
+
+def test_compare_abba_selects_lower_skew_with_fixed_worker_budget(
+    tmp_path: Path,
+) -> None:
+    """Matched ABBA trials select worksteal without adding workers."""
+    paths = [
+        _metrics(
+            tmp_path / "loadscope-a.json",
+            wall_seconds=120.0,
+            finish_skew_seconds=20.0,
+            peak_rss_bytes=1_000_000,
+        ),
+        _metrics(
+            tmp_path / "worksteal-a.json",
+            wall_seconds=100.0,
+            finish_skew_seconds=5.0,
+            peak_rss_bytes=1_020_000,
+        ),
+        _metrics(
+            tmp_path / "worksteal-b.json",
+            wall_seconds=102.0,
+            finish_skew_seconds=7.0,
+            peak_rss_bytes=1_030_000,
+        ),
+        _metrics(
+            tmp_path / "loadscope-b.json",
+            wall_seconds=122.0,
+            finish_skew_seconds=22.0,
+            peak_rss_bytes=1_010_000,
+        ),
+    ]
+
+    comparison = compare_abba(paths, runner_memory_bytes=8_000_000)
+
+    assert comparison["selected_scheduler"] == "worksteal"
+    assert comparison["invariants"]["effective_worker_count"] == 2
+    assert comparison["schedulers"]["loadscope"][
+        "median_finish_spread_seconds"
+    ] == pytest.approx(21.0)
+    assert comparison["schedulers"]["worksteal"][
+        "median_finish_spread_seconds"
+    ] == pytest.approx(6.0)
+    assert comparison["session_guardrail"][
+        "maximum_regression_fraction"
+    ] == pytest.approx(0.05)
+
+
+def test_compare_abba_rejects_median_session_regression(tmp_path: Path) -> None:
+    """A lower worker tail cannot justify a catastrophic wall-time regression."""
+    paths = [
+        _metrics(
+            tmp_path / "loadscope-a.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "worksteal-a.json",
+            wall_seconds=1_000.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "worksteal-b.json",
+            wall_seconds=1_000.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "loadscope-b.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+    ]
+
+    with pytest.raises(ComparisonError, match="median session regression"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_different_node_inventory(tmp_path: Path) -> None:
+    """All four trials must execute the same collected nodes."""
+    paths = [
+        _metrics(
+            tmp_path / "a.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b1.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+            node_ids=("test/a.py::test_a", "test/c.py::test_c"),
+        ),
+        _metrics(
+            tmp_path / "b2.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "a2.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        ),
+    ]
+
+    with pytest.raises(ComparisonError, match="inventory mismatch"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_different_outcomes(tmp_path: Path) -> None:
+    """Passing, skipped and expected-failure outcomes must all match."""
+    paths = [
+        _metrics(
+            tmp_path / "a.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b1.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+            skipped=1,
+        ),
+        _metrics(
+            tmp_path / "b2.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "a2.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        ),
+    ]
+
+    with pytest.raises(ComparisonError, match="outcome mismatch"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_different_effective_worker_counts(tmp_path: Path) -> None:
+    """Scheduler candidates must use the same resolved worker budget."""
+    paths = [
+        _metrics(
+            tmp_path / "a.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b1.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+            worker_count=3,
+        ),
+        _metrics(
+            tmp_path / "b2.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "a2.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        ),
+    ]
+
+    with pytest.raises(ComparisonError, match="worker count mismatch"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_enforces_expected_hosted_worker_count(tmp_path: Path) -> None:
+    """The hosted workflow fails closed unless all four workers resolve."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+
+    with pytest.raises(ComparisonError, match="expected 4 effective workers"):
+        compare_abba(paths, runner_memory_bytes=1_000, expected_worker_count=4)
+
+
+def test_compare_abba_rejects_invalid_worker_assignment_hash(tmp_path: Path) -> None:
+    """Each worker record must fingerprint its own assigned nodes."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+    payload = json.loads(paths[1].read_text(encoding="utf-8"))
+    payload["execution"]["workers"][0]["node_id_sha256"] = "wrong"
+    paths[1].write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ComparisonError, match="worker gw0 assignment fingerprint"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_inconsistent_finish_skew(tmp_path: Path) -> None:
+    """Reported finish skew must equal the spread of worker finish times."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+    payload = json.loads(paths[2].read_text(encoding="utf-8"))
+    payload["execution"]["worker_finish_skew_seconds"] = 99.0
+    paths[2].write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ComparisonError, match="finish skew does not match"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_requires_complete_outcome_counts(tmp_path: Path) -> None:
+    """All five terminal pytest outcome counts are required."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+    for path in paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        del payload["result"]["outcomes"]["xfailed"]
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ComparisonError, match="complete outcome counts"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_inconsistent_tail_over_median(tmp_path: Path) -> None:
+    """Reported tail must equal the slowest finish minus the median finish."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+    payload = json.loads(paths[0].read_text(encoding="utf-8"))
+    payload["execution"]["worker_tail_over_median_seconds"] = 99.0
+    paths[0].write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ComparisonError, match="tail over median does not match"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_scheduler_tie(tmp_path: Path) -> None:
+    """Worksteal requires a strict finish-tail improvement over loadscope."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+
+    with pytest.raises(
+        ComparisonError, match="strictly lower median finish spread and tail"
+    ):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_peak_rss_without_runner_headroom(tmp_path: Path) -> None:
+    """One memory spike fails even when the other worksteal run is small."""
+    paths = [
+        _metrics(
+            tmp_path / "a1.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b1.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=850,
+        ),
+        _metrics(
+            tmp_path / "b2.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "a2.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+    ]
+
+    with pytest.raises(ComparisonError, match="memory headroom"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_zero_workers(tmp_path: Path) -> None:
+    """A zero-worker artefact is invalid even when it claims xdist was active."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+    for path in paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["execution"].update({
+            "effective_worker_count": 0,
+            "workers": [],
+            "worker_finish_skew_seconds": 0.0,
+            "worker_tail_over_median_seconds": 0.0,
+        })
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ComparisonError, match="effective worker count must be between 1 and 4"
+    ):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_nonfinite_timing(tmp_path: Path) -> None:
+    """NaN timings cannot participate in a scheduler decision."""
+    paths = [
+        _metrics(
+            tmp_path / "a1.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b1.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b2.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "a2.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+    ]
+    payload = json.loads(paths[1].read_text(encoding="utf-8"))
+    payload["phases"]["session"]["duration_seconds"] = float("nan")
+    paths[1].write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ComparisonError, match="session duration must be finite and non-negative"
+    ):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_reports_malformed_schema_as_contract_error(
+    tmp_path: Path,
+) -> None:
+    """Missing schema-v2 fields never escape as raw KeyError exceptions."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+    payload = json.loads(paths[0].read_text(encoding="utf-8"))
+    del payload["resources"]
+    paths[0].write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ComparisonError, match="malformed schema-v2 metrics"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_requires_resource_samples(tmp_path: Path) -> None:
+    """Peak RSS evidence must come from at least one process-tree sample."""
+    paths = [
+        _metrics(
+            tmp_path / f"run-{index}.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=2.0,
+            peak_rss_bytes=100,
+        )
+        for index in range(4)
+    ]
+    for path in paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["resources"]["sample_count"] = 0
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ComparisonError, match="resource sample count must be positive"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_requires_outcomes_to_cover_inventory(tmp_path: Path) -> None:
+    """Four identically incomplete outcome records still fail closed."""
+    paths = [
+        _metrics(
+            tmp_path / "a1.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b1.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b2.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "a2.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+    ]
+    for path in paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["result"]["outcomes"]["passed"] = 1
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ComparisonError, match="outcome total does not match inventory"):
+        compare_abba(paths, runner_memory_bytes=1_000)
+
+
+def test_compare_abba_rejects_source_sha_mismatch(tmp_path: Path) -> None:
+    """The downloaded wheel run and checked-out source must share one SHA."""
+    paths = [
+        _metrics(
+            tmp_path / "a1.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b1.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "b2.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=100,
+        ),
+        _metrics(
+            tmp_path / "a2.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+        ),
+    ]
+    provenance = {
+        "source_run_id": 123,
+        "source_sha": "a" * 40,
+        "expected_source_sha": "b" * 40,
+        "wheel_artifact_name": "cp312-manylinux-x86_64",
+        "wheel_sha256": "c" * 64,
+    }
+
+    with pytest.raises(ComparisonError, match="source SHA mismatch"):
+        compare_abba(paths, runner_memory_bytes=1_000, provenance=provenance)
+
+
+def test_cli_writes_provenance_manifest_and_step_summary(tmp_path: Path) -> None:
+    """The hosted CLI independently fingerprints its one downloaded wheel."""
+    paths = [
+        _metrics(
+            tmp_path / "a1.json",
+            wall_seconds=10.0,
+            finish_skew_seconds=4.0,
+            peak_rss_bytes=100,
+            worker_count=4,
+        ),
+        _metrics(
+            tmp_path / "b1.json",
+            wall_seconds=9.0,
+            finish_skew_seconds=1.0,
+            peak_rss_bytes=102,
+            worker_count=4,
+        ),
+        _metrics(
+            tmp_path / "b2.json",
+            wall_seconds=9.2,
+            finish_skew_seconds=1.2,
+            peak_rss_bytes=103,
+            worker_count=4,
+        ),
+        _metrics(
+            tmp_path / "a2.json",
+            wall_seconds=10.2,
+            finish_skew_seconds=4.2,
+            peak_rss_bytes=101,
+            worker_count=4,
+        ),
+    ]
+    wheel = tmp_path / "supy.whl"
+    wheel.write_bytes(b"exact wheel")
+    output = tmp_path / "comparison.json"
+    summary = tmp_path / "summary.md"
+    source_sha = "a" * 40
+
+    exit_code = main([
+        *(str(path) for path in paths),
+        "--runner-memory-bytes",
+        "10000",
+        "--source-run-id",
+        "123",
+        "--source-sha",
+        source_sha,
+        "--expected-source-sha",
+        source_sha,
+        "--wheel",
+        str(wheel),
+        "--max-median-session-regression-fraction",
+        "0.20",
+        "--output",
+        str(output),
+        "--summary",
+        str(summary),
+    ])
+
+    assert exit_code == 0
+    manifest = json.loads(output.read_text(encoding="utf-8"))
+    assert manifest["status"] == "passed"
+    assert manifest["session_guardrail"][
+        "maximum_regression_fraction"
+    ] == pytest.approx(0.20)
+    assert (
+        manifest["provenance"]["wheel_sha256"]
+        == hashlib.sha256(b"exact wheel").hexdigest()
+    )
+    assert "worksteal" in summary.read_text(encoding="utf-8")


### PR DESCRIPTION
Refs #1626

## Summary

- Adds a manual one-job benchmark that uses one GitHub-hosted runner, installs one exact successful Linux wheel, and runs `loadscope`, `worksteal`, `worksteal`, `loadscope` in A-B-B-A order.
- Keeps the hosted CPU budget fixed with `-n auto --maxprocesses=4`; the comparison fails unless exactly four effective workers resolve in every trial.
- Fails closed on source-run, source-SHA and wheel provenance; node inventory, outcomes and worker-count equality; strict median finish-skew and tail improvements; process-tree RSS safety; and a maximum 5% median-session regression.
- Uploads the four raw schema-v2 metrics artefacts and a decision manifest for post-merge evidence review.

## Validation

- Focused provider, phase, critical-path and comparator contracts: 41 passed.
- Smoke tier: 7 passed, 1 skipped.
- Ruff check and format, marker-axis audit, Action SHA pins, YAML parsing, zizmor and diff checks passed.

The hosted A-B-B-A run is intentionally deferred until this workflow is available on the default branch, so this PR references rather than closes #1626.