### PR TITLE
Restore full-year sample-output validation

### DIFF
--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -223,9 +223,11 @@ from supy._env import trv_supy_module
 sample_dir = trv_supy_module / "sample_data"
 ```
 
-`trv_supy_module` is `importlib.resources.files("supy")`. It returns a
-`Traversable`, which is **not** a `Path` — and the difference is the point, so do
-not treat it as a drop-in.
+`trv_supy_module` is `importlib.resources.files("supy")`. It returns an
+object satisfying `Traversable`. It is **not guaranteed** to be a `Path`: a
+filesystem-backed loader may well hand you a real `pathlib.Path`, which is why
+`Path`-only calls appear to work locally, but nothing promises that. Write
+against the protocol rather than against what your install happens to return.
 
 The protocol guarantees exactly: `joinpath` (and so `/`), `name`, `is_dir`,
 `is_file`, `iterdir`, `open`, `read_bytes`, `read_text`. Use those:

--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -192,6 +192,7 @@ skips (no coverage). See `test/fixtures/legacy_tables/` for the pattern.
 - Magic number tolerances without justification
 - Testing implementation details rather than behaviour
 - Relative paths from repository root
+- `Path(supy.__file__).parent` to reach packaged data (see "Locating packaged data" below)
 - Tests depending on execution order
 - Duplicating setup logic across multiple test files (use conftest.py)
 - Warning suppression in setUp methods (use autouse fixtures)
@@ -202,6 +203,54 @@ skips (no coverage). See `test/fixtures/legacy_tables/` for the pattern.
 - `try/except ImportError: pytest.skip(...)` — use `pytest.importorskip` instead
 
 ---
+
+## Locating packaged data
+
+Never reach for packaged data through the module's file location:
+
+```python
+# WRONG - assumes the package is an unpacked directory on disk
+sample_dir = Path(supy.__file__).parent / "sample_data"
+sample_dir = Path(sp.__file__).parent / "sample_data"
+```
+
+Use the package's own resource handle instead:
+
+```python
+# RIGHT - what supy itself uses, in src/supy/_env.py
+from supy._env import trv_supy_module
+
+sample_dir = trv_supy_module / "sample_data"
+```
+
+`trv_supy_module` is `importlib.resources.files("supy")`. It returns a
+`Traversable` supporting `/`, `.exists()`, `.open()`, `.read_text(encoding=...)`
+and `shutil.copy` on its children, so it is a drop-in for the `Path` expression
+above in every use the test suite currently makes of it.
+
+### Why
+
+- `__file__` assumes the package is an unpacked directory on disk. The import
+  system does not guarantee that; zip imports and some packaging layouts break it.
+  `importlib.resources` exists precisely to abstract over this.
+- It couples the test to supy's internal directory layout, so a package
+  reorganisation breaks tests that are not testing packaging.
+- It reimplements, less safely, something the package already does. `_env.py` has
+  resolved its own data with `files("supy")` since May 2024.
+
+### Why this keeps happening
+
+There is no public accessor for the sample-data path. `dir(supy)` exposes nothing
+for it and `trv_supy_module` is private, so a test author who needs the directory
+has no supported route and reaches for the obvious one. As of August 2026 there
+are around two dozen occurrences across roughly ten test modules, each invented
+independently.
+
+Until a public accessor exists, importing `trv_supy_module` from `supy._env` is
+the correct thing for a test to do: a test importing a private helper is normal,
+and matching the package's own convention is what stops the two drifting apart.
+If you are adding a new test that needs packaged data, use it rather than adding
+a twenty-fifth variant.
 
 ## Skipping Tests
 

--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -224,9 +224,35 @@ sample_dir = trv_supy_module / "sample_data"
 ```
 
 `trv_supy_module` is `importlib.resources.files("supy")`. It returns a
