### PR TITLE
Define water-use forcing in millimetres

### DIFF
--- a/docs/source/data-structures/df_forcing.rst
+++ b/docs/source/data-structures/df_forcing.rst
@@ -34,7 +34,7 @@
 .. option:: Wuh
 
     :Description:
-        External water use [|m^3|]
+        Site-mean external water-use depth accumulated over the forcing interval [mm]
 
 
 .. option:: fcld

--- a/docs/source/inputs/forcing-data.rst
+++ b/docs/source/inputs/forcing-data.rst
@@ -140,6 +140,12 @@ matched, case-insensitively, against the canonical column list above.
 * **Optional canonical columns**: missing canonical columns outside the
   required set are filled with ``-999.0`` (the SUEWS sentinel). Column
   order is irrelevant.
+* **External water use**: bulk ``Wuh`` (also accepted as ``wu_mm``) is a
+  non-negative, site-mean depth in **mm accumulated over the forcing time
+  step**. It has no finite upper validation cap and is resampled as a sum,
+  like ``rain``. Use ``-999`` when this optional input is missing. Legacy
+  bulk values in m3 must be converted explicitly; see
+  :ref:`migrate_bulk_wuh`.
 * **Per-landcover variants**: the loader also accepts whitelisted
   ``<var>_<surface>`` columns:
 
@@ -171,9 +177,11 @@ matched, case-insensitively, against the canonical column list above.
   continues to use the bulk ``lai`` and ``Wuh`` columns as default
   values for legacy or bulk calculations. These bulk values are applied
   to all applicable surfaces unless a corresponding land-cover-specific
-  value is provided, in which case the surface-specific value overrides
-  the bulk value. Soil-moisture deficit (``xsmd``) is a bulk site-level
-  quantity and is intentionally not per-landcover.
+  column is provided, in which case its value overrides the bulk value.
+  An explicit ``-999`` in a surface-specific column is preserved as missing;
+  it does not silently fall back to bulk ``Wuh``. Soil-moisture deficit
+  (``xsmd``) is a bulk site-level quantity and is intentionally not
+  per-landcover.
 * **Unknown columns**: any column not in the canonical or whitelisted
   sets emits a ``UserWarning`` and is dropped.
 

--- a/docs/source/inputs/tables/SUEWS_SiteInfo/Input_Options.rst
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/Input_Options.rst
@@ -4446,7 +4446,7 @@ Input Options
 .. option:: Wuh
 
 	:Description:
-		External water use [|m^3|]
+		Site-mean external water-use depth accumulated over the forcing interval [mm]
 
 	:Configuration:
 		.. csv-table::

--- a/docs/source/inputs/tables/SUEWS_SiteInfo/csv-table/Wuh.csv
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/csv-table/Wuh.csv
@@ -1,2 +1,2 @@
 "Referencing Table","Requirement","Comment"
-"`SSss_YYYY_data_tt.txt`","`O`","External water use [ |m^3|]"
+"`SSss_YYYY_data_tt.txt`","`O`","Site-mean external water-use depth accumulated over the forcing interval [mm]"

--- a/docs/source/inputs/transition_guide.rst
+++ b/docs/source/inputs/transition_guide.rst
@@ -165,6 +165,49 @@ The converter intelligently handles various directory structures by reading the 
   
 This ensures compatibility with various SUEWS installation structures while respecting user configurations.
 
