### PR TITLE
Add Windows checkout provenance ABBA benchmark

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -77,6 +77,7 @@ ci:
   - '.github/path-filters.yml'
   - '.github/ci-metrics-needs.json'
   - '.github/workflows/benchmark-pytest-scheduler.yml'
+  - '.github/workflows/benchmark-checkout-provenance.yml'
   - '.github/workflows/build-publish_to_pypi.yml'
   - '.github/workflows/build-wheels-reusable.yml'
   - '.github/workflows/cibuildwheel-debug.yml'

--- a/.github/workflows/benchmark-checkout-provenance.yml
+++ b/.github/workflows/benchmark-checkout-provenance.yml
@@ -111,10 +111,12 @@ jobs:
 
       - name: Record A1 checkout and provenance
         shell: pwsh
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: >-
           python checkout-abba/a1/scripts/suews/compare_checkout_provenance.py collect
           --repository checkout-abba/a1 --label A1 --mode full
-          --expected-sha "${{ steps.source.outputs.sha }}"
+          --expected-sha "$env:SOURCE_SHA"
           --started-at-epoch-ms "$env:A1_START_MS"
           --output "$env:RUNNER_TEMP/checkout-abba/trial-a1.json"
 
@@ -135,10 +137,12 @@ jobs:
 
       - name: Record B1 checkout and provenance
         shell: pwsh
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: >-
           python checkout-abba/b1/scripts/suews/compare_checkout_provenance.py collect
           --repository checkout-abba/b1 --label B1 --mode blob:none
-          --expected-sha "${{ steps.source.outputs.sha }}"
+          --expected-sha "$env:SOURCE_SHA"
           --started-at-epoch-ms "$env:B1_START_MS"
           --output "$env:RUNNER_TEMP/checkout-abba/trial-b1.json"
 
@@ -159,10 +163,12 @@ jobs:
 
       - name: Record B2 checkout and provenance
         shell: pwsh
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: >-
           python checkout-abba/b2/scripts/suews/compare_checkout_provenance.py collect
           --repository checkout-abba/b2 --label B2 --mode blob:none
-          --expected-sha "${{ steps.source.outputs.sha }}"
+          --expected-sha "$env:SOURCE_SHA"
           --started-at-epoch-ms "$env:B2_START_MS"
           --output "$env:RUNNER_TEMP/checkout-abba/trial-b2.json"
 
@@ -182,10 +188,12 @@ jobs:
 
       - name: Record A2 checkout and provenance
         shell: pwsh
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: >-
           python checkout-abba/a2/scripts/suews/compare_checkout_provenance.py collect
           --repository checkout-abba/a2 --label A2 --mode full
-          --expected-sha "${{ steps.source.outputs.sha }}"
+          --expected-sha "$env:SOURCE_SHA"
           --started-at-epoch-ms "$env:A2_START_MS"
           --output "$env:RUNNER_TEMP/checkout-abba/trial-a2.json"
 
@@ -225,13 +233,15 @@ jobs:
 
       - name: Compare checkout, git and wheel provenance
         shell: pwsh
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: >-
           python scripts/suews/compare_checkout_provenance.py compare
           "$env:RUNNER_TEMP/checkout-abba/trial-a1.json"
           "$env:RUNNER_TEMP/checkout-abba/trial-b1.json"
           "$env:RUNNER_TEMP/checkout-abba/trial-b2.json"
           "$env:RUNNER_TEMP/checkout-abba/trial-a2.json"
-          --expected-sha "${{ steps.source.outputs.sha }}"
+          --expected-sha "$env:SOURCE_SHA"
           --baseline-wheel "$env:BASELINE_WHEEL"
           --filtered-wheel "$env:FILTERED_WHEEL"
           --baseline-metrics "$env:RUNNER_TEMP/baseline-metrics/physics-cp312-win-AMD64-wheel-job.json"