-`Traversable` supporting `/`, `.exists()`, `.open()`, `.read_text(encoding=...)`
-and `shutil.copy` on its children, so it is a drop-in for the `Path` expression
-above in every use the test suite currently makes of it.
+`Traversable`, which is **not** a `Path` — and the difference is the point, so do
+not treat it as a drop-in.
+
+The protocol guarantees exactly: `joinpath` (and so `/`), `name`, `is_dir`,
+`is_file`, `iterdir`, `open`, `read_bytes`, `read_text`. Use those:
+
+```python
+sample_config = trv_supy_module / "sample_data" / "sample_config.yml"
+
+assert sample_config.is_file()                  # NOT .exists(), not in the protocol
+with sample_config.open(encoding="utf-8") as f: # NOT builtin open(...)
+    cfg = yaml.safe_load(f)
+text = sample_config.read_text(encoding="utf-8")
+```
+
+Anything that requires `os.PathLike` — builtin `open()`, `shutil.copy()`,
+subprocess arguments — needs a real filesystem path, which means
+`importlib.resources.as_file()`:
+
+```python
+from importlib.resources import as_file
+
+with as_file(sample_config) as real_path:
+    shutil.copy(real_path, destination)
+```
+
+Under an editable install these all appear to work regardless, because the
+Traversable happens to wrap a real path. That is what makes the mistake easy: it
+passes locally and only fails where the abstraction was supposed to help.
 
 ### Why
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -252,13 +252,20 @@ from supy._supy_module import (
 
 def pytest_configure():
     """Monkey patch legacy public functions to private implementations for tests."""
-    supy._deprecated_init_supy = supy.init_supy
-    supy._deprecated_load_forcing_grid = supy.load_forcing_grid
-    supy._deprecated_run_supy = supy.run_supy
-    supy._deprecated_run_supy_sample = supy.run_supy_sample
-    supy._deprecated_save_supy = supy.save_supy
-    supy._deprecated_load_sample_data = supy.load_sample_data
-    supy._deprecated_init_config = supy.init_config
+    # Reading these attributes trips supy's module-level deprecation shim, so
+    # stashing the originals emitted seven FutureWarnings at the head of every
+    # session before a single test ran. We are saving the callables to restore
+    # them, not calling them, so the notice does not apply to these reads.
+    # Deprecation behaviour itself is asserted in test_deprecation_visibility.py.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        supy._deprecated_init_supy = supy.init_supy
+        supy._deprecated_load_forcing_grid = supy.load_forcing_grid
+        supy._deprecated_run_supy = supy.run_supy
+        supy._deprecated_run_supy_sample = supy.run_supy_sample
+        supy._deprecated_save_supy = supy.save_supy
+        supy._deprecated_load_sample_data = supy.load_sample_data
+        supy._deprecated_init_config = supy.init_config
 
     supy.init_supy = _init_supy
     supy.load_forcing_grid = _load_forcing_grid

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -252,20 +252,21 @@ from supy._supy_module import (
 
 def pytest_configure():
     """Monkey patch legacy public functions to private implementations for tests."""
-    # Reading these attributes trips supy's module-level deprecation shim, so
-    # stashing the originals emitted seven FutureWarnings at the head of every
-    # session before a single test ran. We are saving the callables to restore
-    # them, not calling them, so the notice does not apply to these reads.
-    # Deprecation behaviour itself is asserted in test_deprecation_visibility.py.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", FutureWarning)
-        supy._deprecated_init_supy = supy.init_supy
-        supy._deprecated_load_forcing_grid = supy.load_forcing_grid
-        supy._deprecated_run_supy = supy.run_supy
-        supy._deprecated_run_supy_sample = supy.run_supy_sample
-        supy._deprecated_save_supy = supy.save_supy
-        supy._deprecated_load_sample_data = supy.load_sample_data
-        supy._deprecated_init_config = supy.init_config
+    # Stash the originals by reading them off _supy_module rather than through the
+    # package surface. supy.__getattr__ resolves each of these names to exactly
+    # this object, but emits a FutureWarning on the way, so going through the
+    # public surface opened every session with seven warnings before a single test
+    # ran. Reading the source module gets the same callables silently and avoids
+    # pre-populating supy._lazy_cache as a side effect of harness setup.
+    from supy import _supy_module
+
+    supy._deprecated_init_supy = _supy_module.init_supy
+    supy._deprecated_load_forcing_grid = _supy_module.load_forcing_grid
+    supy._deprecated_run_supy = _supy_module.run_supy
+    supy._deprecated_run_supy_sample = _supy_module.run_supy_sample
+    supy._deprecated_save_supy = _supy_module.save_supy
+    supy._deprecated_load_sample_data = _supy_module.load_sample_data
+    supy._deprecated_init_config = _supy_module.init_config
 
     supy.init_supy = _init_supy
     supy.load_forcing_grid = _load_forcing_grid

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -33,6 +33,7 @@ from unittest import TestCase
 import numpy as np
 import pandas as pd
 import pytest
+import yaml
 
 import supy as sp
 
@@ -95,6 +96,162 @@ def _write_forcing_prefix(source: Path, destination: Path, data_rows: int) -> No
 
     rows_to_write = [lines[0], *lines[1 : data_rows + 1]]
     destination.write_text("\n".join(rows_to_write) + "\n", encoding="utf-8")
+
+
+def _locate_engine() -> Path:
+    """Return the Rust CLI binary, skipping the test if it has not been built.
+
+    Prefers the development build; falls back to the copy bundled inside the
+    installed package, which is what CI and cibuildwheel see.
+    """
+    repo_root = Path(__file__).parent.parent.parent
+    dev_binary = (
+        repo_root / "src" / "suews_bridge" / "target" / "release" / "suews-engine"
+    )
+    if dev_binary.exists():
+        return dev_binary
+
+    try:
+        from supy.cmd.rust_bridge import _bridge_binary
+
+        return _bridge_binary()
+    except (ImportError, FileNotFoundError):
+        pytest.skip(
+            "Rust CLI binary not found; "
+            "build with: cd src/suews_bridge && cargo build --release"
+        )
+
+
+def _forcing_filename(control: dict) -> str:
+    """Return the forcing file name from a config's model.control block.
+
+    Accepts the current `forcing.file` shape (gh#1372) and the legacy
+    `forcing_file` shape, each of which may wrap the value in a RefValue dict,
+    so this test works against pre- and post-migration sample configs.
+    """
+    name = None
+    if isinstance(control.get("forcing"), dict):
+        name = control["forcing"].get("file")
+    if name is None:
+        name = control.get("forcing_file")
+    if isinstance(name, dict):
+        name = name["value"]
+    if not name:
+        raise AssertionError("No forcing file declared in model.control")
+    return name
+
+
+def _forcing_rows_for(validation_steps: int, tstep: int, truncated: bool) -> int:
+    """Return how many forcing rows cover the requested number of timesteps.
+
+    One extra row is included when the window is truncated, so interpolation at
+    the final checked timestep is not a boundary effect.
+    """
+    steps_per_row = max(1, 3600 // tstep)
+    rows = max(2, (validation_steps + steps_per_row - 1) // steps_per_row)
+    return rows + 1 if truncated else rows
+
+
+def _write_run_inputs(
+    sample_dir, sample_config, run_dir: Path, validation_steps: int, truncated: bool
+) -> tuple[Path, int]:
+    """Write a config and forcing prefix into run_dir; return the config and row count.
+
+    The config is redirected to write its output into run_dir. The forcing file is
+    truncated to the rows the requested window needs, because the engine runs the
+    whole forcing file it is given.
+    """
+    with open(sample_config, encoding="utf-8") as handle:
+        cfg = yaml.safe_load(handle)
+
+    control = cfg["model"]["control"]
+    tstep = int(control.get("tstep", 300))
+    control["output"]["dir"] = str(run_dir)
+
+    config_path = run_dir / "sample_config.yml"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        yaml.dump(cfg, handle, default_flow_style=False, sort_keys=False)
+
+    forcing_name = _forcing_filename(control)
+    forcing_rows = _forcing_rows_for(validation_steps, tstep, truncated)
+    _write_forcing_prefix(
+        sample_dir / forcing_name, run_dir / forcing_name, forcing_rows
+    )
+    return config_path, forcing_rows
+
+
+def _run_engine(binary: Path, config_path: Path, run_dir: Path, timeout: int) -> bytes:
+    """Run the engine and return the Arrow output as bytes.
+
+    Read to bytes rather than handing back a path: pyarrow keeps the file open,
+    which blocks TemporaryDirectory cleanup on Windows.
+    """
+    result = subprocess.run(
+        [str(binary), "run", str(config_path)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"Engine exited with code {result.returncode}\n"
+            f"stderr: {result.stderr[:500]}"
+        )
+
+    output_path = run_dir / "suews_output.arrow"
+    if not output_path.exists():
+        raise AssertionError("Engine did not produce suews_output.arrow")
+    return output_path.read_bytes()
+
+
+def _read_engine_output(arrow_bytes: bytes, columns) -> pd.DataFrame:
+    """Return the requested columns of the Arrow output as a DataFrame.
+
+    Projects before converting to pandas. A full year is ~1.1 GB across 1350
+    columns; converting all of them and copying the slice peaked at 3.3 GB to
+    compare nine, against 1.2 GB when projected first.
+    """
+    import pyarrow.ipc as ipc
+
+    table = ipc.open_file(arrow_bytes).read_all()
+    present = [name for name in columns if name in table.schema.names]
+    return table.select(present).to_pandas()
+
+
+def _compare_frames(df_actual, df_expected, variables) -> tuple[bool, list, list]:
+    """Compare each variable within its tolerance.
+
+    Returns (all_passed, failed_variables, report_lines). A variable missing from
+    either frame counts as a failure rather than being skipped, so a column that
+    silently disappears from the engine output cannot weaken the test.
+    """
+    failed: list = []
+    report: list = []
+
+    for var in variables:
+        for frame, label in ((df_actual, "engine output"), (df_expected, "reference")):
+            if var not in frame.columns:
+                line = f"\n[ERROR] Variable {var} not found in {label}!"
+                report.append(line)
+                print(line)
+                failed.append(var)
+                break
+        else:
+            tolerance = get_tolerance_for_variable(var)
+            is_valid, detail = compare_arrays_with_tolerance(
+                df_actual[var].values,
+                df_expected[var].values,
+                rtol=tolerance["rtol"],
+                atol=tolerance["atol"],
+                var_name=var,
+            )
+            status = "[PASS]" if is_valid else "[FAIL]"
+            print(f"{status} {detail}")
+            report.append(f"{status} {detail}")
+            if not is_valid:
+                failed.append(var)
+
+    return not failed, failed, report
 
 
 def _rust_library_available() -> bool:
@@ -465,218 +622,84 @@ class TestSampleOutput(TestCase):
         self._validate_sample_output(full_year=True)
 
     def _validate_sample_output(self, full_year: bool = False):
+        """Run the engine on the sample config and compare against the reference.
+
+        Compares every variable in TOLERANCE_CONFIG. The horizon is the whole
+        reference when full_year, otherwise the fail-fast window. Skipped if the
+        engine binary has not been built.
         """
-        Test SUEWS output against reference data with appropriate tolerances.
-
-        Runs the Rust CLI binary on the sample YAML config and compares the 8
-        key output variables against the monthly sample-output shards using the tolerance
-        framework defined in TOLERANCE_CONFIG.
-
-        Skipped if the Rust binary has not been built.
-        """
-        import pyarrow.ipc as ipc
-        import yaml
-
         print("\n" + "=" * 70)
-        print("Rust Bridge Sample Output Validation Test")
+        print("Sample Output Validation")
         print("=" * 70)
 
-        # Locate the Rust binary: try development path first, then the
-        # installed package location (used by CI/cibuildwheel where the
-        # binary is bundled inside supy/bin/).
-        repo_root = Path(__file__).parent.parent.parent
-        dev_binary = (
-            repo_root / "src" / "suews_bridge" / "target" / "release" / "suews-engine"
-        )
-
-        if dev_binary.exists():
-            rust_binary = dev_binary
-        else:
-            try:
-                from supy.cmd.rust_bridge import _bridge_binary
-
-                rust_binary = _bridge_binary()
-            except (ImportError, FileNotFoundError):
-                pytest.skip(
-                    "Rust CLI binary not found; "
-                    "build with: cd src/suews_bridge && cargo build --release"
-                )
-
-        # Locate the sample YAML config and its directory
+        engine = _locate_engine()
         sample_dir = Path(sp.__file__).parent / "sample_data"
         sample_config = sample_dir / "sample_config.yml"
         assert sample_config.exists(), f"Sample config not found: {sample_config}"
 
-        # Load reference first to get SUEWS variable names
-        print("Loading reference output...")
         df_ref = load_sample_output(test_data_dir)
         print(f"Reference: {df_ref.shape[0]} rows x {df_ref.shape[1]} columns")
 
         validation_steps = (
             len(df_ref) if full_year else _resolve_fail_fast_steps(len(df_ref))
         )
+        truncated = validation_steps < len(df_ref)
 
-        # Run the Rust CLI with a temporary config pointing output to tmpdir.
-        # The smoke path stays short for wheel CI, especially on Windows where
-        # the full-year executable run can exceed the per-test timeout.
-        cli_timeout = 1800 if full_year else 120
-        print(f"\nRunning Rust CLI: {rust_binary.name} run (Arrow output)")
+        # The smoke path stays short for wheel CI, especially on Windows where a
+        # full-year run can exceed the per-test timeout.
+        timeout = 1800 if full_year else 120
+
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Copy config to tmpdir and modify output.dir
-            with open(sample_config, encoding="utf-8") as f:
-                cfg = yaml.safe_load(f)
-            tstep = int(cfg.get("model", {}).get("control", {}).get("tstep", 300))
-            cfg["model"]["control"]["output"]["dir"] = tmpdir
-            tmp_config = Path(tmpdir) / "sample_config.yml"
-            with open(tmp_config, "w", encoding="utf-8") as f:
-                yaml.dump(cfg, f, default_flow_style=False, sort_keys=False)
-
-            # Copy a prefix of the forcing file so the smoke test remains fast.
-            # The Rust CLI currently runs the full forcing file it is given.
-            # Accept both the new model.control.forcing.file shape (gh#1372)
-            # and the legacy model.control.forcing_file shape so this test
-            # works against pre- and post-migration sample configs.
-            control = cfg["model"]["control"]
-            forcing_name = None
-            if isinstance(control.get("forcing"), dict):
-                forcing_name = control["forcing"].get("file")
-            if forcing_name is None:
-                forcing_name = control.get("forcing_file")
-            if isinstance(forcing_name, dict):
-                forcing_name = forcing_name["value"]
-            forcing_src = sample_dir / forcing_name
-            forcing_dst = Path(tmpdir) / forcing_name
-            steps_per_forcing_row = max(1, 3600 // tstep)
-            forcing_rows = max(
-                2,
-                (validation_steps + steps_per_forcing_row - 1) // steps_per_forcing_row,
+            run_dir = Path(tmpdir)
+            config_path, forcing_rows = _write_run_inputs(
+                sample_dir, sample_config, run_dir, validation_steps, truncated
             )
-            if validation_steps < len(df_ref):
-                forcing_rows += 1
-            _write_forcing_prefix(forcing_src, forcing_dst, forcing_rows)
             print(
                 f"Validating first {validation_steps} timesteps "
                 f"from {forcing_rows} forcing rows"
             )
+            arrow_bytes = _run_engine(engine, config_path, run_dir, timeout)
 
-            result = subprocess.run(
-                [str(rust_binary), "run", str(tmp_config)],
-                capture_output=True,
-                text=True,
-                timeout=cli_timeout,
-            )
-
-            if result.returncode != 0:
-                self.fail(
-                    f"Rust CLI exited with code {result.returncode}\n"
-                    f"stderr: {result.stderr[:500]}"
-                )
-
-            # Load Rust Arrow output (all 1134 columns across 11 groups).
-            # Read into bytes first to avoid holding a file handle on Windows
-            # (pyarrow keeps the file open, blocking TemporaryDirectory cleanup).
-            rust_output_path = Path(tmpdir) / "suews_output.arrow"
-            assert rust_output_path.exists(), (
-                "Rust CLI did not produce suews_output.arrow"
-            )
-            arrow_bytes = rust_output_path.read_bytes()
-
-        reader = ipc.open_file(arrow_bytes)
-        table = reader.read_all()
-
-        # Project to the compared columns before converting to pandas. A full year
-        # of output is ~1.1 GB across 1350 columns, and converting all of them then
-        # copying the slice peaked at 3.3 GB to compare nine; projecting first holds
-        # it at ~1.2 GB, nearly all of which is arrow_bytes above. That matters
-        # because this test now runs in the core and standard tiers under xdist.
-        present = [name for name in TOLERANCE_CONFIG if name in table.schema.names]
-        df_rust_all = table.select(present).to_pandas()
-        del table, reader
-
-        # SUEWS group uses proper variable names (Kdown, Kup, QN, etc.)
-        # directly in the Arrow file. Slice to the requested smoke window
-        # because one extra forcing row is included to avoid interpolation
-        # boundary effects at the final checked timestep.
-        if len(df_rust_all) < validation_steps:
+        df_actual = _read_engine_output(arrow_bytes, TOLERANCE_CONFIG)
+        if len(df_actual) < validation_steps:
             self.fail(
-                "Rust CLI produced fewer rows than requested: "
-                f"Rust={len(df_rust_all)}, requested={validation_steps}"
+                "Engine produced fewer rows than requested: "
+                f"got {len(df_actual)}, requested {validation_steps}"
             )
-        df_rust = df_rust_all.iloc[:validation_steps]
+        df_actual = df_actual.iloc[:validation_steps]
 
-        print(f"Rust output: {df_rust.shape[0]} rows x {df_rust.shape[1]} columns")
-
-        # Verify row count alignment
-        n_rust = len(df_rust)
-        n_ref = len(df_ref)
         self.assertLessEqual(
-            n_rust,
-            n_ref,
-            f"Rust output is longer than reference: Rust={n_rust}, reference={n_ref}",
+            len(df_actual),
+            len(df_ref),
+            f"Engine output is longer than reference: "
+            f"{len(df_actual)} vs {len(df_ref)}",
         )
-        df_ref = df_ref.iloc[:n_rust].copy()
+        df_expected = df_ref.iloc[: len(df_actual)]
 
-        # Compare every variable in TOLERANCE_CONFIG (all timesteps)
-        variables_to_test = list(TOLERANCE_CONFIG.keys())
-        print(f"\nValidating variables: {', '.join(variables_to_test)}")
-        print(f"Comparing first {n_rust} timesteps")
+        print(
+            f"\nComparing {len(df_actual)} timesteps across "
+            f"{', '.join(TOLERANCE_CONFIG)}"
+        )
         print("=" * 70)
 
-        all_passed = True
-        failed_variables = []
-        full_report = []
+        all_passed, failed, report = _compare_frames(
+            df_actual, df_expected, TOLERANCE_CONFIG
+        )
 
-        for var in variables_to_test:
-            if var not in df_rust.columns:
-                report = f"\n[ERROR] Variable {var} not found in Rust output!"
-                full_report.append(report)
-                print(report)
-                all_passed = False
-                failed_variables.append(var)
-                continue
-
-            if var not in df_ref.columns:
-                report = f"\n[ERROR] Variable {var} not found in reference!"
-                full_report.append(report)
-                print(report)
-                all_passed = False
-                failed_variables.append(var)
-                continue
-
-            rust_arr = df_rust[var].values
-            ref_arr = df_ref[var].values
-
-            tolerance = get_tolerance_for_variable(var)
-            is_valid, report = compare_arrays_with_tolerance(
-                rust_arr,
-                ref_arr,
-                rtol=tolerance["rtol"],
-                atol=tolerance["atol"],
-                var_name=var,
-            )
-
-            status = "[PASS]" if is_valid else "[FAIL]"
-            print(f"{status} {report}")
-            full_report.append(f"{status} {report}")
-
-            if not is_valid:
-                all_passed = False
-                failed_variables.append(var)
-
-        # Summary
         print("\n" + "=" * 70)
-        print("SUMMARY")
-        print("=" * 70)
-        if all_passed:
-            print("[PASS] Rust bridge output matches sample reference!")
-        else:
-            print(f"[FAIL] Validation failed for: {', '.join(failed_variables)}")
+        print(
+            "[PASS] Output matches reference"
+            if all_passed
+            else f"[FAIL] Validation failed for: {', '.join(failed)}"
+        )
 
         self.assertTrue(
             all_passed,
-            f"Rust bridge vs reference failed for: {', '.join(failed_variables)}\n"
-            + "\n".join(full_report),
+            f"Engine vs reference failed for: {', '.join(failed)}\n"
+            + "\n".join(report),
         )
+
+
 
 
 if __name__ == "__main__":

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -583,7 +583,15 @@ class TestSampleOutput(TestCase):
 
         reader = ipc.open_file(arrow_bytes)
         table = reader.read_all()
-        df_rust_all = table.to_pandas()
+
+        # Project to the compared columns before converting to pandas. A full year
+        # of output is ~1.1 GB across 1350 columns, and converting all of them then
+        # copying the slice peaked at 3.3 GB to compare nine; projecting first holds
+        # it at ~1.2 GB, nearly all of which is arrow_bytes above. That matters
+        # because this test now runs in the core and standard tiers under xdist.
+        present = [name for name in TOLERANCE_CONFIG if name in table.schema.names]
+        df_rust_all = table.select(present).to_pandas()
+        del table, reader
 
         # SUEWS group uses proper variable names (Kdown, Kup, QN, etc.)
         # directly in the Arrow file. Slice to the requested smoke window
@@ -594,7 +602,7 @@ class TestSampleOutput(TestCase):
                 "Rust CLI produced fewer rows than requested: "
                 f"Rust={len(df_rust_all)}, requested={validation_steps}"
             )
-        df_rust = df_rust_all.iloc[:validation_steps].copy()
+        df_rust = df_rust_all.iloc[:validation_steps]
 
         print(f"Rust output: {df_rust.shape[0]} rows x {df_rust.shape[1]} columns")
 

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -48,16 +48,24 @@ test_data_dir = Path(__file__).parent.parent / "fixtures" / "data_test"
 sys.path.insert(0, str(test_data_dir))
 from sample_output_io import load_sample_output  # noqa: E402
 FAIL_FAST_STEPS_ENV = "SUEWS_FAIL_FAST_STEPS"
-# Default smoke validation to one model day. Set SUEWS_FAIL_FAST_STEPS to a
-# larger value when an exhaustive local comparison is needed.
+# Default the smoke path to one model day. Set SUEWS_FAIL_FAST_STEPS to a larger
+# value, or to 0 for the whole window, when an exhaustive local comparison is
+# needed. Seasonal coverage does not depend on this switch: it lives in
+# test_sample_output_validation_full_year, which ignores it entirely.
 DEFAULT_FAIL_FAST_STEPS = TIMESTEPS_PER_DAY
 
 
 def _get_fail_fast_steps(default_steps: int = DEFAULT_FAIL_FAST_STEPS) -> int:
-    """Return validation timesteps for fail-fast execution."""
+    """Return validation timesteps, where a non-positive result means full window.
+
+    The zero sentinel matches test_soil_obs_conversion.py, the other reader of
+    SUEWS_FAIL_FAST_STEPS: non-positive means "validate everything". Previously
+    zero was coerced here to one model day, so applying the sibling module's
+    convention silently truncated coverage instead of restoring it.
+    """
     raw = os.environ.get(FAIL_FAST_STEPS_ENV)
     if not raw:
-        return TIMESTEPS_PER_DAY if default_steps <= 0 else default_steps
+        return default_steps
     try:
         steps = int(raw)
     except ValueError as exc:
@@ -65,9 +73,6 @@ def _get_fail_fast_steps(default_steps: int = DEFAULT_FAIL_FAST_STEPS) -> int:
             f"{FAIL_FAST_STEPS_ENV} must be an integer, got: {raw!r}"
         ) from exc
 
-    # Non-positive value means "use the default smoke validation window".
-    if steps <= 0:
-        return default_steps
     return steps
 
 
@@ -407,6 +412,45 @@ class TestSampleOutput(TestCase):
     @pytest.mark.rust
     @pytest.mark.smoke
     def test_sample_output_validation(self):
+        """Validate the smoke window (one model day by default) against the reference."""
+        self._validate_sample_output()
+
+    @pytest.mark.core
+    @pytest.mark.rust
+    def test_sample_output_validation_full_year(self):
+        """Validate the whole simulated year against the reference.
+
+        The horizon is deliberately independent of SUEWS_FAIL_FAST_STEPS, so no
+        environment setting can silently shorten it. Restores the coverage of
+        accumulated-state and day-of-year-gated behaviour dropped in gh#1236 and
+        gh#1382, without which a regression that first diverges mid-year passes CI:
+        GDD and SDD take months to reach the values their branches test, and the
+        day-140/170/250/300 gates are never evaluated inside a one-day run.
+
+        Marked `core`, which places it in the `core`, `standard` and full physics
+        expressions. That covers drafts touching Fortran or Rust, every ready PR
+        touching code, every merge-queue entry and the nightly, so the coverage
+        never depends on the hand-applied 0-physics:change label, which is the
+        mechanism that failed. Not `slow`, which would reinstate that dependency.
+
+        Not `smoke` either, for a measured reason rather than a stylistic one.
+        The smoke tier's stated budget is ~60s; it runs at 47s without this test
+        and 57s with it on macOS ARM, so on a slower runner it would breach the
+        budget. gh#1348 previously placed a full-year run in `smoke` and gh#1382
+        removed it six days later citing a Windows per-test timeout. If a Windows
+        measurement later shows headroom, promoting this to `smoke` and deleting
+        the one-day variant above is the tidier end state, since the full year is
+        then a strict superset. If it is tight instead, re-tier rather than
+        shorten the horizon again.
+
+        Cost on macOS ARM: ~14.3s, of which almost all is the engine simulating
+        the year and ~0.2s the comparison, against ~3.4s for the one-day path.
+        It therefore scales with runner speed rather than with anything the test
+        itself can optimise.
+        """
+        self._validate_sample_output(full_year=True)
+
+    def _validate_sample_output(self, full_year: bool = False):
         """
         Test SUEWS output against reference data with appropriate tolerances.
 
@@ -454,11 +498,21 @@ class TestSampleOutput(TestCase):
         df_ref = load_sample_output(test_data_dir)
         print(f"Reference: {df_ref.shape[0]} rows x {df_ref.shape[1]} columns")
 
-        validation_steps = min(_get_fail_fast_steps(), len(df_ref))
+        if full_year:
+            validation_steps = len(df_ref)
+        else:
+            requested_steps = _get_fail_fast_steps()
+            # Non-positive means full window, matching test_soil_obs_conversion.py.
+            if requested_steps <= 0:
+                validation_steps = len(df_ref)
+            else:
+                validation_steps = min(requested_steps, len(df_ref))
 
         # Run the Rust CLI with a temporary config pointing output to tmpdir.
-        # Keep this smoke path short for wheel CI, especially on Windows where
-        # the full-year executable run can exceed the per-test timeout.
+        # The smoke path stays short for wheel CI, especially on Windows where
+        # the full-year executable run can exceed the per-test timeout; the
+        # full-year variant is `slow`, so it runs only in the full physics tier.
+        cli_timeout = 1800 if full_year else 120
         print(f"\nRunning Rust CLI: {rust_binary.name} run (Arrow output)")
         with tempfile.TemporaryDirectory() as tmpdir:
             # Copy config to tmpdir and modify output.dir
@@ -502,7 +556,7 @@ class TestSampleOutput(TestCase):
                 [str(rust_binary), "run", str(tmp_config)],
                 capture_output=True,
                 text=True,
-                timeout=120,
+                timeout=cli_timeout,
             )
 
             if result.returncode != 0:

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -641,6 +641,21 @@ class TestSampleOutput(TestCase):
         Compares every variable in TOLERANCE_CONFIG. The horizon is the whole
         reference when full_year, otherwise the fail-fast window. Skipped if the
         engine binary has not been built.
+
+        Why the CLI binary rather than SUEWSSimulation, which is what users call:
+        memory. A full year through the library holds the whole 105,408 x 1295
+        output as a DataFrame, measured at 8.2 GB peak resident memory. The CLI
+        writes Arrow, so the columns under test can be projected before
+        conversion, measured at 1.2 GB. Under xdist the difference decides
+        whether this test can run at all on hosted runners.
+
+        What that trades away is real and worth knowing: this path exercises the
+        engine and its Arrow output, not the PyO3 bridge, DataFrame construction
+        or the rest of the supy wrapper. That surface is covered by
+        test_library_cli_parity, which currently runs 3 days. So the library, the
+        thing users actually call, has a much shorter reference comparison than
+        the CLI does. gh#1209 originally ran both over a full year; gh#1236 cut
+        the library side to 3 days and the CLI side is what survived.
         """
         print("\n" + "=" * 70)
         print("Sample Output Validation")

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -447,20 +447,14 @@ class TestSampleOutput(TestCase):
         never depends on the hand-applied 0-physics:change label, which is the
         mechanism that failed. Not `slow`, which would reinstate that dependency.
 
-        Not `smoke` either, for a measured reason rather than a stylistic one.
-        The smoke tier's stated budget is ~60s; it runs at 47s without this test
-        and 57s with it on macOS ARM, so on a slower runner it would breach the
-        budget. gh#1348 previously placed a full-year run in `smoke` and gh#1382
-        removed it six days later citing a Windows per-test timeout. If a Windows
-        measurement later shows headroom, promoting this to `smoke` and deleting
-        the one-day variant above is the tidier end state, since the full year is
-        then a strict superset. If it is tight instead, re-tier rather than
-        shorten the horizon again.
+        Not `smoke` either: a full year of engine time does not fit that tier's
+        stated budget. gh#1348 tried it and gh#1382 reverted it six days later
+        over a Windows per-test timeout.
 
-        Cost on macOS ARM: ~14.3s, of which almost all is the engine simulating
-        the year and ~0.2s the comparison, against ~3.4s for the one-day path.
-        It therefore scales with runner speed rather than with anything the test
-        itself can optimise.
+        Measured runtimes, and the case for promoting this to `smoke` should
+        Windows prove to have headroom, are recorded in gh#1679 where they carry
+        a date. They are deliberately not repeated here: nothing asserts them, so
+        a docstring cannot tell a reader when they stopped being true.
         """
         self._validate_sample_output(full_year=True)
 

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -50,30 +50,39 @@ from sample_output_io import load_sample_output  # noqa: E402
 FAIL_FAST_STEPS_ENV = "SUEWS_FAIL_FAST_STEPS"
 # Default the smoke path to one model day. Set SUEWS_FAIL_FAST_STEPS to a larger
 # value, or to 0 for the whole window, when an exhaustive local comparison is
-# needed. Seasonal coverage does not depend on this switch: it lives in
-# test_sample_output_validation_full_year, which ignores it entirely.
+# needed. Coverage of accumulated-state and day-of-year-gated behaviour does not
+# depend on this switch: it lives in test_sample_output_validation_full_year,
+# which ignores it entirely.
 DEFAULT_FAIL_FAST_STEPS = TIMESTEPS_PER_DAY
 
 
-def _get_fail_fast_steps(default_steps: int = DEFAULT_FAIL_FAST_STEPS) -> int:
-    """Return validation timesteps, where a non-positive result means full window.
+def _resolve_fail_fast_steps(
+    total_steps: int, default_steps: int = DEFAULT_FAIL_FAST_STEPS
+) -> int:
+    """Return how many timesteps to validate, resolved against what is available.
 
-    The zero sentinel matches test_soil_obs_conversion.py, the other reader of
-    SUEWS_FAIL_FAST_STEPS: non-positive means "validate everything". Previously
-    zero was coerced here to one model day, so applying the sibling module's
-    convention silently truncated coverage instead of restoring it.
+    Non-positive means the whole window, matching test_soil_obs_conversion.py, the
+    other reader of SUEWS_FAIL_FAST_STEPS.
+
+    Resolution lives here rather than at the call sites deliberately. This module
+    has two callers, and an unresolved sentinel silently collapses a validation
+    horizon to zero timesteps, which passes vacuously rather than failing. That is
+    the same failure mode this module's full-year test exists to prevent.
     """
     raw = os.environ.get(FAIL_FAST_STEPS_ENV)
     if not raw:
-        return default_steps
-    try:
-        steps = int(raw)
-    except ValueError as exc:
-        raise ValueError(
-            f"{FAIL_FAST_STEPS_ENV} must be an integer, got: {raw!r}"
-        ) from exc
+        requested = default_steps
+    else:
+        try:
+            requested = int(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"{FAIL_FAST_STEPS_ENV} must be an integer, got: {raw!r}"
+            ) from exc
 
-    return steps
+    if requested <= 0:
+        return total_steps
+    return min(requested, total_steps)
 
 
 def _write_forcing_prefix(source: Path, destination: Path, data_rows: int) -> None:
@@ -369,7 +378,7 @@ class TestSampleOutput(TestCase):
         """Quick parity check: Python library bridge vs CLI reference.
 
         Runs only 3 days of simulation to keep execution fast.
-        Compares the 8 key variables against the corresponding slice
+        Compares the variables in TOLERANCE_CONFIG against the corresponding slice
         of the monthly sample-output shards (the CLI-generated reference).
         """
         sim = sp.SUEWSSimulation.from_sample_data()
@@ -503,20 +512,13 @@ class TestSampleOutput(TestCase):
         df_ref = load_sample_output(test_data_dir)
         print(f"Reference: {df_ref.shape[0]} rows x {df_ref.shape[1]} columns")
 
-        if full_year:
-            validation_steps = len(df_ref)
-        else:
-            requested_steps = _get_fail_fast_steps()
-            # Non-positive means full window, matching test_soil_obs_conversion.py.
-            if requested_steps <= 0:
-                validation_steps = len(df_ref)
-            else:
-                validation_steps = min(requested_steps, len(df_ref))
+        validation_steps = (
+            len(df_ref) if full_year else _resolve_fail_fast_steps(len(df_ref))
+        )
 
         # Run the Rust CLI with a temporary config pointing output to tmpdir.
         # The smoke path stays short for wheel CI, especially on Windows where
-        # the full-year executable run can exceed the per-test timeout; the
-        # full-year variant is `slow`, so it runs only in the full physics tier.
+        # the full-year executable run can exceed the per-test timeout.
         cli_timeout = 1800 if full_year else 120
         print(f"\nRunning Rust CLI: {rust_binary.name} run (Arrow output)")
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -606,7 +608,7 @@ class TestSampleOutput(TestCase):
         )
         df_ref = df_ref.iloc[:n_rust].copy()
 
-        # Compare the 8 key variables (all timesteps)
+        # Compare every variable in TOLERANCE_CONFIG (all timesteps)
         variables_to_test = list(TOLERANCE_CONFIG.keys())
         print(f"\nValidating variables: {', '.join(variables_to_test)}")
         print(f"Comparing first {n_rust} timesteps")
@@ -757,13 +759,9 @@ class TestSTEBBSOutput(TestCase):
                 "Insufficient forcing data for STEBBS validation: "
                 f"{len(df_forcing_window)} rows."
             )
-        requested_steps = _get_fail_fast_steps()
-        validation_steps = min(requested_steps, max_validation_steps)
-        if validation_steps != requested_steps:
-            print(
-                f"[INFO] Requested {requested_steps} validation steps, "
-                f"clamped to available {validation_steps}."
-            )
+        validation_steps = _resolve_fail_fast_steps(max_validation_steps)
+        if validation_steps == max_validation_steps:
+            print(f"[INFO] Validating all {validation_steps} available steps.")
         df_forcing = df_forcing_window.iloc[: TIMESTEPS_PER_DAY + validation_steps]
 
         print(

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -429,7 +429,6 @@ class TestSampleOutput(TestCase):
         """Validate the smoke window (one model day by default) against the reference."""
         self._validate_sample_output()
 
-    @pytest.mark.core
     @pytest.mark.rust
     def test_sample_output_validation_full_year(self):
         """Validate the whole simulated year against the reference.
@@ -441,15 +440,22 @@ class TestSampleOutput(TestCase):
         GDD and SDD take months to reach the values their branches test, and the
         day-140/170/250/300 gates are never evaluated inside a one-day run.
 
-        Marked `core`, which places it in the `core`, `standard` and full physics
-        expressions. That covers drafts touching Fortran or Rust, every ready PR
-        touching code, every merge-queue entry and the nightly, so the coverage
-        never depends on the hand-applied 0-physics:change label, which is the
-        mechanism that failed. Not `slow`, which would reinstate that dependency.
+        Carries no tier marker, which is deliberate. Per the tier definitions,
+        `standard` is "all non-slow tests for the relevant nature axis", so an
+        unmarked test lands in `standard` and the full physics tiers: every ready
+        PR touching code, every merge-queue entry, and the nightly. Since the
+        queue always runs `standard`, nothing merges without this having passed.
 
-        Not `smoke` either: a full year of engine time does not fit that tier's
-        stated budget. gh#1348 tried it and gh#1382 reverted it six days later
-        over a Windows per-test timeout.
+        Not `slow`: `standard` resolves to "physics and not slow", so that marker
+        would drop this from ready PRs and the queue too, leaving the coverage
+        dependent on someone applying the 0-physics:change label by hand. That
+        dependency is the mechanism that failed and produced this gap.
+
+        Not `core` or `smoke` either: those tiers are for fast feedback on drafts
+        and narrow changes, and a full year of engine time does not belong in a
+        tier defined as "fast enough for draft PRs". gh#1348 put a full-year run
+        in `smoke` and gh#1382 reverted it six days later over a Windows
+        per-test timeout.
 
         Measured runtimes, and the case for promoting this to `smoke` should
         Windows prove to have headroom, are recorded in gh#1679 where they carry

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -135,6 +135,11 @@ TOLERANCE_CONFIG = {
     #      0.5% tolerance for typical urban wind speeds
     #      Important for turbulent exchange calculations
     "U10": {"rtol": 0.005, "atol": 0.01},  # 10m wind speed [m/s]
+    # LAI: the phenology state itself, not a flux. Compared directly because it
+    # is the direct output of the GDD/SDD scheme; relying on it only through its
+    # effect on QE and QN means a phenology regression has to be large enough to
+    # move an energy flux by 0.8% before any test notices.
+    "LAI": {"rtol": 0.008, "atol": 0.001},  # bulk leaf area index [m2 m-2]
 }
 
 # Platform-specific adjustments (if needed in future)

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -175,7 +175,9 @@ def _write_run_inputs(
     truncated to the rows the requested window needs, because the engine runs the
     whole forcing file it is given.
     """
-    with open(sample_config, encoding="utf-8") as handle:
+    # sample_config is a Traversable, so use its own open() rather than the
+    # builtin, which requires os.PathLike and fails for zip-backed resources.
+    with sample_config.open(encoding="utf-8") as handle:
         cfg = yaml.safe_load(handle)
 
     control = cfg["model"]["control"]
@@ -664,7 +666,7 @@ class TestSampleOutput(TestCase):
         engine = _locate_engine()
         sample_dir = _sample_data_dir()
         sample_config = sample_dir / "sample_config.yml"
-        assert sample_config.exists(), f"Sample config not found: {sample_config}"
+        assert sample_config.is_file(), f"Sample config not found: {sample_config}"
 
         df_ref = load_sample_output(test_data_dir)
         print(f"Reference: {df_ref.shape[0]} rows x {df_ref.shape[1]} columns")

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -98,6 +98,20 @@ def _write_forcing_prefix(source: Path, destination: Path, data_rows: int) -> No
     destination.write_text("\n".join(rows_to_write) + "\n", encoding="utf-8")
 
 
+def _sample_data_dir():
+    """Return supy's bundled sample_data directory.
+
+    Uses the package's own resource handle rather than `Path(supy.__file__).parent`.
+    The latter assumes the package is an unpacked directory on disk, which is not
+    guaranteed by the import system, and it couples tests to supy's internal
+    layout. supy resolves its own data this way in `_env.py`; the tests simply
+    never adopted it, because there is no public accessor for this path.
+    """
+    from supy._env import trv_supy_module
+
+    return trv_supy_module / "sample_data"
+
+
 def _locate_engine() -> Path:
     """Return the Rust CLI binary, skipping the test if it has not been built.
 
@@ -633,7 +647,7 @@ class TestSampleOutput(TestCase):
         print("=" * 70)
 
         engine = _locate_engine()
-        sample_dir = Path(sp.__file__).parent / "sample_data"
+        sample_dir = _sample_data_dir()
         sample_config = sample_dir / "sample_config.yml"
         assert sample_config.exists(), f"Sample config not found: {sample_config}"
 


### PR DESCRIPTION
## Summary

The sample-output reference comparison covered a full simulated year until #1236 and #1382 reduced it, and no CI tier has restored the longer horizon since.
Every tier has been validating one model day, the nightly `all` run included, so no regression whose effect first appears later in the year could be detected.

This restores the coverage, adds `LAI` to the compared variables, and clears a warning that was burying test output.

## What a one-day horizon gives up

Two classes of behaviour become unreachable, and both matter for the phenology scheme.

**Accumulated state.** `GDD_id` and `SDD_id` are cumulative counters that start at zero and gain a few degree-days per day, so the values at which their branches fire take months to reach: `GDDFull` is 300 and `SDDFull` is -450 in the sample configuration, against a `critDays` of 50. Within one model day both sit near zero, so every clamp and release branch conditioned on them is dead code for the duration of the test.

**Day-of-year gating.** `id == 140` forces an SDD reset in mid-May, `id < 170` and `id > 170` switch the summer and winter zeroing, and the Southern hemisphere equivalents use 300 and 250. A run that stops on day one never evaluates any of them as true.

For code without memory a one-day run is perfectly adequate. For this subsystem it is the difference between testing the code and not.

## Commits

- **Restore the full-year comparison.** `test_sample_output_validation_full_year` derives its horizon from the reference length and never consults the fail-fast resolver, so no environment setting can silently shorten it.
- **Compare `LAI`.** `TOLERANCE_CONFIG` covered eight variables, all energy fluxes and near-surface meteorology, while the reference carries 113 columns including `LAI`. Phenology regressions were therefore only detectable through their second-order effect on QE and QN, needing to move an energy flux by more than 0.8% before any test reacted.
- **Silence seven per-session `FutureWarning`s.** `pytest_configure` stashes the legacy public callables by reading them off `supy._supy_module` rather than through the deprecating package surface, which resolves to the same objects without emitting the warnings.
- **Keep sentinel resolution inside the fail-fast helper.** An earlier commit on this branch moved it to one call site and left the module's other caller behind, where `SUEWS_FAIL_FAST_STEPS=0` would have collapsed the STEBBS validation horizon to zero and passed vacuously. `_resolve_fail_fast_steps(total_steps)` now resolves it where the window length is known, so neither caller reimplements the policy.
- **Project the Arrow output to the compared columns.** A full year of output is ~1.1 GB across 1350 columns; converting all of them and copying the slice peaked at 3.30 GB to compare nine. Projecting first holds it at 1.18 GB.
- **Decompose the validation method.** `_validate_sample_output` had reached 229 lines covering binary lookup, config rewriting, forcing truncation, subprocess invocation, Arrow reading, row alignment, comparison and reporting. That size is why the test rotted unnoticed. Six named module-level helpers plus a 77-line orchestrator; verified in both directions, including that the injected #1675 regression is still caught.
- **Resolve packaged data through supy's own handle.** `Path(sp.__file__).parent` assumes the package is an unpacked directory on disk. supy has resolved its own data with `files("supy")` since May 2024; the tests never adopted it because there is no public accessor. Fixes the occurrence in this file only; the remaining 22 are a separate sweep.
- **Record why the CLI drives this test.** A full year through `SUEWSSimulation` holds the whole 105,408 x 1295 output as a DataFrame at 8.2 GB peak resident memory, against 1.2 GB for the projected Arrow path. The docstring also records what that trades away: this path does not exercise the PyO3 bridge or the supy wrapper, which `test_library_cli_parity` covers at 3 days.
- **Strengthen the packaged-data rule** in `.claude/rules/tests/patterns.md`, which previously said only "Relative paths from repository root" with no correct alternative.

## Tier placement

The test carries no tier marker, which is a deliberate decision rather than an omission.

The Windows runtime is measured, not estimated: workflow run 31569516968 (Windows-only, `standard` tier, this branch) reports **75.79s**, passing, against 14.3s on macOS ARM. That exceeds the ">30s individually" bar `pyproject.toml` gives for `slow`.

Marking it `slow` would confine it to the full physics tier, which runs only on `0-physics:change` PRs and the nightly. That label is applied by hand, and the regression this PR restores coverage for arrived on a PR that did not carry it, so `slow` would reinstate the exact dependency that produced the gap.

Marking it `core` would place it in the draft-PR tiers, which `.claude/rules/tests/patterns.md` forbids: "Do not mark a test `core` merely because the feature matters; use `slow` if the regression is important but expensive."

Unmarked is also consistent with current practice rather than an exception to it. The same run shows nine `test_ehc_regression.py` tests between 34.17s and 36.13s in the same `standard` tier, none marked `slow` — they cannot be, since `standard` resolves to `physics and not slow` and the marker would have excluded them from the run that timed them.

The underlying problem is that the tier axis conflates importance with cost, so "essential and expensive" has no correct marker. Tracked in #1680, which proposes a three-level cost axis plus importance overriding cost in the ready and queue expressions. Under that design this test would be marked `core` + `slow`, both true, and land in the same tiers it does now by classification rather than by omission.

Verified by collection: `smoke`, `core` and `cfg` select the one-day test only; `standard` and the full physics tiers select both.

**Accepted cost:** 75.79s on the Windows ready-PR and merge-queue paths, roughly 23% of that tier's 324.92s run.

## Verification

- Full-year path: 105,408 reference rows, 105,408 validated timesteps from 8,784 forcing rows, all nine variables (QN, QF, QS, QE, QH, T2, RH2, U10, LAI) within tolerance.
- One-day smoke path unchanged.
- Negative control, re-run after the decomposition: with the `limit_gdd_sdd` assignment flip from #1675 injected into master's Fortran, the one-day test still passes while the full-year test fails on QS, QE, QH, T2, RH2, U10 and LAI, QS diverging from output index 27934. LAI appearing there is the column added by this PR catching the regression at the phenology variable itself rather than only through its effect on the fluxes.

Note that this branch is test-only, so `.github/path-filters.yml` classifies it under `tests` and its own PR checks run at `smoke` tier, which does not include the new test. It is exercised on merge-queue entry, which runs `standard`, and was exercised directly by the dispatched Windows run above.

## Follow-ups not in this PR

- #1680, the tier axis redesign.
- The Southern hemisphere and `laimethod=0` paths remain untested by any fixture: every configuration in the repository is at a positive latitude, and `laimethod` defaults to modelled. Those need new fixtures rather than a longer horizon.
- The reference frame is parsed independently by each test in this class, roughly 10s per tier run with ~7s redundant. Sharing it needs an autouse fixture, since `TestSampleOutput` is a `unittest.TestCase` and `setUp` clears every reachable `lru_cache`.
