### PR TITLE
Reuse sample inputs in API wrapper contract tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -375,7 +375,7 @@ def pytest_collection_finish(session):
 # (`supy.run_supy`), memoising by forcing window rather than always the full
 # range - see its own docstring for the copy contract.
 #
-# All five fixtures are lazy (nothing runs at import or collection time) and
+# All six fixtures are lazy (nothing runs at import or collection time) and
 # session-scoped, so each underlying sample run happens at most once per
 # `pytest` invocation, however many tests request it.
 
@@ -387,6 +387,20 @@ def sample_yaml_path() -> Path:
     Session-scoped since the path is fixed for the process lifetime.
     """
     return Path(supy.__file__).parent / "sample_data" / "sample_config.yml"
+
+
+@pytest.fixture(scope="session")
+def sample_config_loaded(sample_yaml_path):
+    """The validated sample config, without loading its full forcing file.
+
+    READ-ONLY: consumers that mutate the config MUST take a deep model copy.
+    This supports wrapper tests whose execution backend is mocked: they need
+    a structurally real config, but repeatedly parsing 105,408 forcing rows
+    would add no coverage to their argument-forwarding contract.
+    """
+    from supy.data_model import SUEWSConfig
+
+    return SUEWSConfig.from_yaml(str(sample_yaml_path))
 
 
 @pytest.fixture(scope="session")

--- a/test/core/test_public_api_wrappers.py
+++ b/test/core/test_public_api_wrappers.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 # Import the module to access both versions
 import supy as sp
+import supy._supy_module as supy_module
 from supy.suews_sim import SUEWSSimulation
 
 # The conftest.py saves deprecated versions before monkeypatching
@@ -222,51 +223,108 @@ class TestPublicAPIDeprecationMessages:
             "save_supy",
         ],
     )
-    def test_all_functions_emit_warnings(self, func_name, tmp_path):
-        """Test each deprecated function emits a warning."""
-        # Setup minimal data for testing (use monkeypatched for speed)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            df_state, df_forcing = sp.load_sample_data()
-            df_output, df_state_final = sp.run_supy(df_forcing.iloc[:24], df_state)
+    def test_all_functions_emit_warnings(self, func_name, monkeypatch):
+        """Each public wrapper warns and forwards its complete call contract."""
+        implementation_result = object()
+        calls = []
 
-        # Get the deprecated function
-        func_map = {
-            "load_SampleData": sp.load_SampleData,
-            "load_sample_data": sp._deprecated_load_sample_data,
-            "init_supy": sp._deprecated_init_supy,
-            "load_config_from_df": sp.load_config_from_df,
-            "init_config": sp._deprecated_init_config,
-            "run_supy": sp._deprecated_run_supy,
-            "save_supy": sp._deprecated_save_supy,
-        }
-        func = func_map[func_name]
+        implementation_name = {
+            "load_SampleData": "_load_sample_data",
+            "load_sample_data": "_load_sample_data",
+            "init_supy": "_init_supy",
+            "load_config_from_df": "_config_from_df_state",
+            "init_config": "_init_config",
+            "run_supy": "_run_supy",
+            "save_supy": "_save_supy",
+        }[func_name]
 
-        # Test the specific function
+        def fake_implementation(*args, **kwargs):
+            calls.append((args, kwargs))
+            return implementation_result
+
+        monkeypatch.setattr(
+            supy_module,
+            implementation_name,
+            fake_implementation,
+        )
+
+        func = getattr(supy_module, func_name)
+
+        df_state = object()
+        df_forcing = object()
+        df_output = object()
+        output_config = object()
+
+        if func_name in {"load_sample_data", "load_SampleData"}:
+            call_args = ()
+            call_kwargs = {}
+            expected_call = ((), {})
+        elif func_name == "init_supy":
+            call_args = ("sample.yml",)
+            call_kwargs = {"force_reload": False, "check_input": True}
+            expected_call = (
+                ("sample.yml",),
+                {"force_reload": False, "check_input": True},
+            )
+        elif func_name in {"load_config_from_df", "init_config"}:
+            call_args = (df_state,)
+            call_kwargs = {}
+            expected_call = ((df_state,), {})
+        elif func_name == "run_supy":
+            call_args = (df_forcing, df_state)
+            call_kwargs = {
+                "save_state": True,
+                "chunk_day": 2,
+                "logging_level": 10,
+                "check_input": True,
+                "serial_mode": True,
+                "debug_mode": True,
+            }
+            expected_call = (
+                (),
+                {
+                    "df_forcing": df_forcing,
+                    "df_state_init": df_state,
+                    **call_kwargs,
+                },
+            )
+        else:
+            call_args = (df_output, df_state)
+            call_kwargs = {
+                "freq_s": 1800,
+                "site": "Test",
+                "path_dir_save": "output",
+                "path_runcontrol": "RunControl.nml",
+                "save_tstep": True,
+                "logging_level": 10,
+                "output_level": 2,
+                "debug": True,
+                "output_config": output_config,
+                "output_format": "parquet",
+            }
+            expected_call = (
+                (),
+                {
+                    "df_output": df_output,
+                    "df_state_final": df_state,
+                    **call_kwargs,
+                },
+            )
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
+            result = func(*call_args, **call_kwargs)
 
-            if func_name in {"load_sample_data", "load_SampleData"}:
-                func()
-            elif func_name == "init_supy":
-                from supy._env import trv_supy_module
-
-                config_path = trv_supy_module / "sample_data" / "sample_config.yml"
-                func(str(config_path))
-            elif func_name in {"load_config_from_df", "init_config"}:
-                func(df_state)
-            elif func_name == "run_supy":
-                func(df_forcing.iloc[:24], df_state)
-            elif func_name == "save_supy":
-                func(df_output, df_state_final, path_dir_save=str(tmp_path))
-
-            # Verify warning was emitted
-            expected = f"`supy.{func_name}`"
-            assert any(
-                issubclass(warning.category, FutureWarning)
-                and expected in str(warning.message)
-                for warning in w
-            ), f"{func_name} should emit FutureWarning"
+        expected_message = (
+            f"`supy.{func_name}` is deprecated and will be removed in a future "
+            "release. Please migrate to "
+            f"{supy_module._FUNCTIONAL_DEPRECATIONS[func_name]}."
+        )
+        assert result is implementation_result
+        assert calls == [expected_call]
+        assert [(warning.category, str(warning.message)) for warning in w] == [
+            (FutureWarning, expected_message)
+        ]
 
     def test_init_config_does_not_warn_via_load_config_from_df(self):
         """Test init_config(df_state) does not emit nested public API warnings."""

--- a/test/core/test_suews_simulation.py
+++ b/test/core/test_suews_simulation.py
@@ -680,9 +680,9 @@ class TestRun:
     """Test simulation execution."""
 
     @staticmethod
-    def _multi_site_config():
+    def _multi_site_config(sample_config_loaded):
         """Return a sample config with two distinct grids."""
-        config = SUEWSSimulation.from_sample_data().config.model_copy(deep=True)
+        config = sample_config_loaded.model_copy(deep=True)
         site2 = config.sites[0].model_copy(deep=True)
         site2.gridiv = 2
         site2.name = "Grid 2"
@@ -701,6 +701,16 @@ class TestRun:
             )
             list_df_output.append(pd.DataFrame({"QH": 0.0}, index=index))
         return pd.concat(list_df_output)
+
+    @staticmethod
+    def _sim_for_mocked_run(sample_config_loaded, sample_data_loaded):
+        """Build an isolated two-step simulation without reloading sample files."""
+        sample_state, sample_forcing = sample_data_loaded
+        sim = SUEWSSimulation()
+        sim._config = sample_config_loaded.model_copy(deep=True)
+        sim._df_state_init = sample_state.copy()
+        sim._df_forcing = sample_forcing.iloc[:2].copy()
+        return sim
 
     @staticmethod
     def _patch_run_suews_rust_chunked(monkeypatch):
@@ -737,10 +747,14 @@ class TestRun:
         )
         return captured
 
-    def test_run_n_jobs_defaults_to_rayon_default(self, monkeypatch):
+    def test_run_n_jobs_defaults_to_rayon_default(
+        self,
+        monkeypatch,
+        sample_config_loaded,
+        sample_data_loaded,
+    ):
         """Test default n_jobs preserves uncapped parallel execution."""
-        sim = SUEWSSimulation.from_sample_data()
-        sim._df_forcing = sim._df_forcing.iloc[:2]
+        sim = self._sim_for_mocked_run(sample_config_loaded, sample_data_loaded)
         captured = self._patch_run_suews_rust_chunked(monkeypatch)
 
         sim.run()
@@ -748,10 +762,14 @@ class TestRun:
         assert captured["serial_mode"] is False
         assert captured["max_workers"] is None
 
-    def test_run_n_jobs_one_forces_serial(self, monkeypatch):
+    def test_run_n_jobs_one_forces_serial(
+        self,
+        monkeypatch,
+        sample_config_loaded,
+        sample_data_loaded,
+    ):
         """Test n_jobs=1 disables the multi-grid Rayon path."""
-        sim = SUEWSSimulation.from_sample_data()
-        sim._df_forcing = sim._df_forcing.iloc[:2]
+        sim = self._sim_for_mocked_run(sample_config_loaded, sample_data_loaded)
         captured = self._patch_run_suews_rust_chunked(monkeypatch)
 
         sim.run(n_jobs=1)
@@ -759,10 +777,14 @@ class TestRun:
         assert captured["serial_mode"] is True
         assert captured["max_workers"] == 1
 
-    def test_run_n_jobs_positive_caps_workers(self, monkeypatch):
+    def test_run_n_jobs_positive_caps_workers(
+        self,
+        monkeypatch,
+        sample_config_loaded,
+        sample_data_loaded,
+    ):
         """Test positive n_jobs reaches the Rust bridge as max_workers."""
-        sim = SUEWSSimulation.from_sample_data()
-        sim._df_forcing = sim._df_forcing.iloc[:2]
+        sim = self._sim_for_mocked_run(sample_config_loaded, sample_data_loaded)
         captured = self._patch_run_suews_rust_chunked(monkeypatch)
 
         sim.run(n_jobs=3)
@@ -778,12 +800,16 @@ class TestRun:
         with pytest.raises(ValueError, match="n_jobs must be"):
             sim.run(n_jobs=n_jobs)
 
-    def test_chunked_run_forwards_worker_cap_per_chunk(self, monkeypatch):
+    def test_chunked_run_forwards_worker_cap_per_chunk(
+        self,
+        monkeypatch,
+        sample_config_loaded,
+        sample_data_loaded,
+    ):
         """Test chunked multi-grid runs keep n_jobs after the first chunk."""
-        config = self._multi_site_config()
-        df_forcing = SUEWSSimulation.from_sample_data()._df_forcing.iloc[
-            : TIMESTEPS_PER_DAY + 1
-        ]
+        config = self._multi_site_config(sample_config_loaded)
+        _, sample_forcing = sample_data_loaded
+        df_forcing = sample_forcing.iloc[: TIMESTEPS_PER_DAY + 1].copy()
         calls = []
 
         def fake_run_suews_rust_multi(
@@ -829,10 +855,16 @@ class TestRun:
 
         assert calls == [("fresh", False, 3), ("state", False, 3)]
 
-    def test_checkpointed_run_forwards_worker_cap(self, monkeypatch):
+    def test_checkpointed_run_forwards_worker_cap(
+        self,
+        monkeypatch,
+        sample_config_loaded,
+        sample_data_loaded,
+    ):
         """Test resumed multi-grid runs keep n_jobs on the first chunk."""
-        config = self._multi_site_config()
-        df_forcing = SUEWSSimulation.from_sample_data()._df_forcing.iloc[:2]
+        config = self._multi_site_config(sample_config_loaded)
+        _, sample_forcing = sample_data_loaded
+        df_forcing = sample_forcing.iloc[:2].copy()
         calls = []
 
         def fail_run_suews_rust_multi(*args, **kwargs):
@@ -872,10 +904,16 @@ class TestRun:
 
         assert calls == [("state", False, 4)]
 
-    def test_multi_with_state_passes_worker_cap_to_rust(self, monkeypatch):
+    def test_multi_with_state_passes_worker_cap_to_rust(
+        self,
+        monkeypatch,
+        sample_config_loaded,
+        sample_data_loaded,
+    ):
         """Test state-aware multi-grid wrapper forwards max_workers."""
-        config = self._multi_site_config()
-        df_forcing = SUEWSSimulation.from_sample_data()._df_forcing.iloc[:2]
+        config = self._multi_site_config(sample_config_loaded)
+        _, sample_forcing = sample_data_loaded
+        df_forcing = sample_forcing.iloc[:2].copy()
         captured = {}
 
         class FakeRustModule:


### PR DESCRIPTION
## Summary

- Reuse one session-scoped validated sample config and sample-data load across six worker-cap tests whose Rust execution paths are already mocked.
- Keep each test isolated with deep config/state copies and only the two or 289 forcing rows required by its contract.
- Replace repeated real simulations inside the seven deprecation-warning cases with stubbed underlying implementations, while still calling each real public wrapper and asserting its returned value, exact forwarded arguments, warning category and exact registry-backed message.
- Do not add workers, change serial execution, delete tests, alter markers or change the workflow matrix.

## Evidence

The latest comparable Windows API job, run 29467372414 job 87524613363, still took 1,144.66 s (19:04). Three mocked worker-forwarding nodes were its second through fourth slowest tests at 17.99 s, 17.64 s and 17.62 s. Two warning-only sample-load cases took 9.56 s and 9.52 s.

A controlled local comparison used the same installed wheel and the same 13 node IDs on this branch base and head:

| Group | Before | After structure |
|---|---:|---:|
| Three public n_jobs forwarding nodes | 8.45 s cumulative calls | shared in the 2.39 s focused session |
| Three lower-level worker/checkpoint forwarding nodes | 16.54 s cumulative calls | shared in the 2.39 s focused session |
| Seven deprecation-wrapper nodes | 15.71 s session | shared in the 2.39 s focused session |
| Total focused set | 40.70 s | 2.39 s |

That is a 94.1% reduction for the focused local set. It is directional evidence for the implementation, not a claim that GitHub-hosted Windows will scale identically.

The full standard API collection remains exactly 1,669 nodes with SHA-256 inventory `5aa8b506fe46f208d5b1a9bd615d390ab197c6bff51a73b2945f4edad0382e67`, matching the metrics artefact from run 29467372414. Node IDs, markers and outcomes are unchanged.

## Coverage retained

- The six worker-cap nodes still exercise the installed SUEWSSimulation/Rust-wrapper code and retain their exact serial/max-worker/state-path assertions; only redundant sample file loading is shared.
- The seven warning nodes still invoke the real public wrappers. Their expensive implementation calls are replaced with recording stubs because these nodes test warning and forwarding contracts, not simulation physics.
- Real deprecated-wrapper functionality and functional-versus-OOP numerical equivalence remain in TestPublicAPIFunctionality and TestPublicAPIEquivalence; the complete file passes 15/15 tests.
- The workflow still performs a clean installed-wheel API lane on Linux, macOS and Windows and leaves the explicitly named physics wheel-build lane unchanged.

## Validation

- Focused 13-node set: 13 passed in 2.39 s.
- test/core/test_public_api_wrappers.py: 15 passed.
- TestRun class: 15 passed before the final extension; all six subsequently changed worker-cap nodes pass together.
- Static nature-marker lint: 121 direct files plus five conftest-applied files pass.
- Standard API inventory: 1,669 nodes; unchanged hash above.
- make PYTHON=.venv/bin/python test-smoke: 6 passed, 2 skipped.
- git diff --check: clean.

## Remaining acceptance evidence

This PR does not claim the issue target of a Windows median at or below 15 minutes. That requires at least three comparable post-merge Windows runs plus the final matrix and emitted resource/native-state evidence. The PR is intentionally a focused, independently revertible reduction of the measured repeated setup.

Refs #1625
Refs #1621

## First hosted Windows observation

Stacked merge-group run [29478577913](https://github.com/UMEP-dev/SUEWS/actions/runs/29478577913), Windows API job 87558903664, passed on one effective worker. The machine-readable session was 792.378 s (13 min 12 s) and the whole job was 14 min 40 s, versus the 1,144.66 s (19 min 04 s) session baseline: a 30.8% directional reduction. Outcomes were 1,663 passed and 7 skipped. The stacked inventory was 1,671 nodes because the two preceding PRs each added a CI contract test; this PR preserved its own 1,669-node base inventory.

This is observation 1 of the required three, not a final performance claim. The merge queue was speculatively validating several stacked heads concurrently, so hosted-load effects remain uncontrolled; #1625 stays open until two more natural comparable Windows runs establish the median.