### PR TITLE
Allow unpublished bibliography entries without a DOI (Issue 1644)

### DIFF
--- a/.claude/rules/docs/bib-topic-tags.md
+++ b/.claude/rules/docs/bib-topic-tags.md
@@ -9,9 +9,10 @@ These bib files drive `docs/source/related_publications.rst` and `docs/source/co
 ## Required metadata
 
 Every entry MUST include non-empty `title`, `author`, and `year` fields.
-Published entries MUST also include a non-empty `doi`. An `@unpublished`
-entry MUST instead include a non-empty `note` describing its publication
-status, such as `In preparation` or `Under review`; its `doi` is optional.
+All entry types other than `@unpublished` MUST also include a non-empty `doi`.
+An `@unpublished` entry MUST instead include a non-empty `note` describing its
+publication status, such as `In preparation` or `Under review`; its `doi` is
+optional.
 
 ## Every entry MUST carry at least one topic slug
 

--- a/.claude/rules/docs/bib-topic-tags.md
+++ b/.claude/rules/docs/bib-topic-tags.md
@@ -1,10 +1,17 @@
-# Bibliography topic tags
+# Bibliography conventions
 
-Rules for the `keywords` field on entries in `docs/source/assets/refs/refs-SUEWS.bib` and `docs/source/assets/refs/refs-community.bib`.
+Rules for entries in `docs/source/assets/refs/refs-SUEWS.bib` and `docs/source/assets/refs/refs-community.bib`.
 
 These bib files drive `docs/source/related_publications.rst` and `docs/source/community_publications.rst`, which render per-topic subsections with stable `.. _pub-<slug>:` anchors for external deep-linking. The `audit-docs` skill (`.claude/skills/audit-docs/`) enforces this convention and backfills missing metadata.
 
 ---
+
+## Required metadata
+
+Every entry MUST include non-empty `title`, `author`, and `year` fields.
+Published entries MUST also include a non-empty `doi`. An `@unpublished`
+entry MUST instead include a non-empty `note` describing its publication
+status, such as `In preparation` or `Under review`; its `doi` is optional.
 
 ## Every entry MUST carry at least one topic slug
 

--- a/.claude/skills/audit-docs/SKILL.md
+++ b/.claude/skills/audit-docs/SKILL.md
@@ -85,8 +85,11 @@ subsections via `sphinxcontrib-bibtex`'s `:filter:` on the `keywords` field.
 
 - Checks **convention compliance**: every entry has a `keywords` field, every
   slug is in the approved vocabulary, slug format is lowercase-hyphen, no
-  duplicate citation keys, required fields present, abstracts populated
-  (informational, not a failure).
+  duplicate citation keys, and required fields are present. Every entry
+  requires `title`, `author`, and `year`; published entries also require
+  `doi`, while `@unpublished` entries require a publication-status `note`
+  (for example, `In preparation` or `Under review`) and may omit `doi`.
+  Missing abstracts are reported as informational warnings, not failures.
 - Does **not** verify DOI-to-paper correctness -- use the user-level
   `refs-checker` skill for that.
 

--- a/.claude/skills/audit-docs/SKILL.md
+++ b/.claude/skills/audit-docs/SKILL.md
@@ -86,10 +86,11 @@ subsections via `sphinxcontrib-bibtex`'s `:filter:` on the `keywords` field.
 - Checks **convention compliance**: every entry has a `keywords` field, every
   slug is in the approved vocabulary, slug format is lowercase-hyphen, no
   duplicate citation keys, and required fields are present. Every entry
-  requires `title`, `author`, and `year`; published entries also require
-  `doi`, while `@unpublished` entries require a publication-status `note`
-  (for example, `In preparation` or `Under review`) and may omit `doi`.
-  Missing abstracts are reported as informational warnings, not failures.
+  requires `title`, `author`, and `year`; all entry types other than
+  `@unpublished` also require `doi`. An `@unpublished` entry instead requires
+  a publication-status `note` (for example, `In preparation` or `Under
+  review`) and may omit `doi`. Missing abstracts are reported as informational
+  warnings, not failures.
 - Does **not** verify DOI-to-paper correctness -- use the user-level
   `refs-checker` skill for that.
 

--- a/.claude/skills/audit-docs/scripts/audit.py
+++ b/.claude/skills/audit-docs/scripts/audit.py
@@ -16,9 +16,9 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
 
 VOCAB: set[str] = {
     "energy-balance",
@@ -32,9 +32,11 @@ VOCAB: set[str] = {
 }
 
 SLUG_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
-ENTRY_START = re.compile(r"^@[A-Za-z]+\{([^,\s]+)\s*,", re.MULTILINE)
+ENTRY_START = re.compile(
+    r"^@(?P<entry_type>[A-Za-z]+)\{(?P<key>[^,\s]+)\s*,", re.MULTILINE
+)
 
-REQUIRED_FIELDS = ("title", "author", "year", "doi")
+COMMON_REQUIRED_FIELDS = ("title", "author", "year")
 
 
 def _line_number(text: str, offset: int) -> int:
@@ -102,8 +104,12 @@ def audit_entry(entry: dict, file_path: str, all_keys: dict[str, str],
                     f"(allowed: {', '.join(sorted(VOCAB))})"
                 )
 
-    # Required fields
-    for field in REQUIRED_FIELDS:
+    # DOI is optional only for manuscripts that are explicitly unpublished.
+    required_fields = COMMON_REQUIRED_FIELDS
+    if entry["entry_type"] != "unpublished":
+        required_fields += ("doi",)
+
+    for field in required_fields:
         val = extract_field(body, field)
         if val is None or not val.strip():
             violations.append(f"{prefix}: missing or empty `{field}`")
@@ -121,7 +127,8 @@ def find_entries(text: str) -> list[dict]:
         start = m.start()
         end = starts[i + 1].start() if i + 1 < len(starts) else len(text)
         entries.append({
-            "key": m.group(1),
+            "entry_type": m.group("entry_type").lower(),
+            "key": m.group("key"),
             "start": start,
             "end": end,
             "body": text[start:end],

--- a/.claude/skills/audit-docs/scripts/audit.py
+++ b/.claude/skills/audit-docs/scripts/audit.py
@@ -13,6 +13,7 @@ Exit codes:
     0   all convention checks passed (abstract warnings may appear)
     1   one or more convention violations found
 """
+
 from __future__ import annotations
 
 import argparse
@@ -60,7 +61,7 @@ def _match_field(body: str, name: str) -> tuple[int, int, str] | None:
         i += 1
     if depth != 0:
         return None
-    return m.start() + len(m.group(1)), i - 1, body[open_brace + 1:i - 1]
+    return m.start() + len(m.group(1)), i - 1, body[open_brace + 1 : i - 1]
 
 
 def extract_field(body: str, name: str) -> str | None:
@@ -72,8 +73,13 @@ def parse_slugs(raw: str) -> list[str]:
     return [s.strip() for s in raw.split(",") if s.strip()]
 
 
-def audit_entry(entry: dict, file_path: str, all_keys: dict[str, str],
-                violations: list[str], warnings: list[str]) -> None:
+def audit_entry(
+    entry: dict,
+    file_path: str,
+    all_keys: dict[str, str],
+    violations: list[str],
+    warnings: list[str],
+) -> None:
     key = entry["key"]
     body = entry["body"]
     line = entry["line"]
@@ -118,7 +124,9 @@ def audit_entry(entry: dict, file_path: str, all_keys: dict[str, str],
     # Abstract (warning only — collaborators without WoS access can still pass)
     abstract = extract_field(body, "abstract")
     if abstract is None or not abstract.strip():
-        warnings.append(f"{prefix}: missing `abstract` (run `/audit-docs` refs enrichment if you have WoS/Crossref access)")
+        warnings.append(
+            f"{prefix}: missing `abstract` (run `/audit-docs` refs enrichment if you have WoS/Crossref access)"
+        )
 
 
 def find_entries(text: str) -> list[dict]:
@@ -138,7 +146,9 @@ def find_entries(text: str) -> list[dict]:
     return entries
 
 
-def audit_file(path: Path, all_keys: dict[str, str]) -> tuple[int, list[str], list[str]]:
+def audit_file(
+    path: Path, all_keys: dict[str, str]
+) -> tuple[int, list[str], list[str]]:
     text = path.read_text(encoding="utf-8")
     entries = find_entries(text)
     violations: list[str] = []
@@ -151,8 +161,11 @@ def audit_file(path: Path, all_keys: dict[str, str]) -> tuple[int, list[str], li
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
     ap.add_argument("paths", nargs="+", help="Bib files to audit")
-    ap.add_argument("--quiet", action="store_true",
-                    help="Suppress per-file summary (only show violations/warnings/total)")
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-file summary (only show violations/warnings/total)",
+    )
     args = ap.parse_args()
 
     all_keys: dict[str, str] = {}
@@ -170,7 +183,9 @@ def main() -> int:
         all_violations.extend(violations)
         all_warnings.extend(warnings)
         if not args.quiet:
-            print(f"  {p}: {n} entries, {len(violations)} violations, {len(warnings)} warnings")
+            print(
+                f"  {p}: {n} entries, {len(violations)} violations, {len(warnings)} warnings"
+            )
 
     if all_warnings:
         print("\n=== warnings ===")
@@ -181,11 +196,15 @@ def main() -> int:
         print("\n=== violations ===")
         for v in all_violations:
             print(f"  {v}")
-        print(f"\n[FAIL] {len(all_violations)} violation(s) across {total_entries} entries")
+        print(
+            f"\n[FAIL] {len(all_violations)} violation(s) across {total_entries} entries"
+        )
         return 1
 
-    print(f"\n[OK] {total_entries} entries pass convention audit"
-          f" ({len(all_warnings)} warning(s))")
+    print(
+        f"\n[OK] {total_entries} entries pass convention audit"
+        f" ({len(all_warnings)} warning(s))"
+    )
     return 0
 
 

--- a/.claude/skills/audit-docs/scripts/audit.py
+++ b/.claude/skills/audit-docs/scripts/audit.py
@@ -105,7 +105,7 @@ def audit_entry(entry: dict, file_path: str, all_keys: dict[str, str],
                 )
 
     # Unpublished manuscripts use a status note instead of a DOI.
-    if entry["entry_type"] == "unpublished":
+    if entry.get("entry_type") == "unpublished":
         required_fields = (*COMMON_REQUIRED_FIELDS, "note")
     else:
         required_fields = (*COMMON_REQUIRED_FIELDS, "doi")

--- a/.claude/skills/audit-docs/scripts/audit.py
+++ b/.claude/skills/audit-docs/scripts/audit.py
@@ -104,10 +104,11 @@ def audit_entry(entry: dict, file_path: str, all_keys: dict[str, str],
                     f"(allowed: {', '.join(sorted(VOCAB))})"
                 )
 
-    # DOI is optional only for manuscripts that are explicitly unpublished.
-    required_fields = COMMON_REQUIRED_FIELDS
-    if entry["entry_type"] != "unpublished":
-        required_fields += ("doi",)
+    # Unpublished manuscripts use a status note instead of a DOI.
+    if entry["entry_type"] == "unpublished":
+        required_fields = (*COMMON_REQUIRED_FIELDS, "note")
+    else:
+        required_fields = (*COMMON_REQUIRED_FIELDS, "doi")
 
     for field in required_fields:
         val = extract_field(body, field)

--- a/docs/source/assets/refs/refs-SUEWS.bib
+++ b/docs/source/assets/refs/refs-SUEWS.bib
@@ -6,9 +6,10 @@
    hyphen-separated, no spaces, no uppercase.
 
    Required metadata: every entry must include non-empty title, author, and
-   year fields. Published entries must also include a non-empty DOI.
-   An @unpublished entry must instead include a non-empty note describing
-   its status, such as "In preparation" or "Under review"; its DOI is optional.
+   year fields. All entry types other than unpublished must also include a
+   non-empty DOI. An unpublished entry must instead include a non-empty note
+   describing its status, such as "In preparation" or "Under review"; its DOI
+   is optional.
 
    Controlled vocabulary:
      energy-balance         Surface energy balance partitioning, flux schemes

--- a/docs/source/assets/refs/refs-SUEWS.bib
+++ b/docs/source/assets/refs/refs-SUEWS.bib
@@ -5,6 +5,11 @@
    one slug from the controlled vocabulary below. Slugs are lowercase,
    hyphen-separated, no spaces, no uppercase.
 
+   Required metadata: every entry must include non-empty title, author, and
+   year fields. Published entries must also include a non-empty DOI.
+   An @unpublished entry must instead include a non-empty note describing
+   its status, such as "In preparation" or "Under review"; its DOI is optional.
+
    Controlled vocabulary:
      energy-balance         Surface energy balance partitioning, flux schemes
      water-balance          Urban hydrology: evapotranspiration, snow, irrigation

--- a/docs/source/assets/refs/refs-community.bib
+++ b/docs/source/assets/refs/refs-community.bib
@@ -6,9 +6,10 @@
    hyphen-separated, no spaces, no uppercase.
 
    Required metadata: every entry must include non-empty title, author, and
-   year fields. Published entries must also include a non-empty DOI.
-   An @unpublished entry must instead include a non-empty note describing
-   its status, such as "In preparation" or "Under review"; its DOI is optional.
+   year fields. All entry types other than unpublished must also include a
+   non-empty DOI. An unpublished entry must instead include a non-empty note
+   describing its status, such as "In preparation" or "Under review"; its DOI
+   is optional.
 
    Controlled vocabulary:
      energy-balance         Surface energy balance partitioning, flux schemes

--- a/docs/source/assets/refs/refs-community.bib
+++ b/docs/source/assets/refs/refs-community.bib
@@ -5,6 +5,11 @@
    one slug from the controlled vocabulary below. Slugs are lowercase,
    hyphen-separated, no spaces, no uppercase.
 
+   Required metadata: every entry must include non-empty title, author, and
+   year fields. Published entries must also include a non-empty DOI.
+   An @unpublished entry must instead include a non-empty note describing
+   its status, such as "In preparation" or "Under review"; its DOI is optional.
+
    Controlled vocabulary:
      energy-balance         Surface energy balance partitioning, flux schemes
      water-balance          Urban hydrology: evapotranspiration, snow, irrigation

--- a/test/docs/test_audit_bibliography.py
+++ b/test/docs/test_audit_bibliography.py
@@ -32,6 +32,7 @@ def _bib_entry(
     *,
     omit: tuple[str, ...] = (),
     keywords: str = "storage-heat",
+    note: str = "In preparation",
     include_doi: bool = False,
 ) -> str:
     fields = {
@@ -41,6 +42,8 @@ def _bib_entry(
         "keywords": keywords,
         "abstract": "An example abstract.",
     }
+    if entry_type.lower() == "unpublished":
+        fields["note"] = note
     if include_doi:
         fields["doi"] = "10.0000/example"
 
@@ -64,9 +67,12 @@ def test_parser_records_normalized_entry_type() -> None:
     assert entries[0]["key"] == "Example2026"
 
 
-def test_unpublished_entry_without_doi_passes(tmp_path: Path) -> None:
+@pytest.mark.parametrize("note", ["In preparation", "Under review"])
+def test_unpublished_entry_without_doi_passes(
+    tmp_path: Path, note: str
+) -> None:
     count, violations, warnings = _audit_text(
-        tmp_path, _bib_entry("unpublished")
+        tmp_path, _bib_entry("unpublished", note=note)
     )
 
     assert count == 1
@@ -92,8 +98,8 @@ def test_other_entry_type_with_doi_passes(tmp_path: Path) -> None:
     assert warnings == []
 
 
-@pytest.mark.parametrize("field", ["title", "author", "year"])
-def test_unpublished_entry_still_requires_common_fields(
+@pytest.mark.parametrize("field", ["title", "author", "year", "note"])
+def test_unpublished_entry_still_requires_required_fields(
     tmp_path: Path, field: str
 ) -> None:
     _, violations, _ = _audit_text(

--- a/test/docs/test_audit_bibliography.py
+++ b/test/docs/test_audit_bibliography.py
@@ -80,6 +80,16 @@ def test_unpublished_entry_without_doi_passes(
     assert warnings == []
 
 
+def test_unpublished_entry_with_doi_passes(tmp_path: Path) -> None:
+    count, violations, warnings = _audit_text(
+        tmp_path, _bib_entry("unpublished", include_doi=True)
+    )
+
+    assert count == 1
+    assert violations == []
+    assert warnings == []
+
+
 @pytest.mark.parametrize("entry_type", ["article", "inproceedings"])
 def test_other_entry_types_without_doi_fail(
     tmp_path: Path, entry_type: str

--- a/test/docs/test_audit_bibliography.py
+++ b/test/docs/test_audit_bibliography.py
@@ -59,7 +59,7 @@ def _audit_text(tmp_path: Path, text: str):
     return AUDIT.audit_file(bib_path, {})
 
 
-def test_parser_records_normalized_entry_type() -> None:
+def test_parser_records_lowercased_entry_type() -> None:
     entries = AUDIT.find_entries(_bib_entry("Unpublished"))
 
     assert len(entries) == 1

--- a/test/docs/test_audit_bibliography.py
+++ b/test/docs/test_audit_bibliography.py
@@ -10,8 +10,10 @@ import pytest
 pytestmark = pytest.mark.api
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-AUDIT_PATH = (
-    PROJECT_ROOT / ".claude" / "skills" / "audit-docs" / "scripts" / "audit.py"
+AUDIT_PATH = PROJECT_ROOT / ".claude" / "skills" / "audit-docs" / "scripts" / "audit.py"
+BIB_PATHS = (
+    PROJECT_ROOT / "docs" / "source" / "assets" / "refs" / "refs-SUEWS.bib",
+    PROJECT_ROOT / "docs" / "source" / "assets" / "refs" / "refs-community.bib",
 )
 
 
@@ -59,6 +61,18 @@ def _audit_text(tmp_path: Path, text: str):
     return AUDIT.audit_file(bib_path, {})
 
 
+@pytest.mark.parametrize("bib_path", BIB_PATHS, ids=lambda path: path.name)
+def test_bibliography_comment_header_has_no_nested_commands(
+    bib_path: Path,
+) -> None:
+    text = bib_path.read_text(encoding="utf-8")
+    header, separator, _ = text.partition("\n}\n")
+
+    assert separator
+    assert header.startswith("@comment{")
+    assert header.count("@") == 1
+
+
 def test_parser_records_lowercased_entry_type() -> None:
     entries = AUDIT.find_entries(_bib_entry("Unpublished"))
 
@@ -68,9 +82,7 @@ def test_parser_records_lowercased_entry_type() -> None:
 
 
 @pytest.mark.parametrize("note", ["In preparation", "Under review"])
-def test_unpublished_entry_without_doi_passes(
-    tmp_path: Path, note: str
-) -> None:
+def test_unpublished_entry_without_doi_passes(tmp_path: Path, note: str) -> None:
     count, violations, warnings = _audit_text(
         tmp_path, _bib_entry("unpublished", note=note)
     )
@@ -91,9 +103,7 @@ def test_unpublished_entry_with_doi_passes(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("entry_type", ["article", "inproceedings"])
-def test_other_entry_types_without_doi_fail(
-    tmp_path: Path, entry_type: str
-) -> None:
+def test_other_entry_types_without_doi_fail(tmp_path: Path, entry_type: str) -> None:
     _, violations, _ = _audit_text(tmp_path, _bib_entry(entry_type))
 
     assert any("missing or empty `doi`" in violation for violation in violations)
@@ -112,9 +122,7 @@ def test_other_entry_type_with_doi_passes(tmp_path: Path) -> None:
 def test_unpublished_entry_still_requires_required_fields(
     tmp_path: Path, field: str
 ) -> None:
-    _, violations, _ = _audit_text(
-        tmp_path, _bib_entry("unpublished", omit=(field,))
-    )
+    _, violations, _ = _audit_text(tmp_path, _bib_entry("unpublished", omit=(field,)))
 
     assert any(f"missing or empty `{field}`" in violation for violation in violations)
 

--- a/test/docs/test_audit_bibliography.py
+++ b/test/docs/test_audit_bibliography.py
@@ -1,0 +1,116 @@
+"""Tests for the bibliography convention audit."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.api
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+AUDIT_PATH = (
+    PROJECT_ROOT / ".claude" / "skills" / "audit-docs" / "scripts" / "audit.py"
+)
+
+
+def _load_audit_module():
+    spec = importlib.util.spec_from_file_location("audit_docs_for_test", AUDIT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+AUDIT = _load_audit_module()
+
+
+def _bib_entry(
+    entry_type: str,
+    *,
+    omit: tuple[str, ...] = (),
+    keywords: str = "storage-heat",
+    include_doi: bool = False,
+) -> str:
+    fields = {
+        "title": "Example manuscript",
+        "author": "Example, Alice",
+        "year": "2026",
+        "keywords": keywords,
+        "abstract": "An example abstract.",
+    }
+    if include_doi:
+        fields["doi"] = "10.0000/example"
+
+    rendered_fields = [
+        f"  {name} = {{{value}}}," for name, value in fields.items() if name not in omit
+    ]
+    return "\n".join([f"@{entry_type}{{Example2026,", *rendered_fields, "}", ""])
+
+
+def _audit_text(tmp_path: Path, text: str):
+    bib_path = tmp_path / "references.bib"
+    bib_path.write_text(text, encoding="utf-8")
+    return AUDIT.audit_file(bib_path, {})
+
+
+def test_parser_records_normalized_entry_type() -> None:
+    entries = AUDIT.find_entries(_bib_entry("Unpublished"))
+
+    assert len(entries) == 1
+    assert entries[0]["entry_type"] == "unpublished"
+    assert entries[0]["key"] == "Example2026"
+
+
+def test_unpublished_entry_without_doi_passes(tmp_path: Path) -> None:
+    count, violations, warnings = _audit_text(
+        tmp_path, _bib_entry("unpublished")
+    )
+
+    assert count == 1
+    assert violations == []
+    assert warnings == []
+
+
+@pytest.mark.parametrize("entry_type", ["article", "inproceedings"])
+def test_other_entry_types_without_doi_fail(
+    tmp_path: Path, entry_type: str
+) -> None:
+    _, violations, _ = _audit_text(tmp_path, _bib_entry(entry_type))
+
+    assert any("missing or empty `doi`" in violation for violation in violations)
+
+
+def test_other_entry_type_with_doi_passes(tmp_path: Path) -> None:
+    _, violations, warnings = _audit_text(
+        tmp_path, _bib_entry("article", include_doi=True)
+    )
+
+    assert violations == []
+    assert warnings == []
+
+
+@pytest.mark.parametrize("field", ["title", "author", "year"])
+def test_unpublished_entry_still_requires_common_fields(
+    tmp_path: Path, field: str
+) -> None:
+    _, violations, _ = _audit_text(
+        tmp_path, _bib_entry("unpublished", omit=(field,))
+    )
+
+    assert any(f"missing or empty `{field}`" in violation for violation in violations)
+
+
+def test_unpublished_entry_still_requires_controlled_keywords(
+    tmp_path: Path,
+) -> None:
+    _, violations, _ = _audit_text(
+        tmp_path, _bib_entry("unpublished", keywords="not-controlled")
+    )
+
+    assert any(
+        "slug `not-controlled` not in controlled vocabulary" in violation
+        for violation in violations
+    )


### PR DESCRIPTION
## Summary

This PR updates the bibliography audit to support manuscripts that do not yet have a DOI.

- Preserve each BibTeX entry type during parsing.
- Allow `@unpublished` entries without a `doi`.
- Require `title`, `author`, `year`, and `note` for `@unpublished` entries.
- Continue requiring `doi` for all other entry types.
- Preserve the existing controlled-keyword and metadata checks.
- Add focused tests for the new behaviour.

The `note` field records the manuscript status, such as `In preparation` or `Under review`, and ensures that accepted entries can be rendered by the existing Pybtex bibliography style.

This PR changes only the bibliography audit and its tests. It does not add any unpublished papers or modify the controlled keyword vocabulary. The papers will be added in a separate documentation PR after this change is merged.

Closes #1644
