### PR TITLE
Skip empty submodule checkout in wheel builds

### DIFF
--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -57,7 +57,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          submodules: recursive
           persist-credentials: false
 
       - name: Stop checkout phase timing

--- a/test/core/test_ci_phase_metrics.py
+++ b/test/core/test_ci_phase_metrics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 import pytest
 
@@ -206,3 +207,22 @@ def test_every_local_build_action_caller_passes_metrics_host_dir() -> None:
                     f"{workflow.name}:{index + 1} must pass metrics_host_dir"
                 )
     assert callers
+
+
+@pytest.mark.smoke
+def test_wheel_checkout_skips_empty_submodules_but_keeps_version_history() -> None:
+    """Wheel checkout avoids empty submodules without weakening git describe."""
+    workflow = (PROJECT_ROOT / ".github/workflows/build-wheels-reusable.yml").read_text(
+        encoding="utf-8"
+    )
+    checkout = re.search(
+        r"uses: actions/checkout@[^\n]+\n(?P<inputs>(?:[ \t]+[^\n]+\n){1,8})",
+        workflow,
+    )
+
+    assert checkout is not None
+    checkout_inputs = checkout.group("inputs")
+    assert "fetch-depth: 0" in checkout_inputs
+    assert "persist-credentials: false" in checkout_inputs
+    assert "submodules:" not in checkout_inputs
+    assert not (PROJECT_ROOT / ".gitmodules").read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Summary

- remove recursive submodule setup from the reusable wheel checkout while `.gitmodules` is empty
- retain `fetch-depth: 0`, so `get_ver_git.py` still sees the complete commit/tag history used by `git describe`
- add a smoke workflow contract covering full history, credentials and the empty-submodule condition

Refs #1627. Parent: #1621.

## Evidence

The latest full scheduled run, [29467913161](https://github.com/UMEP-dev/SUEWS/actions/runs/29467913161), spent 12 min 59 s in the Windows standard-wheel job. Its uploaded machine-readable phase record reports:

| Phase | Duration |
|---|---:|
| tests | 416.790 s |
| build | 121.802 s |
| install | 64.223 s |
| checkout | 56.293 s |
| toolchain setup | 45.363 s |
| repair | 0.730 s |

All 136 selected physics tests passed. This identifies tests as the dominant phase; checkout is a smaller but measurable setup cost.

The tracked `.gitmodules` file is zero bytes, so `submodules: recursive` cannot retrieve project content. Removing it avoids only that empty action path. The checkout still uses `fetch-depth: 0`; at the base SHA the retained full-history provenance resolves to version `2026.7.15.dev8`, short commit `432dafa`, full commit `432dafaf827093277631b9e260070ac85c99fea6`, from `git describe` output `2026.7.15.dev-8-g432dafaf82`.

This PR deliberately does not add `filter: blob:none`. That remains a valid follow-up only after exact version, commit, tag and wheel-metadata equivalence is demonstrated on GitHub-hosted runners.

## Validation

- regression test failed before the workflow edit and passes after it
- `9 passed` for the wheel checkout/phase contracts and focused `get_ver_git.py` provenance tests
- `make test-smoke`: `7 passed, 2 skipped`
- workflow YAML parsed successfully
- `zizmor --no-online-audits`: no findings
- Ruff formatting/lint, test-marker lint and `git diff --check`: pass

## Remaining issue-level acceptance

This is an incremental, provenance-safe setup improvement. It does not claim the issue-level 10% median reduction: that requires at least three comparable post-merge Windows runs. Cache cold/warm trials and any blob-filter trial also remain outstanding. Existing wheel repair and installed-wheel/platform validation are unchanged and will run in CI.

## First merge-queue observation (not attribution)

Stacked speculative merge-group run [29478002818](https://github.com/UMEP-dev/SUEWS/actions/runs/29478002818) completed its Windows wheel job in 11 min 12 s, versus the 12 min 59 s scheduled baseline. However, machine-readable checkout time was 65.755 s versus 56.293 s in the baseline, while the physics-test phase was 309.379 s versus 416.790 s. The shorter headline duration therefore cannot be attributed to removing empty submodule work; it is dominated by hosted-runner/test-phase variation. This is directional evidence only, and the issue-level three-run 10% criterion remains open.