### PR TITLE
test: shorten LAI runtime-switch regression

### DIFF
--- a/test/core/test_laimethod.py
+++ b/test/core/test_laimethod.py
@@ -34,6 +34,18 @@ from conftest import TIMESTEPS_PER_DAY
 pytestmark = pytest.mark.physics
 
 
+@pytest.fixture(scope="module")
+def lai_runtime_inputs(sample_yaml_path):
+    """Return immutable sample inputs for independent LAI branch simulations."""
+    sim = SUEWSSimulation(str(sample_yaml_path))
+    config = sim.config.model_copy(deep=True)
+    for surf_type in ("evetr", "dectr", "grass"):
+        surf = getattr(config.sites[0].properties.land_cover, surf_type)
+        surf.lai.lai_min = 0.0
+        surf.lai.lai_max = 10.0
+    return config, sim.forcing.df
+
+
 def _base_forcing_df(n_timesteps: int = 24) -> pd.DataFrame:
     """Build a minimal hourly forcing DataFrame (mirrors the pattern in
     `test_wind_speed_validation.TestPhysicsSpecificValidation`)."""
@@ -262,11 +274,13 @@ class TestLAIMethodNegativeRejected:
 class TestLAIMethodRuntime:
     """End-to-end test that the switch actually gates the observed-LAI override.
 
-    Runs the sample-data simulation twice over ~30 days with a seasonally-varying
-    forcing `lai` column: once with laimethod=0 (expect daily LAI outputs to track
-    the forcing) and once with laimethod=1 (default; expect outputs NOT to track).
+    The core regression uses the first complete day because ``update_GDDLAI``
+    applies the switch on the final timestep of each day, immediately before the
+    DailyState write.  The longer seasonal scenario remains as slow integration
+    coverage.
     """
 
+    SHORT_N_DAYS = 1
     N_DAYS = 30
     LAI_OBS_LOW = 1.0
     LAI_OBS_HIGH = 6.0
@@ -280,25 +294,18 @@ class TestLAIMethodRuntime:
         return mid - amp * np.cos(phase)
 
     def _run_sim(
-        self, laimethod_value: int, lai_series: np.ndarray
+        self,
+        config,
+        df_forcing_base: pd.DataFrame,
+        laimethod_value: int,
+        lai_series: np.ndarray,
     ) -> pd.DataFrame:
         """Run a short simulation with the chosen laimethod and supplied lai column.
 
         Returns the DailyState sub-frame keyed by calendar date for easy alignment.
         """
-        sim = SUEWSSimulation.from_sample_data()
-
-        # Widen per-class LAI envelope so the seasonal forcing curve is not
-        # clipped at runtime — this test is about the laimethod switch, not
-        # about bound enforcement.
-        for surf_type in ("evetr", "dectr", "grass"):
-            surf = getattr(sim._config.sites[0].properties.land_cover, surf_type)
-            surf.lai.lai_min = 0.0
-            surf.lai.lai_max = 10.0
-
-        df_forcing = sim.forcing.df.copy()
-        end_index = TIMESTEPS_PER_DAY * self.N_DAYS - 1
-        df_forcing = df_forcing.iloc[: end_index + 1].copy()
+        sim = SUEWSSimulation(config.model_copy(deep=True))
+        df_forcing = df_forcing_base.iloc[: len(lai_series)].copy()
         df_forcing["lai"] = lai_series
 
         sim._config.model.physics.laimethod = LAIMethod(laimethod_value)
@@ -318,15 +325,27 @@ class TestLAIMethodRuntime:
         df_lai_daily.index = df_lai_daily.index.normalize()
         return df_lai_daily
 
-    def test_laimethod_runtime_switch(self):
-        """Observed LAI tracks forcing only when laimethod=0."""
-        sim = SUEWSSimulation.from_sample_data()
-        end_index = TIMESTEPS_PER_DAY * self.N_DAYS - 1
-        index = sim.forcing.df.index[: end_index + 1]
-        lai_series = self._seasonal_lai(index)
-
-        df_obs = self._run_sim(laimethod_value=0, lai_series=lai_series)
-        df_calc = self._run_sim(laimethod_value=1, lai_series=lai_series)
+    def _assert_runtime_switch(
+        self,
+        runtime_inputs,
+        index: pd.DatetimeIndex,
+        lai_series: np.ndarray,
+        minimum_aligned_days: int,
+    ) -> None:
+        """Assert that only the observed branch tracks the forcing LAI."""
+        config, df_forcing_base = runtime_inputs
+        df_obs = self._run_sim(
+            config,
+            df_forcing_base,
+            laimethod_value=0,
+            lai_series=lai_series,
+        )
+        df_calc = self._run_sim(
+            config,
+            df_forcing_base,
+            laimethod_value=1,
+            lai_series=lai_series,
+        )
 
         # Daily mean of forcing, keyed by normalised date.
         ser_forcing_daily = pd.Series(lai_series, index=index).resample("1D").mean()
