### PR TITLE
Guard data-interface version histories

### DIFF
--- a/scripts/lint/check_data_interface_version_history.py
+++ b/scripts/lint/check_data_interface_version_history.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Check that forcing and output version histories remain append-only.
+
+This audit covers only the version ownership established in ``data_model``.
+Contract-specific checks belong with the forcing and output definitions once
+their machine-readable representations are available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Literal, NamedTuple
+
+type InterfaceKind = Literal["forcing", "output"]
+
+
+class VersionState(NamedTuple):
+    """Literal values read from one interface version module."""
+
+    current: str | None
+    versions: tuple[tuple[str, str], ...]
+
+
+_INTERFACES: dict[InterfaceKind, tuple[str, str, str]] = {
+    "forcing": (
+        "src/supy/data_model/forcing/version.py",
+        "CURRENT_FORCING_VERSION",
+        "FORCING_VERSIONS",
+    ),
+    "output": (
+        "src/supy/data_model/output/version.py",
+        "CURRENT_OUTPUT_VERSION",
+        "OUTPUT_VERSIONS",
+    ),
+}
+_SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class AuditFailure(RuntimeError):
+    """Raised for a version-history violation that a contributor can fix."""
+
+
+def _run(args: list[str]) -> str:
+    result = subprocess.run(args, check=True, capture_output=True, text=True)
+    return result.stdout
+
+
+def _assignment(tree: ast.Module, name: str) -> object:
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+            and node.value is not None
+        ):
+            return ast.literal_eval(node.value)
+    raise ValueError(f"could not read {name}")
+
+
+def _parse_state(source: str, current_name: str, versions_name: str) -> VersionState:
+    tree = ast.parse(source)
+    current = _assignment(tree, current_name)
+    versions = _assignment(tree, versions_name)
+    if current is not None and not isinstance(current, str):
+        raise ValueError(f"{current_name} must be a string or None")
+    if not isinstance(versions, dict) or any(
+        not isinstance(version, str) or not isinstance(digest, str)
+        for version, digest in versions.items()
+    ):
+        raise ValueError(f"{versions_name} must be a string-to-string dict literal")
+    return VersionState(current, tuple(versions.items()))
+
+
+def _validate_state(kind: InterfaceKind, state: VersionState) -> None:
+    if not state.versions:
+        if state.current is not None:
+            raise AuditFailure(f"{kind}: an empty history requires current=None")
+        return
+
+    if state.current != state.versions[-1][0]:
+        raise AuditFailure(f"{kind}: current must be the last registered version")
+
+    previous: tuple[int, int, int] | None = None
+    for index, (version, digest) in enumerate(state.versions):
+        match = _SEMVER.fullmatch(version)
+        if match is None:
+            raise AuditFailure(
+                f"{kind}: version {version!r} must use stable MAJOR.MINOR.PATCH SemVer"
+            )
+        parsed = tuple(int(part) for part in match.groups())
+        if index == 0 and parsed != (1, 0, 0):
+            raise AuditFailure(f"{kind}: the first public version must be '1.0.0'")
+        if previous is not None and parsed <= previous:
+            raise AuditFailure(f"{kind}: version history must increase monotonically")
+        if _DIGEST.fullmatch(digest) is None:
+            raise AuditFailure(
+                f"{kind}: version {version!r} needs a lowercase SHA-256 digest"
+            )
+        previous = parsed
+
+
+def _validate_transition(
+    kind: InterfaceKind,
+    base: VersionState,
+    current: VersionState,
+) -> bool:
+    base_length = len(base.versions)
+    if (
+        len(current.versions) < base_length
+        or current.versions[:base_length] != base.versions
+    ):
+        raise AuditFailure(f"{kind}: released version history is append-only")
+
+    appended = len(current.versions) > base_length
+    current_changed = current.current != base.current
+    if appended != current_changed:
+        raise AuditFailure(
+            f"{kind}: current version and version history must change together"
+        )
+    return appended
+
+
+def _state_at_base(
+    merge_base: str,
+    path: str,
+    current_name: str,
+    versions_name: str,
+) -> VersionState:
+    try:
+        source = _run(["git", "show", f"{merge_base}:{path}"])
+    except subprocess.CalledProcessError:
+        return VersionState(None, ())
+    return _parse_state(source, current_name, versions_name)
+
+
+def _audit(base_ref: str) -> list[InterfaceKind]:
+    merge_base = _run(["git", "merge-base", base_ref, "HEAD"]).strip()
+    changed: list[InterfaceKind] = []
+    for kind, (path, current_name, versions_name) in _INTERFACES.items():
+        base = _state_at_base(merge_base, path, current_name, versions_name)
+        current = _parse_state(
+            Path(path).read_text(encoding="utf-8"),
+            current_name,
+            versions_name,
+        )
+        _validate_state(kind, current)
+        if _validate_transition(kind, base, current):
+            changed.append(kind)
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the forcing/output version-history audit."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="origin/master",
+        help="Git ref to compare against (default: origin/master).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        changed = _audit(args.base)
+    except AuditFailure as exc:
+        print(f"[data-interface-version-history] FAILED: {exc}", file=sys.stderr)
+        return 1
+    except (OSError, SyntaxError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"[data-interface-version-history] ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if changed:
+        print(
+            "[data-interface-version-history] appended version history: "
+            + ", ".join(changed)
+        )
+    else:
+        print("[data-interface-version-history] no version-history changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    os.chdir(Path(__file__).resolve().parents[2])
+    sys.exit(main())

--- a/test/core/test_check_data_interface_version_history.py
+++ b/test/core/test_check_data_interface_version_history.py
@@ -1,0 +1,225 @@
+"""Tests for the forcing/output version-history audit."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.api
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "lint"
+    / "check_data_interface_version_history.py"
+)
+SCRIPT_SPEC = importlib.util.spec_from_file_location(
+    "check_data_interface_version_history",
+    SCRIPT_PATH,
+)
+assert SCRIPT_SPEC is not None
+assert SCRIPT_SPEC.loader is not None
+audit = importlib.util.module_from_spec(SCRIPT_SPEC)
+sys.modules[SCRIPT_SPEC.name] = audit
+SCRIPT_SPEC.loader.exec_module(audit)
+
+_DIGEST_A = f"sha256:{'a' * 64}"
+_DIGEST_B = f"sha256:{'b' * 64}"
+
+
+def _state(current: str | None, *versions: tuple[str, str]) -> audit.VersionState:
+    return audit.VersionState(current, versions)
+
+
+def test_unpublished_interfaces_are_valid() -> None:
+    audit._validate_state("forcing", _state(None))
+    audit._validate_state("output", _state(None))
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        _state("1.0.0"),
+        _state(None, ("1.0.0", _DIGEST_A)),
+        _state("1.1.0", ("1.0.0", _DIGEST_A)),
+    ],
+)
+def test_current_version_must_match_history(state: audit.VersionState) -> None:
+    with pytest.raises(audit.AuditFailure, match=r"empty history|current must"):
+        audit._validate_state("forcing", state)
+
+
+@pytest.mark.parametrize(
+    ("versions", "message"),
+    [
+        ((("0.1.0", _DIGEST_A),), "first public version"),
+        ((("1.0", _DIGEST_A),), "MAJOR.MINOR.PATCH"),
+        ((("1.0.0", "not-a-digest"),), "SHA-256"),
+        (
+            (("1.0.0", _DIGEST_A), ("1.0.0", _DIGEST_B)),
+            "increase monotonically",
+        ),
+        (
+            (("1.1.0", _DIGEST_A), ("1.0.0", _DIGEST_B)),
+            "first public version",
+        ),
+    ],
+)
+def test_invalid_history_is_rejected(
+    versions: tuple[tuple[str, str], ...],
+    message: str,
+) -> None:
+    with pytest.raises(audit.AuditFailure, match=message):
+        audit._validate_state("output", _state(versions[-1][0], *versions))
+
+
+def test_stable_semver_history_may_append() -> None:
+    state = _state(
+        "2.0.0",
+        ("1.0.0", _DIGEST_A),
+        ("1.3.0", _DIGEST_B),
+        ("2.0.0", f"sha256:{'c' * 64}"),
+    )
+
+    audit._validate_state("forcing", state)
+
+
+@pytest.mark.parametrize(
+    ("base", "current", "message"),
+    [
+        (
+            _state("1.0.0", ("1.0.0", _DIGEST_A)),
+            _state("1.0.0", ("1.0.0", _DIGEST_B)),
+            "append-only",
+        ),
+        (
+            _state("1.0.0", ("1.0.0", _DIGEST_A)),
+            _state("1.1.0", ("1.0.0", _DIGEST_A)),
+            "change together",
+        ),
+        (
+            _state("1.0.0", ("1.0.0", _DIGEST_A)),
+            _state(
+                "1.0.0",
+                ("1.0.0", _DIGEST_A),
+                ("1.1.0", _DIGEST_B),
+            ),
+            "change together",
+        ),
+    ],
+)
+def test_history_transition_rejects_rewrites_and_partial_bumps(
+    base: audit.VersionState,
+    current: audit.VersionState,
+    message: str,
+) -> None:
+    with pytest.raises(audit.AuditFailure, match=message):
+        audit._validate_transition("output", base, current)
+
+
+def test_history_transition_accepts_one_or_more_new_versions() -> None:
+    base = _state("1.0.0", ("1.0.0", _DIGEST_A))
+    current = _state(
+        "2.0.0",
+        ("1.0.0", _DIGEST_A),
+        ("1.1.0", _DIGEST_B),
+        ("2.0.0", f"sha256:{'c' * 64}"),
+    )
+
+    assert audit._validate_transition("forcing", base, current)
+
+
+def test_version_module_parser_reads_literal_dict() -> None:
+    source = f'''\
+CURRENT_OUTPUT_VERSION: str | None = "1.0.0"
+OUTPUT_VERSIONS: dict[str, str] = {{"1.0.0": "{_DIGEST_A}"}}
+'''
+
+    assert audit._parse_state(
+        source,
+        "CURRENT_OUTPUT_VERSION",
+        "OUTPUT_VERSIONS",
+    ) == _state("1.0.0", ("1.0.0", _DIGEST_A))
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _write_versions(
+    repo: Path,
+    kind: str,
+    current: str | None,
+    versions: dict[str, str],
+) -> None:
+    upper = kind.upper()
+    path = repo / f"src/supy/data_model/{kind}/version.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"CURRENT_{upper}_VERSION: str | None = {current!r}\n"
+        f"{upper}_VERSIONS: dict[str, str] = {versions!r}\n",
+        encoding="utf-8",
+    )
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(repo, "add", "-A")
+    _git(
+        repo,
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-qm",
+        message,
+    )
+
+
+def test_cli_audits_the_real_forcing_and_output_layout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "master")
+    _write_versions(repo, "forcing", None, {})
+    _write_versions(repo, "output", None, {})
+    _commit(repo, "initial")
+    _git(repo, "checkout", "-qb", "feature")
+    _write_versions(repo, "output", "1.0.0", {"1.0.0": _DIGEST_A})
+    monkeypatch.chdir(repo)
+
+    assert audit.main(["--base", "master"]) == 0
+    assert "output" in capsys.readouterr().out
+
+
+def test_cli_rejects_a_released_digest_rewrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "master")
+    _write_versions(repo, "forcing", "1.0.0", {"1.0.0": _DIGEST_A})
+    _write_versions(repo, "output", None, {})
+    _commit(repo, "publish forcing")
+    _git(repo, "checkout", "-qb", "feature")
+    _write_versions(repo, "forcing", "1.0.0", {"1.0.0": _DIGEST_B})
+    monkeypatch.chdir(repo)
+
+    assert audit.main(["--base", "master"]) == 1
+    assert "append-only" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- guard the independent forcing and output version histories introduced in #1659
- validate literal registries, current-version pointers, stable SemVer keys and digest syntax
- reject edits, removals and reordering of released history by comparing with the merge base
- keep both interfaces explicitly unpublished until their contracts are complete

## Scope

This PR deliberately covers version-history integrity only. It does not infer
contract compatibility or decide whether a forcing/output source change needs a
version bump: the machine-readable forcing and output contracts do not yet
exist. Contract-specific content and parity checks belong with #1655 and #1656.

This keeps #1654 open until those checks are connected. PR #1661 must be
rebased and narrowed to the same architecture before it can follow this layer.

## Stack

1. #1659 — version ownership primitives (merged)
2. **This PR:** append-only version-history guard
3. #1661 — CI and contributor documentation (to be revised after this PR)

Refs #1654 and #1658.

## Validation

- focused history/governance tests: 19 passed
- Python 3.12 isolated history tests: 17 passed
- audit CLI against `origin/master`: passed
- Ruff format and lint checks: passed
- `make test-smoke`: 9 passed, 1 skipped
