### PR TITLE
Project the output contract from OUTPUT_REGISTRY

### DIFF
--- a/docs/generate_output_variable_rst.py
+++ b/docs/generate_output_variable_rst.py
@@ -9,9 +9,9 @@ To run this script, navigate to the `docs/` directory and execute:
 """
 
 import argparse
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
 from typing import Any
 
 # Import supy - it must be installed (via make dev) for docs to build
@@ -36,6 +36,11 @@ class OutputVariableRSTGenerator:
     def __init__(self):
         """Initialize the RST generator."""
         self.registry = OUTPUT_REGISTRY
+        self.groups = tuple(
+            dict.fromkeys(
+                OutputGroup(variable.group) for variable in self.registry.variables
+            )
+        )
 
     VALID_STYLES = frozenset({"simple", "tabbed", "dropdown"})
 
@@ -58,7 +63,7 @@ class OutputVariableRSTGenerator:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Generate RST for each output group
-        for group in OutputGroup:
+        for group in self.groups:
             variables = self.registry.by_group(group)
             if not variables:
                 continue
@@ -84,7 +89,7 @@ class OutputVariableRSTGenerator:
             f.write(index_content)
         print(f"Generated: {index_file} (style: {style})")
 
-        print(f"\nGenerated documentation for {len(list(OutputGroup))} output groups")
+        print(f"\nGenerated documentation for {len(self.groups)} output groups")
         print(f"Total variables documented: {len(self.registry.variables)}")
 
     def _format_group(self, group: OutputGroup, variables: list) -> str:
@@ -127,11 +132,8 @@ class OutputVariableRSTGenerator:
         lines.append(f"This group contains {len(variables)} output variables.")
         lines.append("")
 
-        # Sort variables by name
-        sorted_vars = sorted(variables, key=lambda v: v.name)
-
-        # Format each variable
-        for var in sorted_vars:
+        # Preserve registry order: it defines each variable's contract ordinal.
+        for var in variables:
             lines.extend(self._format_variable(var))
             lines.append("")  # Blank line between variables
 
@@ -346,7 +348,7 @@ class OutputVariableRSTGenerator:
         ]
 
         # List all groups
-        for group in OutputGroup:
+        for group in self.groups:
             variables = self.registry.by_group(group)
             if not variables:
                 continue
@@ -366,7 +368,7 @@ class OutputVariableRSTGenerator:
             "",
         ])
 
-        for group in OutputGroup:
+        for group in self.groups:
             if self.registry.by_group(group):
                 lines.append(f"   {group.value.lower()}")
 
@@ -387,7 +389,7 @@ class OutputVariableRSTGenerator:
         ]
 
         # Create dropdown for each group
-        for group in OutputGroup:
+        for group in self.groups:
             variables = self.registry.by_group(group)
             if not variables:
                 continue
@@ -418,7 +420,7 @@ class OutputVariableRSTGenerator:
             "",
         ])
 
-        for group in OutputGroup:
+        for group in self.groups:
             if self.registry.by_group(group):
                 lines.append(f"   {group.value.lower()}")
 
@@ -439,7 +441,7 @@ class OutputVariableRSTGenerator:
         ]
 
         # Create tab for each group
-        for group in OutputGroup:
+        for group in self.groups:
             variables = self.registry.by_group(group)
             if not variables:
                 continue
@@ -468,7 +470,7 @@ class OutputVariableRSTGenerator:
             "",
         ])
 
-        for group in OutputGroup:
+        for group in self.groups:
             if self.registry.by_group(group):
                 lines.append(f"   {group.value.lower()}")
 

--- a/src/supy/data_model/output/README.md
+++ b/src/supy/data_model/output/README.md
@@ -1,211 +1,122 @@
-# SUEWS Output Variable Definitions
+# SUEWS output-variable definitions
 
 ## Overview
 
-This module defines all SUEWS output variables using Python Pydantic models. The `OUTPUT_REGISTRY` serves as the **single source of truth** for output variable metadata, providing type-safe definitions with validation, aggregation rules for temporal resampling, and automatic documentation generation.
+`OUTPUT_REGISTRY` is the source of truth for Python-side output labels and
+metadata. It supplies variable names, units, descriptions, temporal aggregation
+rules, groups, and selection levels. The compiled model still produces the
+numerical arrays; separate checks compare its per-group column counts with the
+registry. A count match does not by itself prove the scientific meaning of each
+compiled column.
 
-## Variable Groups
+Query the live registry size with `len(OUTPUT_REGISTRY.variables)` rather than
+copying the count into code or documentation.
 
-Output variables are organised by group:
+## Groups and contract scope
 
-| Group | Description |
-|-------|-------------|
-| datetime | Year, DOY, Hour, Min, Dectime |
-| SUEWS | Core energy, water, met, carbon, surface temperatures |
-| snow | Snow properties by surface type |
-| ESTM | Element surface temperatures |
-| EHC | Element heat capacity (surface, roof layers, wall layers) |
-| RSL | Roughness sublayer profiles |
-| DailyState | Daily accumulated states |
-| BL | Boundary layer profiles |
-| BEERS | Detailed radiation |
-| debug | Diagnostic outputs with soil store and atmospheric vars |
-| SPARTACUS | SPARTACUS radiation model (scalars and layer profiles) |
-| STEBBS | Building energy model |
-| NHood | Neighbourhood iteration count |
+The output contract classifies groups according to their current intended
+stability:
 
-To get the current count: `len(OUTPUT_REGISTRY)`
+| Scope | Groups |
+|-------|--------|
+| coordinate | `datetime` |
+| stable | `SUEWS`, `snow`, `ESTM`, `RSL`, `BL`, `DailyState` |
+| provisional | `EHC`, `BEERS`, `SPARTACUS`, `STEBBS`, `NHood` |
+| internal | `debug` |
+
+These classifications are exposed by `OUTPUT_GROUP_SCOPES`. The interface is
+not published yet: `CURRENT_OUTPUT_VERSION` remains `None` until the observable
+layouts and a versioned artefact have been validated.
 
 ## Architecture
 
+```text
+Per-group OutputVariable definitions
+    |
+    v
+OUTPUT_REGISTRY
+    |-- pandas labels and aggregation rules
+    |-- generated RST reference
+    `-- get_output_contract_catalogue()
 ```
-Python Pydantic Models (source of truth)
-    ↓
-OUTPUT_REGISTRY (type-safe registry)
-    ↓
-Runtime metadata (DataFrame compatible)
-    ↓
-Post-processing & output
-```
 
-Key design principles:
-- **Python as source of truth**: All output metadata defined in Python, Fortran produces raw arrays
-- **No code generation**: Definitions are used directly at runtime
-- **Auto-generated documentation**: Sphinx docs built from Pydantic models via `docs/generate_output_variable_rst.py`
+`get_output_contract_catalogue()` returns a cached, in-memory deterministic
+projection of the registry. The catalogue is constructed only when requested.
+Each variable is identified by `(group, name)`, and its zero-based ordinal is
+derived from registry order. The catalogue does not create a second registry.
 
-## Key Components
+Common value metadata is recorded once for the catalogue. It describes the
+missing-value encoding when a group is present in each representation; the
+format-specific placement of coordinate fields is handled separately:
 
-### 1. Core Models (`variables.py`)
+- values are numeric scalars;
+- pandas output uses `NaN` for missing values;
+- text output uses the `-999.0` sentinel;
+- Parquet uses null values.
 
-- **`OutputVariable`**: Complete variable metadata
-- **`OutputVariableRegistry`**: Central registry with querying methods
-- **`AggregationMethod`**: Enum for resampling methods (T/A/S/L)
-- **`OutputGroup`**: Enum for logical grouping
-- **`OutputLevel`**: Enum for output selection (0/1/2)
+`output_contract_json_schema()` returns the JSON Schema for this in-memory
+catalogue. Stored version artefacts and their digests are added only when the
+first output contract is published.
 
-### 2. Variable Definitions
+## Core models
 
-Variables organized by group in separate modules:
+- `OutputVariable`: metadata for one registry entry.
+- `OutputVariableRegistry`: ordered collection and query methods.
+- `AggregationMethod`: resampling behaviour (`T`, `A`, `S`, or `L`).
+- `OutputGroup`: logical output group.
+- `OutputLevel`: variable-selection level used by SUEWS text output.
 
-- `datetime_vars.py`: Timestamp variables (Year, DOY, Hour, Min, Dectime)
-- `suews_vars.py`: Core SUEWS variables (QH, QE, T2, Rain, etc.)
-- `snow_vars.py`, `estm_vars.py`, `rsl_vars.py`, `dailystate_vars.py`, etc.
+Definitions are organised in one module per group, such as `suews_vars.py`,
+`snow_vars.py`, and `dailystate_vars.py`. Add new variables to the appropriate
+group module; do not edit the contract catalogue directly.
 
-### 3. Integration
-
-The registry integrates with existing SUEWS code via `_post.py`:
+## Usage
 
 ```python
-# Python OUTPUT_REGISTRY is the single source of truth
-df_var = get_output_info_df()  # Returns same structure as before
-```
+from supy.data_model.output import (
+    OUTPUT_REGISTRY,
+    OutputGroup,
+    get_output_contract_catalogue,
+)
 
-## Usage Examples
-
-### Basic Registry Access
-
-```python
-from supy.data_model.output import OUTPUT_REGISTRY, OutputGroup, OutputLevel
-
-# Get all SUEWS variables
-suews_vars = OUTPUT_REGISTRY.by_group(OutputGroup.SUEWS)
-
-# Get default output level variables
-default_vars = OUTPUT_REGISTRY.by_level(OutputLevel.DEFAULT)
-
-# Get specific variable
+suews_variables = OUTPUT_REGISTRY.by_group(OutputGroup.SUEWS)
 qh = OUTPUT_REGISTRY.by_name("QH")
-print(f"{qh.name}: {qh.description} [{qh.unit}]")
-# Output: QH: Sensible heat flux [W m-2]
+aggregation_rules = OUTPUT_REGISTRY.get_aggregation_rules()
+
+first_contract_entry = get_output_contract_catalogue().variables[0]
+print(first_contract_entry.group, first_contract_entry.name)
 ```
 
-### Aggregation Rules
+`by_name()` returns the first matching name across all groups. Use a group
+filter when the same variable name occurs in more than one group.
 
-```python
-# Generate aggregation rules for pandas resample()
-agg_rules = OUTPUT_REGISTRY.get_aggregation_rules()
+The compatibility DataFrame is available through `OUTPUT_REGISTRY.to_dataframe()`.
+It has a `(group, var)` index and `aggm`, `outlevel`, and `func` columns.
 
-# Use in resampling
-df_resampled = df.resample('1h').agg(agg_rules['SUEWS'])
-```
+## Documentation and tests
 
-### DataFrame Conversion
-
-```python
-# Convert to backward-compatible DataFrame
-df_var = OUTPUT_REGISTRY.to_dataframe()
-
-# Same structure as before: MultiIndex (group, var) with columns (aggm, outlevel, func)
-print(df_var.loc[('SUEWS', 'QH')])
-```
-
-## Variable Metadata
-
-Each variable has complete metadata:
-
-| Attribute | Description | Example |
-|-----------|-------------|---------|
-| `name` | Variable name | `"QH"` |
-| `unit` | Physical units | `"W m-2"` |
-| `description` | Long description | `"Sensible heat flux"` |
-| `aggregation` | Resampling method | `AVERAGE` |
-| `group` | Logical group | `SUEWS` |
-| `level` | Output priority | `DEFAULT` (0) |
-| `format` | Fortran format | `"f104"` |
-
-## Output Groups
-
-| Group | Purpose | Variables |
-|-------|---------|-----------|
-| `datetime` | Timestamps | Year, DOY, Hour, Min, Dectime |
-| `SUEWS` | Core outputs | QH, QE, QN, T2, Rain, etc. |
-| `snow` | Snow-specific | SWE_*, Sd_*, DensSnow_*, etc. |
-| `ESTM` | Surface temperatures | QS, TWALL*, TROOF*, etc. |
-| `RSL` | Roughness sublayer | T_1..T_30, U_1..U_30, etc. |
-| `DailyState` | Daily states | LAI_*, GDD_*, SDD_*, etc. |
-| `BL` | Boundary layer | z, theta, q, etc. |
-| `BEERS` | Radiation | Kdown2d, Ldown2d, Tmrt, etc. |
-| `debug` | Diagnostics | RA, RS, Ts_*, QN_*, etc. |
-
-## Output Levels
-
-Variables are prioritised for selective output:
-
-- **Level 0 (DEFAULT)**: Core variables always included
-  - Example: QH, QE, T2, RH2, Rain, Evap
-- **Level 1 (EXTENDED)**: Extended variable set
-  - Example: RA, RS, QHlumps, SMD by surface type
-- **Level 2 (SNOW_DETAILED)**: Snow-specific detailed output
-  - Example: QNSnow, AlbSnow, SWE, MeltWater
-
-## Aggregation Methods
-
-| Method | Code | Pandas Function | Use Case |
-|--------|------|-----------------|----------|
-| `TIME` | `T` | Last value | Timestamps |
-| `AVERAGE` | `A` | `mean` | Fluxes (QH, QE) |
-| `SUM` | `S` | `sum` | Accumulations (Rain, Evap) |
-| `LAST` | `L` | Last value | State variables (SMD, State) |
-
-## Testing
-
-Run the test suite:
+Generate the RST reference from the repository root with:
 
 ```bash
-make test  # or: pytest test/data_model/test_output_models.py
+python docs/generate_output_variable_rst.py
 ```
 
-## Design Benefits
+The generator preserves registry order so that the reference agrees with
+contract ordinals. Focused registry and contract tests live under
+`test/data_model/`.
 
-- **Type Safety**: Pydantic validation ensures correctness at definition time
-- **IDE Support**: Full autocomplete and type hints for variable metadata
-- **Self-Documenting**: Rich metadata enables automatic documentation generation
-- **Extensibility**: Adding new variables requires only Python changes
-- **Testing**: Variable definitions have unit test coverage
-- **Ecosystem Integration**: Works naturally with pandas, numpy, and scientific Python stack
+## Files
 
-## Backward Compatibility
-
-The registry provides backward-compatible interfaces:
-
-- `get_output_info_df()` returns the same DataFrame structure used historically
-- `resample_output()` uses aggregation rules from the registry
-- Existing code continues to work without modification
-
-## File Structure
-
-```
+```text
 src/supy/data_model/output/
-├── __init__.py              # Registry assembly & exports
-├── README.md                # This file
-├── variables.py             # Core Pydantic models & enums
-├── datetime_vars.py         # Datetime variables
-├── suews_vars.py            # Core SUEWS variables
-├── snow_vars.py             # Snow variables
-├── estm_vars.py             # ESTM variables
-├── rsl_vars.py              # RSL profile variables
-├── dailystate_vars.py       # Daily state variables
-├── bl_vars.py               # Boundary layer variables
-├── beers_vars.py            # BEERS radiation variables
-├── debug_vars.py            # Debug variables
-├── ehc_vars.py              # EHC variables
-├── spartacus_vars.py        # SPARTACUS variables
-├── stebbs_vars.py           # STEBBS variables
-└── nhood_vars.py            # NHood variables
+|-- __init__.py          # Public exports
+|-- variables.py         # Registry models and enums
+|-- contract.py          # Output-owned contract projection
+|-- registry.py          # Registry assembly
+|-- version.py           # Output contract version history
+|-- *_vars.py            # Per-group variable definitions
+`-- README.md
 ```
 
-## References
-
-- **Integration point**: `src/supy/_post.py`
-- **Documentation generator**: `docs/generate_output_variable_rst.py`
-- **Test module**: `test/data_model/test_output_models.py`
+Related integration points are `src/supy/_post.py`, `src/supy/_save.py`, and
+`docs/generate_output_variable_rst.py`.

--- a/src/supy/data_model/output/__init__.py
+++ b/src/supy/data_model/output/__init__.py
@@ -1,7 +1,8 @@
 """Output variable definitions for SUEWS.
 
