### PR TITLE
Restrict schema audit to YAML-owned models

### DIFF
--- a/.github/workflows/schema-version-audit.yml
+++ b/.github/workflows/schema-version-audit.yml
@@ -1,20 +1,15 @@
 name: Schema version audit
 
-# Enforce that any PR touching the Pydantic data model or the shipped
-# sample_config also bumps `CURRENT_SCHEMA_VERSION` in
+# Enforce that PRs changing the YAML-owned Pydantic models or the shipped
+# sample_config also bump `CURRENT_SCHEMA_VERSION` in
 # `src/supy/data_model/schema/version.py`. Maintainers can label a PR
 # with `0-ci:schema-audit-ok` to bypass the check when the diff is genuinely
-# cosmetic. Motivated by gh#1304.
+# cosmetic. Forcing and output contracts have an independent audit.
 
 on:
+  # Run unconditionally so a required check succeeds for unrelated PRs and so
+  # path-filter edge cases (especially renames) still reach the audit script.
   pull_request:
-    paths:
-      - 'src/supy/data_model/**'
-      - 'src/supy/sample_data/sample_config.yml'
-      - 'docs/source/contributing/schema/schema_versioning.rst'
-      - 'docs/source/inputs/transition_guide.rst'
-      - 'scripts/lint/check_schema_version_bump.py'
-      - '.github/workflows/schema-version-audit.yml'
 
 permissions:
   contents: read
@@ -45,6 +40,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Set up Python
+        if: steps.bypass.outputs.bypass != 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
 
       - name: Fetch base ref
         if: steps.bypass.outputs.bypass != 'true'

--- a/scripts/lint/check_schema_version_bump.py
+++ b/scripts/lint/check_schema_version_bump.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Guard: PRs touching data_model must bump CURRENT_SCHEMA_VERSION
-AND sync the user-facing schema documentation.
+"""Guard YAML configuration shape changes with CURRENT_SCHEMA_VERSION.
 
 Usage
 -----
@@ -9,8 +8,9 @@ Usage
 Compares the working tree (or HEAD in CI) against `BASE_REF` (defaults
 to `origin/master`). The script enforces two coupled invariants:
 
-1. Schema bump invariant — if any file under `src/supy/data_model/` or
-   the `src/supy/sample_data/sample_config.yml` sample has changed
+1. Schema bump invariant — if a YAML-owned Pydantic model under
+   `src/supy/data_model/core/` or the
+   `src/supy/sample_data/sample_config.yml` sample has changed
    *and* `CURRENT_SCHEMA_VERSION` in
    `src/supy/data_model/schema/version.py` has *not* changed, exit
    non-zero with remediation guidance.
@@ -64,11 +64,20 @@ import re
 import subprocess
 import sys
 
-# Paths whose change implies a schema change (relative to repo root).
+# Paths that own the public YAML configuration shape (relative to repo root).
+# Output registries, forcing contracts and validation implementation are
+# deliberately governed elsewhere and must not consume YAML schema versions.
 _WATCHED_PREFIXES: tuple[str, ...] = (
-    "src/supy/data_model/",
+    "src/supy/data_model/core/",
     "src/supy/sample_data/sample_config.yml",
 )
+
+# These core helpers do not contribute fields to SUEWSConfig.model_json_schema().
+_EXCLUDED_PATHS: frozenset[str] = frozenset({
+    "src/supy/data_model/core/__init__.py",
+    "src/supy/data_model/core/df_column_renames.py",
+    "src/supy/data_model/core/forcing_validation.py",
+})
 
 # The file that must be touched when any of the watched paths changes.
 _SCHEMA_VERSION_FILE = "src/supy/data_model/schema/version.py"
@@ -107,6 +116,24 @@ def _merge_base(base_ref: str) -> str:
     return _run(["git", "merge-base", base_ref, "HEAD"]).strip()
 
 
+def _paths_from_name_status(output: str) -> set[str]:
+    """Return both paths from NUL-delimited ``git --name-status -z`` output."""
+    paths: set[str] = set()
+    fields = output.split("\0")
+    if fields and not fields[-1]:
+        fields.pop()
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        path_count = 2 if status.startswith(("R", "C")) else 1
+        record_end = index + 1 + path_count
+        if not status or record_end > len(fields):
+            raise ValueError("cannot parse NUL-delimited git name-status output")
+        paths.update(fields[index + 1 : record_end])
+        index = record_end
+    return paths
+
+
 def _list_changed_files(base_ref: str, include_worktree: bool) -> list[str]:
     """Return files changed between `base_ref` and the branch tip.
 