--- a/.github/workflows/benchmark-checkout-provenance.yml
+++ b/.github/workflows/benchmark-checkout-provenance.yml
@@ -1,0 +1,249 @@
+# Evidence harness for gh#1627. This workflow never changes production checkout.
+name: Windows checkout provenance ABBA
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Successful Build and Publish run with the exact Windows cp312 wheel
+        required: true
+        type: string
+      expected_sha:
+        description: Exact 40-character default-branch SHA built by source_run_id
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: windows-checkout-provenance-abba
+  cancel-in-progress: false
+
+jobs:
+  compare:
+    name: Same-runner full/blob:none ABBA
+    runs-on: windows-2025
+    timeout-minutes: 90
+    steps:
+      - name: Set up Python 3.12 for evidence collection
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify default-branch source run and exact SHA
+        id: source
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "source_run_id must be a positive integer" >&2
+            exit 2
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" > "$RUNNER_TEMP/source-run.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import re
+
+          expected_sha = os.environ["EXPECTED_SHA"]
+          if re.fullmatch(r"[0-9a-f]{40}", expected_sha) is None:
+              raise SystemExit("expected_sha must be a lowercase 40-character hex digest")
+          if os.environ["REF_NAME"] != os.environ["DEFAULT_BRANCH"]:
+              raise SystemExit("dispatch this evidence workflow from the default branch")
+          if expected_sha != os.environ["WORKFLOW_SHA"]:
+              raise SystemExit(
+                  "expected_sha must equal the dispatched default-branch SHA"
+              )
+          payload = json.loads(
+              (Path(os.environ["RUNNER_TEMP"]) / "source-run.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          if payload.get("conclusion") != "success":
+              raise SystemExit("source workflow run did not conclude successfully")
+          if payload.get("path") != ".github/workflows/build-publish_to_pypi.yml":
+              raise SystemExit("source_run_id is not the Build and Publish workflow")
+          if payload.get("head_sha") != expected_sha:
+              raise SystemExit("source workflow SHA does not match expected_sha")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"sha={expected_sha}\n")
+          PY
+
+      - name: Download full-checkout Windows wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cp312-win-AMD64
+          path: ${{ runner.temp }}/baseline-wheel
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Download full-checkout Windows phase metrics
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ci-metrics-physics-cp312-win-AMD64
+          path: ${{ runner.temp }}/baseline-metrics
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Start A1 timer
+        shell: pwsh
+        run: |
+          $now = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          Add-Content -Path $env:GITHUB_ENV -Value "A1_START_MS=$now"
+
+      - name: A1 - full checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          path: checkout-abba/a1
+
+      - name: Record A1 checkout and provenance
+        shell: pwsh
+        run: >-
+          python checkout-abba/a1/scripts/suews/compare_checkout_provenance.py collect
+          --repository checkout-abba/a1 --label A1 --mode full
+          --expected-sha "${{ steps.source.outputs.sha }}"
+          --started-at-epoch-ms "$env:A1_START_MS"
+          --output "$env:RUNNER_TEMP/checkout-abba/trial-a1.json"
+
+      - name: Start B1 timer
+        shell: pwsh
+        run: |
+          $now = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          Add-Content -Path $env:GITHUB_ENV -Value "B1_START_MS=$now"
+
+      - name: B1 - blob:none checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+          path: checkout-abba/b1
+
+      - name: Record B1 checkout and provenance
+        shell: pwsh
+        run: >-
+          python checkout-abba/b1/scripts/suews/compare_checkout_provenance.py collect
+          --repository checkout-abba/b1 --label B1 --mode blob:none
+          --expected-sha "${{ steps.source.outputs.sha }}"
+          --started-at-epoch-ms "$env:B1_START_MS"
+          --output "$env:RUNNER_TEMP/checkout-abba/trial-b1.json"
+
+      - name: Start B2 timer
+        shell: pwsh
+        run: |
+          $now = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          Add-Content -Path $env:GITHUB_ENV -Value "B2_START_MS=$now"
+
+      - name: B2 - blob:none checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+          path: checkout-abba/b2
+
+      - name: Record B2 checkout and provenance
+        shell: pwsh
+        run: >-
+          python checkout-abba/b2/scripts/suews/compare_checkout_provenance.py collect
+          --repository checkout-abba/b2 --label B2 --mode blob:none
+          --expected-sha "${{ steps.source.outputs.sha }}"
+          --started-at-epoch-ms "$env:B2_START_MS"
+          --output "$env:RUNNER_TEMP/checkout-abba/trial-b2.json"
+
+      - name: Start A2 timer
+        shell: pwsh
+        run: |
+          $now = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+          Add-Content -Path $env:GITHUB_ENV -Value "A2_START_MS=$now"
+
+      - name: A2 - full checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          path: checkout-abba/a2
+
+      - name: Record A2 checkout and provenance
+        shell: pwsh
+        run: >-
+          python checkout-abba/a2/scripts/suews/compare_checkout_provenance.py collect
+          --repository checkout-abba/a2 --label A2 --mode full
+          --expected-sha "${{ steps.source.outputs.sha }}"
+          --started-at-epoch-ms "$env:A2_START_MS"
+          --output "$env:RUNNER_TEMP/checkout-abba/trial-a2.json"
+
+      - name: Remove trial worktrees before the wheel build
+        shell: pwsh
+        run: Remove-Item -Recurse -Force checkout-abba
+
+      - name: Check out filtered source for one provenance build
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+
+      - name: Build and smoke-test one blob-filtered Windows wheel
+        uses: ./.github/actions/build-suews
+        with:
+          buildplat: windows-2025
+          buildplat_name: win
+          buildplat_arch: AMD64
+          python: cp312
+          test_tier: smoke
+          is_testpypi_build: false
+          metrics_host_dir: ${{ runner.temp }}/suews-ci-metrics
+
+      - name: Resolve the two exact wheels
+        shell: pwsh
+        run: |
+          $baseline = @(Get-ChildItem "$env:RUNNER_TEMP/baseline-wheel" -Filter *.whl)
+          $filtered = @(Get-ChildItem wheelhouse -Filter *.whl)
+          if ($baseline.Count -ne 1 -or $filtered.Count -ne 1) {
+            throw "Expected one baseline and one filtered wheel; found $($baseline.Count) and $($filtered.Count)."
+          }
+          Add-Content -Path $env:GITHUB_ENV -Value "BASELINE_WHEEL=$($baseline[0].FullName)"
+          Add-Content -Path $env:GITHUB_ENV -Value "FILTERED_WHEEL=$($filtered[0].FullName)"
+
+      - name: Compare checkout, git and wheel provenance
+        shell: pwsh
+        run: >-
+          python scripts/suews/compare_checkout_provenance.py compare
+          "$env:RUNNER_TEMP/checkout-abba/trial-a1.json"
+          "$env:RUNNER_TEMP/checkout-abba/trial-b1.json"
+          "$env:RUNNER_TEMP/checkout-abba/trial-b2.json"
+          "$env:RUNNER_TEMP/checkout-abba/trial-a2.json"
+          --expected-sha "${{ steps.source.outputs.sha }}"
+          --baseline-wheel "$env:BASELINE_WHEEL"
+          --filtered-wheel "$env:FILTERED_WHEEL"
+          --baseline-metrics "$env:RUNNER_TEMP/baseline-metrics/physics-cp312-win-AMD64-wheel-job.json"
+          --filtered-metrics "$env:RUNNER_TEMP/suews-ci-metrics/physics-cp312-win-AMD64-wheel-job.json"
+          --output "$env:RUNNER_TEMP/checkout-abba/comparison.json"
+          --summary "$env:GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw trials and comparison manifest
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: windows-checkout-provenance-abba-${{ github.run_id }}
+          path: ${{ runner.temp }}/checkout-abba/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/benchmark-checkout-provenance.yml
+++ b/.github/workflows/benchmark-checkout-provenance.yml
@@ -201,6 +201,17 @@ jobs:
         shell: pwsh
         run: Remove-Item -Recurse -Force checkout-abba
 
+      - name: Start filtered checkout phase timing
+        shell: pwsh
+        env:
+          SUEWS_CI_PHASES: ${{ runner.temp }}/suews-ci-metrics/physics-cp312-win-AMD64-phases.json
+        run: >-
+          python -c "import json, os, time; from pathlib import Path;
+          path = Path(os.environ['SUEWS_CI_PHASES']); path.parent.mkdir(parents=True, exist_ok=True);
+          path.write_text(json.dumps({'schema_version': 1, 'phases': {'checkout':
+          {'source': 'runner-step-wall-clock', 'started_at_epoch_seconds': time.time(),
+          'status': 'running'}}}, indent=2, sort_keys=True) + '\n', encoding='utf-8')"
+
       - name: Check out filtered source for one provenance build
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -208,6 +219,12 @@ jobs:
           fetch-depth: 0
           filter: blob:none
           persist-credentials: false
+
+      - name: Stop filtered checkout phase timing
+        shell: pwsh
+        env:
+          SUEWS_CI_PHASES: ${{ runner.temp }}/suews-ci-metrics/physics-cp312-win-AMD64-phases.json
+        run: python scripts/suews/ci_phase_metrics.py stop checkout
 
       - name: Build and smoke-test one blob-filtered Windows wheel
         uses: ./.github/actions/build-suews

--- a/scripts/suews/compare_checkout_provenance.py
+++ b/scripts/suews/compare_checkout_provenance.py
@@ -8,6 +8,7 @@ from email.parser import BytesParser
 from email.policy import default
 import hashlib
 import json
+import math
 from pathlib import Path
 import re
 from statistics import median
@@ -279,6 +280,12 @@ def build_comparison(
 
 def _validate_wheel_metrics(metrics: dict[str, Any], *, label: str) -> None:
     """Require the existing machine-readable wheel phase evidence contract."""
+    if (
+        metrics.get("schema_version") != 1
+        or metrics.get("kind") != "wheel-job-ci-metrics"
+        or metrics.get("job_name") != "physics-cp312-win-AMD64"
+    ):
+        raise ValueError(f"{label} wheel metrics have the wrong identity")
     required = {"checkout", "toolchain_setup", "build", "repair", "install", "tests"}
     phases = metrics.get("phases")
     if not isinstance(phases, dict):
@@ -286,6 +293,22 @@ def _validate_wheel_metrics(metrics: dict[str, Any], *, label: str) -> None:
     missing = required.difference(phases)
     if missing:
         raise ValueError(f"{label} wheel metrics omit phases: {sorted(missing)}")
+    for phase in required:
+        record = phases[phase]
+        duration = record.get("duration_seconds")
+        if (
+            record.get("available") is not True
+            or record.get("status") != "measured"
+            or not isinstance(duration, (int, float))
+            or not math.isfinite(duration)
+            or duration <= 0
+        ):
+            raise ValueError(f"{label} wheel phase {phase} is not measured")
+    pytest_metrics = metrics.get("pytest_metrics") or {}
+    result = pytest_metrics.get("result") or {}
+    inventory = pytest_metrics.get("inventory") or {}
+    if result.get("exit_code") != 0 or not inventory.get("node_id_sha256"):
+        raise ValueError(f"{label} wheel pytest evidence did not pass")
 
 
 def _append_summary(path: Path, comparison: dict[str, Any]) -> None:

--- a/scripts/suews/compare_checkout_provenance.py
+++ b/scripts/suews/compare_checkout_provenance.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Collect and compare full/blob-filtered checkout provenance evidence."""
+
+from __future__ import annotations
+
+import argparse
+from email.parser import BytesParser
+from email.policy import default
+import hashlib
+import json
+from pathlib import Path
+import re
+from statistics import median
+import subprocess
+import sys
+import time
+from typing import Any
+import zipfile
+
+TRIAL_ORDER = (
+    ("A1", "full"),
+    ("B1", "blob:none"),
+    ("B2", "blob:none"),
+    ("A2", "full"),
+)
+GIT_EQUIVALENCE_FIELDS = (
+    "commit_sha",
+    "tree_sha",
+    "git_describe",
+    "derived_version",
+    "generated_commit_hash",
+    "generated_version_file_sha256",
+    "tags_sha256",
+)
+WHEEL_EQUIVALENCE_FIELDS = (
+    "metadata_sha256",
+    "name",
+    "version",
+    "tags",
+    "embedded_version_sha256",
+)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    return subprocess.check_output(
+        ["git", *arguments],
+        cwd=repository,
+        stderr=subprocess.STDOUT,
+        text=True,
+    ).strip()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def collect_checkout_provenance(
+    repository: Path,
+    *,
+    label: str,
+    mode: str,
+    expected_sha: str,
+    started_at_epoch_ms: int,
+) -> dict[str, Any]:
+    """Collect provenance after checkout without including it in the timing."""
+    completed_at_epoch_ms = time.time_ns() // 1_000_000
+    repository = repository.resolve()
+    if (label, mode) not in TRIAL_ORDER:
+        raise ValueError(f"unsupported trial pair: {label}/{mode}")
+    if re.fullmatch(r"[0-9a-f]{40}", expected_sha) is None:
+        raise ValueError("expected_sha must be a lowercase 40-character hex digest")
+
+    commit_sha = _git(repository, "rev-parse", "HEAD^{}")
+    if commit_sha != expected_sha:
+        raise ValueError(f"{label} checked out {commit_sha}, expected {expected_sha}")
+    generated = subprocess.check_output(
+        [sys.executable, "get_ver_git.py"],
+        cwd=repository,
+        stderr=subprocess.STDOUT,
+        text=True,
+    ).strip()
+    version_file = repository / "src/supy/_version_scm.py"
+    version_text = version_file.read_text(encoding="utf-8")
+    commit_match = re.search(
+        r"^__commit_hash__\s*=\s*commit_hash\s*=\s*['\"]([^'\"]+)",
+        version_text,
+        re.MULTILINE,
+    )
+    if commit_match is None:
+        raise ValueError(f"{label} generated no readable commit hash")
+    tags = _git(
+        repository,
+        "for-each-ref",
+        "--format=%(refname)%00%(objectname)%00%(*objectname)",
+        "refs/tags",
+    ).encode("utf-8")
+    partial_filter = subprocess.run(
+        ["git", "config", "--get", "remote.origin.partialclonefilter"],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return {
+        "schema_version": 1,
+        "label": label,
+        "mode": mode,
+        "duration_seconds": round(
+            (completed_at_epoch_ms - started_at_epoch_ms) / 1000.0, 6
+        ),
+        "started_at_epoch_ms": started_at_epoch_ms,
+        "completed_at_epoch_ms": completed_at_epoch_ms,
+        "commit_sha": commit_sha,
+        "tree_sha": _git(repository, "rev-parse", "HEAD^{tree}"),
+        "git_describe": _git(
+            repository,
+            "describe",
+            "--tags",
+            "--long",
+            "--match=[0-9]*",
+        ),
+        "derived_version": generated.splitlines()[-1],
+        "generated_commit_hash": commit_match.group(1),
+        "generated_version_file_sha256": _sha256(version_text.encode("utf-8")),
+        "tags_sha256": _sha256(tags),
+        "partial_clone_filter": partial_filter or None,
+    }
+
+
+def read_wheel_provenance(path: Path) -> dict[str, Any]:
+    """Read deterministic provenance fields from a built wheel."""
+    path = path.resolve()
+    if not path.is_file():
+        raise ValueError(f"wheel not found: {path}")
+    with zipfile.ZipFile(path) as archive:
+        names = archive.namelist()
+        metadata_names = [
+            name for name in names if name.endswith(".dist-info/METADATA")
+        ]
+        wheel_names = [name for name in names if name.endswith(".dist-info/WHEEL")]
+        version_names = [
+            name for name in names if name.endswith("supy/_version_scm.py")
+        ]
+        if len(metadata_names) != 1 or len(wheel_names) != 1 or len(version_names) != 1:
+            raise ValueError(
+                "wheel must contain exactly one METADATA, WHEEL and "
+                "supy/_version_scm.py file"
+            )
+        metadata_bytes = archive.read(metadata_names[0])
+        wheel_bytes = archive.read(wheel_names[0])
+        embedded_version = archive.read(version_names[0])
+
+    metadata = BytesParser(policy=default).parsebytes(metadata_bytes)
+    wheel_metadata = BytesParser(policy=default).parsebytes(wheel_bytes)
+    return {
+        "file": path.name,
+        "file_sha256": _file_sha256(path),
+        "metadata_sha256": _sha256(metadata_bytes),
+        "name": metadata.get("Name"),
+        "version": metadata.get("Version"),
+        "tags": sorted(wheel_metadata.get_all("Tag", [])),
+        "embedded_version_sha256": _sha256(embedded_version),
+    }
+
+
+def build_comparison(
+    trials: list[dict[str, Any]],
+    baseline_wheel: dict[str, Any],
+    filtered_wheel: dict[str, Any],
+    *,
+    expected_sha: str,
+    baseline_metrics: dict[str, Any] | None = None,
+    filtered_metrics: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate the ABBA order and provenance equality, then reduce timings."""
+    observed_order = [(trial.get("label"), trial.get("mode")) for trial in trials]
+    if observed_order != list(TRIAL_ORDER):
+        raise ValueError(
+            f"trial order must be {list(TRIAL_ORDER)}, got {observed_order}"
+        )
+    if any(trial.get("commit_sha") != expected_sha for trial in trials):
+        raise ValueError("one or more trials do not match expected_sha")
+    if any(trial.get("generated_commit_hash") != expected_sha[:7] for trial in trials):
+        raise ValueError(
+            "one or more generated commit hashes do not match expected_sha"
+        )
+    for trial in trials:
+        expected_filter = "blob:none" if trial["mode"] == "blob:none" else None
+        if trial.get("partial_clone_filter") != expected_filter:
+            raise ValueError(
+                f"{trial['label']} did not enact {trial['mode']} checkout mode"
+            )
+
+    reference = trials[0]
+    for field in GIT_EQUIVALENCE_FIELDS:
+        values = {str(trial.get(field)) for trial in trials}
+        if len(values) != 1:
+            raise ValueError(
+                f"checkout provenance mismatch for {field}: {sorted(values)}"
+            )
+        if reference.get(field) in {None, ""}:
+            raise ValueError(f"checkout provenance field {field} is empty")
+
+    wheel_mismatches = [
+        field
+        for field in WHEEL_EQUIVALENCE_FIELDS
+        if baseline_wheel.get(field) != filtered_wheel.get(field)
+        or baseline_wheel.get(field) in (None, "", [])
+    ]
+    if wheel_mismatches:
+        raise ValueError("wheel provenance mismatch for " + ", ".join(wheel_mismatches))
+
+    full = [
+        float(trial["duration_seconds"]) for trial in trials if trial["mode"] == "full"
+    ]
+    filtered = [
+        float(trial["duration_seconds"])
+        for trial in trials
+        if trial["mode"] == "blob:none"
+    ]
+    full_median = median(full)
+    filtered_median = median(filtered)
+    if full_median <= 0 or filtered_median <= 0:
+        raise ValueError("checkout durations must be positive")
+    for label, metrics in (
+        ("baseline", baseline_metrics),
+        ("blob_none", filtered_metrics),
+    ):
+        if metrics is not None:
+            _validate_wheel_metrics(metrics, label=label)
+
+    return {
+        "schema_version": 1,
+        "passed": True,
+        "expected_sha": expected_sha,
+        "checkout": {
+            "order": [trial["label"] for trial in trials],
+            "trials": trials,
+            "full_median_seconds": round(full_median, 6),
+            "blob_none_median_seconds": round(filtered_median, 6),
+            "blob_none_change_percent": round(
+                ((filtered_median / full_median) - 1.0) * 100.0, 6
+            ),
+            "performance_interpretation": (
+                "same-runner observational evidence; not a general hosted-runner speed-up"
+            ),
+            "provenance_equivalent": True,
+        },
+        "wheel_provenance": {
+            "equivalent": True,
+            "compared_fields": list(WHEEL_EQUIVALENCE_FIELDS),
+            "baseline": baseline_wheel,
+            "blob_none": filtered_wheel,
+        },
+        "wheel_phase_metrics": {
+            "baseline": baseline_metrics,
+            "blob_none": filtered_metrics,
+        },
+    }
+
+
+def _validate_wheel_metrics(metrics: dict[str, Any], *, label: str) -> None:
+    """Require the existing machine-readable wheel phase evidence contract."""
+    required = {"checkout", "toolchain_setup", "build", "repair", "install", "tests"}
+    phases = metrics.get("phases")
+    if not isinstance(phases, dict):
+        raise ValueError(f"{label} wheel metrics have no phases mapping")
+    missing = required.difference(phases)
+    if missing:
+        raise ValueError(f"{label} wheel metrics omit phases: {sorted(missing)}")
+
+
+def _append_summary(path: Path, comparison: dict[str, Any]) -> None:
+    checkout = comparison["checkout"]
+    wheel = comparison["wheel_provenance"]
+    lines = [
+        "## Windows checkout provenance ABBA",
+        "",
+        "| Mode | Median checkout |",
+        "|---|---:|",
+        f"| Full history | {checkout['full_median_seconds']:.3f} s |",
+        f"| `blob:none` | {checkout['blob_none_median_seconds']:.3f} s |",
+        "",
+        f"Observed same-runner change: {checkout['blob_none_change_percent']:.2f}%.",
+        "This is hosted-runner observational evidence, not a general speed-up claim.",
+        "",
+        f"Git provenance equivalent: **{str(checkout['provenance_equivalent']).lower()}**.",
+        f"Wheel provenance equivalent: **{str(wheel['equivalent']).lower()}**.",
+        "",
+    ]
+    with path.open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    collect = subparsers.add_parser("collect")
+    collect.add_argument("--repository", type=Path, required=True)
+    collect.add_argument("--label", required=True)
+    collect.add_argument("--mode", required=True)
+    collect.add_argument("--expected-sha", required=True)
+    collect.add_argument("--started-at-epoch-ms", type=int, required=True)
+    collect.add_argument("--output", type=Path, required=True)
+
+    compare = subparsers.add_parser("compare")
+    compare.add_argument("trials", nargs=4, type=Path)
+    compare.add_argument("--expected-sha", required=True)
+    compare.add_argument("--baseline-wheel", type=Path, required=True)
+    compare.add_argument("--filtered-wheel", type=Path, required=True)
+    compare.add_argument("--baseline-metrics", type=Path, required=True)
+    compare.add_argument("--filtered-metrics", type=Path, required=True)
+    compare.add_argument("--output", type=Path, required=True)
+    compare.add_argument("--summary", type=Path)
+    return parser
+
+
+def main() -> int:
+    """Run the requested evidence collection or comparison command."""
+    args = _parser().parse_args()
+    if args.command == "collect":
+        payload = collect_checkout_provenance(
+            args.repository,
+            label=args.label,
+            mode=args.mode,
+            expected_sha=args.expected_sha,
+            started_at_epoch_ms=args.started_at_epoch_ms,
+        )
+        _write_json(args.output, payload)
+        return 0
+
+    trials = [json.loads(path.read_text(encoding="utf-8")) for path in args.trials]
+    baseline_metrics = json.loads(args.baseline_metrics.read_text(encoding="utf-8"))
+    filtered_metrics = json.loads(args.filtered_metrics.read_text(encoding="utf-8"))
+    try:
+        comparison = build_comparison(
+            trials,
+            read_wheel_provenance(args.baseline_wheel),
+            read_wheel_provenance(args.filtered_wheel),
+            expected_sha=args.expected_sha,
+            baseline_metrics=baseline_metrics,
+            filtered_metrics=filtered_metrics,
+        )
+    except (ValueError, KeyError, TypeError) as error:
+        _write_json(
+            args.output,
+            {"schema_version": 1, "passed": False, "error": str(error)},
+        )
+        raise SystemExit(str(error)) from error
+    _write_json(args.output, comparison)
+    if args.summary:
+        _append_summary(args.summary, comparison)
+    json.dump(comparison, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/core/test_ci_run_metrics.py
+++ b/test/core/test_ci_run_metrics.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from fnmatch import fnmatchcase
 from pathlib import Path
 import re
+import zipfile
 
 import pytest
 import yaml
@@ -15,6 +16,10 @@ from scripts.suews.benchmark_ci_metrics import (
     compute_overhead,
     file_sha256,
     validate_command,
+)
+from scripts.suews.compare_checkout_provenance import (
+    build_comparison,
+    read_wheel_provenance,
 )
 
 pytestmark = pytest.mark.api
@@ -242,6 +247,114 @@ def test_publish_jobs_download_only_cpython_wheel_artifacts() -> None:
     assert not fnmatchcase("ci-metrics-api-cp312-manylinux-x86_64", wheel_pattern)
     assert not fnmatchcase("ci-metrics-physics-cp312-macosx-arm64", wheel_pattern)
     assert not fnmatchcase("suews-mcp-dist", wheel_pattern)
+
+
+@pytest.mark.core
+def test_checkout_abba_requires_matching_git_and_wheel_provenance(
+    tmp_path: Path,
+) -> None:
+    """The checkout trial is evidence-only unless every provenance field agrees."""
+    expected_sha = "a" * 40
+    common = {
+        "commit_sha": expected_sha,
+        "derived_version": "2026.7.16.dev3",
+        "generated_commit_hash": expected_sha[:7],
+        "generated_version_file_sha256": "e" * 64,
+        "git_describe": "2026.7.16-3-gaaaaaaa",
+        "tags_sha256": "b" * 64,
+        "tree_sha": "c" * 40,
+    }
+    trials = [
+        {
+            "label": label,
+            "mode": mode,
+            "duration_seconds": duration,
+            "partial_clone_filter": "blob:none" if mode == "blob:none" else None,
+            **common,
+        }
+        for label, mode, duration in (
+            ("A1", "full", 10.0),
+            ("B1", "blob:none", 8.0),
+            ("B2", "blob:none", 7.0),
+            ("A2", "full", 11.0),
+        )
+    ]
+    baseline = _write_test_wheel(tmp_path / "baseline.whl")
+    filtered = _write_test_wheel(tmp_path / "filtered.whl")
+
+    comparison = build_comparison(
+        trials,
+        read_wheel_provenance(baseline),
+        read_wheel_provenance(filtered),
+        expected_sha=expected_sha,
+    )
+
+    assert comparison["passed"] is True
+    assert comparison["checkout"]["order"] == ["A1", "B1", "B2", "A2"]
+    assert comparison["checkout"]["performance_interpretation"] == (
+        "same-runner observational evidence; not a general hosted-runner speed-up"
+    )
+    assert comparison["checkout"]["full_median_seconds"] == pytest.approx(10.5)
+    assert comparison["checkout"]["blob_none_median_seconds"] == pytest.approx(7.5)
+    assert comparison["wheel_provenance"]["equivalent"] is True
+
+    trials[2]["tree_sha"] = "d" * 40
+    with pytest.raises(ValueError, match="tree_sha"):
+        build_comparison(
+            trials,
+            read_wheel_provenance(baseline),
+            read_wheel_provenance(filtered),
+            expected_sha=expected_sha,
+        )
+
+
+@pytest.mark.smoke
+def test_checkout_abba_workflow_is_manual_sequential_and_non_production() -> None:
+    """The blob-filter experiment stays on one Windows runner and out of CI."""
+    root = Path(__file__).resolve().parents[2]
+    workflow = (root / ".github/workflows/benchmark-checkout-provenance.yml").read_text(
+        encoding="utf-8"
+    )
+    path_filters = (root / ".github/path-filters.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "pull_request:" not in workflow
+    assert "push:" not in workflow
+    assert workflow.count("runs-on: windows-2025") == 1
+    assert "A1 - full checkout" in workflow
+    assert "B1 - blob:none checkout" in workflow
+    assert "B2 - blob:none checkout" in workflow
+    assert "A2 - full checkout" in workflow
+    assert (
+        workflow.index("A1 - full checkout")
+        < workflow.index("B1 - blob:none checkout")
+        < workflow.index("B2 - blob:none checkout")
+        < workflow.index("A2 - full checkout")
+    )
+    assert workflow.count("filter: blob:none") == 3  # B1, B2, final build source
+    assert "fetch-depth: 0" in workflow
+    assert "expected_sha must equal the dispatched default-branch SHA" in workflow
+    assert "test_tier: smoke" in workflow
+    assert "uses: ./.github/actions/build-suews" in workflow
+    assert "- '.github/workflows/benchmark-checkout-provenance.yml'" in path_filters
+
+
+def _write_test_wheel(path: Path) -> Path:
+    """Create a minimal deterministic wheel archive for provenance contracts."""
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            "supy-2026.7.16.dist-info/METADATA",
+            "Metadata-Version: 2.4\nName: supy\nVersion: 2026.7.16.dev3\n",
+        )
+        archive.writestr(
+            "supy-2026.7.16.dist-info/WHEEL",
+            "Wheel-Version: 1.0\nTag: cp312-abi3-win_amd64\n",
+        )
+        archive.writestr(
+            "supy/_version_scm.py",
+            "__version__ = '2026.7.16.dev3'\n__commit_hash__ = 'aaaaaaa'\n",
+        )
+    return path
 
 
 def _job(

--- a/test/core/test_ci_run_metrics.py
+++ b/test/core/test_ci_run_metrics.py
@@ -281,12 +281,15 @@ def test_checkout_abba_requires_matching_git_and_wheel_provenance(
     ]
     baseline = _write_test_wheel(tmp_path / "baseline.whl")
     filtered = _write_test_wheel(tmp_path / "filtered.whl")
+    metrics = _measured_wheel_metrics()
 
     comparison = build_comparison(
         trials,
         read_wheel_provenance(baseline),
         read_wheel_provenance(filtered),
         expected_sha=expected_sha,
+        baseline_metrics=metrics,
+        filtered_metrics=metrics,
     )
 
     assert comparison["passed"] is True
@@ -305,6 +308,18 @@ def test_checkout_abba_requires_matching_git_and_wheel_provenance(
             read_wheel_provenance(baseline),
             read_wheel_provenance(filtered),
             expected_sha=expected_sha,
+        )
+
+    trials[2]["tree_sha"] = common["tree_sha"]
+    metrics["phases"]["checkout"]["available"] = False
+    with pytest.raises(ValueError, match="checkout is not measured"):
+        build_comparison(
+            trials,
+            read_wheel_provenance(baseline),
+            read_wheel_provenance(filtered),
+            expected_sha=expected_sha,
+            baseline_metrics=metrics,
+            filtered_metrics=_measured_wheel_metrics(),
         )
 
 
@@ -355,6 +370,30 @@ def _write_test_wheel(path: Path) -> Path:
             "__version__ = '2026.7.16.dev3'\n__commit_hash__ = 'aaaaaaa'\n",
         )
     return path
+
+
+def _measured_wheel_metrics() -> dict[str, object]:
+    phases = {
+        phase: {"available": True, "status": "measured", "duration_seconds": 1.0}
+        for phase in (
+            "checkout",
+            "toolchain_setup",
+            "build",
+            "repair",
+            "install",
+            "tests",
+        )
+    }
+    return {
+        "schema_version": 1,
+        "kind": "wheel-job-ci-metrics",
+        "job_name": "physics-cp312-win-AMD64",
+        "phases": phases,
+        "pytest_metrics": {
+            "result": {"exit_code": 0},
+            "inventory": {"node_id_sha256": "f" * 64},
+        },
+    }
 
 
 def _job(


### PR DESCRIPTION
Refs #1627
Refs #1621

## Summary

- Add a manual one-runner Windows ABBA harness for full-history versus `blob:none` checkout.
- Pin the experiment to one successful default-branch source run and exact source SHA.
- Fail closed unless commit, tree, tag digest, `git describe`, generated version and commit provenance match across all four checkouts.
- Build only one filtered wheel, smoke-test it, and compare its METADATA, version, wheel tags and embedded version with the exact full-checkout source artifact.
- Keep production checkout and pytest worker counts unchanged.

## Interpretation boundary

The ABBA result is same-runner observational evidence under GitHub-hosted load.
It is not, by itself, a general hosted-runner speed-up claim.
A production `blob:none` change remains gated on positive net timing and exact provenance equivalence.

## Validation

- `actionlint` v1.7.7 passed.
- Ruff check and format passed.
- `test/core/test_ci_run_metrics.py`: 11 passed.
- `make test-smoke`: 9 passed, 1 skipped, 1,859 deselected in 49.75 s.
- `git diff --check` passed.