+.. _migrate_bulk_wuh:
+
+Migrating legacy bulk ``Wuh`` volumes
+--------------------------------------
+
+Bulk ``Wuh`` is now a site-mean external water-use depth in mm accumulated
+over each forcing interval. This is a breaking unit change from historical
+forcing files that supplied bulk ``Wuh`` as a volume in m3. Convert each old
+interval value before running:
+
+.. math::
+
+   Wuh_{mm} = 1000 \, \frac{Wuh_{m^3}}{A_{grid,m^2}}
+
+where :math:`A_{grid,m^2}` is the horizontal plan area of the grid cell.
+This conversion preserves the grid-total water volume, but it does **not**
+preserve the historical allocation between surfaces. The old runtime divided
+the volume by the total irrigated area and then applied each surface's
+``irrigation_fraction``. Consequently, using only the converted bulk value can
+change surface stores and evaporation even though the grid-total input is the
+same.
+
+To reproduce that historical surface allocation, supply all seven
+``wuh_<surface>`` columns (including explicit zeros) using
+
+.. math::
+
+   wuh_i = 1000 \, \frac{Wuh_{m^3}}{A_{grid,m^2}
+            \sum_j (sfr_j \, IrrFrac_j)} \, IrrFrac_i
+
+where :math:`sfr_j` and :math:`IrrFrac_j` are the historical surface fraction
+and irrigation fraction for surface :math:`j`. If the denominator is zero,
+the historical runtime supplied zero observed water use. Supplying every
+surface column is necessary because an omitted surface otherwise falls back
+to bulk ``Wuh``.
+
+The ``wu_mm`` header remains an alias for ``Wuh``, but aliases do not perform
+unit conversion. SUEWS deliberately provides no magnitude detection or
+legacy-unit runtime mode, so copying historical bulk values unchanged will
+give a different water input. Surface-specific ``wuh_<surface>`` columns are
+also non-negative depths in mm per forcing interval and override bulk ``Wuh``
+for that surface.
+
 YAML Schema Migrations
 ----------------------
 

--- a/src/suews/src/suews_phys_waterdist.f95
+++ b/src/suews/src/suews_phys_waterdist.f95
@@ -1340,9 +1340,8 @@ CONTAINS
                           bsoilPrm%irrigation_fraction_bsoil, waterPrm%irrigation_fraction_water]
 
                ! --------------------------------------------------------------------------------
-               ! If water used is observed and provided in the met forcing file, units are m3
-               ! Divide observed water use (in m3) by water use area to find water use (in mm)
-               ! 2026-05-19, MP: Updated to only take per land cover forcing (incoming in mm)
+               ! Resolved per-surface observed water-use inputs passed to the kernel
+               ! are depths [mm] accumulated over the forcing interval.
                IF (WaterUseMethod == 1) THEN !If water use is observed
                   ! Reset per-surface observed water use each timestep so a
                   ! surface whose forcing column is missing (-999 sentinel)

--- a/src/suews_bridge/src/forcing.rs
+++ b/src/suews_bridge/src/forcing.rs
@@ -205,7 +205,7 @@ suews_fields! {
 
     (fcld, 17, ["fcld"], InterpKind::Instantaneous, false),
 
-    (wu_mm, 18, ["wu_mm", "wuh"], InterpKind::Instantaneous, false),
+    (wu_mm, 18, ["wu_mm", "wuh"], InterpKind::Sum, false),
 
     (xsmd, 19, ["xsmd"], InterpKind::Instantaneous, false),
 

--- a/src/suews_bridge/src/forcing_io.rs
+++ b/src/suews_bridge/src/forcing_io.rs
@@ -273,6 +273,8 @@ pub fn read_forcing_block(path: &Path) -> Result<ForcingData, String> {
             )?;
         }
 
+        validate_wuh_fields(&row, line_no)?;
+
         // Convert pressure from kPa (SUEWS input convention) to hPa (Fortran internal).
         // Matches supy/_load.py: df_forcing_met["pres"] *= 10.
         // pres is in BASELINE_FORCING_COLUMNS so it is always read; defend against
@@ -380,6 +382,20 @@ fn apply_field(
         ));
     }
 