@@ -116,16 +143,36 @@ def _list_changed_files(base_ref: str, include_worktree: bool) -> list[str]:
     against the merge-base so uncommitted edits are included but
     unrelated commits on `base_ref` are still filtered out.
     """
+    comparison = _merge_base(base_ref) if include_worktree else f"{base_ref}...HEAD"
+    output = _run([
+        "git",
+        "diff",
+        "--name-status",
+        "-z",
+        "--find-renames",
+        comparison,
+    ])
+    paths = _paths_from_name_status(output)
     if include_worktree:
-        output = _run(["git", "diff", "--name-only", _merge_base(base_ref)])
-    else:
-        output = _run(["git", "diff", "--name-only", f"{base_ref}...HEAD"])
-    return [line.strip() for line in output.splitlines() if line.strip()]
+        paths.update(
+            path
+            for path in _run([
+                "git",
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+                "-z",
+            ]).split("\0")
+            if path
+        )
+    return sorted(paths)
 
 
 def _is_watched(path: str) -> bool:
     """Return True if `path` falls under the schema-monitored prefix set."""
-    return any(path == p or path.startswith(p) for p in _WATCHED_PREFIXES)
+    return path not in _EXCLUDED_PATHS and any(
+        path == prefix or path.startswith(prefix) for prefix in _WATCHED_PREFIXES
+    )
 
 
 _CURRENT_SCHEMA_VERSION_PATTERN = re.compile(

--- a/test/core/test_check_schema_version_bump.py
+++ b/test/core/test_check_schema_version_bump.py
@@ -15,6 +15,7 @@ Covers two follow-up regressions after gh#1304:
 from __future__ import annotations
 
 import importlib.util
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -60,8 +61,6 @@ def _git(repo: Path, *args: str) -> str:
 
 
 def _path_env() -> str:
-    import os
-
     return os.environ.get("PATH", "/usr/bin:/bin")
 
 
@@ -81,7 +80,7 @@ def branched_repo(tmp_path: Path) -> Path:
 
     Layout mirrors the real paths the script watches so the watched
     prefix logic matches: `src/supy/data_model/schema/version.py` and a
-    sibling file under `src/supy/data_model/`.
+    YAML-owned model under `src/supy/data_model/core/`.
 
     Timeline:
       1. master commit sets CURRENT_SCHEMA_VERSION="1.0".
@@ -98,7 +97,7 @@ def branched_repo(tmp_path: Path) -> Path:
     _git(repo, "symbolic-ref", "HEAD", "refs/heads/master")
 
     version_rel = "src/supy/data_model/schema/version.py"
-    sibling_rel = "src/supy/data_model/sample.py"
+    sibling_rel = "src/supy/data_model/core/model.py"
 
     _write(repo, version_rel, _make_version_file("1.0"))
     _write(repo, sibling_rel, "# initial\n")
@@ -119,7 +118,9 @@ def branched_repo(tmp_path: Path) -> Path:
 
 
 def test_merge_base_ignores_unrelated_master_bump(
-    branched_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    branched_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A bump that lands on `master` after divergence must NOT be
     attributed to this branch. Reading from the merge-base keeps the
@@ -155,6 +156,7 @@ def test_main_entry_chdirs_to_repo_root(branched_repo: Path) -> None:
 
     result = subprocess.run(
         [sys.executable, str(script_copy), "--base", "master"],
+        check=False,
         cwd=nested,
         capture_output=True,
         text=True,
@@ -178,17 +180,40 @@ def test_extract_current_schema_version_parses_literal() -> None:
         'CURRENT_SCHEMA_VERSION = "2026.4"\n'
         "more_code = 1\n"
     )
-    assert (
-        check_schema_version_bump._extract_current_schema_version(source)
-        == "2026.4"
-    )
+    assert check_schema_version_bump._extract_current_schema_version(source) == "2026.4"
 
 
 def test_extract_current_schema_version_returns_none_when_missing() -> None:
     """An unrecognisable file must return None rather than guess."""
     assert (
-        check_schema_version_bump._extract_current_schema_version(
-            "some other file\n"
-        )
+        check_schema_version_bump._extract_current_schema_version("some other file\n")
         is None
     )
+
+
+@pytest.mark.parametrize(
+    ("path", "watched"),
+    [
+        ("src/supy/data_model/core/config.py", True),
+        ("src/supy/data_model/core/model.py", True),
+        ("src/supy/sample_data/sample_config.yml", True),
+        ("src/supy/data_model/core/__init__.py", False),
+        ("src/supy/data_model/core/forcing_validation.py", False),
+        ("src/supy/data_model/core/df_column_renames.py", False),
+        ("src/supy/data_model/output/variables.py", False),
+        ("src/supy/data_model/forcing/variables.py", False),
+        ("src/supy/data_model/interfaces/version.py", False),
+        ("src/supy/data_model/validation/core/controller.py", False),
+    ],
+)
+def test_only_yaml_owned_paths_are_watched(path: str, watched: bool) -> None:
+    assert check_schema_version_bump._is_watched(path) is watched
+
+
+def test_name_status_keeps_both_sides_of_a_rename() -> None:
+    output = "R100\0src/supy/data_model/core/model.py\0src/supy/internal.py\0"
+
+    assert check_schema_version_bump._paths_from_name_status(output) == {
+        "src/supy/data_model/core/model.py",
+        "src/supy/internal.py",
+    }


### PR DESCRIPTION
## Summary

- restrict the YAML schema-version audit to configuration models that contribute to `SUEWSConfig.model_json_schema()`
- exclude forcing validation, DataFrame rename helpers, forcing contracts and output registries from YAML schema ownership
- make rename detection NUL-safe and run the required check unconditionally so unrelated PRs receive a successful fast-skip

## Ordered series

1. **This PR:** correct the existing YAML schema-audit boundary
2. #1659 — data-interface governance primitives and snapshot packaging
3. #1660 — data-interface audit engine and focused tests
4. #1661 — CI activation and contributor documentation

This prerequisite prevents the new forcing/output governance package from consuming unrelated YAML schema versions.

Refs #1654 and #1658.

## Validation

- 15 focused schema-audit tests passed
- schema-version audit CLI passed against `origin/master`
- `make test-smoke`: 9 passed, 1 skipped
- editable Meson build passed