-This module provides Python/Pydantic-first definitions of all SUEWS output variables,
-replacing the previous Fortran-first runtime extraction approach.
+This module provides Python/Pydantic definitions of SUEWS output metadata. The
+compiled model produces numerical arrays whose labels and aggregation behaviour
+are projected from this registry.
 
 The registry pattern provides:
 - Type-safe variable definitions
@@ -19,52 +20,44 @@ Example usage:
     >>> agg_rules = OUTPUT_REGISTRY.get_aggregation_rules()
 """
 
+from .beers_vars import BEERS_VARIABLES as BEERS_VARIABLES
+from .bl_vars import BL_VARIABLES as BL_VARIABLES
+from .contract import (
+    OUTPUT_GROUP_SCOPES,
+    OutputContractScope,
+    output_contract_json_schema,
+)
+from .dailystate_vars import DAILYSTATE_VARIABLES as DAILYSTATE_VARIABLES
+from .datetime_vars import DATETIME_VARIABLES as DATETIME_VARIABLES
+from .debug_vars import DEBUG_VARIABLES as DEBUG_VARIABLES
+from .ehc_vars import EHC_VARIABLES as EHC_VARIABLES
+from .estm_vars import ESTM_VARIABLES as ESTM_VARIABLES
+from .nhood_vars import NHOOD_VARIABLES as NHOOD_VARIABLES
+from .registry import OUTPUT_REGISTRY, get_output_contract_catalogue
+from .rsl_vars import RSL_VARIABLES as RSL_VARIABLES
+from .snow_vars import SNOW_VARIABLES as SNOW_VARIABLES
+from .spartacus_vars import SPARTACUS_VARIABLES as SPARTACUS_VARIABLES
+from .stebbs_vars import STEBBS_VARIABLES as STEBBS_VARIABLES
+from .suews_vars import SUEWS_VARIABLES as SUEWS_VARIABLES
 from .variables import (
-    OutputVariable,
-    OutputVariableRegistry,
     AggregationMethod,
     OutputGroup,
     OutputLevel,
-)
-from .datetime_vars import DATETIME_VARIABLES
-from .suews_vars import SUEWS_VARIABLES
-from .snow_vars import SNOW_VARIABLES
-from .estm_vars import ESTM_VARIABLES
-from .rsl_vars import RSL_VARIABLES
-from .dailystate_vars import DAILYSTATE_VARIABLES
-from .bl_vars import BL_VARIABLES
-from .beers_vars import BEERS_VARIABLES
-from .debug_vars import DEBUG_VARIABLES
-from .ehc_vars import EHC_VARIABLES
-from .spartacus_vars import SPARTACUS_VARIABLES
-from .stebbs_vars import STEBBS_VARIABLES
-from .nhood_vars import NHOOD_VARIABLES
-
-# Assemble the global registry from all variable modules
-OUTPUT_REGISTRY = OutputVariableRegistry(
-    variables=(
-        DATETIME_VARIABLES
-        + SUEWS_VARIABLES
-        + SNOW_VARIABLES
-        + ESTM_VARIABLES
-        + RSL_VARIABLES
-        + DAILYSTATE_VARIABLES
-        + BL_VARIABLES
-        + BEERS_VARIABLES
-        + DEBUG_VARIABLES
-        + EHC_VARIABLES
-        + SPARTACUS_VARIABLES
-        + STEBBS_VARIABLES
-        + NHOOD_VARIABLES
-    )
+    OutputVariable,
+    OutputVariableRegistry,
 )
 
-
+# The per-group lists remain explicit package attributes for compatibility.
+# They are intentionally not part of the star-import API in ``__all__``.
 __all__ = [
+    "OUTPUT_GROUP_SCOPES",
     "OUTPUT_REGISTRY",
-    "OutputVariable",
-    "OutputVariableRegistry",
     "AggregationMethod",
+    "OutputContractScope",
     "OutputGroup",
     "OutputLevel",
+    "OutputVariable",
+    "OutputVariableRegistry",
+    "get_output_contract_catalogue",
+    "output_contract_json_schema",
 ]

--- a/src/supy/data_model/output/contract.py
+++ b/src/supy/data_model/output/contract.py
@@ -1,0 +1,172 @@
+"""Machine-readable projection of the SUEWS output-variable registry."""
+
+from enum import Enum, StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .variables import (
+    AggregationMethod,
+    OutputGroup,
+    OutputLevel,
+    OutputVariableRegistry,
+)
+
+
+class OutputContractScope(StrEnum):
+    """Stability scope assigned to an output group."""
+
+    COORDINATE = "coordinate"
+    STABLE = "stable"
+    PROVISIONAL = "provisional"
+    INTERNAL = "internal"
+
+
+OUTPUT_GROUP_SCOPES: dict[OutputGroup, OutputContractScope] = {
+    OutputGroup.DATETIME: OutputContractScope.COORDINATE,
+    OutputGroup.SUEWS: OutputContractScope.STABLE,
+    OutputGroup.SNOW: OutputContractScope.STABLE,
+    OutputGroup.ESTM: OutputContractScope.STABLE,
+    OutputGroup.RSL: OutputContractScope.STABLE,
+    OutputGroup.BL: OutputContractScope.STABLE,
+    OutputGroup.DAILYSTATE: OutputContractScope.STABLE,
+    OutputGroup.DEBUG: OutputContractScope.INTERNAL,
+    OutputGroup.EHC: OutputContractScope.PROVISIONAL,
+    OutputGroup.BEERS: OutputContractScope.PROVISIONAL,
+    OutputGroup.SPARTACUS: OutputContractScope.PROVISIONAL,
+    OutputGroup.STEBBS: OutputContractScope.PROVISIONAL,
+    OutputGroup.NHOOD: OutputContractScope.PROVISIONAL,
+}
+
+
+class OutputMissingValues(BaseModel):
+    """Missing-value representation used by each supported output form."""
+
+    dataframe: Literal["nan"] = "nan"
+    text: Literal["sentinel:-999.0"] = "sentinel:-999.0"
+    parquet: Literal["null"] = "null"
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class OutputRepresentation(BaseModel):
+    """Metadata shared by every entry in the current registry."""
+
+    value_type: Literal["number"] = "number"
+    shape: Literal["scalar"] = "scalar"
+    missing_values: OutputMissingValues = Field(default_factory=OutputMissingValues)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class OutputContractGroup(BaseModel):
+    """Ordered output group and its stability scope."""
+
+    group: OutputGroup
+    ordinal: int = Field(ge=0)
+    scope: OutputContractScope
+
+    model_config = ConfigDict(extra="forbid", frozen=True, use_enum_values=True)
+
+
+class OutputContractVariable(BaseModel):
+    """One registry variable projected into the output contract catalogue.
+
+    The pair ``(group, name)`` is the variable identity. ``ordinal`` is its
+    zero-based position inside that group in ``OUTPUT_REGISTRY``.
+    """
+
+    group: OutputGroup
+    name: str
+    ordinal: int = Field(ge=0)
+    unit: str
+    description: str
+    aggregation: AggregationMethod
+    level: OutputLevel
+
+    model_config = ConfigDict(extra="forbid", frozen=True, use_enum_values=True)
+
+
+class OutputContractCatalogue(BaseModel):
+    """Deterministic, in-memory catalogue projected from ``OUTPUT_REGISTRY``."""
+
+    kind: Literal["output"] = "output"
+    representation: OutputRepresentation = Field(default_factory=OutputRepresentation)
+    groups: tuple[OutputContractGroup, ...]
+    variables: tuple[OutputContractVariable, ...]
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        title="SUEWS output contract catalogue",
+    )
+
+
+def _enum_value(value: object) -> object:
+    """Return an enum value while accepting Pydantic's value conversion."""
+    return value.value if isinstance(value, Enum) else value
+
+
+def _project_output_contract(
+    registry: OutputVariableRegistry,
+) -> OutputContractCatalogue:
+    """Project the output contract directly from a variable registry."""
+    list_group_names: list[str] = []
+    dict_next_ordinal: dict[str, int] = {}
+    list_variables: list[OutputContractVariable] = []
+
+    for variable in registry.variables:
+        group_name = str(_enum_value(variable.group))
+        if group_name not in dict_next_ordinal:
+            list_group_names.append(group_name)
+            dict_next_ordinal[group_name] = 0
+
+        list_variables.append(
+            OutputContractVariable(
+                group=OutputGroup(group_name),
+                name=variable.name,
+                ordinal=dict_next_ordinal[group_name],
+                unit=variable.unit,
+                description=variable.description,
+                aggregation=AggregationMethod(_enum_value(variable.aggregation)),
+                level=OutputLevel(_enum_value(variable.level)),
+            )
+        )
+        dict_next_ordinal[group_name] += 1
+
+    set_registry_groups = {OutputGroup(group_name) for group_name in list_group_names}
+    set_scoped_groups = set(OUTPUT_GROUP_SCOPES)
+    if set_registry_groups != set_scoped_groups:
+        missing = sorted(
+            group.value for group in set_registry_groups - set_scoped_groups
+        )
+        unused = sorted(
+            group.value for group in set_scoped_groups - set_registry_groups
+        )
+        raise ValueError(
+            "Output contract scopes must cover the registry exactly "
+            f"(missing={missing}, unused={unused})"
+        )
+
+    groups = tuple(
+        OutputContractGroup(
+            group=OutputGroup(group_name),
+            ordinal=ordinal,
+            scope=OUTPUT_GROUP_SCOPES[OutputGroup(group_name)],
+        )
+        for ordinal, group_name in enumerate(list_group_names)
+    )
+    return OutputContractCatalogue(groups=groups, variables=tuple(list_variables))
+
+
+def output_contract_json_schema() -> dict[str, object]:
+    """Return the JSON Schema for the in-memory output catalogue."""
+    return OutputContractCatalogue.model_json_schema()
+
+
+__all__ = [
+    "OUTPUT_GROUP_SCOPES",
+    "OutputContractCatalogue",
+    "OutputContractScope",
+    "output_contract_json_schema",
+]

