### PR TITLE
Activate data-interface version-history governance

### DIFF
--- a/.claude/rules/python/schema-versioning.md
+++ b/.claude/rules/python/schema-versioning.md
@@ -230,11 +230,19 @@ When reviewing a PR that touches `src/supy/data_model/`:
 ## CI gate and bypass label
 
 The `.github/workflows/schema-version-audit.yml` workflow runs
-`scripts/lint/check_schema_version_bump.py` on every PR that touches
-`src/supy/data_model/**` or `src/supy/sample_data/sample_config.yml`.
-If those paths changed but
+`scripts/lint/check_schema_version_bump.py` on every PR. The script fast-skips
+when no YAML-owned model under `src/supy/data_model/core/**` (excluding forcing
+validation and DataFrame rename helpers) or
+`src/supy/sample_data/sample_config.yml` changed. If those paths changed but
 `src/supy/data_model/schema/version.py` did not, the job fails with
 remediation guidance pointing at this rule.
+
+Forcing and output contract sources are intentionally outside this boundary.
+They have independent semantic-version owners. Their append-only release
+histories use the `.github/workflows/data-interface-version-audit.yml` gate
+documented in
+`docs/source/contributing/schema/data_interface_versioning.rst`; contract
+content checks remain with the forcing and output definitions.
 
 The same script also enforces the docs sync from step 6: when
 `CURRENT_SCHEMA_VERSION` does move, at least one of

--- a/.github/workflows/data-interface-version-audit.yml
+++ b/.github/workflows/data-interface-version-audit.yml
@@ -1,0 +1,38 @@
+name: Data-interface version audit
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-interface-version-history:
+    name: Validate data-interface version histories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Fetch base ref
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+          git fetch --no-tags origin "$BASE_REF"
+
+      - name: Validate data-interface version histories
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+          python scripts/lint/check_data_interface_version_history.py \
+            --base "origin/$BASE_REF"

