### PR TITLE
Test observable output layout parity

### DIFF
--- a/test/core/test_run_rust.py
+++ b/test/core/test_run_rust.py
@@ -63,6 +63,31 @@ def test_validate_output_layout_reports_generated_registry_path(monkeypatch):
     assert "src/supy/data_model/output/dailystate_vars.py" in str(exc_info.value)
 
 
+def test_parse_output_block_preserves_registry_layout_and_missing_values():
+    """Label emitted groups in exact registry order and expose sentinels as NaN."""
+    output = np.zeros((_run_rust.OUTPUT_ALL_COLS,), dtype=np.float64)
+    output[:4] = [2012, 1, 0, 5]
+
+    offset = 0
+    for group_ordinal, (_, ncols) in enumerate(_run_rust.OUTPUT_GROUP_LAYOUT):
+        data_start = offset + _run_rust.OUTPUT_TIME_COLS
+        output[data_start : offset + ncols] = group_ordinal + 1
+        offset += ncols
+    output[_run_rust.OUTPUT_TIME_COLS] = -999.0
+
+    parsed = _run_rust._parse_output_block(output.tolist(), len_sim=1, grid_id=7)
+    expected_columns = [
+        (group, variable)
+        for group, _ in _run_rust.OUTPUT_GROUP_LAYOUT
+        for variable in _run_rust.df_var.xs(group, level="group").index
+    ]
+
+    assert parsed.columns.to_list() == expected_columns
+    assert parsed.columns.names == ["group", "var"]
+    assert parsed.index.names == ["grid", "datetime"]
+    assert pd.isna(parsed.iloc[0, 0])
+
+
 def _minimal_forcing_frame() -> pd.DataFrame:
     index = pd.date_range("2011-01-01 00:05", periods=2, freq="5min")
     return pd.DataFrame(

--- a/test/data_model/test_output_contract.py
+++ b/test/data_model/test_output_contract.py
@@ -111,6 +111,16 @@ def test_catalogue_is_an_exact_registry_projection():
     assert len(set_identities) == len(catalogue.variables)
 
 
+def test_dataframe_index_preserves_exact_registry_order():
+    """Keep DataFrame identities in the registry's authoritative order."""
+    expected = [
+        (str(_value(variable.group)), variable.name)
+        for variable in OUTPUT_REGISTRY.variables
+    ]
+
+    assert OUTPUT_REGISTRY.to_dataframe().index.to_list() == expected
+
+
 def test_group_order_and_scopes_are_explicit():
     """Classify every registry group once without changing registry order."""
     catalogue = get_output_contract_catalogue()

--- a/test/io_tests/test_output_layout_parity.py
+++ b/test/io_tests/test_output_layout_parity.py
@@ -1,0 +1,78 @@
+"""Observable output writer layout parity tests."""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import pyarrow.parquet as pq
+
+from supy._save import save_df_grid_group, save_df_output_parquet
+
+pytestmark = pytest.mark.api
+
+
+def test_text_layout_prefix_sentinel_and_filenames(tmp_path: Path):
+    """Preserve text prefix order, missing sentinel, and group filenames."""
+    index = pd.date_range("2012-01-01 00:05", periods=2, freq="5min")
+    suews = pd.DataFrame(
+        {"QH": [10.0, np.nan], "Rain": [0.0, 1.5]},
+        index=index,
+    )
+
+    path_suews = save_df_grid_group(suews, 7, "SUEWS", tmp_path, "site")
+    header, *rows = path_suews.read_text(encoding="utf-8").splitlines()
+
+    assert path_suews.name == "site7_2012_SUEWS_5.txt"
+    assert [field.strip() for field in header.split("\t")] == [
+        "Year",
+        "DOY",
+        "Hour",
+        "Min",
+        "Dectime",
+        "QH",
+        "Rain",
+    ]
+    assert rows[1].split("\t")[5].strip() == "-999.0000"
+
+    daily = pd.DataFrame({"HDD1_h": [2.0]}, index=index[:1])
+    path_daily = save_df_grid_group(daily, 7, "DailyState", tmp_path, "site")
+    assert path_daily.name == "site7_2012_DailyState.txt"
+
+
+def test_parquet_layout_and_null_round_trip(tmp_path: Path):
+    """Preserve ordered output identities and represent missing values as null."""
+    index = pd.MultiIndex.from_product(
+        [[7], pd.date_range("2012-01-01 00:05", periods=2, freq="5min")],
+        names=["grid", "datetime"],
+    )
+    columns = pd.MultiIndex.from_tuples(
+        [("SUEWS", "QH"), ("SUEWS", "Rain"), ("ESTM", "Ts")],
+        names=["group", "var"],
+    )
+    output = pd.DataFrame(
+        [[10.0, 0.0, 12.0], [np.nan, 1.5, 13.0]],
+        index=index,
+        columns=columns,
+    )
+
+    paths = save_df_output_parquet(
+        output,
+        pd.DataFrame(),
+        site="site",
+        path_dir_save=tmp_path,
+        save_tstep=True,
+        save_state=False,
+    )
+    saved = pd.read_parquet(paths[0])
+    arrow_table = pq.read_table(paths[0])
+
+    assert [path.name for path in paths] == [
+        "site_SUEWS_output.parquet",
+        "site_SUEWS_metadata.parquet",
+    ]
+    assert saved.columns.to_list() == columns.to_list()
+    assert saved.columns.names == ["group", "var"]
+    pd.testing.assert_index_equal(saved.index, index)
+    assert pd.isna(saved.loc[(7, index.levels[1][1]), ("SUEWS", "QH")])
+    assert arrow_table.column("('SUEWS', 'QH')").null_count == 1

--- a/test/io_tests/test_save_supy.py
+++ b/test/io_tests/test_save_supy.py
@@ -94,24 +94,17 @@ class TestSaveSuPy:
         df_output, df_state_final = sample_output
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Save only DailyState group
-            # Note: Currently dict-based output_config doesn't support groups filtering
-            # This would require using the OutputControl class from data_model
-            # For now, we'll test that the default behavior works
-
-            # Test default behavior (should include SUEWS)
             list_files = sp.save_supy(
-                df_output, df_state_final, path_dir_save=tmpdir, site="test"
+                df_output,
+                df_state_final,
+                path_dir_save=tmpdir,
+                site="test",
+                output_config=OutputControl(groups=["SUEWS"]),
+                save_state=False,
             )
 
-            # Check that both SUEWS and state files were created
-            assert len(list_files) >= 2, (
-                "At least SUEWS and state files should be created"
-            )
-
-            # SUEWS file should be created by default
-            suews_files = [f for f in list_files if "SUEWS" in str(f)]
-            assert len(suews_files) > 0, "SUEWS file should be created by default"
+            assert list_files
+            assert all("_SUEWS_" in Path(path).name for path in list_files)
 
     def test_resample_frequency(self, sample_output):
         """Test different resampling frequencies."""


### PR DESCRIPTION
## Summary

- pin the exact `OUTPUT_REGISTRY` order used by the DataFrame projection and parsed runtime groups
- verify text datetime prefixes, `-999.0` missing values, filename conventions, and real text group selection
- verify Parquet `(group, variable)` ordering and physical Arrow null representation
- retain compiled group-count checks as structural parity without claiming per-variable Fortran scientific semantics

This is Layer B of #1656. It adds observable contract tests only and does not change output values, layouts, selection behaviour, or the unpublished output version.

## Validation

- `pytest -q test/data_model/test_output_contract.py test/data_model/test_output_models.py test/core/test_run_rust.py test/core/test_post.py test/io_tests/test_output_config.py test/io_tests/test_output_layout_parity.py test/io_tests/test_resample_output.py test/io_tests/test_dailystate_output.py test/io_tests/test_save_supy.py::TestSaveSuPy::test_save_output_groups_filter` (82 passed)
- `make test-smoke` (9 passed, 1 skipped)
- independent exact-HEAD review clean for `8e7ce0ed97130d71bae978a64371009573762f31`

Refs #1656