--- a/src/supy/data_model/output/registry.py
+++ b/src/supy/data_model/output/registry.py
@@ -1,0 +1,46 @@
+"""Assemble the SUEWS output registry and its contract projection."""
+
+from functools import cache
+
+from .beers_vars import BEERS_VARIABLES
+from .bl_vars import BL_VARIABLES
+from .contract import OutputContractCatalogue, _project_output_contract
+from .dailystate_vars import DAILYSTATE_VARIABLES
+from .datetime_vars import DATETIME_VARIABLES
+from .debug_vars import DEBUG_VARIABLES
+from .ehc_vars import EHC_VARIABLES
+from .estm_vars import ESTM_VARIABLES
+from .nhood_vars import NHOOD_VARIABLES
+from .rsl_vars import RSL_VARIABLES
+from .snow_vars import SNOW_VARIABLES
+from .spartacus_vars import SPARTACUS_VARIABLES
+from .stebbs_vars import STEBBS_VARIABLES
+from .suews_vars import SUEWS_VARIABLES
+from .variables import OutputVariableRegistry
+
+OUTPUT_REGISTRY = OutputVariableRegistry(
+    variables=(
+        DATETIME_VARIABLES
+        + SUEWS_VARIABLES
+        + SNOW_VARIABLES
+        + ESTM_VARIABLES
+        + RSL_VARIABLES
+        + DAILYSTATE_VARIABLES
+        + BL_VARIABLES
+        + BEERS_VARIABLES
+        + DEBUG_VARIABLES
+        + EHC_VARIABLES
+        + SPARTACUS_VARIABLES
+        + STEBBS_VARIABLES
+        + NHOOD_VARIABLES
+    )
+)
+
+
+@cache
+def get_output_contract_catalogue() -> OutputContractCatalogue:
+    """Return the cached contract projection of ``OUTPUT_REGISTRY``."""
+    return _project_output_contract(OUTPUT_REGISTRY)
+
+
+__all__ = ["OUTPUT_REGISTRY", "get_output_contract_catalogue"]

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -147,6 +147,8 @@ py.install_sources(
             'data_model/forcing/variables.py',
             'data_model/forcing/version.py',
             'data_model/output/__init__.py',
+            'data_model/output/contract.py',
+            'data_model/output/registry.py',
             'data_model/output/version.py',
             'data_model/output/variables.py',
             'data_model/output/datetime_vars.py',

--- a/test/data_model/test_output_contract.py
+++ b/test/data_model/test_output_contract.py
@@ -1,0 +1,185 @@
+"""Tests for the output-owned contract projection."""
+
+import importlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from jsonschema import Draft202012Validator, ValidationError
+import pytest
+
+from supy.data_model.output import (
+    OUTPUT_GROUP_SCOPES,
+    OUTPUT_REGISTRY,
+    OutputContractScope,
+    get_output_contract_catalogue,
+    output_contract_json_schema,
+)
+from supy.data_model.output.version import CURRENT_OUTPUT_VERSION
+
+pytestmark = pytest.mark.api
+
+OUTPUT_CONTRACT_CATALOGUE = get_output_contract_catalogue()
+
+_GROUP_VARIABLE_EXPORTS = (
+    ("DATETIME_VARIABLES", "datetime_vars"),
+    ("SUEWS_VARIABLES", "suews_vars"),
+    ("SNOW_VARIABLES", "snow_vars"),
+    ("ESTM_VARIABLES", "estm_vars"),
+    ("RSL_VARIABLES", "rsl_vars"),
+    ("DAILYSTATE_VARIABLES", "dailystate_vars"),
+    ("BL_VARIABLES", "bl_vars"),
+    ("BEERS_VARIABLES", "beers_vars"),
+    ("DEBUG_VARIABLES", "debug_vars"),
+    ("EHC_VARIABLES", "ehc_vars"),
+    ("SPARTACUS_VARIABLES", "spartacus_vars"),
+    ("STEBBS_VARIABLES", "stebbs_vars"),
+    ("NHOOD_VARIABLES", "nhood_vars"),
+)
+
+
+def test_version_import_does_not_construct_contract_catalogue() -> None:
+    """Keep ordinary output imports independent of the contract projection."""
+    data_model_dir = Path(__file__).resolve().parents[2] / "src" / "supy" / "data_model"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import output.version; "
+                "from output.registry import get_output_contract_catalogue; "
+                "assert get_output_contract_catalogue.cache_info().currsize == 0"
+            ),
+        ],
+        check=False,
+        cwd=data_model_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _value(value):
+    """Return an enum value while accepting Pydantic's value conversion."""
+    return value.value if hasattr(value, "value") else value
+
+
+@pytest.mark.parametrize(("attribute", "module_name"), _GROUP_VARIABLE_EXPORTS)
+def test_group_variable_lists_remain_package_attributes(attribute, module_name):
+    """Keep the explicit package imports available after moving assembly."""
+    output_package = importlib.import_module("supy.data_model.output")
+    definition_module = importlib.import_module(f"supy.data_model.output.{module_name}")
+
+    assert getattr(output_package, attribute) is getattr(definition_module, attribute)
+
+
+def test_catalogue_is_an_exact_registry_projection():
+    """Project identity, metadata, and group-relative order without duplication."""
+    assert get_output_contract_catalogue() is OUTPUT_CONTRACT_CATALOGUE
+    assert len(OUTPUT_CONTRACT_CATALOGUE.variables) == len(OUTPUT_REGISTRY.variables)
+
+    dict_next_ordinal: dict[str, int] = {}
+    set_identities: set[tuple[str, str]] = set()
+    for projected, registered in zip(
+        OUTPUT_CONTRACT_CATALOGUE.variables,
+        OUTPUT_REGISTRY.variables,
+        strict=True,
+    ):
+        group = str(_value(registered.group))
+        expected_ordinal = dict_next_ordinal.setdefault(group, 0)
+        assert (
+            projected.group,
+            projected.name,
+            projected.ordinal,
+            projected.unit,
+            projected.description,
+            projected.aggregation,
+            projected.level,
+        ) == (
+            group,
+            registered.name,
+            expected_ordinal,
+            registered.unit,
+            registered.description,
+            _value(registered.aggregation),
+            _value(registered.level),
+        )
+        set_identities.add((projected.group, projected.name))
+        dict_next_ordinal[group] += 1
+
+    assert len(set_identities) == len(OUTPUT_CONTRACT_CATALOGUE.variables)
+
+
+def test_group_order_and_scopes_are_explicit():
+    """Classify every registry group once without changing registry order."""
+    list_registry_groups = list(
+        dict.fromkeys(
+            str(_value(variable.group)) for variable in OUTPUT_REGISTRY.variables
+        )
+    )
+    assert [group.group for group in OUTPUT_CONTRACT_CATALOGUE.groups] == (
+        list_registry_groups
+    )
+    assert [group.ordinal for group in OUTPUT_CONTRACT_CATALOGUE.groups] == list(
+        range(len(list_registry_groups))
+    )
+    assert {group.group: group.scope for group in OUTPUT_CONTRACT_CATALOGUE.groups} == {
+        group.value: scope.value for group, scope in OUTPUT_GROUP_SCOPES.items()
+    }
+
+    assert {
+        group.group
+        for group in OUTPUT_CONTRACT_CATALOGUE.groups
+        if group.scope == OutputContractScope.STABLE
+    } == {"SUEWS", "snow", "ESTM", "RSL", "BL", "DailyState"}
+
+
+def test_representation_metadata_is_uniform_and_unpublished():
+    """Declare shared representation metadata without publishing a version."""
+    assert OUTPUT_CONTRACT_CATALOGUE.representation.model_dump() == {
+        "value_type": "number",
+        "shape": "scalar",
+        "missing_values": {
+            "dataframe": "nan",
+            "text": "sentinel:-999.0",
+            "parquet": "null",
+        },
+    }
+    assert CURRENT_OUTPUT_VERSION is None
+
+
+def test_catalogue_json_schema_is_valid_and_deterministic():
+    """Validate the deterministic JSON projection with its generated schema."""
+    schema_first = output_contract_json_schema()
+    schema_second = output_contract_json_schema()
+    schema_first_json = json.dumps(
+        schema_first,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    schema_second_json = json.dumps(
+        schema_second,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    assert schema_first is not schema_second
+    assert schema_first_json == schema_second_json
+    Draft202012Validator.check_schema(schema_first)
+
+    document = OUTPUT_CONTRACT_CATALOGUE.model_dump(mode="json")
+    Draft202012Validator(schema_first).validate(document)
+    serialised = json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    assert json.loads(serialised) == document
+
+    invalid_document = {**document, "kind": "forcing"}
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema_first).validate(invalid_document)

--- a/test/data_model/test_output_contract.py
+++ b/test/data_model/test_output_contract.py
@@ -20,8 +20,6 @@ from supy.data_model.output.version import CURRENT_OUTPUT_VERSION
 
 pytestmark = pytest.mark.api
 
-OUTPUT_CONTRACT_CATALOGUE = get_output_contract_catalogue()
-
 _GROUP_VARIABLE_EXPORTS = (
     ("DATETIME_VARIABLES", "datetime_vars"),
     ("SUEWS_VARIABLES", "suews_vars"),
@@ -77,13 +75,14 @@ def test_group_variable_lists_remain_package_attributes(attribute, module_name):
 
 def test_catalogue_is_an_exact_registry_projection():
     """Project identity, metadata, and group-relative order without duplication."""
-    assert get_output_contract_catalogue() is OUTPUT_CONTRACT_CATALOGUE
-    assert len(OUTPUT_CONTRACT_CATALOGUE.variables) == len(OUTPUT_REGISTRY.variables)
+    catalogue = get_output_contract_catalogue()
+    assert get_output_contract_catalogue() is catalogue
+    assert len(catalogue.variables) == len(OUTPUT_REGISTRY.variables)
 
     dict_next_ordinal: dict[str, int] = {}
     set_identities: set[tuple[str, str]] = set()
     for projected, registered in zip(
-        OUTPUT_CONTRACT_CATALOGUE.variables,
+        catalogue.variables,
         OUTPUT_REGISTRY.variables,
         strict=True,
     ):
@@ -109,36 +108,35 @@ def test_catalogue_is_an_exact_registry_projection():
         set_identities.add((projected.group, projected.name))
         dict_next_ordinal[group] += 1
 
-    assert len(set_identities) == len(OUTPUT_CONTRACT_CATALOGUE.variables)
+    assert len(set_identities) == len(catalogue.variables)
 
 
 def test_group_order_and_scopes_are_explicit():
     """Classify every registry group once without changing registry order."""
+    catalogue = get_output_contract_catalogue()
     list_registry_groups = list(
         dict.fromkeys(
             str(_value(variable.group)) for variable in OUTPUT_REGISTRY.variables
         )
     )
-    assert [group.group for group in OUTPUT_CONTRACT_CATALOGUE.groups] == (
-        list_registry_groups
-    )
-    assert [group.ordinal for group in OUTPUT_CONTRACT_CATALOGUE.groups] == list(
+    assert [group.group for group in catalogue.groups] == list_registry_groups
+    assert [group.ordinal for group in catalogue.groups] == list(
         range(len(list_registry_groups))
     )
-    assert {group.group: group.scope for group in OUTPUT_CONTRACT_CATALOGUE.groups} == {
+    assert {group.group: group.scope for group in catalogue.groups} == {
         group.value: scope.value for group, scope in OUTPUT_GROUP_SCOPES.items()
     }
 
     assert {
         group.group
-        for group in OUTPUT_CONTRACT_CATALOGUE.groups
+        for group in catalogue.groups
         if group.scope == OutputContractScope.STABLE
     } == {"SUEWS", "snow", "ESTM", "RSL", "BL", "DailyState"}
 
 
 def test_representation_metadata_is_uniform_and_unpublished():
     """Declare shared representation metadata without publishing a version."""
-    assert OUTPUT_CONTRACT_CATALOGUE.representation.model_dump() == {
+    assert get_output_contract_catalogue().representation.model_dump() == {
         "value_type": "number",
         "shape": "scalar",
         "missing_values": {
@@ -170,7 +168,7 @@ def test_catalogue_json_schema_is_valid_and_deterministic():
     assert schema_first_json == schema_second_json
     Draft202012Validator.check_schema(schema_first)
 
-    document = OUTPUT_CONTRACT_CATALOGUE.model_dump(mode="json")
+    document = get_output_contract_catalogue().model_dump(mode="json")
     Draft202012Validator(schema_first).validate(document)
     serialised = json.dumps(
         document,


### PR DESCRIPTION
## Summary

- add an output-owned contract projection derived only from `OUTPUT_REGISTRY`
- classify all 13 groups as coordinate, stable candidate, provisional, or internal and derive `(group, name)` identities and per-group ordinals from registry order
- expose the 1,317-entry catalogue through a cached getter so ordinary output imports do not construct a second object graph
- correct registry documentation drift and preserve registry order in generated RST

## Scope

This is Layer A of #1656. `OUTPUT_REGISTRY` remains the single authoritative registry. `CURRENT_OUTPUT_VERSION` remains `None`; this PR adds no stored artefacts, writer/layout parity, publication, shared framework, or numerical changes.

The stable scope is still a candidate classification until the observable layouts and the first versioned artefact are reviewed.

## Validation

- 28 focused output contract/registry tests passed
- broader independent review passed 45 tests with 1 expected skip
- exact 1,317-entry projection, schema/catalogue determinism, and all 13 compatibility attributes were independently verified
- DataFrame `NaN`, text `-999.0`, and Parquet null representations were exercised
- Ruff, RST generation, Meson registration, and `git diff --check` passed
- prep review covers the rebased HEAD

Refs #1656
