### PR TITLE
Audit CI gates alongside the diff in audit-pr

### DIFF
--- a/.claude/rules/autonomous-workflow.md
+++ b/.claude/rules/autonomous-workflow.md
@@ -16,8 +16,9 @@ Read it alongside `work-sizing.md` (sizing and umbrella decomposition).
 1. `triage-issue` -- issue governance. Emits a `[triage-issue] verdict` block.
 2. `fix-issue` -- one triaged issue to a PR-ready branch. Consumes the verdict
    block; emits a `[fix-issue] PR-ready report`.
-3. `audit-pr` -- reviews the PR; runs a Size Gate first. Emits `Verdict`,
-   `Size gate`, and per-finding `[severity]` tags.
+3. `audit-pr` -- reviews the PR; runs a Size Gate first, and audits the CI gates
+   alongside the diff. Emits `Verdict`, `Size gate`, `CI gate`, and per-finding
+   `[severity]` tags.
 4. `split-pr` -- carves an oversized PR into a stacked series. Emits a
    `[split-pr] stack plan`. Invoked when audit-pr's Size Gate recommends a split.
 5. `queue-pr` -- orders ready PRs and (human-gated) enters the merge queue.
@@ -60,8 +61,11 @@ without reading prose:
 - fix-issue -> audit-pr / merge: `[fix-issue] PR-ready report` with `Audit loop:`
   and `Remaining:`. fix-issue terminates at PR-ready; it never merges.
 - audit-pr -> fix-issue / split-pr: `Verdict: clean|needs-attention`,
-  `Size gate: pass|split-recommended`, per-finding `[severity]`. fix-issue's audit
-  loop branches on these; `split-recommended` routes to split-pr.
+  `Size gate: pass|split-recommended`, `CI gate: green|near-green|red`, per-finding
+  `[severity]`. fix-issue's audit loop branches on these; `split-recommended` routes
+  to split-pr. `CI gate: red` means the PR cannot advance even on a clean diff; each
+  red check must arrive with a named remedy and its tier (author-fixable /
+  maintainer-gated / re-trigger / infrastructure), never as a bare status.
 - split-pr -> queue-pr: `[split-pr] stack plan` with `Completeness:` and
   `Concerns -> Children`.
 - triage-pr -> downstream skills: `[triage-pr] verdict` block per PR. Downstream

--- a/.claude/skills/audit-pr/SKILL.md
+++ b/.claude/skills/audit-pr/SKILL.md
@@ -90,9 +90,9 @@ from the static event payload, so a label added after the run started leaves the
 gate red and `gh run rerun` replays the stale payload. Push a commit or
 close/reopen instead.
 
-Gate-by-gate remedies, the required-vs-blocking distinction, the green/near-green/
-red vocabulary (Part C of `triage-pr`'s rubric, plus its one named amendment), and
-the payload race: `references/ci-gates.md`.
+Gate-by-gate remedies, the required-vs-blocking distinction, the
+green/near-green/red vocabulary (Part C of `triage-pr`'s rubric, plus its one
+named amendment), and the payload race: `references/ci-gates.md`.
 
 ## Governance Check
 

--- a/.claude/skills/audit-pr/SKILL.md
+++ b/.claude/skills/audit-pr/SKILL.md
@@ -47,10 +47,50 @@ recommendation instead of spending the review on an unreviewable diff:
   them in the draft summary without treating them as automatic blockers.
 - **Schema version audit**: If the PR touches `src/supy/data_model/`, apply the triggers in `.claude/rules/python/schema-versioning.md`. Field rename, removal, type change, or required-field addition should be accompanied by a bump to `CURRENT_SCHEMA_VERSION`, a new `SCHEMA_VERSIONS` entry, a matching handler in `src/supy/util/converter/yaml_upgrade.py`, and a `sample_config.yml` resync. Flag any of these that are missing. CI gate `.github/workflows/schema-version-audit.yml` runs the automated check; if the PR carries the `0-ci:schema-audit-ok` bypass label, verify from the diff yourself that the reason is genuinely cosmetic before approving.
 - **Physics-change evidence audit**: If the diff touches physics source (`suews_phys_*.f95`, Rust physics backend), moves a reference fixture (`test/fixtures/data_test/sample_output.csv.gz`, `.../stebbs_test/sample_output_stebbs.csv`, `test/fixtures/benchmark1/*.pkl`), or changes a physics-affecting data-model default, apply `.claude/rules/physics-change-evidence.md`. Confirm the `0-physics:change` label is present (apply or flag if missing), the PR body has a `## Scientific evidence` section (quantities + mechanism, before/after comparison, sign/magnitude reasoning -- a bare "outputs changed" is blocking), the owner sign-off is present for any owned subsystem (STEBBS -> `@yiqing1021`), any moved fixture is refreshed in this PR (or a linked PR), and the full `-m physics` tier (including `slow`) has run green.
-- **Build**: CI status, meson.build
+- **Build**: meson.build inclusion for new source files
+- **CI gate audit**: see "CI Gate Audit" below -- every non-green check gets a named
+  remedy in the draft, not just a status
 - **Draft**: Comments for approval
 - **Approval**: Wait for human confirmation
 - **Post**: Only after approval
+
+## CI Gate Audit
+
+A review that audits the diff but ignores the checks hands back a PR that still
+cannot move. Every non-green check gets a diagnosis and a named remedy in the draft.
+
+1. **Read the checks**, the ruleset's required contexts, and the failing job logs:
+
+   ```bash
+   gh pr checks {pr} --repo UMEP-dev/SUEWS --json name,state,bucket,workflow,link
+   gh run view --repo UMEP-dev/SUEWS --job {job-id} --log-failed
+   ```
+
+   Query which contexts are actually required rather than assuming, and read the
+   `<!-- ci-build-plan -->` bot comment for which lanes this PR's paths selected.
+
+2. **Classify each non-green check by who can clear it** -- author-fixable (a
+   specific edit, in this PR), maintainer-gated (a documented bypass label, with the
+   reason the diff qualifies), re-trigger mechanics (correct already, run is stale),
+   or infrastructure/flake (unrelated to the diff). The classification is the
+   actionable part; state it.
+
+3. **Report it as a finding** with a severity: red required or convention-blocking
+   check -> `[blocking]`; red informational check, or a bypass label applied for a
+   reason the diff does not support -> `[major]`; pending required checks -> a note
+   in the summary.
+
+4. **Propose, never perform.** Applying a bypass label, re-running a workflow,
+   closing/reopening, or pushing a fix onto a PR you do not own are author or
+   maintainer actions. Name them; do not do them.
+
+Two gates (`schema-version-audit`, `knowledge-pack-audit`) read their bypass label
+from the static event payload, so a label added after the run started leaves the
+gate red and `gh run rerun` replays the stale payload. Push a commit or
+close/reopen instead.
+
+Gate-by-gate remedies, the required-vs-blocking distinction, and the payload race:
+`references/ci-gates.md`.
 
 ## Governance Check
 
@@ -112,6 +152,7 @@ Details: `references/style-checks.md`
 **Status**: Needs attention / Ready
 Verdict: clean | needs-attention
 Size gate: pass | split-recommended
+CI gate: green | near-green | red
 
 | Category | Status |
 |----------|--------|
@@ -119,12 +160,21 @@ Size gate: pass | split-recommended
 | Scientific | PASS/FAIL/N/A |
 | Testing | PASS/FAIL |
 | Docs | PASS/FAIL |
+| CI | PASS/FAIL/PENDING |
 
 ### Key Findings
 - [severity] finding (severity = blocking | major | minor | false-positive)
 
-The `Verdict`, `Size gate`, and per-finding `[severity]` tags are the fields a
-consuming skill (e.g. `fix-issue` step 5) branches on; keep them explicit.
+### CI Findings
+- [severity] {check name} -- enforces {what}; red because {cause for this diff}.
+  Remedy: {concrete action} ({author-fixable | maintainer-gated | re-trigger |
+  infrastructure})
+
+Omit the CI Findings section when every check is green. Never list a red check
+without a remedy line.
+
+The `Verdict`, `Size gate`, `CI gate`, and per-finding `[severity]` tags are the
+fields a consuming skill (e.g. `fix-issue` step 5) branches on; keep them explicit.
 
 ### Suggested Reviewers
 - @reviewer (source: dev-ref reviewer guide; reason: changed area)
@@ -151,13 +201,18 @@ every outward write" rule in `.claude/rules/autonomous-workflow.md`.
 audit-pr is a read-only review stage in the issue -> PR -> merge pipeline. Under
 an autonomous orchestrator it NEVER posts to GitHub; its terminal output is the
 drafted review plus the machine-readable handoff block (`Verdict`, `Size gate`,
-per-finding `[severity]`).
+`CI gate`, per-finding `[severity]`).
 
 - Auto-applicable (read-only / self-scoped): gather context, run the Size Gate,