+    Ok(())
+}
+
+fn validate_wuh_fields(row: &[f64], line_no: usize) -> Result<(), String> {
+    let fields = std::iter::once(SuewsField::wu_mm).chain(per_landcover_fields("wuh"));
+    for field in fields {
+        let value = row[field.index()];
+        if value != FORCING_OPTIONAL_FILL && (!value.is_finite() || value < 0.0) {
+            return Err(format!(
+                "forcing value for `{}` at line {line_no} must be finite and non-negative or exact {FORCING_OPTIONAL_FILL}",
+                field.name()
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -642,6 +658,8 @@ mod tests {
         block[SuewsField::u.index()] = 10.0; // U (inst)
         block[SuewsField::kdown.index()] = 100.0; // kdown (avg)
         block[SuewsField::rain.index()] = 12.0; // rain (sum)
+        block[SuewsField::wu_mm.index()] = 12.0; // bulk water use (sum)
+        block[SuewsField::wu_mm_paved.index()] = -999.0; // exact missing sentinel
 
         // Row 1: (2012, 1, 2, 0), U=20
         let r1 = FORCING_BLOCK_STRIDE;
@@ -652,6 +670,8 @@ mod tests {
         block[r1 + SuewsField::u.index()] = 20.0;
         block[r1 + SuewsField::kdown.index()] = 200.0;
         block[r1 + SuewsField::rain.index()] = 24.0;
+        block[r1 + SuewsField::wu_mm.index()] = 24.0;
+        block[r1 + SuewsField::wu_mm_paved.index()] = -999.0;
         // Row 2: (2012, 1, 3, 0), U=30
         let r2 = 2 * FORCING_BLOCK_STRIDE;
         block[r2] = 2012.0;
@@ -661,6 +681,8 @@ mod tests {
         block[r2 + SuewsField::u.index()] = 30.0;
         block[r2 + SuewsField::kdown.index()] = 300.0;
         block[r2 + SuewsField::rain.index()] = 0.0;
+        block[r2 + SuewsField::wu_mm.index()] = -999.0;
+        block[r2 + SuewsField::wu_mm_paved.index()] = -999.0;
 
         let forcing = ForcingData {
             block,
@@ -695,6 +717,15 @@ mod tests {
         assert!((row_val(&result, 11, SuewsField::rain.index()) - 1.0).abs() < 1e-9);
         // Row 12 maps to input row 1: rain=24.0 → 2.0
         assert!((row_val(&result, 12, SuewsField::rain.index()) - 2.0).abs() < 1e-9);
+        // Bulk Wuh uses the same sum redistribution as rain.
+        assert!((row_val(&result, 0, SuewsField::wu_mm.index()) - 1.0).abs() < 1e-9);
+        assert!((row_val(&result, 11, SuewsField::wu_mm.index()) - 1.0).abs() < 1e-9);
+        assert!((row_val(&result, 12, SuewsField::wu_mm.index()) - 2.0).abs() < 1e-9);
+        // Exact bulk and surface missing values stay missing instead of
+        // becoming a flux.
+        assert_eq!(row_val(&result, 24, SuewsField::wu_mm.index()), -999.0);
+        assert_eq!(row_val(&result, 0, SuewsField::wu_mm_paved.index()), -999.0);
+        assert_eq!(row_val(&result, 12, SuewsField::wu_mm_paved.index()), -999.0);
     }
 
     #[test]
@@ -830,6 +861,34 @@ mod tests {
         assert_eq!(row_val(&forcing, 0, SuewsField::wu_mm_grass.index()), -999.0);
         assert_eq!(row_val(&forcing, 0, SuewsField::wu_mm_bsoil.index()), 2.5);
         assert_eq!(row_val(&forcing, 0, SuewsField::wu_mm_water.index()), 2.5);
+    }
+
+    #[test]
+    fn invalid_wuh_values_are_rejected_at_reader_boundary() {
+        use std::io::Write;
+
+        for invalid in ["-950", "NaN", "inf"] {
+            let dir = tempfile::tempdir().unwrap();
+
+            let bulk_path = dir.path().join("invalid-bulk-wuh.txt");
+            let mut bulk = std::fs::File::create(&bulk_path).unwrap();
+            writeln!(bulk, "iy id it imin Tair RH U pres kdown rain Wuh").unwrap();
+            writeln!(bulk, "2011 1 0 5 18 80 2 100 0 0 {invalid}").unwrap();
+            let error = read_forcing_block(&bulk_path).expect_err("invalid bulk Wuh");
+            assert!(error.contains("wu_mm"), "error: {error}");
+
+            let surface_path = dir.path().join("invalid-surface-wuh.txt");
+            let mut surface = std::fs::File::create(&surface_path).unwrap();
+            writeln!(
+                surface,
+                "iy id it imin Tair RH U pres kdown rain Wuh wuh_paved"
+            )
+            .unwrap();
+            writeln!(surface, "2011 1 0 5 18 80 2 100 0 0 2 {invalid}").unwrap();
+            let error =
+                read_forcing_block(&surface_path).expect_err("invalid surface Wuh");
+            assert!(error.contains("wu_mm_paved"), "error: {error}");
+        }
     }
 
     #[test]

--- a/src/supy/_check.py
+++ b/src/supy/_check.py
@@ -55,6 +55,28 @@ _FORCING_RUNTIME_RULES = {
     }
     for name, (lower, upper, unit) in FORCING_REGISTRY.runtime_validation_ranges.items()
 }
+_FORCING_RUNTIME_RULES.update({
+    variable.name.casefold(): {
+        "cat": "grid",
+        "logic": "range",
+        "optional": True,
+        "param": {
+            "min": (
+                "-inf"
+                if variable.validation_range[0] is None
+                else variable.validation_range[0] * variable.runtime_scale
+            ),
+            "max": (
+                "inf"
+                if variable.validation_range[1] is None
+                else variable.validation_range[1] * variable.runtime_scale
+            ),
+        },
+        "unit": variable.runtime_unit or variable.unit or "unresolved",
+    }
+    for variable in FORCING_REGISTRY.variables
+    if variable.fallback == "Wuh" and variable.validation_range is not None
+})
 
 
 # checking the range of each parameter
@@ -74,11 +96,20 @@ def check_range(ser_to_check: pd.Series, rule_var: dict) -> Tuple:
 
     # if the parameter is optional and not set, it is accepted
     from .util import to_nan
+    from .util._missing import SUEWS_MISSING
 
-    ser_to_check_nan = to_nan(ser_to_check)
-    if flag_optional:
+    # Observed water use is consumed by the kernel with an exact -999
+    # sentinel check. Do not let other large negative values pass as missing.
+    is_wuh = var == "wuh" or var.startswith("wuh_")
+    if is_wuh:
+        ser_to_check_nan = ser_to_check.loc[ser_to_check != SUEWS_MISSING]
+    else:
+        ser_to_check_nan = to_nan(ser_to_check)
+    if flag_optional and not is_wuh:
         ser_to_check_nan = ser_to_check_nan.dropna()
     ser_flag = ~ser_to_check_nan.between(min_v, max_v)
+    if is_wuh:
+        ser_flag = ser_flag | ~np.isfinite(ser_to_check_nan)
     n_flag = ser_flag.sum()
     if ser_flag.sum() > 0:
         is_accepted_flag = False
@@ -387,7 +418,19 @@ def check_forcing(
                 var_check = var.lower()
                 min_v = rules[var_check]["param"]["min"]
                 max_v = rules[var_check]["param"]["max"]
+                min_v = -np.inf if isinstance(min_v, str) else min_v
+                max_v = np.inf if isinstance(max_v, str) else max_v
+                missing_mask = None
+                nonfinite_mask = None
+                if var_check == "wuh" or var_check.startswith("wuh_"):
+                    from .util._missing import SUEWS_MISSING
+
+                    missing_mask = ser_var == SUEWS_MISSING
+                    nonfinite_mask = ~np.isfinite(ser_var)
                 ser_var = ser_var.clip(lower=min_v, upper=max_v)
+                if missing_mask is not None:
+                    ser_var.loc[missing_mask] = SUEWS_MISSING
+                    ser_var.loc[nonfinite_mask] = SUEWS_MISSING
                 df_forcing_fix.loc[:, var] = ser_var.values
 
     # 4. check physics-specific requirements if physics dict is provided

--- a/src/supy/_load.py
+++ b/src/supy/_load.py
@@ -160,6 +160,27 @@ def _per_landcover_forcing_var(name: str) -> Optional[str]:
     return None
 
 
+def _validate_wuh_values(data_forcing: pd.DataFrame) -> None:
+    """Validate observed water use before generic sentinel normalisation."""
+    for column in data_forcing.columns:
+        is_wuh = str(column).casefold() == "wuh" or (
+            _per_landcover_forcing_var(str(column)) == "wuh"
+        )
+        if not is_wuh:
+            continue
+        values = data_forcing[column]
+        invalid = (values != FORCING_OPTIONAL_FILL) & (
+            ~np.isfinite(values) | (values < 0)
+        )
+        if invalid.any():
+            positions = np.flatnonzero(invalid.to_numpy()).tolist()
+            raise ValueError(
+                f"forcing column '{column}' must contain finite non-negative "
+                f"water-use depths or exact {FORCING_OPTIONAL_FILL}; invalid "
+                f"row position(s): {positions}"
+            )
+
+
 def _coalesce_case_variant_columns(
     df: pd.DataFrame,
     columns: list[str],
@@ -484,12 +505,11 @@ def resample_kdn(data_raw_kdn, tstep_mod, timezone, lat, lon, alt):
 # correct precipitation by even redistribution over resampled periods
 def resample_sum(data_raw_precip, tstep_in, tstep_mod):
     # gh#1372 review: preserve the FORCING_OPTIONAL_FILL (-999) sentinel
-    # for sum columns that carry no real data. ``to_nan`` upstream has
-    # already converted the sentinel to NaN; without this guard the
+    # for ordinary sum columns that carry no real data. ``to_nan`` upstream
+    # has converted their sentinel to NaN; without this guard the
     # ``fillna(0.0)`` at the end would silently turn "missing" into
-    # "valid zero", masking truly absent inputs (e.g. an hourly forcing
-    # file that omits Wuh would surface as zero water use instead of
-    # being treated as missing under the observed-water-use path).
+    # "valid zero". Wuh is restored before this function and handled per
+    # input interval below because it uses the exact -999 contract.
     sentinel_columns = [
         c for c in data_raw_precip.columns if data_raw_precip[c].isna().all()
     ]
@@ -512,6 +532,23 @@ def resample_sum(data_raw_precip, tstep_in, tstep_mod):
     # Restore sentinel for columns that were entirely missing on input.
     for col in sentinel_columns:
         data_tstep_precip_adj[col] = FORCING_OPTIONAL_FILL
+    # Wuh uses an exact per-interval sentinel contract. Split each valid
+    # accumulated depth evenly and repeat -999 across the corresponding
+    # output interval, matching the Rust reader.
+    ratio_steps = int(tstep_in / tstep_mod)
+    for col in data_raw_precip.columns:
+        is_wuh = str(col).casefold() == "wuh" or (
+            _per_landcover_forcing_var(str(col)) == "wuh"
+        )
+        if not is_wuh:
+            continue
+        expanded = np.repeat(data_raw_precip[col].to_numpy(), ratio_steps)
+        expanded = expanded[: len(data_tstep_precip_adj)]
+        data_tstep_precip_adj[col] = np.where(
+            expanded == FORCING_OPTIONAL_FILL,
+            FORCING_OPTIONAL_FILL,
+            expanded * ratio_precip,
+        )
     return data_tstep_precip_adj
 
 
@@ -598,8 +635,17 @@ def resample_forcing_met(
 
     from .util import to_nan
 
+    _validate_wuh_values(data_met_raw)
+    wuh_columns = [
+        column
+        for column in data_met_raw.columns
+        if str(column).casefold() == "wuh"
+        or _per_landcover_forcing_var(str(column)) == "wuh"
+    ]
+    data_wuh_raw = data_met_raw.loc[:, wuh_columns].copy()
     data_met_raw = data_met_raw.copy()
     data_met_raw = to_nan(data_met_raw)
+    data_met_raw.loc[:, wuh_columns] = data_wuh_raw
     # this line is kept for occasional debugging:
     if logger_supy.level < 20:
         p_data_met_raw = "data_met_raw.pkl"
@@ -903,6 +949,7 @@ def _apply_named_column_matching(df_forcing_met: pd.DataFrame) -> pd.DataFrame:
         df_canonical[name] = series.to_numpy()
 
     # 6) Existing post-processing.
+    _validate_wuh_values(df_canonical)
     df_canonical["pres"] *= 10  # kPa -> hPa
     df_canonical["isec"] = 0
     complete_dt_columns = list(BASELINE_DATETIME_FORCING_COLUMNS) + ["isec"]

--- a/src/supy/checker_rules_indiv.json
+++ b/src/supy/checker_rules_indiv.json
@@ -2253,10 +2253,10 @@
         "cat": "grid",
         "logic": "range",
         "param": {
-            "max": 10,
+            "max": "inf",
             "min": 0
         },
-        "unit": "m3"
+        "unit": "mm"
     },
     "wuprofa_24hr": {
         "cat": "grid",

--- a/src/supy/data_model/forcing/variables.py
+++ b/src/supy/data_model/forcing/variables.py
@@ -261,7 +261,7 @@ _FORCING_VARIABLES = (
     ),
     _variable(
         "Wuh",
-        None,
+        "mm",
         "Bulk external water use accumulated over the forcing interval",
         "driver",
         "sum",
@@ -269,14 +269,8 @@ _FORCING_VARIABLES = (
         "sentinel",
         accessor_aliases=("water_use", "external_water", "wu_mm"),
         file_aliases=("wu_mm",),
+        validation_range=(0, None),
         legacy_position=19,
-        metadata_note=(
-            "Python resampling treats bulk Wuh as a sum, while the Rust reader "
-            "currently treats it as instantaneous. The forcing documentation now "
-            "declares mm per interval, while the legacy checker still declares m3 "
-            "and an upper bound of 10; resolve #1440, #1441, and #1447 before "
-            "publication"
-        ),
     ),
     _variable(
         "xsmd",
@@ -387,6 +381,7 @@ _FORCING_VARIABLES = (
         "conditional",
         "fallback",
         file_aliases=("wu_mm_paved",),
+        validation_range=(0, None),
         fallback="Wuh",
     ),
     _variable(
@@ -398,6 +393,7 @@ _FORCING_VARIABLES = (
         "conditional",
         "fallback",
         file_aliases=("wu_mm_bldgs",),
+        validation_range=(0, None),
         fallback="Wuh",
     ),
     _variable(
@@ -409,6 +405,7 @@ _FORCING_VARIABLES = (
         "conditional",
         "fallback",
         file_aliases=("wu_mm_evetr",),
+        validation_range=(0, None),
         fallback="Wuh",
     ),
     _variable(
@@ -420,6 +417,7 @@ _FORCING_VARIABLES = (
         "conditional",
         "fallback",
         file_aliases=("wu_mm_dectr",),
+        validation_range=(0, None),
         fallback="Wuh",
     ),
     _variable(
@@ -431,6 +429,7 @@ _FORCING_VARIABLES = (
         "conditional",
         "fallback",
         file_aliases=("wu_mm_grass",),
+        validation_range=(0, None),
         fallback="Wuh",
     ),
     _variable(
@@ -442,6 +441,7 @@ _FORCING_VARIABLES = (
         "conditional",
         "fallback",
         file_aliases=("wu_mm_bsoil",),
+        validation_range=(0, None),
         fallback="Wuh",
     ),
     _variable(
@@ -453,6 +453,7 @@ _FORCING_VARIABLES = (
         "conditional",
         "fallback",
         file_aliases=("wu_mm_water",),
+        validation_range=(0, None),
         fallback="Wuh",
     ),
 )

--- a/src/supy/suews_forcing.py
+++ b/src/supy/suews_forcing.py
@@ -301,7 +301,8 @@ class SUEWSForcing:
         of length ``len(self.df)``. Empty when the file carries no
         whitelisted per-landcover columns. The kernel-facing adapter
         consumes ``lai_evetr``, ``lai_dectr`` and ``lai_grass`` when
-        present; ``wuh_*`` remains metadata for future water-use work.
+        present; ``wuh_*`` supplies the corresponding surface-specific
+        observed water-use depth to the kernel.
 
         Returns
         -------

--- a/src/supy/util/_io.py
+++ b/src/supy/util/_io.py
@@ -12,7 +12,7 @@ from .._load import (
     resample_forcing_met,
     set_index_dt,
 )
-from ._missing import from_nan, to_nan
+from ._missing import from_nan
 
 # Surface air pressure is never below ~300 hPa (that altitude is well into
 # the free troposphere, not a surface site). A DataFrame whose median
@@ -112,9 +112,8 @@ def resample_forcing_df(df_forcing_raw: pd.DataFrame, tstep_mod=300) -> pd.DataF
 
     # resampling only when necessary
     if tstep_mod is not None and tstep_mod < tstep_met_in:
-        df_forcing = to_nan(df_forcing_raw)
         df_forcing = resample_forcing_met(
-            df_forcing, tstep_met_in, tstep_mod, kdownzen=0
+            df_forcing_raw, tstep_met_in, tstep_mod, kdownzen=0
         )
         df_forcing = from_nan(df_forcing)
 

--- a/test/data_model/test_forcing_registry.py
+++ b/test/data_model/test_forcing_registry.py
@@ -2,6 +2,7 @@
 
 # This parity test intentionally inspects the current private forcing constants.
 
+import json
 from pathlib import Path
 import re
 import subprocess
@@ -229,12 +230,10 @@ def test_rust_file_aliases_exclude_internal_positions() -> None:
     )
     assert re.search(
         r'\(wu_mm,\s*18,\s*\["wu_mm",\s*"wuh"\],\s*'
-        r"InterpKind::Instantaneous",
+        r"InterpKind::Sum",
         rust_source,
     )
-    assert "Rust reader currently treats it as instantaneous" in (
-        bulk_wuh.metadata_note or ""
-    )
+    assert bulk_wuh.temporal == "sum"
     assert all(
         variable.legacy_position is None
         for variable in FORCING_REGISTRY.variables
@@ -318,17 +317,26 @@ def test_registry_rejects_ambiguous_aliases_and_unknown_requirements() -> None:
         ForcingRegistry(variables=(first,), requirement_rules=(bad_rule,))
 
 
-def test_unresolved_scientific_metadata_stays_explicit_and_unpublished() -> None:
-    """Do not turn conflicting sources into a published scientific claim."""
+def test_resolved_wuh_contract_and_unresolved_metadata_stay_explicit() -> None:
+    """Pin the approved Wuh depth contract without resolving unrelated science."""
     dict_variables = {
         variable.name: variable for variable in FORCING_REGISTRY.variables
     }
 
-    assert dict_variables["Wuh"].unit is None
-    assert dict_variables["Wuh"].validation_range is None
+    assert dict_variables["Wuh"].unit == "mm"
+    assert dict_variables["Wuh"].validation_range == (0.0, None)
+    assert dict_variables["Wuh"].metadata_note is None
     assert dict_variables["xsmd"].unit is None
     assert dict_variables["snow"].metadata_note is not None
     assert all(
         dict_variables[f"wuh_{suffix}"].unit == "mm"
+        and dict_variables[f"wuh_{suffix}"].validation_range == (0.0, None)
         for suffix in WUH_LANDCOVER_SUFFIXES
     )
+
+    checker_path = (
+        Path(__file__).resolve().parents[2] / "src/supy/checker_rules_indiv.json"
+    )
+    checker_rule = json.loads(checker_path.read_text(encoding="utf-8"))["wuh"]
+    assert checker_rule["param"] == {"max": "inf", "min": 0}
+    assert checker_rule["unit"] == "mm"

--- a/test/io_tests/test_forcing_interpolation.py
+++ b/test/io_tests/test_forcing_interpolation.py
@@ -166,6 +166,38 @@ class TestForcingInterpolation:
             f"Resampled time step should be {tstep_mod}s, got {time_diff.total_seconds()}s"
         )
 
+    def test_wuh_sum_preserves_mixed_exact_sentinel_intervals(self):
+        """Each missing Wuh interval stays -999 when cumulative data are split."""
+        time_index = pd.date_range("2023-01-01 01:00:00", periods=3, freq="3600s")
+        df_forcing = pd.DataFrame(
+            {
+                "Tair": np.full(3, 20.0),
+                "RH": np.full(3, 70.0),
+                "U": np.full(3, 5.0),
+                "pres": np.full(3, 1013.0),
+                "kdown": np.zeros(3),
+                "rain": np.zeros(3),
+                "Wuh": np.array([-999.0, 12.0, -999.0]),
+                "wuh_paved": np.array([-999.0, 12.0, -999.0]),
+                "iy": time_index.year,
+                "id": time_index.dayofyear,
+                "it": time_index.hour,
+                "imin": time_index.minute,
+                "isec": time_index.second,
+            },
+            index=time_index,
+        )
+
+        resampled = resample_forcing_met(df_forcing, 3600, 300)
+
+        expected = np.concatenate([
+            np.full(12, -999.0),
+            np.full(12, 1.0),
+            np.full(12, -999.0),
+        ])
+        np.testing.assert_array_equal(resampled["Wuh"].to_numpy(), expected)
+        np.testing.assert_array_equal(resampled["wuh_paved"].to_numpy(), expected)
+
     def test_average_variable_interpolation_shift(self):
         """Test that average variables are correctly shifted during interpolation.
 

--- a/test/io_tests/test_named_column_forcing.py
+++ b/test/io_tests/test_named_column_forcing.py
@@ -372,6 +372,84 @@ def test_check_forcing_accepts_per_landcover_extras():
     )
 
 
+def test_check_forcing_enforces_wuh_depth_range_without_finite_cap():
+    """Bulk and surface Wuh are non-negative depths with no finite maximum."""
+    from supy._check import check_forcing
+
+    df_forcing = _read_canonical()
+    df_forcing["Wuh"] = 12.0
+    df_forcing["wuh_paved"] = 12.0
+    assert check_forcing(df_forcing, fix=False) is None
+
+    df_forcing["wuh_paved"] = -0.1
+    issues = check_forcing(df_forcing, fix=False)
+    assert any("wuh_paved" in issue for issue in issues)
+
+    df_forcing["wuh_paved"] = -999.0
+    assert check_forcing(df_forcing, fix=False) is None
+    assert np.isclose(df_forcing["wuh_paved"], -999.0).all()
+
+    df_forcing["Wuh"] = -950.0
+    df_forcing["wuh_paved"] = -950.0
+    issues = check_forcing(df_forcing, fix=False)
+    assert any("`wuh`" in issue for issue in issues)
+    assert any("wuh_paved" in issue for issue in issues)
+
+    df_forcing["Wuh"] = np.nan
+    df_forcing["wuh_paved"] = np.nan
+    issues = check_forcing(df_forcing, fix=False)
+    assert any("`wuh`" in issue for issue in issues)
+    assert any("wuh_paved" in issue for issue in issues)
+
+    df_forcing["Wuh"] = np.inf
+    df_forcing["wuh_paved"] = np.inf
+    issues = check_forcing(df_forcing, fix=False)
+    assert any("`wuh`" in issue for issue in issues)
+    assert any("wuh_paved" in issue for issue in issues)
+
+
+def test_check_forcing_fixes_invalid_wuh_without_clipping_missing_sentinel():
+    """Unbounded Wuh rules support fix mode and preserve exact -999 values."""
+    from supy._check import check_forcing
+
+    df_forcing = _read_canonical()
+    df_forcing["Wuh"] = 12.0
+    df_forcing.iloc[0, df_forcing.columns.get_loc("Wuh")] = -999.0
+    df_forcing.iloc[1, df_forcing.columns.get_loc("Wuh")] = -950.0
+    df_forcing.iloc[2, df_forcing.columns.get_loc("Wuh")] = np.inf
+    df_forcing.iloc[3, df_forcing.columns.get_loc("Wuh")] = np.nan
+
+    fixed = check_forcing(df_forcing, fix=True)
+    assert fixed["Wuh"].iloc[0] == -999.0
+    assert fixed["Wuh"].iloc[1] == 0.0
+    assert fixed["Wuh"].iloc[2] == -999.0
+    assert fixed["Wuh"].iloc[3] == -999.0
+    assert np.isclose(fixed["Wuh"].iloc[4:], 12.0).all()
+
+
+@pytest.mark.parametrize("invalid", ("-950", "nan", "inf"))
+@pytest.mark.parametrize("tstep_mod", (None, 300))
+def test_file_resampling_rejects_invalid_wuh_before_missing_normalisation(
+    tmp_path, invalid, tstep_mod
+):
+    """File loading must reject invalid Wuh before generic sentinel handling."""
+    from supy.util._io import read_forcing
+
+    path = tmp_path / f"invalid-wuh-{invalid}.txt"
+    path.write_text(
+        "\n".join([
+            "iy id it imin Tair RH U pres rain kdown Wuh wuh_paved",
+            "2012 1 1 0 10 50 2 101.3 0 0 2 2",
+            f"2012 1 2 0 10 50 2 101.3 0 0 {invalid} {invalid}",
+            "2012 1 3 0 10 50 2 101.3 0 0 2 2",
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"Wuh|wuh_paved"):
+        read_forcing(str(path), tstep_mod=tstep_mod)
+
+
 def test_check_forcing_flags_truly_unknown_columns():
     """gh#1413: the name-based unknown-column check (replacing the legacy
     positional zip) must still reject columns that are neither canonical,


### PR DESCRIPTION
## Summary

- define bulk `Wuh` and surface `wuh_<surface>` as finite, non-negative millimetre depths accumulated per forcing interval
- align Python and Rust readers on sum resampling, exact `-999` handling, range validation, aliases, and surface fallback behaviour
- remove the grid-area-independent `Wuh <= 10 m3` cap and document the explicit breaking migration from legacy bulk volumes

## Compatibility

This deliberately does not guess units or add a runtime legacy mode. Historical bulk `Wuh` values in m3 must be converted. The transition guide documents both the site-mean volume conversion and the all-surface conversion needed to reproduce the former irrigation-fraction allocation.

## Validation

- 67 focused forcing registry, validation, reader, and interpolation tests
- `make test-smoke`: 9 passed, 1 skipped
- Rust clippy with all features and targets, warnings denied
- release Rust bridge and Fortran extension rebuild
- independent specification, quality, and exact-SHA reviews

Closes #1440
Closes #1441
Refs #1447
