### PR TITLE
Migrate internal configuration schema imports

### DIFF
--- a/.claude/agents/schema-migration-checker.md
+++ b/.claude/agents/schema-migration-checker.md
@@ -49,7 +49,7 @@ When uncertain, check whether the vendored release fixtures under `test/fixtures
 
 Check each of these is present in the SAME diff. A missing one is a `[blocking]` finding:
 
-1. `src/supy/data_model/schema/version.py`
+1. `src/supy/data_model/configuration/version.py`
    - `CURRENT_SCHEMA_VERSION` advanced. During a dev cycle this is `<target>.devN` (first structural PR after a release -> `.dev1`; subsequent -> `.devN+1`); only the release PR drops the suffix to plain CalVer. Use the shortest form (`2026.5`, not `2026.05`).
    - A new `SCHEMA_VERSIONS` entry keyed on the new label, describing only this PR's delta (not a cumulative summary), with issue/PR references.
 2. `src/supy/util/converter/yaml_upgrade.py`

--- a/.claude/rules/python/schema-versioning.md
+++ b/.claude/rules/python/schema-versioning.md
@@ -1,7 +1,7 @@
 # YAML Schema Versioning
 
 Rules for bumping `CURRENT_SCHEMA_VERSION` in
-`src/supy/data_model/schema/version.py` and for keeping the
+`src/supy/data_model/configuration/version.py` and for keeping the
 `yaml_upgrade` migration path aligned with reality.
 
 Motivated by the gap closed in gh#1304: `CURRENT_SCHEMA_VERSION` stayed
@@ -126,7 +126,7 @@ use `packaging.version.Version` for the comparison.
 
 ## How to bump
 
-1. Edit `src/supy/data_model/schema/version.py`:
+1. Edit `src/supy/data_model/configuration/version.py`:
    - Set `CURRENT_SCHEMA_VERSION` per the dev-label convention above
      — `"<target>.dev1"` for the first structural PR of a new cycle,
      `.devN+1` for subsequent PRs, plain CalVer (e.g. `"2026.5"`)
@@ -215,7 +215,7 @@ If any of these are missing, stop the release and add them first. The
 When reviewing a PR that touches `src/supy/data_model/`:
 
 - If the diff includes a field rename, removal, type change, required
-  addition, or structural reshape, `src/supy/data_model/schema/version.py`
+  addition, or structural reshape, `src/supy/data_model/configuration/version.py`
   must also be touched in the same PR. Flag otherwise.
 - The PR should add or update a handler in
   `src/supy/util/converter/yaml_upgrade.py` that covers the new delta.
@@ -234,7 +234,7 @@ The `.github/workflows/schema-version-audit.yml` workflow runs
 when no YAML-owned model under `src/supy/data_model/core/**` (excluding forcing
 validation and DataFrame rename helpers) or
 `src/supy/sample_data/sample_config.yml` changed. If those paths changed but
-`src/supy/data_model/schema/version.py` did not, the job fails with
+`src/supy/data_model/configuration/version.py` did not, the job fails with
 remediation guidance pointing at this rule.
 
 Forcing and output contract sources are intentionally outside this boundary.

--- a/.claude/skills/audit-pr/references/review-checklist.md
+++ b/.claude/skills/audit-pr/references/review-checklist.md
@@ -137,7 +137,7 @@ Detailed checklist for comprehensive PR review.
 
 ### Schema version bump (trigger-specific)
 
-If the PR changes `src/supy/data_model/schema/version.py` so that
+If the PR changes `src/supy/data_model/configuration/version.py` so that
 `CURRENT_SCHEMA_VERSION` takes a new value, check each item below in
 addition to the general "User Documentation" bullets above:
 

--- a/.claude/skills/audit-pr/references/workflow-steps.md
+++ b/.claude/skills/audit-pr/references/workflow-steps.md
@@ -67,7 +67,7 @@ Check: FIRST principles, AAA pattern, tolerance assertions.
 - **CHANGELOG** — entry with correct category
 - **PR description** — scientific rationale (if physics)
 - **User docs** — updated if user-facing
-- **Schema bump trigger** — if `src/supy/data_model/schema/version.py`
+- **Schema bump trigger** — if `src/supy/data_model/configuration/version.py`
   moved `CURRENT_SCHEMA_VERSION`, the PR must also touch
   `docs/source/contributing/schema/schema_versioning.rst` and
   `docs/source/inputs/transition_guide.rst`. See the full trigger-specific

--- a/.claude/skills/verify-build/SKILL.md
+++ b/.claude/skills/verify-build/SKILL.md
@@ -25,7 +25,7 @@ Details: `references/checks-detail.md`
 - `meson.build` — Build system
 - `pyproject.toml` — Python packaging
 - `.github/workflows/` — CI
-- `src/supy/data_model/schema/version.py` — CURRENT_SCHEMA_VERSION
+- `src/supy/data_model/configuration/version.py` — CURRENT_SCHEMA_VERSION
 - `src/supy/sample_data/sample_config.yml` — schema_version field
 
 ## Output Format

--- a/.claude/skills/verify-build/references/checks-detail.md
+++ b/.claude/skills/verify-build/references/checks-detail.md
@@ -20,12 +20,12 @@ ISSUE: src/suews/src/suews_phys_new.f95 not in meson.build
 
 ### 3. Schema Version Sync
 
-`CURRENT_SCHEMA_VERSION` in `src/supy/data_model/schema/version.py` must match the `schema_version` field in `src/supy/sample_data/sample_config.yml`. A mismatch means either:
+`CURRENT_SCHEMA_VERSION` in `src/supy/data_model/configuration/version.py` must match the `schema_version` field in `src/supy/sample_data/sample_config.yml`. A mismatch means either:
 - The schema was bumped but sample_config wasn't updated, or
 - sample_config was edited but the code constant wasn't bumped
 
 ```bash
-CODE_VER=$(python -c "from supy.data_model.schema import CURRENT_SCHEMA_VERSION; print(CURRENT_SCHEMA_VERSION)")
+CODE_VER=$(python -c "from supy.data_model.configuration import CURRENT_SCHEMA_VERSION; print(CURRENT_SCHEMA_VERSION)")
 YAML_VER=$(python -c "import yaml; print(yaml.safe_load(open('src/supy/sample_data/sample_config.yml'))['schema_version'])")
 [ "$CODE_VER" = "$YAML_VER" ] && echo "[OK] Schema version sync: $CODE_VER" || echo "[FAIL] Schema version mismatch: code=$CODE_VER, sample_config=$YAML_VER"
 ```

--- a/.github/scripts/generate_schema.py
+++ b/.github/scripts/generate_schema.py
@@ -9,7 +9,7 @@ Usage:
     python .github/scripts/generate_schema.py [--preview --pr-number N]
 
 For CI, prefer using the module directly:
-    python -m supy.data_model.schema.exporter
+    python -m supy.data_model.configuration.exporter
 """
 
 import sys
@@ -18,7 +18,7 @@ import sys
 def main():
     """Run the schema exporter."""
     try:
-        from supy.data_model.schema.exporter import main as exporter_main
+        from supy.data_model.configuration.exporter import main as exporter_main
     except ImportError as e:
         print(
             f"Error: Could not import supy. Make sure SUEWS is installed.\n"

--- a/.gitignore
+++ b/.gitignore
@@ -669,8 +669,8 @@ test/fixtures/gh846/*.zip
 # Conductor agent collaboration directory
 .context/
 
-# Auto-generated schema-publisher artefacts
-# (produced by `python -m supy.data_model.schema.exporter` /
+# Auto-generated configuration-schema publisher artefacts
+# (produced by `python -m supy.data_model.configuration.exporter` /
 # `suews-schema publish`; the canonical committed copy lives at
 # docs/source/inputs/tables/schema.json)
 site/schemas/

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -162,7 +162,7 @@ def main() -> int:
 
     schema_version = None
     try:
-        from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+        from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION
         schema_version = CURRENT_SCHEMA_VERSION
     except Exception:
         pass

--- a/docs/source/api/python-cli-equivalents/schema.rst
+++ b/docs/source/api/python-cli-equivalents/schema.rst
@@ -1,7 +1,7 @@
-Schema Management
------------------
+Configuration Schema Management
+-------------------------------
 
-Managing configuration schemas programmatically.
+Managing SUEWS configuration schemas programmatically.
 
 CLI Commands
 ~~~~~~~~~~~~
@@ -17,7 +17,7 @@ Python Equivalent (Schema Export)
 
 .. code-block:: python
 
-    from supy.data_model.schema.publisher import generate_json_schema, save_schema
+    from supy.data_model.configuration.publisher import generate_json_schema, save_schema
     import json
     from pathlib import Path
 
@@ -40,7 +40,7 @@ Python Equivalent (Schema Validation)
 
     import yaml
     import jsonschema
-    from supy.data_model.schema.publisher import generate_json_schema
+    from supy.data_model.configuration.publisher import generate_json_schema
     from supy.data_model.core.config import SUEWSConfig
 
     # Load configuration
@@ -70,8 +70,8 @@ Python Equivalent (Schema Migration)
 .. code-block:: python
 
     import yaml
-    from supy.data_model.schema.migration import SchemaMigrator
-    from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+    from supy.data_model.configuration.migration import SchemaMigrator
+    from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION
 
     # Load old configuration
     with open("old_config.yml", "r") as f:
@@ -104,7 +104,7 @@ Batch Operations
 
     import yaml
     from pathlib import Path
-    from supy.data_model.schema.publisher import generate_json_schema
+    from supy.data_model.configuration.publisher import generate_json_schema
     from supy.cmd.validate_config import validate_single_file
 
     # Process multiple configuration files

--- a/docs/source/api/python-cli-equivalents/validation.rst
+++ b/docs/source/api/python-cli-equivalents/validation.rst
@@ -19,7 +19,7 @@ Quick schema validation for checking configuration files:
 
     from pathlib import Path
     from supy.cmd.validate_config import validate_single_file
-    from supy.data_model.schema.publisher import generate_json_schema
+    from supy.data_model.configuration.publisher import generate_json_schema
 
     # Generate the current schema
     schema = generate_json_schema()

--- a/docs/source/contributing/schema/schema-developer.rst
+++ b/docs/source/contributing/schema/schema-developer.rst
@@ -1,18 +1,18 @@
-Schema Development Documentation
-=================================
+Configuration Schema Development
+================================
 
 .. note::
    This page is for developers working on the SUEWS data model. Users
    should refer to :ref:`schema_versioning` for the user-facing
    policy and to :ref:`transition_guide` for YAML upgrade paths.
 
-Schema Versioning Basics
-------------------------
+Configuration Schema Versioning Basics
+--------------------------------------
 
 - Schema labels are **CalVer** (``YYYY.M``), aligned with the SUEWS
   release in which each shape first shipped. The current label lives
   in ``CURRENT_SCHEMA_VERSION`` in
-  ``src/supy/data_model/schema/version.py``.
+  ``src/supy/data_model/configuration/version.py``.
 - SUEWS model versions (for example ``2026.4.3``) track code; schema
   versions track the YAML structure. One schema usually spans several
   SUEWS releases.
@@ -22,8 +22,8 @@ Schema Versioning Basics
   ``(old, current)`` has a registered handler (or the labels match).
   There is no separate compatibility table.
 
-When a Schema Bump Is Required
-------------------------------
+When a Configuration Schema Bump Is Required
+--------------------------------------------
 
 Bump when a PR changes a YAML-owned model under
 ``src/supy/data_model/core/`` in a way that prevents a previously valid
@@ -55,7 +55,7 @@ When a bump is required, touch every item below in the same PR. The
 definitive checklist is in
 ``.claude/rules/python/schema-versioning.md``.
 
-1. Edit ``src/supy/data_model/schema/version.py``: set
+1. Edit ``src/supy/data_model/configuration/version.py``: set
    ``CURRENT_SCHEMA_VERSION`` to the next CalVer label (shortest
    form, for example ``"2026.5"``), and add a ``SCHEMA_VERSIONS``
    entry describing precisely what changed, with issue / PR links.
@@ -116,8 +116,8 @@ policy in :ref:`data_interface_versioning`. The
 ``data-interface-version-audit`` workflow checks that those histories remain
 valid and append-only; contract-specific checks own content drift.
 
-Schema Management Commands
---------------------------
+Configuration Schema Management Commands
+----------------------------------------
 
 For developers, the ``suews schema`` command exposes schema
 management operations:
@@ -155,20 +155,20 @@ Python API
    schema = SUEWSConfig.model_json_schema()
 
    # Migrate between versions via the registered handler chain
-   from supy.data_model.schema.migration import SchemaMigrator
+   from supy.data_model.configuration.migration import SchemaMigrator
    migrator = SchemaMigrator()
    upgraded = migrator.migrate(old_config, to_version="2026.4")
 
 Implementation Map
 ------------------
 
-- ``src/supy/data_model/schema/`` — configuration schema version registry and
+- ``src/supy/data_model/configuration/`` — configuration schema version registry and
   compatibility helpers.
 - ``src/supy/data_model/forcing/version.py`` — forcing contract version
   ownership and release history.
 - ``src/supy/data_model/output/version.py`` — output contract version
   ownership and release history.
-- ``src/supy/data_model/schema/migration.py`` — ``SchemaMigrator``
+- ``src/supy/data_model/configuration/migration.py`` — ``SchemaMigrator``
   that consults the handler registry.
 - ``src/supy/util/converter/yaml_upgrade.py`` — migration handlers
   and the ``release-tag → schema`` mapping.

--- a/docs/source/contributing/schema/schema_versioning.rst
+++ b/docs/source/contributing/schema/schema_versioning.rst
@@ -154,12 +154,12 @@ Python API
 
 .. code-block:: python
 
-   from supy.data_model.schema.migration import SchemaMigrator
+   from supy.data_model.configuration.migration import SchemaMigrator
 
    migrator = SchemaMigrator()
    upgraded = migrator.migrate(old_config, to_version="2026.5")
 
-   from supy.data_model.schema.version import is_schema_compatible
+   from supy.data_model.configuration.version import is_schema_compatible
    if is_schema_compatible("2026.4"):
        print("2026.4 has a registered migration path to current")
 
@@ -169,7 +169,7 @@ Version History
 ---------------
 
 The lineage below mirrors ``SCHEMA_VERSIONS`` in
-``src/supy/data_model/schema/version.py``. Each release tag maps to
+``src/supy/data_model/configuration/version.py``. Each release tag maps to
 the schema that shipped with it via
 ``supy.util.converter.yaml_upgrade._PACKAGE_TO_SCHEMA``.
 

--- a/src/supy/cmd/init_case.py
+++ b/src/supy/cmd/init_case.py
@@ -16,7 +16,7 @@ import sys
 
 import click
 
-from ..data_model.schema.version import CURRENT_SCHEMA_VERSION
+from ..data_model.configuration.version import CURRENT_SCHEMA_VERSION
 from .json_envelope import EXIT_USER_ERROR, Envelope, _now_iso
 
 # Mapping of template name -> (relative path under ``src/supy/sample_data``,

--- a/src/supy/cmd/json_envelope.py
+++ b/src/supy/cmd/json_envelope.py
@@ -133,7 +133,7 @@ def _coerce_messages(items: Optional[Sequence[Any]]) -> list:
 
 def _build_meta(command: str, started_at: Optional[str]) -> dict[str, Any]:
     from supy import __version__ as supy_version
-    from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+    from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION
 
     started = started_at or _now_iso()
     return {

--- a/src/supy/cmd/schema_cli.py
+++ b/src/supy/cmd/schema_cli.py
@@ -28,9 +28,9 @@ import yaml
 # Import from supy modules
 try:
     from ..data_model.core.config import SUEWSConfig
-    from ..data_model.schema.migration import SchemaMigrator, check_migration_needed
-    from ..data_model.schema.publisher import generate_json_schema, save_schema
-    from ..data_model.schema.version import (
+    from ..data_model.configuration.migration import SchemaMigrator, check_migration_needed
+    from ..data_model.configuration.publisher import generate_json_schema, save_schema
+    from ..data_model.configuration.version import (
         CURRENT_SCHEMA_VERSION,
         SCHEMA_VERSIONS,
         get_schema_compatibility_message,
@@ -42,9 +42,9 @@ except ImportError:
 
     sys.path.append(str(Path(__file__).parent.parent.parent))
     from supy.data_model.core.config import SUEWSConfig
-    from supy.data_model.schema.migration import SchemaMigrator, check_migration_needed
-    from supy.data_model.schema.publisher import generate_json_schema, save_schema
-    from supy.data_model.schema.version import (
+    from supy.data_model.configuration.migration import SchemaMigrator, check_migration_needed
+    from supy.data_model.configuration.publisher import generate_json_schema, save_schema
+    from supy.data_model.configuration.version import (
         CURRENT_SCHEMA_VERSION,
         SCHEMA_VERSIONS,
         get_schema_compatibility_message,

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -71,9 +71,9 @@ try:
         STEBBS_PHYSICS_LEAF_RENAMES as _STEBBS_PHYSICS_LEAF_RENAMES,
     )
     from ..data_model.core.physics_families import flatten_physics_in_config
-    from ..data_model.schema.version import CURRENT_SCHEMA_VERSION
-    from ..data_model.schema.publisher import generate_json_schema
-    from ..data_model.schema.migration import SchemaMigrator, check_migration_needed
+    from ..data_model.configuration.version import CURRENT_SCHEMA_VERSION
+    from ..data_model.configuration.publisher import generate_json_schema
+    from ..data_model.configuration.migration import SchemaMigrator, check_migration_needed
 except ImportError:
     # Fallback for direct script execution
     import sys
@@ -86,9 +86,9 @@ except ImportError:
         STEBBS_PHYSICS_LEAF_RENAMES as _STEBBS_PHYSICS_LEAF_RENAMES,
     )
     from supy.data_model.core.physics_families import flatten_physics_in_config
-    from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
-    from supy.data_model.schema.publisher import generate_json_schema
-    from supy.data_model.schema.migration import SchemaMigrator, check_migration_needed
+    from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION
+    from supy.data_model.configuration.publisher import generate_json_schema
+    from supy.data_model.configuration.migration import SchemaMigrator, check_migration_needed
 
 # Sentinel used by the critical-physics-presence check below; module-level
 # so identity comparison stays stable across calls.
@@ -781,7 +781,7 @@ def version(files, update, target_version, backup):
     # Reuse common logic
     try:
         # Inline import to keep CLI startup light
-        from ..data_model.schema.version import CURRENT_SCHEMA_VERSION  # noqa: F401
+        from ..data_model.configuration.version import CURRENT_SCHEMA_VERSION  # noqa: F401
     except Exception:
         pass
     # Implement inline to avoid refactor breadth
@@ -793,7 +793,7 @@ def version(files, update, target_version, backup):
         table.add_column("Action", style="yellow")
 
     try:
-        from ..data_model.schema.version import (
+        from ..data_model.configuration.version import (
             CURRENT_SCHEMA_VERSION,
             is_schema_compatible,
         )
@@ -860,8 +860,8 @@ def version(files, update, target_version, backup):
 def export(output, version, fmt):
     """Export the configuration JSON Schema as JSON or YAML."""
     try:
-        from ..data_model.schema.version import CURRENT_SCHEMA_VERSION
-        from ..data_model.schema.publisher import generate_json_schema
+        from ..data_model.configuration.version import CURRENT_SCHEMA_VERSION
+        from ..data_model.configuration.publisher import generate_json_schema
     except Exception as e:
         console.print(f"[red]✗ Unable to load schema publisher: {e}[/red]")
         sys.exit(1)

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -570,7 +570,7 @@ class SUEWSConfig(BaseModel):
         SUEWSConfig
             The validated SUEWSConfig instance (self).
         """
-        from ..schema import validate_schema_version, CURRENT_SCHEMA_VERSION
+        from ..configuration import validate_schema_version, CURRENT_SCHEMA_VERSION
 
         # If no schema version specified, set to current
         if self.schema_version is None:
@@ -4500,8 +4500,8 @@ class SUEWSConfig(BaseModel):
         self-contradictory hint that pointed users at a command that could
         not work.
         """
-        from ..schema import CURRENT_SCHEMA_VERSION
-        from ..schema.migration import SchemaMigrator
+        from ..configuration import CURRENT_SCHEMA_VERSION
+        from ..configuration.migration import SchemaMigrator
 
         if had_signature:
             try:
@@ -4624,7 +4624,7 @@ class SUEWSConfig(BaseModel):
         config_data["_yaml_raw"] = yaml_raw_snapshot
 
         # Log schema version information if present
-        from ..schema import CURRENT_SCHEMA_VERSION, get_schema_compatibility_message
+        from ..configuration import CURRENT_SCHEMA_VERSION, get_schema_compatibility_message
 
         # Remember whether the source YAML carried a schema_version field so the
         # drift-hint builder does not report the default-stamped CURRENT_SCHEMA_VERSION

--- a/src/supy/util/converter/yaml_upgrade.py
+++ b/src/supy/util/converter/yaml_upgrade.py
@@ -40,8 +40,8 @@ from ...data_model.core.field_renames import (
     VEGETATEDSURFACEPROPERTIES_RENAMES,
     rename_keys_recursive,
 )
-from ...data_model.schema import CURRENT_SCHEMA_VERSION
-from ...data_model.schema.migration import SchemaMigrator
+from ...data_model.configuration import CURRENT_SCHEMA_VERSION
+from ...data_model.configuration.migration import SchemaMigrator
 
 # ---------------------------------------------------------------------------
 # Package-version -> schema-version resolver
@@ -52,7 +52,7 @@ from ...data_model.schema.migration import SchemaMigrator
 # ---------------------------------------------------------------------------
 
 # Retrospectively-assigned schema versions per formal release tag. The
-# `SCHEMA_VERSIONS` lineage in `src/supy/data_model/schema/version.py`
+# `SCHEMA_VERSIONS` lineage in `src/supy/data_model/configuration/version.py`
 # anchors each value here — see that file's docstring for the history of
 # why the schema version was frozen at "2025.12" through several structural
 # changes (gh#1304) and how the retrospective audit settled on these

--- a/test/cmd/test_json_envelope.py
+++ b/test/cmd/test_json_envelope.py
@@ -62,7 +62,7 @@ class TestEnvelopeMeta:
         assert env.meta["command"] == "suews validate"
 
     def test_meta_schema_version_matches_module(self) -> None:
-        from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+        from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION
 
         env = Envelope.success(data={}, command="suews schema info")
         assert env.meta["schema_version"] == CURRENT_SCHEMA_VERSION

--- a/test/cmd/test_validate_config.py
+++ b/test/cmd/test_validate_config.py
@@ -283,7 +283,7 @@ def test_validate_single_file_rejects_negative_sfr(tmp_path: Path) -> None:
     validator still has its own regression here.
     """
     from supy.cmd.validate_config import validate_single_file
-    from supy.data_model.schema.publisher import generate_json_schema
+    from supy.data_model.configuration.publisher import generate_json_schema
 
     payload = _load_sample_dict()
     _mutate_negative(payload)
@@ -302,7 +302,7 @@ def test_validate_single_file_rejects_storage_value_plus_nested_qf(
 ) -> None:
     """Malformed storage-heat family values must not be partially folded."""
     from supy.cmd.validate_config import validate_single_file
-    from supy.data_model.schema.publisher import generate_json_schema
+    from supy.data_model.configuration.publisher import generate_json_schema
 
     payload = _load_sample_dict()
     payload["model"]["physics"]["storage_heat"] = {
@@ -385,8 +385,8 @@ def test_validate_flags_missing_critical_physics_params(tmp_path: Path) -> None:
     user-facing semantics.
     """
     from supy.cmd.validate_config import validate_single_file
-    from supy.data_model.schema.publisher import generate_json_schema
-    from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+    from supy.data_model.configuration.publisher import generate_json_schema
+    from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION
     from supy.data_model.validation.pipeline.orchestrator import (
         CRITICAL_PHYSICS_PARAMS,
     )
@@ -435,8 +435,8 @@ def test_validate_flat_stebbs_form_not_flagged_missing(tmp_path: Path) -> None:
     them missing.
     """
     from supy.cmd.validate_config import validate_single_file
-    from supy.data_model.schema.publisher import generate_json_schema
-    from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+    from supy.data_model.configuration.publisher import generate_json_schema
+    from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION
 
     payload = _minimal_paved_only_config(CURRENT_SCHEMA_VERSION)
     # Populate every required family switch plus the relocated STEBBS leaves
@@ -609,7 +609,7 @@ def test_validate_full_pipeline_experimental_restriction_emits_json_envelope(
     needs its own envelope path rather than printing Rich text.
     """
     from supy.cmd.validate_config import cli as validate_cli
-    from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION
+    from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION
 
     payload = _minimal_paved_only_config(CURRENT_SCHEMA_VERSION)
     payload["model"]["physics"] = {"stebbs": {"value": 1}}
@@ -829,7 +829,7 @@ def test_validate_passes_when_critical_physics_present(tmp_path: Path) -> None:
     Guards against over-eager flagging that would break the happy path.
     """
     from supy.cmd.validate_config import validate_single_file
-    from supy.data_model.schema.publisher import generate_json_schema
+    from supy.data_model.configuration.publisher import generate_json_schema
 
     schema = generate_json_schema()
     with _sample_yaml_path() as sample:

--- a/test/data_model/test_forcing_validation.py
+++ b/test/data_model/test_forcing_validation.py
@@ -37,7 +37,7 @@ def test_model_control_accepts_legacy_forcing_file():
 
 def test_current_schema_version_bumped_for_forcing_restructure():
     """gh#1372 forcing.file restructure must be documented in the 2026.5 entry."""
-    from supy.data_model.schema.version import CURRENT_SCHEMA_VERSION, SCHEMA_VERSIONS
+    from supy.data_model.configuration.version import CURRENT_SCHEMA_VERSION, SCHEMA_VERSIONS
 
     # The gh#1372 forcing+output restructure landed during the 2026.5
     # development cycle (originally the dev9 cumulative bump). That cycle

--- a/test/data_model/test_from_yaml_errors.py
+++ b/test/data_model/test_from_yaml_errors.py
@@ -17,7 +17,7 @@ import yaml
 
 from supy._env import trv_supy_module
 from supy.data_model.core.config import SUEWSConfig
-from supy.data_model.schema import CURRENT_SCHEMA_VERSION
+from supy.data_model.configuration import CURRENT_SCHEMA_VERSION
 
 pytestmark = pytest.mark.api
 

--- a/test/data_model/test_release_compat.py
+++ b/test/data_model/test_release_compat.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 from supy.data_model.core.config import SUEWSConfig
-from supy.data_model.schema import CURRENT_SCHEMA_VERSION
+from supy.data_model.configuration import CURRENT_SCHEMA_VERSION
 from supy.util.converter.yaml_upgrade import (
     _PACKAGE_TO_SCHEMA,  # noqa: PLC2701 - test introspects the registry
     upgrade_yaml,

--- a/test/data_model/test_schema_version_sync.py
+++ b/test/data_model/test_schema_version_sync.py
@@ -1,7 +1,7 @@
 """
 Guard against `CURRENT_SCHEMA_VERSION` drifting from `sample_config.yml`.
 
-`src/supy/data_model/schema/version.py::CURRENT_SCHEMA_VERSION` is the
+`src/supy/data_model/configuration/version.py::CURRENT_SCHEMA_VERSION` is the
 canonical version label; `src/supy/sample_data/sample_config.yml` ships
 with `schema_version: '<version>'`. The two must agree, otherwise:
 
@@ -23,7 +23,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from supy.data_model.schema import CURRENT_SCHEMA_VERSION
+from supy.data_model.configuration import CURRENT_SCHEMA_VERSION
 
 pytestmark = pytest.mark.api
 

--- a/test/data_model/test_schema_versioning.py
+++ b/test/data_model/test_schema_versioning.py
@@ -51,7 +51,7 @@ def write_temp_sparse_schema_file(schema_version: str) -> Path:
 
 from supy.data_model.core import SUEWSConfig
 from supy.cmd.schema_cli import validate_file_against_schema
-from supy.data_model.schema import (
+from supy.data_model.configuration import (
     CURRENT_SCHEMA_VERSION,
     is_schema_compatible,
     get_schema_compatibility_message,

--- a/test/data_model/test_yaml_upgrade.py
+++ b/test/data_model/test_yaml_upgrade.py
@@ -20,7 +20,7 @@ import yaml
 
 from supy.cmd.table_converter import convert_table_cmd
 from supy.data_model.core.config import SUEWSConfig
-from supy.data_model.schema import CURRENT_SCHEMA_VERSION
+from supy.data_model.configuration import CURRENT_SCHEMA_VERSION
 from supy.util.converter.yaml_upgrade import (
     YamlUpgradeError,
     upgrade_yaml,

--- a/test/umep/test_preprocessor.py
+++ b/test/umep/test_preprocessor.py
@@ -24,14 +24,14 @@ class TestDatabaseManagerAPI(TestCase):
 
     def test_generate_json_schema_import(self):
         """Test that generate_json_schema is importable from expected location."""
-        from supy.data_model.schema.publisher import generate_json_schema
+        from supy.data_model.configuration.publisher import generate_json_schema
 
         self.assertIsNotNone(generate_json_schema)
         self.assertTrue(callable(generate_json_schema))
 
     def test_generate_json_schema_returns_valid_schema(self):
         """Test that generate_json_schema returns a valid JSON schema."""
-        from supy.data_model.schema.publisher import generate_json_schema
+        from supy.data_model.configuration.publisher import generate_json_schema
 
         schema = generate_json_schema()
 
@@ -50,7 +50,7 @@ class TestDatabaseManagerAPI(TestCase):
 
     def test_generate_json_schema_has_definitions(self):
         """Test that schema contains $defs used by Database Manager for validation."""
-        from supy.data_model.schema.publisher import generate_json_schema
+        from supy.data_model.configuration.publisher import generate_json_schema
 
         schema = generate_json_schema()
 
@@ -79,7 +79,7 @@ class TestDatabasePrepareAPI(TestCase):
     def test_validate_single_file_valid_config(self):
         """Test validation of a valid configuration file."""
         from supy.cmd.validate_config import validate_single_file
-        from supy.data_model.schema.publisher import generate_json_schema
+        from supy.data_model.configuration.publisher import generate_json_schema
 
         # Get sample config path
         sample_config = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
@@ -100,7 +100,7 @@ class TestDatabasePrepareAPI(TestCase):
     def test_validate_single_file_invalid_config(self):
         """Test validation handles invalid config gracefully."""
         from supy.cmd.validate_config import validate_single_file
-        from supy.data_model.schema.publisher import generate_json_schema
+        from supy.data_model.configuration.publisher import generate_json_schema
 
         schema = generate_json_schema()
 
@@ -120,7 +120,7 @@ class TestDatabasePrepareAPI(TestCase):
     def test_validate_single_file_sparse_config_is_invalid(self):
         """Sparse YAML must fail file-backed model validation."""
         from supy.cmd.validate_config import validate_single_file
-        from supy.data_model.schema.publisher import generate_json_schema
+        from supy.data_model.configuration.publisher import generate_json_schema
 
         schema = generate_json_schema()
         sparse_config = Path(__file__).parent.parent / "fixtures" / "sparse_site.yml"
@@ -135,7 +135,7 @@ class TestDatabasePrepareAPI(TestCase):
     def test_validate_single_file_explicit_older_schema_stays_schema_only(self):
         """Explicit older targets should not run current-schema semantic checks."""
         from supy.cmd.validate_config import validate_single_file
-        from supy.data_model.schema.publisher import generate_json_schema
+        from supy.data_model.configuration.publisher import generate_json_schema
 
         sparse_config = Path(__file__).parent.parent / "fixtures" / "sparse_site.yml"
         schema = generate_json_schema(version="2026.5.dev5")


### PR DESCRIPTION
## Summary

- migrate production, CLI, converter, generation, and benchmark imports to `supy.data_model.configuration`
- update current tests, documentation, and repository guidance to the canonical configuration-schema owner
- preserve the silent `supy.data_model.schema` compatibility package, dedicated UMEP compatibility tests, stable CLI names, schema constants, and documentation URLs
- retain knowledge-pack classification for both canonical modules and compatibility wrappers; canonical version ownership was established in Layer A

## Validation

- `make test-smoke` (9 passed, 1 skipped)
- focused configuration/CLI/UMEP/knowledge tests (222 passed, 17 skipped)
- canonical and legacy exporter entry-point smoke checks
- schema-version audit, knowledge-pack freshness audit, pathlib encoding audit
- exact-HEAD independent review: clean
- residual legacy-import scan: clean outside compatibility surfaces

Closes #1663