-  perform the review, and emit the verdict block. This review-and-emit tier is the
-  only one an opt-in standing approval can cover.
+  read the checks and failing job logs, perform the review, and emit the verdict
+  block. This review-and-emit tier is the only one an opt-in standing approval can
+  cover.
 - Human-gated, always escalate (never auto-applied, in any mode): posting any line
-  comment or review onto the PR. The "Wait for human confirmation" step is NOT
+  comment or review onto the PR, and every CI remedy that mutates the PR --
+  applying a bypass label, re-running a workflow, closing/reopening to refresh the
+  event payload, or pushing a fix. Naming such a remedy in the draft is part of the
+  read-only review tier; carrying it out never is. The "Wait for human
+  confirmation" step is NOT
   satisfied by a batch standing approval; there is no standing approval for
   posting. The autonomous terminal is escalate-with-draft, the same shape as
   `triage-issue`'s needs-discussion and `queue-pr`'s merge escalation.
@@ -166,6 +221,7 @@ per-finding `[severity]`).
 
 - `references/review-checklist.md` - Detailed checklist
 - `references/workflow-steps.md` - Full workflow
+- `references/ci-gates.md` - CI gate diagnosis, remedies, and bypass-label policy
 - `references/style-checks.md` - Style rules
 - `dev-ref/CODING_GUIDELINES.md`
 - `dev-ref/REVIEW_PROCESS.md`

--- a/.claude/skills/audit-pr/SKILL.md
+++ b/.claude/skills/audit-pr/SKILL.md
@@ -73,12 +73,13 @@ cannot move. Every non-green check gets a diagnosis and a named remedy in the dr
    specific edit, in this PR), maintainer-gated (a documented bypass label, with the
    reason the diff qualifies), re-trigger mechanics (correct already, run is stale),
    or infrastructure/flake (unrelated to the diff). The classification is the
-   actionable part; state it.
+   actionable part; state it. Remedies compound: gh#1642 needed
+   `maintainer-gated -> re-trigger`, and neither half alone cleared the gate.
 
 3. **Report it as a finding** with a severity: red required or convention-blocking
-   check -> `[blocking]`; red informational check, or a bypass label applied for a
-   reason the diff does not support -> `[major]`; pending required checks -> a note
-   in the summary.
+   check -> `[blocking]`; a bypass label applied for a reason the diff does not
+   support -> `[major]`; red informational check -> `[minor]` or a note; pending
+   required checks -> a note in the summary.
 
 4. **Propose, never perform.** Applying a bypass label, re-running a workflow,
    closing/reopening, or pushing a fix onto a PR you do not own are author or
@@ -168,7 +169,8 @@ CI gate: green | near-green | red
 ### CI Findings
 - [severity] {check name} -- enforces {what}; red because {cause for this diff}.
   Remedy: {concrete action} ({author-fixable | maintainer-gated | re-trigger |
-  infrastructure})
+  infrastructure}; compound remedies chain, e.g. `maintainer-gated -> re-trigger`,
+  with the actor named at each step)
 
 Omit the CI Findings section when every check is green. Never list a red check
 without a remedy line.