@@ -339,8 +358,9 @@ class TestLAIMethodRuntime:
                 join="inner",
             ).dropna()
             aligned.columns = ["obs", "calc", "forcing"]
-            assert len(aligned) >= self.N_DAYS - 2, (
-                f"{column}: expected at least {self.N_DAYS - 2} aligned days, got {len(aligned)}"
+            assert len(aligned) >= minimum_aligned_days, (
+                f"{column}: expected at least {minimum_aligned_days} aligned "
+                f"days, got {len(aligned)}"
             )
 
             rmse_obs = float(
@@ -357,6 +377,35 @@ class TestLAIMethodRuntime:
                 f"{column}: laimethod=1 output (RMSE {rmse_calc:.3f}) should diverge "
                 f"from forcing more than laimethod=0 ({rmse_obs:.3f})"
             )
+
+    def test_laimethod_runtime_switch(self, lai_runtime_inputs):
+        """Observed LAI reaches the first DailyState write only for method 0."""
+        _, df_forcing_base = lai_runtime_inputs
+        n_timesteps = TIMESTEPS_PER_DAY * self.SHORT_N_DAYS
+        index = df_forcing_base.index[:n_timesteps]
+        lai_series = np.full(n_timesteps, self.LAI_OBS_HIGH)
+
+        self._assert_runtime_switch(
+            runtime_inputs=lai_runtime_inputs,
+            index=index,
+            lai_series=lai_series,
+            minimum_aligned_days=self.SHORT_N_DAYS,
+        )
+
+    @pytest.mark.slow
+    def test_laimethod_seasonal_integration(self, lai_runtime_inputs):
+        """Observed LAI continues to track a 30-day seasonal forcing curve."""
+        _, df_forcing_base = lai_runtime_inputs
+        end_index = TIMESTEPS_PER_DAY * self.N_DAYS - 1
+        index = df_forcing_base.index[: end_index + 1]
+        lai_series = self._seasonal_lai(index)
+
+        self._assert_runtime_switch(
+            runtime_inputs=lai_runtime_inputs,
+            index=index,
+            lai_series=lai_series,
+            minimum_aligned_days=self.N_DAYS - 2,
+        )
 
     def test_laimethod_runtime_tracks_per_vegetation_lai(self):
         """DailyState LAI outputs follow lai_evetr/lai_dectr/lai_grass separately."""


### PR DESCRIPTION
## Summary

- prove both `laimethod` branches at the first complete DailyState horizon (one five-minute day)
- retain the original 30-day seasonal scenario as `slow` integration coverage
- share immutable sample inputs while keeping independent branch simulations

## Scientific rationale

`update_GDDLAI` applies `laimethod` only on the final timestep of a day, immediately before the DailyState write. The first complete day is therefore the earliest causal observation point. A constant observed LAI of 6.0 deliberately separates the branches on that first write: the observed branch produces 6.0 for EveTr, DecTr and Grass, while the internally calculated branch remains near 4.0003, 1.0003 and 1.6003. The existing columns, RMSE tolerance and relative divergence assertion are unchanged.

The 30-day seasonally varying scenario remains intact under the `slow` marker, so seasonal evolution and repeated daily writes are still exercised by full physics coverage.

## Timing evidence

On the same local macOS build used before and after this change:

- previous focused call: 13.49 s
- new focused call: 2.16 s
- new one-time module fixture setup: 2.08 s
- recurring call reduction: 84.0%
- first-item setup plus call reduction: 68.6%

Exact-head manual run [29478072638](https://github.com/UMEP-dev/SUEWS/actions/runs/29478072638), Linux wheel job 87555373119, ran `-m physics`: 137 passed and 1 skipped in 205.51 s with inventory hash `75579483416cbeba534122726c2922d26d6c16900e12a1318b216eb9e97c9540`. Hosted log timestamps bound the short test, including fixture/setup, at approximately 4.74 s versus the 36.06 s Linux baseline: an approximately 86.9% reduction, above the 70% acceptance threshold. The retained seasonal test and all four native-state order permutations are present in the passing inventory. After that physics evidence and the CPython 3.12 API job passed, the redundant manual CPython 3.14 API job was cancelled because three speculative merge-group matrices were already validating the stacked heads; no publisher ran.

## Validation

- `test_laimethod.py -m physics`: 24 passed, including retained slow scenario
- fast then slow and slow then fast: passed
- native state A-to-B, B-to-A, A-to-A and B-to-B: 4 passed
- focused DailyState regressions: 2 passed
- test marker audit: passed
- `make test-smoke`: 6 passed, 2 skipped

Refs #1622
Part of #1621