### PR TITLE
Filter wheel checkout blobs with full provenance

### DIFF
--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -56,6 +56,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          filter: blob:none
           fetch-depth: 0
           persist-credentials: false
 

--- a/test/core/test_ci_phase_metrics.py
+++ b/test/core/test_ci_phase_metrics.py
@@ -210,8 +210,8 @@ def test_every_local_build_action_caller_passes_metrics_host_dir() -> None:
 
 
 @pytest.mark.smoke
-def test_wheel_checkout_skips_empty_submodules_but_keeps_version_history() -> None:
-    """Wheel checkout avoids empty submodules without weakening git describe."""
+def test_wheel_checkout_filters_blobs_but_keeps_provenance_safeguards() -> None:
+    """Wheel checkout filters blobs without weakening history or credentials."""
     workflow = (PROJECT_ROOT / ".github/workflows/build-wheels-reusable.yml").read_text(
         encoding="utf-8"
     )
@@ -222,6 +222,7 @@ def test_wheel_checkout_skips_empty_submodules_but_keeps_version_history() -> No
 
     assert checkout is not None
     checkout_inputs = checkout.group("inputs")
+    assert "filter: blob:none" in checkout_inputs
     assert "fetch-depth: 0" in checkout_inputs
     assert "persist-credentials: false" in checkout_inputs
     assert "submodules:" not in checkout_inputs


### PR DESCRIPTION
Refs #1627
Refs #1621

## Summary

- Add `filter: blob:none` to the production reusable wheel checkout.
- Retain `fetch-depth: 0`, full tags/history and non-persisted credentials.
- Keep test tiers, platforms, caches and worker counts unchanged.
- Extend the existing CI contract to require the filter and provenance safeguards.

## Evidence

Hosted same-runner ABBA run 29503113021 compared full, `blob:none`, `blob:none`, full at exact default-branch SHA `e6f49319d755a4b2b46ff4ddde4f495e6f9dae03`.
The full-checkout median was 60.020 s and the filtered median was 16.9095 s, an observed checkout-only change of -71.826891%.
All commit, tree, tag digest, `git describe`, generated version and generated commit fields matched.
The filtered smoke-tested wheel matched the exact full-checkout wheel for METADATA hash, name/version, wheel tags and embedded version hash.
This evidence supports a positive checkout-phase change; it is not a claim of matched whole-job speed-up.

## Validation

- Focused CI contract: 1 passed.
- `make test-smoke`: 9 passed, 1 skipped, 1,859 deselected.
- `actionlint` passed.
- `zizmor` reported no findings.
- Action SHA-pin check passed.
- All workflow YAML files parsed successfully.
- `git diff --check` passed.