--- a/.claude/skills/audit-pr/SKILL.md
+++ b/.claude/skills/audit-pr/SKILL.md
@@ -90,8 +90,9 @@ from the static event payload, so a label added after the run started leaves the
 gate red and `gh run rerun` replays the stale payload. Push a commit or
 close/reopen instead.
 
-Gate-by-gate remedies, the required-vs-blocking distinction, and the payload race:
-`references/ci-gates.md`.
+Gate-by-gate remedies, the required-vs-blocking distinction, the green/near-green/
+red vocabulary (Part C of `triage-pr`'s rubric, plus its one named amendment), and
+the payload race: `references/ci-gates.md`.
 
 ## Governance Check
 

--- a/.claude/skills/audit-pr/references/ci-gates.md
+++ b/.claude/skills/audit-pr/references/ci-gates.md
@@ -104,9 +104,11 @@ Fold CI findings into the same severity vocabulary as the rest of the review:
   support -> `[major]`. The label is doing work the diff has not earned.
 - Red informational check -> `[minor]`, or a note. Do not use `[major]`:
   `fix-issue` step 5 treats blocking/major as must-fix-before-ready, so a `[major]`
-  on a check that does not gate the merge would block the PR on nothing. In
-  practice this class is nearly empty -- `continue-on-error` jobs (zizmor in
-  `workflow-security.yml`, the advisory pip-audit step) report green regardless.
+  on a check that does not gate the merge would block the PR on nothing. Note that
+  the `continue-on-error` subset of this class (zizmor in `workflow-security.yml`,
+  the advisory pip-audit step) reports green regardless, so it never surfaces at
+  all; the observability jobs (`Post CI summary comment`, `CI observability
+  summary`) carry no such guard and can genuinely go red.
 - Pending required checks at review time -> note in the summary, not a finding.
 
 Each CI finding states, in one line: the check name, what it is enforcing, why it
@@ -119,8 +121,10 @@ is red *for this diff*, the remedy, and who can apply it.
 Workflow-to-remedy map for the gates that most often stop a SUEWS PR. Check names
 are the job display names as they appear in `gh pr checks` -- which is the job's
 `name:` where it has one, and the job *key* where it does not (see `validate`
-below). "Fires on" lists the principal trigger paths, not the exhaustive set; each
-gate also re-runs on changes to its own workflow file and lint script.
+below). "Fires on" lists the principal trigger paths, not the exhaustive set; most
+gates also list their own workflow file and lint script, but not all do
+(`validate-claude-md.yml` lists neither). Read the workflow's `paths:` rather than
+assuming.
 
 - **`Require schema version bump`** (`schema-version-audit.yml`)
   - Fires on: `src/supy/data_model/**`, `sample_config.yml`, the two schema doc
@@ -171,6 +175,9 @@ gate also re-runs on changes to its own workflow file and lint script.
     - legacy fused identifiers in Rust parameter structs -> rename the Rust struct
       field to the canonical snake_case spelling (the failure prints
       `path:line: 'legacy' -> should be 'canonical'`).
+  - Same asymmetry as the knowledge pack: that third check scans the Rust parameter
+    modules (`soil.rs`, `lai.rs`, `ohm_prm.rs` and siblings), none of which are
+    trigger paths -- so a diff touching only those files never fires the gate.
   - Author-fixable only -- no bypass label exists.
 - **`Enforce SHA-pinned actions`** (`workflow-security.yml`)
   - Fires on: `.github/workflows/**`, `.github/actions/**`.