--- a/docs/source/contributing/schema/data_interface_versioning.rst
+++ b/docs/source/contributing/schema/data_interface_versioning.rst
@@ -1,0 +1,91 @@
+.. _data_interface_versioning:
+
+Data-interface versioning
+=========================
+
+SUEWS has three independently governed data interfaces:
+
+``YAML configuration schema``
+   Describes the structure accepted by ``SUEWSConfig``. Its CalVer version and
+   migration chain remain under :ref:`schema_versioning`.
+
+``Forcing contract``
+   Describes the forcing data accepted by SUEWS. It owns
+   ``src/supy/data_model/forcing/version.py``.
+
+``Output contract``
+   Describes the output data produced by SUEWS. It owns
+   ``src/supy/data_model/output/version.py``.
+
+A change to one interface does not consume a version of either of the others.
+
+Current status
+--------------
+
+The forcing and output contracts are currently unpublished. Their
+``CURRENT_*_VERSION`` values are ``None`` and their version histories are
+empty. This is deliberate: a public version is not recorded until its
+machine-readable contract and implementation checks exist.
+
+The first public version of each contract must be ``1.0.0``. Later releases use
+stable ``MAJOR.MINOR.PATCH`` semantic versions independently:
+
+- ``MAJOR`` for changes that require consumers to adapt;
+- ``MINOR`` for backwards-compatible additions;
+- ``PATCH`` for non-breaking corrections.
+
+Version histories
+-----------------
+
+Each released version is paired with a lowercase SHA-256 digest. The digest is
+an opaque contract identifier at this governance layer; the forcing and output
+contract implementations define which canonical bytes it identifies.
+
+The histories are append-only. A contributor may append a newer version and
+digest, but must not edit, reorder, or remove an existing entry. The current
+version pointer must name the last entry, and the pointer and history must move
+together.
+
+CI enforcement
+--------------
+
+The ``data-interface-version-audit`` workflow runs
+``scripts/lint/check_data_interface_version_history.py`` against the pull
+request's merge base. It checks that:
+
+- versions use stable SemVer and increase monotonically;
+- the first public version is ``1.0.0``;
+- digests have the expected SHA-256 form;
+- existing history remains unchanged;
+- the current pointer and history are updated together.
+
+The audit does not yet generate contract artefacts, detect contract-content
+drift, or decide whether a change requires a major, minor, or patch release.
+Those checks belong with the real forcing and output definitions. The forcing
+contract work is tracked in #1655, the output contract work in #1656, and
+version-addressed publication in #1657.
+
+Contributor workflow
+--------------------
+
+Until a contract is published, leave its current version as ``None`` and its
+history empty. When contract-specific work publishes a release:
+
+1. Generate and validate the interface's canonical artefact.
+2. Choose the SemVer change from the interface-specific compatibility policy.
+3. Append the new version and canonical digest to the matching history.
+4. Move only that interface's current pointer to the new last entry.
+5. Run the contract-specific checks and the version-history audit.
+
+Never rewrite a released entry. Shared mechanical helpers may be extracted only
+after the configuration, forcing, and output policies are concrete (#1664).
+
+YAML audit boundary
+-------------------
+
+``schema-version-audit`` watches the Pydantic models that own the public YAML
+shape under ``src/supy/data_model/core/`` and the shipped sample
+configuration. Contract definitions under ``data_model/forcing/`` and
+``data_model/output/`` are outside that boundary, while YAML-owned
+``ForcingControl`` and ``OutputControl`` remain inside it. Contract-only changes
+therefore do not spuriously require a YAML configuration schema bump.

--- a/docs/source/contributing/schema/index.rst
+++ b/docs/source/contributing/schema/index.rst
@@ -1,13 +1,13 @@
-:orphan:
+Schema and Data-interface Development
+=====================================
 
-Schema Development
-==================
-
-This section documents the SUEWS schema system for developers.
+This section documents configuration schemas and independently governed data
+interfaces for SUEWS developers.
 
 .. toctree::
    :maxdepth: 1
 
    schema-developer
    schema_versioning
+   data_interface_versioning
    schema_cli

--- a/docs/source/contributing/schema/schema-developer.rst
+++ b/docs/source/contributing/schema/schema-developer.rst
@@ -25,8 +25,9 @@ Schema Versioning Basics
 When a Schema Bump Is Required
 ------------------------------
 
-Bump when a PR touches ``src/supy/data_model/`` in a way that prevents
-a previously valid YAML from round-tripping:
+Bump when a PR changes a YAML-owned model under
+``src/supy/data_model/core/`` in a way that prevents a previously valid
+YAML from round-tripping:
 
 - Rename a public field (for example ``DeepSoilTemperature`` →
   ``AnnualMeanAirTemperature``).
@@ -87,12 +88,11 @@ Two automated gates defend the invariant that a schema bump lands
 with everything it needs:
 
 **CI workflow: schema-version-audit**
-   ``.github/workflows/schema-version-audit.yml`` runs on every PR
-   that touches ``src/supy/data_model/**``,
-   ``src/supy/sample_data/sample_config.yml``, or the schema
-   documentation. It invokes
+   ``.github/workflows/schema-version-audit.yml`` runs on every PR and
+   fast-skips when no YAML-owned model under ``src/supy/data_model/core/``
+   or shipped sample configuration changed. It invokes
    ``scripts/lint/check_schema_version_bump.py``, which fails if
-   either (a) the data model changed but
+   either (a) the YAML configuration shape changed but
    ``CURRENT_SCHEMA_VERSION`` did not, or (b)
    ``CURRENT_SCHEMA_VERSION`` moved but neither
    ``docs/source/contributing/schema/schema_versioning.rst`` nor
@@ -110,6 +110,11 @@ with everything it needs:
 The ``prep-release`` and ``audit-pr`` skills encode the same
 checklist so a release or a review-in-progress cannot silently drift
 past a missing bump.
+
+Forcing and output version histories follow the independent semantic-version
+policy in :ref:`data_interface_versioning`. The
+``data-interface-version-audit`` workflow checks that those histories remain
+valid and append-only; contract-specific checks own content drift.
 
 Schema Management Commands
 --------------------------
@@ -157,8 +162,12 @@ Python API
 Implementation Map
 ------------------
 
-- ``src/supy/data_model/schema/`` — schema version registry and
+- ``src/supy/data_model/schema/`` — configuration schema version registry and
   compatibility helpers.
+- ``src/supy/data_model/forcing/version.py`` — forcing contract version
+  ownership and release history.
+- ``src/supy/data_model/output/version.py`` — output contract version
+  ownership and release history.
 - ``src/supy/data_model/schema/migration.py`` — ``SchemaMigrator``
   that consults the handler registry.
 - ``src/supy/util/converter/yaml_upgrade.py`` — migration handlers

--- a/docs/source/contributing/schema/schema_versioning.rst
+++ b/docs/source/contributing/schema/schema_versioning.rst
@@ -64,8 +64,9 @@ which comes after ``2026.5``,
 which comes after ``2026.4``, which comes after ``2026.1``, which comes
 after ``2025.12``.
 
-A bump happens when a PR to ``src/supy/data_model/`` makes a previously
-valid user YAML no longer round-trip. In practice that means any of:
+A bump happens when a PR changes a YAML-owned model under
+``src/supy/data_model/core/`` in a way that makes a previously valid user YAML
+no longer round-trip. In practice that means any of:
 
 - a public field is **renamed** (for example ``DeepSoilTemperature`` →
   ``AnnualMeanAirTemperature``)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -149,6 +149,7 @@ How to support SUEWS?
    :hidden:
 
    contributing/contributing
+   contributing/schema/index
    acknowledgement
    GitHub repository <https://github.com/UMEP-dev/SUEWS>
 

--- a/src/supy/data_model/forcing/version.py
+++ b/src/supy/data_model/forcing/version.py
@@ -3,5 +3,5 @@
 # No public version is declared until the forcing registry is complete.
 CURRENT_FORCING_VERSION: str | None = None
 
-# Published version -> manifest digest.
+# Published version -> contract digest.
 FORCING_VERSIONS: dict[str, str] = {}

--- a/src/supy/data_model/output/version.py
+++ b/src/supy/data_model/output/version.py
@@ -3,5 +3,5 @@
 # No public version is declared until the output registry is complete.
 CURRENT_OUTPUT_VERSION: str | None = None
 
-# Published version -> manifest digest.
+# Published version -> contract digest.
 OUTPUT_VERSIONS: dict[str, str] = {}


### PR DESCRIPTION
## Summary

- run the append-only forcing/output version-history audit on every pull request
  using full Git history and Python 3.12, with no project dependency install
- document the independent configuration, forcing, and output version owners,
  their current unpublished state, and the exact limits of the Wave 1 guard
- align configuration-schema guidance with the YAML-owned audit boundary and
  keep the recorded digest terminology contract-neutral

## Wave 1

1. #1662 — restrict the YAML schema audit to configuration-owned surfaces
2. #1659 — establish separate forcing and output version owners
3. #1660 — add the append-only version-history audit and focused tests
4. **This PR** — activate the audit in CI and document the implemented boundary

This completes the governance foundation. Contract artefact generation,
content-drift checks, and compatibility-specific rules remain with #1655 and
#1656; publication remains with #1657.

Closes #1654. Refs #1651 and #1658.

## Validation

- workflow YAML parsed successfully
- `check_data_interface_version_history.py --base origin/master` passed
- focused version-history tests: 17 passed
- independent specification and workflow/documentation reviews are clean for
  exact HEAD `fd2315befb681d9a3e5a97bebc9471efa8cef02d`
- full Sphinx HTML build succeeded; the repository's pre-existing warning
  backlog remains outside this PR
- local smoke selection: 6 passed, 1 skipped; two runtime tests could not run
  because this worktree has no compiled Rust backend, and will be exercised by
  the repository wheel/API CI lanes