--- a/.claude/skills/audit-pr/references/ci-gates.md
+++ b/.claude/skills/audit-pr/references/ci-gates.md
@@ -1,0 +1,203 @@
+# CI Gate Diagnosis and Remedies
+
+How to turn a red or pending check on a SUEWS PR into a named, actionable remedy
+inside the review, instead of leaving the author to work it out.
+
+**Origin**: gh#1642. An audit-pr pass produced good findings, the author addressed
+every one of them, and the PR still sat blocked because the review never said what
+the remaining red check (`Require schema version bump`) meant or how to clear it.
+The author had to stop and ask a maintainer. The remedy was a bypass label, not a
+code defect -- exactly the class of blocker a review is meant to name. A review that
+audits the diff but ignores the checks hands back a PR that still cannot move.
+
+---
+
+## Step 1 -- read the checks before drafting
+
+```bash
+# All checks with their state, bucket, and originating workflow
+gh pr checks {pr} --repo UMEP-dev/SUEWS --json name,state,bucket,workflow,link
+
+# Which contexts the branch ruleset actually requires (do not assume; ask)
+gh api repos/UMEP-dev/SUEWS/rulesets \
+  --jq '.[] | select(.target=="branch") | .id'
+gh api repos/UMEP-dev/SUEWS/rulesets/{id} \
+  --jq '.rules[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[].context'
+
+# Failure detail for a specific red check (job id is the tail of the check link)
+gh run view --repo UMEP-dev/SUEWS --job {job-id} --log-failed
+```
+
+Read the failure output. Every SUEWS lint gate prints its own remediation text
+(`scripts/lint/check_schema_version_bump.py`, `check_knowledge_pack_freshness.py`
+and siblings all end with a "what to do" paragraph). Quote the operative sentence
+into the finding rather than paraphrasing it from memory.
+
+Also read the `<!-- ci-build-plan -->` bot comment on the PR. It states which
+platforms, Python versions, and test tier this PR's paths selected, which explains
+why a check some other PR ran is absent here.
+
+## Step 2 -- required is not the same as blocking
+
+`gh pr checks` renders every check identically; the ruleset decides which ones
+actually gate the merge, and project convention adds more:
+
+- **Ruleset-required** -- listed under `required_status_checks` above. A red one
+  blocks the merge unconditionally.
+- **Convention-blocking** -- the `0-ci:*` audit family (schema version, knowledge
+  pack, encoding, clippy, Rust/Python alias parity, workflow security). These may
+  not appear in the ruleset, but the project does not merge over them. Treat a red
+  one as blocking and say so.
+- **Informational** -- summary/observability jobs, `skipping` entries for release
+  paths, and anything `continue-on-error`. Note, do not block.
+
+For the green / near-green / red vocabulary itself, defer to the single canonical
+definition in `.claude/skills/triage-pr/references/rubric.md` -> "Part C". Do not
+restate or fork it here.
+
+## Step 3 -- classify each non-green check by who can clear it
+
+This classification is the actionable part of the finding. Name it explicitly.
+
+- **Author-fixable** -- the check is right and the diff is wrong or incomplete.
+  Remedy: a specific edit, in this PR. Example: a public field was renamed, so bump
+  `CURRENT_SCHEMA_VERSION`, add the `SCHEMA_VERSIONS` entry, register the
+  `_HANDLERS` migration, and touch the two schema doc pages.
+- **Maintainer-gated** -- the check is a false positive for this diff and the
+  documented escape is a bypass label. Remedy: state the reason the diff is
+  genuinely non-structural or cosmetic, and *ask a maintainer* to apply the label.
+  Never apply it yourself as the reviewer (see "Never do these" below).
+- **Re-trigger mechanics** -- the code and labels are already correct and the run is
+  stale. Remedy: the specific re-trigger that works for that gate (see the payload
+  race below). "Re-run the job" is often the one thing that does not work.
+- **Infrastructure or flake** -- runner timeout, network failure, upstream outage.
+  Remedy: name it as unrelated to the diff so it is not mistaken for a code defect,
+  and escalate if it recurs. There is no acknowledged flaky-check list for this
+  repository; do not invent one.
+
+## Step 4 -- severity and the draft
+
+Fold CI findings into the same severity vocabulary as the rest of the review:
+
+- Red ruleset-required or convention-blocking check -> `[blocking]`.
+- Red informational check, or a green gate whose bypass label was applied for a
+  reason the diff does not support -> `[major]`.
+- Pending required checks at review time -> note in the summary, not a finding.
+
+Each CI finding states, in one line: the check name, what it is enforcing, why it
+is red *for this diff*, the remedy, and who can apply it.
+
+---
+
+## Gate catalogue
+
+Workflow-to-remedy map for the gates that most often stop a SUEWS PR. Check names
+are the job display names as they appear in `gh pr checks`.
+
+- **`Require schema version bump`** (`schema-version-audit.yml`)
+  - Fires on: `src/supy/data_model/**`, `sample_config.yml`, the two schema doc
+    pages, the lint script, the workflow itself.
+  - Enforces: a structural YAML-surface change moves `CURRENT_SCHEMA_VERSION`; and,
+    if the version did move, that the user-facing schema docs moved with it.
+  - Author-fixable when: the diff renames, removes, retypes, or requires a public
+    field, or restructures a nested section. Full checklist in
+    `.claude/rules/python/schema-versioning.md`.
+  - Maintainer-gated when: the `data_model` diff is genuinely non-structural
+    (docstrings, comments, validator-rule tightening, internal refactor). Label:
+    `0-ci:schema-audit-ok`. Subject to the payload race below.
+- **`Require knowledge-pack rebuild`** (`knowledge-pack-audit.yml`)
+  - Fires on: `src/supy/data_model/**`, `src/supy/cmd/**`, `src/supy/knowledge/**`.
+  - Enforces: the committed knowledge pack still binds to the current tree.
+  - Author-fixable when: the pack genuinely needs rebuilding.
+  - Maintainer-gated when: the diff cannot affect pack content. Label:
+    `0-ci:knowledge-pack-audit-ok`. Subject to the payload race below.
+- **`Require explicit encoding on text I/O`** (`encoding-audit.yml`)
+  - Fires on: any `**.py`.
+  - Enforces: `ruff PLW1514` plus a `read_text`/`write_text` sweep -- no implicit
+    locale encoding.
+  - Author-fixable: add `encoding="utf-8"`. This is nearly always the right fix.
+  - Bypass label `0-ci:encoding-audit-ok` is referenced by the workflow but does not
+    currently exist in the repository, so proposing it means asking a maintainer to
+    create the label first. Prefer the code fix.
+- **`cargo clippy (suews_bridge)`** (`rust-clippy.yml`)
+  - Fires on: `src/suews_bridge/**`.
+  - Enforces: clippy with warnings denied.
+  - Author-fixable: fix the lint, or justify a scoped `#[allow]`.
+  - Bypass label `0-ci:clippy-ok` is likewise referenced but not yet created.
+- **`Require Rust/Python registry parity`** (`rust-yaml-aliases-audit.yml`)
+  - Fires on: `field_renames.py`, `physics_families.py`, `field_renames.rs`.
+  - Enforces: the Python and Rust alias registries agree.
+  - Author-fixable only -- no bypass. Update whichever side is behind.
+- **`Enforce SHA-pinned actions`** (`workflow-security.yml`)
+  - Fires on: `.github/workflows/**`, `.github/actions/**`.
+  - Enforces: every action pinned to a full commit SHA with a version comment.
+  - Author-fixable only -- no bypass. `Advisory workflow audit` (zizmor) in the same
+    workflow is informational.
+- **`Audit Python dependency intake`** (`dependency-audit.yml`)
+  - Fires on: `pyproject.toml`, `Makefile`, `scripts/security/**`, the build
+    workflows.
+  - Enforces: `pip-audit` advisories and the Python startup-hook sweep.
+  - See `.claude/rules/dependency-safety.md`. A startup-hook hit is never a bypass
+    case -- stop and escalate.
+- **`Validate CLAUDE.md`** (`validate-claude-md.yml`)
+  - Fires on: `CLAUDE.md`, `.claude/rules/**`.
+  - Enforces: integrity plus a content-reduction guard.
+  - Author-fixable: restore removed content, or justify the reduction in the PR.
+- **`PR build validation`** and the wheel/test matrix
+  (`build-publish_to_pypi.yml`, `test-*-reusable.yml`)
+  - The build and test lanes proper. A red one is ordinary review substance: read
+    the failing job log and treat it as a code finding, not a gate finding.
+
+Do not hardcode the required-check list or the label inventory into a review --
+both change. Query them (Step 1) at review time.
+
+---
+
+## The bypass-label payload race
+
+Two gates read their bypass label from the **static event payload** captured when
+the triggering event fired -- `${{ toJSON(github.event.pull_request.labels.*.name) }}`
+-- and subscribe only to the default `pull_request` types (`opened`, `synchronize`,
+`reopened`):
+
+- `schema-version-audit.yml` (`0-ci:schema-audit-ok`)
+- `knowledge-pack-audit.yml` (`0-ci:knowledge-pack-audit-ok`)
+
+So a label applied *after* the run started is invisible to it, and the gate stays
+red even though the label is plainly on the PR.
+
+- Preferred: apply the label at creation -- `gh pr create ... --label "0-ci:schema-audit-ok"`.
+- Already failed: push a commit (fires `synchronize`) or
+  `gh pr close {pr} && gh pr reopen {pr}` (fires `reopened`). Either regenerates a
+  payload carrying the current labels.
+- **`gh run rerun` does not help** -- it replays the stale payload. Recommending it
+  costs the author a cycle and looks like the fix failed.
+
+`encoding-audit.yml` and `rust-clippy.yml` do include `labeled`/`unlabeled` in their
+trigger types, so labelling those re-triggers them directly. Check the workflow's
+`types:` line before advising a re-trigger.
+
+---
+
+## Never do these
+
+- **Do not apply a bypass label as the reviewer.** It is a repo write on someone
+  else's PR and a maintainer decision by policy
+  (`.claude/rules/python/schema-versioning.md`: "a contributor should not add the
+  label themselves"). Propose it, with the reason, and let a maintainer act. The
+  autonomous tier never creates labels either -- if a bypass label does not exist,
+  say so rather than creating it.
+- **Do not propose a bypass to dodge a real change.** The label is for diffs that
+  do not need the bump, never for diffs that need it and would rather not. Verify
+  the non-structural claim against the diff yourself before writing the sentence.
+- **Do not propose a bypass at all for `0-physics:change`.** Per
+  `.claude/rules/physics-change-evidence.md` that gate has no cosmetic bypass; it is
+  satisfied by supplying the evidence.
+- **Do not re-run, close/reopen, or push to a PR you do not own** to clear a check.
+  Those are author or maintainer actions; the review names them, the review does not
+  perform them.
+- **Do not report "CI is red" without a remedy.** That is the failure mode gh#1642
+  exposed. If the cause is not apparent from the diff and the log, say so explicitly
+  and escalate -- an honest "unexplained, needs a maintainer" is actionable; a bare
+  red status is not.

--- a/.claude/skills/audit-pr/references/ci-gates.md
+++ b/.claude/skills/audit-pr/references/ci-gates.md
@@ -29,10 +29,12 @@ gh api repos/UMEP-dev/SUEWS/rulesets/{id} \
 gh run view --repo UMEP-dev/SUEWS --job {job-id} --log-failed
 ```
 
-Read the failure output. Every SUEWS lint gate prints its own remediation text
-(`scripts/lint/check_schema_version_bump.py`, `check_knowledge_pack_freshness.py`
-and siblings all end with a "what to do" paragraph). Quote the operative sentence
-into the finding rather than paraphrasing it from memory.
+Read the failure output. Most SUEWS lint gates end with their own remediation
+paragraph (`scripts/lint/check_schema_version_bump.py` and
+`check_knowledge_pack_freshness.py` both name the bypass label and the fix). Where
+the log supplies one, quote the operative sentence into the finding rather than
+paraphrasing from memory. Some failure paths print only the cause -- there, derive
+the remedy from the catalogue below, or say plainly that it needs a maintainer.
 
 Also read the `<!-- ci-build-plan -->` bot comment on the PR. It states which
 platforms, Python versions, and test tier this PR's paths selected, which explains
@@ -45,20 +47,37 @@ actually gate the merge, and project convention adds more:
 
 - **Ruleset-required** -- listed under `required_status_checks` above. A red one
   blocks the merge unconditionally.
-- **Convention-blocking** -- the `0-ci:*` audit family (schema version, knowledge
-  pack, encoding, clippy, Rust/Python alias parity, workflow security). These may
-  not appear in the ruleset, but the project does not merge over them. Treat a red
-  one as blocking and say so.
+- **Convention-blocking** -- the audit-gate family: schema version, knowledge pack,
+  encoding, clippy, Rust/Python alias parity, SHA-pinned actions, dependency
+  intake. Some of these carry a `0-ci:*` bypass label and some have no escape at
+  all. None appear in the ruleset, but the project does not merge over them. Treat
+  a red one as blocking and say so.
 - **Informational** -- summary/observability jobs, `skipping` entries for release
   paths, and anything `continue-on-error`. Note, do not block.
 
-For the green / near-green / red vocabulary itself, defer to the single canonical
-definition in `.claude/skills/triage-pr/references/rubric.md` -> "Part C". Do not
-restate or fork it here.
+`.claude/skills/triage-pr/references/rubric.md` -> "Part C" is the canonical
+green / near-green / red definition, and it keys on ruleset-required checks alone.
+audit-pr's `CI gate` field applies Part C with **one named amendment**: a red
+convention-blocking check counts as `red` here, where Part C alone would read it as
+near-green because it is not ruleset-required.
+
+The amendment is deliberate, because the two stages answer different questions.
+Part C asks "may this PR advance towards the queue"; audit-pr asks "can this PR
+merge as it stands". gh#1642 is exactly the case that separates them -- at the time
+of writing the branch ruleset requires a single context (`PR build validation`), so
+the schema gate is not required and Part C alone would have waved that PR through
+while it sat unmergeable. Apply Part C unamended for everything else; do not
+restate it.
 
 ## Step 3 -- classify each non-green check by who can clear it
 
 This classification is the actionable part of the finding. Name it explicitly.
+
+A remedy may be **compound**, and often is. On gh#1642 neither step alone cleared
+the gate: a maintainer applied `0-ci:schema-audit-ok` (which fired no run at all),
+and the author then pushed a commit to regenerate the event payload. Write such a
+remedy as an ordered pair with the actor named at each step
+(`maintainer-gated -> re-trigger`), not as whichever half you noticed first.
 
 - **Author-fixable** -- the check is right and the diff is wrong or incomplete.
   Remedy: a specific edit, in this PR. Example: a public field was renamed, so bump
@@ -81,8 +100,13 @@ This classification is the actionable part of the finding. Name it explicitly.
 Fold CI findings into the same severity vocabulary as the rest of the review:
 
 - Red ruleset-required or convention-blocking check -> `[blocking]`.
-- Red informational check, or a green gate whose bypass label was applied for a
-  reason the diff does not support -> `[major]`.
+- A green gate whose bypass label was applied for a reason the diff does not
+  support -> `[major]`. The label is doing work the diff has not earned.
+- Red informational check -> `[minor]`, or a note. Do not use `[major]`:
+  `fix-issue` step 5 treats blocking/major as must-fix-before-ready, so a `[major]`
+  on a check that does not gate the merge would block the PR on nothing. In
+  practice this class is nearly empty -- `continue-on-error` jobs (zizmor in
+  `workflow-security.yml`, the advisory pip-audit step) report green regardless.
 - Pending required checks at review time -> note in the summary, not a finding.
 
 Each CI finding states, in one line: the check name, what it is enforcing, why it
@@ -93,7 +117,10 @@ is red *for this diff*, the remedy, and who can apply it.
 ## Gate catalogue
 
 Workflow-to-remedy map for the gates that most often stop a SUEWS PR. Check names
-are the job display names as they appear in `gh pr checks`.
+are the job display names as they appear in `gh pr checks` -- which is the job's
+`name:` where it has one, and the job *key* where it does not (see `validate`
+below). "Fires on" lists the principal trigger paths, not the exhaustive set; each
+gate also re-runs on changes to its own workflow file and lint script.
 
 - **`Require schema version bump`** (`schema-version-audit.yml`)
   - Fires on: `src/supy/data_model/**`, `sample_config.yml`, the two schema doc
@@ -108,8 +135,17 @@ are the job display names as they appear in `gh pr checks`.
     `0-ci:schema-audit-ok`. Subject to the payload race below.
 - **`Require knowledge-pack rebuild`** (`knowledge-pack-audit.yml`)
   - Fires on: `src/supy/data_model/**`, `src/supy/cmd/**`, `src/supy/knowledge/**`.
-  - Enforces: the committed knowledge pack still binds to the current tree.
-  - Author-fixable when: the pack genuinely needs rebuilding.
+  - Enforces: that a pack rebuild still succeeds and binds to the current git SHA.
+    Note the asymmetry -- `_GUARDED_ROOTS` in
+    `scripts/lint/check_knowledge_pack_freshness.py` is only `src/supy/data_model/`
+    and `src/supy/cmd/`, so a `src/supy/knowledge/**`-only diff triggers the
+    workflow and then exits 0 without checking anything.
+  - The manifest is *not* committed to git (meson regenerates it per build, which
+    the script calls the normal SUEWS state), so the check does a temporary rebuild
+    and verifies the resulting manifest. "Rebuild and commit the pack" is therefore
+    not the remedy.
+  - Author-fixable when: the temporary rebuild fails, or produces a manifest that is
+    incomplete or bound to a different SHA. Fix the generator input the diff broke.
   - Maintainer-gated when: the diff cannot affect pack content. Label:
     `0-ci:knowledge-pack-audit-ok`. Subject to the payload race below.
 - **`Require explicit encoding on text I/O`** (`encoding-audit.yml`)
@@ -127,8 +163,15 @@ are the job display names as they appear in `gh pr checks`.
   - Bypass label `0-ci:clippy-ok` is likewise referenced but not yet created.
 - **`Require Rust/Python registry parity`** (`rust-yaml-aliases-audit.yml`)
   - Fires on: `field_renames.py`, `physics_families.py`, `field_renames.rs`.
-  - Enforces: the Python and Rust alias registries agree.
-  - Author-fixable only -- no bypass. Update whichever side is behind.
+  - Enforces three independent checks, each with its own remedy -- read the failure
+    message to see which one fired:
+    - rename-registry parity between Python and Rust -> update whichever side is
+      behind;
+    - physics-family parity -> same;
+    - legacy fused identifiers in Rust parameter structs -> rename the Rust struct
+      field to the canonical snake_case spelling (the failure prints
+      `path:line: 'legacy' -> should be 'canonical'`).
+  - Author-fixable only -- no bypass label exists.
 - **`Enforce SHA-pinned actions`** (`workflow-security.yml`)
   - Fires on: `.github/workflows/**`, `.github/actions/**`.
   - Enforces: every action pinned to a full commit SHA with a version comment.
@@ -137,15 +180,28 @@ are the job display names as they appear in `gh pr checks`.
 - **`Audit Python dependency intake`** (`dependency-audit.yml`)
   - Fires on: `pyproject.toml`, `Makefile`, `scripts/security/**`, the build
     workflows.
-  - Enforces: `pip-audit` advisories and the Python startup-hook sweep.
+  - Enforces (blocking): the Python startup-hook sweep and legacy `.pth` removal.
+    The `pip-audit` step is explicitly advisory (`continue-on-error: true`), so
+    advisories alone cannot turn this check red -- do not report them as the cause.
   - See `.claude/rules/dependency-safety.md`. A startup-hook hit is never a bypass
     case -- stop and escalate.
-- **`Validate CLAUDE.md`** (`validate-claude-md.yml`)
+- **`validate`** (`validate-claude-md.yml`; the job has no display name, so it
+  renders as `validate` under the "Validate CLAUDE.md" workflow)
   - Fires on: `CLAUDE.md`, `.claude/rules/**`.
-  - Enforces: integrity plus a content-reduction guard.
-  - Author-fixable: restore removed content, or justify the reduction in the PR.
+  - Enforces: integrity plus a content-reduction guard. The guard fails only when
+    the reduction exceeds 20% **and** one or more of the required rule files is
+    missing; a large reduction with all rule files present is accepted as
+    intentional restructuring.
+  - Author-fixable: restore the removed content, or restore the missing rule files.
+    The job never reads the PR body, so "justify it in the PR" is not a remedy.
+- **`Check pytest marker axis`** (`build-publish_to_pypi.yml`)
+  - Enforces `scripts/lint/check_test_markers.py` -- physics/api marker coverage on
+    tests. It is a `needs:` of `PR build validation`, so a red one turns the single
+    ruleset-required check red too.
+  - Author-fixable: add the missing marker to the new or moved test.
 - **`PR build validation`** and the wheel/test matrix
-  (`build-publish_to_pypi.yml`, `test-*-reusable.yml`)
+  (`build-publish_to_pypi.yml`, `build-wheels-reusable.yml`,
+  `test-api-cross-python-reusable.yml`)
   - The build and test lanes proper. A red one is ordinary review substance: read
     the failing job log and treat it as a code finding, not a gate finding.
 

--- a/.claude/skills/audit-pr/references/ci-gates.md
+++ b/.claude/skills/audit-pr/references/ci-gates.md
@@ -123,8 +123,8 @@ are the job display names as they appear in `gh pr checks` -- which is the job's
 `name:` where it has one, and the job *key* where it does not (see `validate`
 below). "Fires on" lists the principal trigger paths, not the exhaustive set; most
 gates also list their own workflow file and lint script, but not all do
-(`validate-claude-md.yml` lists neither). Read the workflow's `paths:` rather than
-assuming.
+(`validate-claude-md.yml` omits its own workflow file, and lists its lint script
+under `pull_request` only). Read the workflow's `paths:` rather than assuming.
 
 - **`Require schema version bump`** (`schema-version-audit.yml`)
   - Fires on: `src/supy/data_model/**`, `sample_config.yml`, the two schema doc
@@ -194,7 +194,8 @@ assuming.
     case -- stop and escalate.
 - **`validate`** (`validate-claude-md.yml`; the job has no display name, so it
   renders as `validate` under the "Validate CLAUDE.md" workflow)
-  - Fires on: `CLAUDE.md`, `.claude/rules/**`.
+  - Fires on: `CLAUDE.md`, `.claude/rules/**`, and (on `pull_request` only) its own
+    lint script.
   - Enforces: integrity plus a content-reduction guard. The guard fails only when
     the reduction exceeds 20% **and** one or more of the required rule files is
     missing; a large reduction with all rule files present is accepted as

--- a/.claude/skills/audit-pr/references/review-checklist.md
+++ b/.claude/skills/audit-pr/references/review-checklist.md
@@ -174,6 +174,21 @@ block it anyway, and surfacing it in review saves a round trip.
 - [ ] No regression in test coverage
 - [ ] Documentation builds successfully
 
+### CI gate remedies (when any check is not green)
+
+- [ ] Required contexts queried from the branch ruleset, not assumed
+- [ ] Each red check diagnosed from its job log, not from its name alone
+- [ ] Each red check classified: author-fixable / maintainer-gated /
+      re-trigger mechanics / infrastructure
+- [ ] Each red check carries a concrete remedy in the draft, and a severity
+      (red required or convention-blocking -> `[blocking]`)
+- [ ] Any bypass label proposed (not applied), with the reason the diff
+      genuinely qualifies as non-structural or cosmetic
+- [ ] For `schema-version-audit` / `knowledge-pack-audit`, the re-trigger advice
+      is "push a commit or close/reopen", never `gh run rerun`
+- [ ] No bypass proposed for a `0-physics:change` evidence gate (no bypass exists)
+- [ ] Ref: `ci-gates.md`
+
 ---
 
 ## Refactoring Review

--- a/.claude/skills/audit-pr/references/workflow-steps.md
+++ b/.claude/skills/audit-pr/references/workflow-steps.md
@@ -75,12 +75,34 @@ Check: FIRST principles, AAA pattern, tolerance assertions.
 
 ---
 
-## Build Review
+## Build and CI Review
 
 ```bash
-gh pr checks {pr}
-# Verify meson.build includes new files
+# Verify meson.build includes new Fortran files, __init__.py new Python files
+
+# Checks, with the workflow each belongs to
+gh pr checks {pr} --repo UMEP-dev/SUEWS --json name,state,bucket,workflow,link
+
+# Which contexts the ruleset actually requires (query; do not assume)
+gh api repos/UMEP-dev/SUEWS/rulesets --jq '.[] | select(.target=="branch") | .id'
+gh api repos/UMEP-dev/SUEWS/rulesets/{id} \
+  --jq '.rules[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[].context'
+
+# Failure detail (job id is the tail of the check link)
+gh run view --repo UMEP-dev/SUEWS --job {job-id} --log-failed
 ```
+
+For each non-green check, diagnose and classify the remedy -- author-fixable,
+maintainer-gated (bypass label), re-trigger mechanics, or infrastructure -- and
+write it into the draft as a CI finding with a severity. A red check reported
+without a remedy leaves the PR blocked; that is the gap gh#1642 exposed.
+
+Propose remedies, never perform them: applying a bypass label, re-running a
+workflow, closing/reopening, and pushing a fix are author or maintainer actions.
+
+Gate-by-gate catalogue, the required-vs-convention-blocking distinction, and the
+bypass-label payload race: `ci-gates.md`.
 
 ---
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -221,7 +221,7 @@ Branch: <branch>
 PR: <url or not created: reason>
 Scope: <one-line summary>
 Validation: <commands and pass/blocked status>
-Audit loop: <clean after N iters | stopped after 3 iters: persisting | stopped on recurring finding: signature | split: handed to split-pr | not run: reason>
+Audit loop: <clean after N iters | stopped after 3 iters: persisting | stopped on recurring finding: signature | stopped on red CI gate: check | split: handed to split-pr | not run: reason>
 Public GitHub edits: <none | drafted | approved and applied>
 Remaining: <none | explicit blocker>
 Next: ready for the normal review/merge workflow.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -189,10 +189,17 @@ recurring-signature check is the oscillation guard.
      bundled): stop the address-and-re-audit loop and hand off to `split-pr`
      rather than fixing findings against an unreviewable diff. This mirrors the
      pre-implementation split guard in step 2.5.
+   - if `audit-pr` reports `CI gate: red`: the PR is not ready regardless of the
+     diff verdict. Treat each red check's remedy by its tier -- apply an
+     `author-fixable` remedy in this loop like any blocking finding; a
+     `maintainer-gated` (bypass label), `re-trigger` or `infrastructure` remedy is
+     outside fix-issue's authority, so stop and record it in `Remaining` naming
+     the check and the action needed. Never call the PR ready over a red CI gate.
 3. Address all valid blocking/major findings in the branch, run the relevant
    validation again, commit scoped fixes, and push.
 4. Re-run `audit-pr` on the updated PR/head. Repeat this address-and-re-audit loop
-   until `audit-pr` returns `Verdict: clean`, to a maximum of 3 iterations. The
+   until `audit-pr` returns `Verdict: clean` **and** `CI gate` is not `red`, to a
+   maximum of 3 iterations. The
    operative gate is whether any valid blocking/major finding remains, which the
    per-finding `[severity]` field reports: a `needs-attention` verdict carrying
    only minor/false-positive findings still resolves to PR-ready once each is


### PR DESCRIPTION
## Summary

A review that audits the diff but ignores the checks hands back a PR that still cannot move. On #1642 the audit findings were all addressed and the diff was clean, yet the PR stayed blocked on a red `Require schema version bump` until the author stopped and asked a maintainer how to handle it. The blocker was a bypass-label case, not a code defect — precisely the class of thing a review should name.

`audit-pr` now audits the CI gates alongside the diff.

## Changes

- **`skills/audit-pr/SKILL.md`** — new "CI Gate Audit" section: read the checks and failing job logs, query which contexts the ruleset actually requires, classify each non-green check by who can clear it (author-fixable / maintainer-gated / re-trigger mechanics / infrastructure), report it as a finding with a severity, and propose remedies rather than performing them. The thin `**Build**: CI status` bullet is replaced. Remedies may compound (`maintainer-gated -> re-trigger`) with the actor named at each step — on #1642 neither half alone cleared the gate.
- **`skills/audit-pr/references/ci-gates.md`** (new) — gate-by-gate catalogue covering the schema-version, knowledge-pack, encoding, clippy, alias-parity, marker-axis, workflow-security, dependency and CLAUDE.md gates: what fires each one, its canonical fix, and whether a bypass label exists.
  - Records that required and blocking are not the same thing here: the branch ruleset requires a single context (`PR build validation`), while the audit-gate family blocks by project convention. Both are queried at review time rather than hardcoded.
  - Documents the bypass-label payload race. `schema-version-audit.yml` and `knowledge-pack-audit.yml` read labels from the static event payload and do not subscribe to `labeled`, so a label applied after the run started leaves the gate red and `gh run rerun` replays the stale payload — push a commit or close/reopen instead. `encoding-audit.yml` and `rust-clippy.yml` do include `labeled` and re-trigger directly.
  - Notes that `0-ci:encoding-audit-ok` and `0-ci:clippy-ok` are referenced by their workflows but do not exist as repository labels, so proposing either means asking a maintainer to create it first.
  - Bypass policy: propose, never apply. Per `rules/python/schema-versioning.md` the label is a maintainer decision, and the autonomous tier never creates labels. No bypass is ever proposed for the `0-physics:change` evidence gate.
- **Handoff contract** — the draft summary gains a `CI gate: green | near-green | red` field and a `### CI Findings` block where every red check carries a remedy and its tier. `rules/autonomous-workflow.md` and `skills/fix-issue/SKILL.md` are updated to match: fix-issue's audit loop now requires a non-red CI gate before calling a PR ready, applies `author-fixable` remedies in-loop, and records `maintainer-gated` / `infrastructure` remedies in `Remaining` rather than attempting them.
- **`references/review-checklist.md`, `references/workflow-steps.md`** — checklist items and commands aligned with the above.

Every CI remedy that mutates a PR — applying a bypass label, re-running a workflow, closing/reopening, pushing a fix — stays human-gated. Naming one in the draft is part of the read-only review tier; carrying it out is not.

### Relationship to `triage-pr`'s rubric

`triage-pr` rubric Part C stays the canonical green / near-green / red definition. audit-pr applies it with one explicitly named amendment: a red convention-blocking check counts as `red` even though it is not ruleset-required. The two stages answer different questions — Part C asks whether a PR may advance towards the queue, audit-pr asks whether it can merge as it stands — and #1642 is the case that separates them.

## Validation

- Every command written into the guidance was verified live against this repository: `gh pr checks --json name,state,bucket,workflow,link`, the ruleset `required_status_checks` query, and `gh run view --job <id> --log-failed`.
- Bypass-label inventory checked against `gh label list`; workflow `types:` triggers checked against the four audit workflows; job display names checked against this PR's own check run (which is how the `validate` naming was caught).
- Second commit applies an independent review pass: two contract defects (the vocabulary fork against Part C, and a handoff field with no consumer in `fix-issue`) and six catalogue inaccuracies, each re-verified against the workflows and lint scripts before correction.
- `.claude/scripts/validate-claude-md.py` passes (the gate that fires on `.claude/rules/**`).
- No non-ASCII characters introduced (checked against `origin/master`, not the stale local `master`).
- Documentation-only change to the Claude Code workspace; no source, build, or test surface touched.
