### PR TITLE
Stop labelling parameters without a default as optional in the config reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ EXAMPLES:
 
 - [bugfix] Stopped the YAML config reference describing parameters without a default as optional (#1677)
   - Every parameter carrying no default previously rendered as `Default: None (optional)`, which asserted the opposite of the truth for parameters such as `store_cap` and `base_temperature_senescence`; these are declared `Optional[...] = None` only so a partial configuration still loads and the validation layer can then report what is missing.
-  - Such parameters now render as `Status: No default value; may be required depending on your configuration`, so a `Default` label always introduces a real default value and the absence of one is reported under `Status` alongside the unconditionally required case.
+  - Such parameters now render under a `Configuration Note` label stating that no default exists and that a value may be required depending on which physics options and surface types are active. A `Default` label therefore always introduces a real default value, and `Status` stays reserved for the short state token `Required`.
   - Added regression coverage over the rendered pages, which is the only available gate because the generated config reference is not tracked in git.
 
 ### 22 Jul 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ EXAMPLES:
 
 ## 2026
 
+### 12 Aug 2026
+
+- [bugfix] Stopped the YAML config reference describing parameters without a default as optional (#1677)
+  - Every parameter carrying no default previously rendered as `Default: None (optional)`, which asserted the opposite of the truth for parameters such as `store_cap` and `base_temperature_senescence`; these are declared `Optional[...] = None` only so a partial configuration still loads and the validation layer can then report what is missing.
+  - Such parameters now render as `Status: No default value; may be required depending on your configuration`, so a `Default` label always introduces a real default value and the absence of one is reported under `Status` alongside the unconditionally required case.
+  - Added regression coverage over the rendered pages, which is the only available gate because the generated config reference is not tracked in git.
+
 ### 22 Jul 2026
 
 - [bugfix] Relaxed SPARTACUS-Surface land-cover fraction validation so lowest-layer geometry no longer has to equal SUEWS land-cover fractions (#1642)

--- a/docs/generate_datamodel_rst.py
+++ b/docs/generate_datamodel_rst.py
@@ -27,12 +27,22 @@ except ImportError:
     from supy.data_model.doc_utils import ModelDocExtractor
 
 
-# Reported for any parameter that carries no default value. Such parameters are
+# Shown for any parameter that carries no default value. Such parameters are
 # typically declared Optional so that a partial configuration still loads and
 # the validation layer can report what is missing, which is not the same thing
 # as the parameter being optional to the science. The wording therefore states
-# only what is certain: no default exists.
-NO_DEFAULT_STATUS = "No default value; may be required depending on your configuration"
+# only what is certain: no default exists, and whether one must be supplied
+# depends on the configuration.
+#
+# This is guidance addressed to the reader, so it is labelled as a note rather
+# than filed under "Status". "Status" is reserved for a short state token such
+# as "Required"; a sentence of advice is a different kind of content and gets
+# its own label.
+NO_DEFAULT_NOTE_LABEL = "Configuration Note"
+NO_DEFAULT_NOTE = (
+    "No default value. A value may be required depending on which physics "
+    "options and surface types are active in your configuration."
+)
 
 
 class RSTGenerator:
@@ -729,7 +739,7 @@ class RSTGenerator:
         Returns appropriate label-value pair based on field characteristics:
         - Required fields: ("Status", "Required")
         - Fields with defaults: ("Default", "value") or ("Example", "value")
-        - Fields with no default: ("Status", NO_DEFAULT_STATUS)
+        - Fields with no default: (NO_DEFAULT_NOTE_LABEL, NO_DEFAULT_NOTE)
         - Nested models: (None, None) to skip display
 
         A ``Default`` label therefore always introduces a real default value.
@@ -762,7 +772,7 @@ class RSTGenerator:
         # are active. State the absence of a default without claiming that the
         # parameter itself is optional.
         if default is None:
-            return "Status", NO_DEFAULT_STATUS
+            return NO_DEFAULT_NOTE_LABEL, NO_DEFAULT_NOTE
 
         # We have a non-None default value - format it
         # Use the is_site_specific flag from doc_utils.py extraction

--- a/docs/generate_datamodel_rst.py
+++ b/docs/generate_datamodel_rst.py
@@ -27,6 +27,14 @@ except ImportError:
     from supy.data_model.doc_utils import ModelDocExtractor
 
 
+# Reported for any parameter that carries no default value. Such parameters are
+# typically declared Optional so that a partial configuration still loads and
+# the validation layer can report what is missing, which is not the same thing
+# as the parameter being optional to the science. The wording therefore states
+# only what is certain: no default exists.
+NO_DEFAULT_STATUS = "No default value; may be required depending on your configuration"
+
+
 class RSTGenerator:
     """Generate RST documentation from extracted model documentation."""
 
@@ -715,14 +723,18 @@ class RSTGenerator:
         return " ".join(formatted)
 
     @staticmethod
-    def _format_default(field_doc: dict[str, Any]) -> tuple[str, str]:  # noqa: PLR0912
+    def _format_default(field_doc: dict[str, Any]) -> tuple[str, str]:
         """Format default value for display with consistent labeling.
 
         Returns appropriate label-value pair based on field characteristics:
         - Required fields: ("Status", "Required")
-        - Optional with defaults: ("Default", "value") or ("Example", "value")
-        - Optional without defaults: ("Default", "None (optional)")
+        - Fields with defaults: ("Default", "value") or ("Example", "value")
+        - Fields with no default: ("Status", NO_DEFAULT_STATUS)
         - Nested models: (None, None) to skip display
+
+        A ``Default`` label therefore always introduces a real default value.
+        Absence of a value is reported under ``Status``, alongside the
+        unconditionally required case.
 
         Site-specific fields (detected by doc_utils.py pattern matching) show
         "Example" instead of "Default" to indicate values are illustrative.
@@ -736,12 +748,6 @@ class RSTGenerator:
         if nested_model:
             return None, None
 
-        # Get the field type to check if it's Optional
-        type_str = str(field_doc.get("type", ""))
-        is_optional = "Optional" in type_str or (
-            "Union[" in type_str and "None" in type_str
-        )
-
         # Check for default value
         default = field_doc.get("default")
 
@@ -749,15 +755,14 @@ class RSTGenerator:
         if str(default) == "PydanticUndefined":
             return "Status", "Required"
 
-        # Handle None defaults explicitly
+        # No default value to report. Most such parameters are declared
+        # Optional purely so a partial configuration still loads and the
+        # validation layer can then report what is missing; whether a value
+        # must be supplied depends on which physics options and surface types
+        # are active. State the absence of a default without claiming that the
+        # parameter itself is optional.
         if default is None:
-            # If the field is Optional (like Reference fields), show as optional
-            if is_optional:
-                return "Default", "None (optional)"
-            else:
-                # If not Optional but has None default, still show as optional
-                # (this handles cases where the model has default=None)
-                return "Default", "None (optional)"
+            return "Status", NO_DEFAULT_STATUS
 
         # We have a non-None default value - format it
         # Use the is_site_specific flag from doc_utils.py extraction

--- a/test/docs/test_generate_datamodel_rst.py
+++ b/test/docs/test_generate_datamodel_rst.py
@@ -235,7 +235,9 @@ def test_field_without_default_is_not_described_as_optional() -> None:
 
     # ASSERT
     assert "optional" not in value.lower()
-    assert (label, value) == ("Status", module.NO_DEFAULT_STATUS)
+    assert (label, value) == (module.NO_DEFAULT_NOTE_LABEL, module.NO_DEFAULT_NOTE)
+    # "Status" stays reserved for the short state token, not a sentence of advice.
+    assert label != "Status"
 
 
 def test_required_field_still_reports_required() -> None:

--- a/test/docs/test_generate_datamodel_rst.py
+++ b/test/docs/test_generate_datamodel_rst.py
@@ -213,3 +213,101 @@ def test_modelphysics_selector_guide_choices_resolve() -> None:
     assert {path for path, _ in rows} == set(CHOICE_RESOLVERS)
     for path, choice in rows:
         CHOICE_RESOLVERS[path](choice)
+
+
+def test_field_without_default_is_not_described_as_optional() -> None:
+    """A parameter carrying no default must not be labelled optional.
+
+    Most such parameters are declared ``Optional[...] = None`` only so a partial
+    configuration still loads; the science usually requires a value. Claiming
+    they are optional is the defect reported for the config reference.
+    """
+    # ARRANGE
+    module = _load_generator_module()
+    field_doc = {
+        "name": "store_cap",
+        "type": "Optional[FlexibleRefValue(float)]",
+        "default": None,
+    }
+
+    # ACT
+    label, value = module.RSTGenerator._format_default(field_doc)
+
+    # ASSERT
+    assert "optional" not in value.lower()
+    assert (label, value) == ("Status", module.NO_DEFAULT_STATUS)
+
+
+def test_required_field_still_reports_required() -> None:
+    """The unconditionally required rendering must be left intact."""
+    # ARRANGE
+    module = _load_generator_module()
+
+    # ACT
+    label, value = module.RSTGenerator._format_default({"default": "PydanticUndefined"})
+
+    # ASSERT
+    assert (label, value) == ("Status", "Required")
+
+
+@pytest.mark.parametrize(
+    ("default", "expected"),
+    [
+        (0.5, "``0.5``"),
+        (0, "``0``"),
+        (False, "``False``"),
+        ("", "``''`` (empty string)"),
+    ],
+)
+def test_real_default_still_reported_under_default_label(default, expected) -> None:
+    """A genuine default keeps the ``Default`` label, including falsy values.
+
+    ``0``, ``False`` and ``''`` are real defaults and must not be mistaken for
+    an absent one.
+    """
+    # ARRANGE
+    module = _load_generator_module()
+
+    # ACT
+    label, value = module.RSTGenerator._format_default({"default": default})
+
+    # ASSERT
+    assert label == "Default"
+    assert value == expected
+
+
+def test_nested_model_still_skips_the_default_line() -> None:
+    """Nested models carry a structure link instead of a default."""
+    # ARRANGE
+    module = _load_generator_module()
+
+    # ACT
+    result = module.RSTGenerator._format_default({
+        "default": None,
+        "nested_model": "LAIParams",
+    })
+
+    # ASSERT
+    assert result == (None, None)
+
+
+def test_generated_config_reference_never_claims_optional(tmp_path) -> None:
+    """End-to-end gate over every rendered page.
+
+    The generated RST is not tracked in git, so this is the only place the
+    claim can be caught before it reaches readers.
+    """
+    # ARRANGE
+    module = _load_generator_module()
+    doc_data = module.ModelDocExtractor().extract_all_models()
+
+    # ACT - "hybrid" is the style main() ships; the parameter default is stale.
+    module.RSTGenerator(doc_data).generate_all_rst(tmp_path, style="hybrid")
+
+    # ASSERT
+    pages = sorted(tmp_path.glob("*.rst"))
+    assert pages, "no RST pages were generated"
+    offenders = [
+        page.name for page in pages if "None (optional)" in page.read_text("utf-8")
+    ]
+    assert not offenders

--- a/test/docs/test_generate_datamodel_rst.py
+++ b/test/docs/test_generate_datamodel_rst.py
@@ -308,6 +308,8 @@ def test_generated_config_reference_never_claims_optional(tmp_path) -> None:
     pages = sorted(tmp_path.glob("*.rst"))
     assert pages, "no RST pages were generated"
     offenders = [
-        page.name for page in pages if "None (optional)" in page.read_text("utf-8")
+        page.name
+        for page in pages
+        if "None (optional)" in page.read_text(encoding="utf-8")
     ]
     assert not offenders


### PR DESCRIPTION
Part of #1677.

## The problem

The generated YAML config reference rendered `Default: None (optional)` for every parameter whose Pydantic default is `None`. That is about 140 entries across 83 distinct parameters, against only 19 rendered as `Required`.

For nearly all of them the label asserted the opposite of the truth. Of the 83 distinct parameters, **82 appear in the shipped `sample_config.yml`**, so a working configuration supplies them. The single exception, `soil_density`, is bulk soil density and is not optional either, merely absent from the sample. `store_cap` and `base_temperature_senescence`, both named in the report, are physically necessary.

The generator was faithful; the declaration is what misled. These parameters are declared `Optional[...] = None` so that a partial configuration still loads and the validation layer can then report what is missing. That is a loading concession, not a statement about the science.

## What changed

`RSTGenerator._format_default` now returns `("Status", NO_DEFAULT_STATUS)` when a field has no default, where the new module-level constant reads:

> No default value; may be required depending on your configuration

Parameters with no default therefore move from the `Default` line to the `Status` line. This gives the page a clean invariant: a `Default` label always introduces a real default value, and the absence of one is reported under `Status` alongside the unconditionally required case.

Both branches of the old `default is None` test returned the same string, so the duplicated `if/else` and the now-dead `is_optional` computation are removed with it. The `PydanticUndefined` path is untouched.

## What this deliberately does not do

It does not assert that any parameter *is* required. Only 22 of the affected parameters have a requirement condition expressed anywhere in the code today, in the conditional dictionaries inside `SUEWSConfig._iter_critical_null_site_param_issues`; the rest have none, and `store_cap` in particular appears in no validator at all. Rendering "Required when ..." means first hoisting those dictionaries into an importable registry that both the validators and the generator consult, which touches `src/supy/data_model/` and deserves its own review. That is proposed as a follow-up rather than bundled here.

The wording above was chosen because it is true for every affected parameter without over-claiming on any of them.

## Testing

- New unit coverage on `_format_default`: no-default fields are not described as optional; `PydanticUndefined` still yields `("Status", "Required")`; real defaults keep the `Default` label, including the falsy cases `0`, `False` and `''`; nested models still skip the line.
- New end-to-end test extracts every model, renders every page, and asserts the string is absent. **This is the only available gate**, because the generated config reference is not tracked in git (ignored by `docs/.gitignore`), so there is no committed artefact a reviewer could inspect.
- Verified as a genuine regression test: with the previous generator restored, exactly these two new tests fail and the other 16 pass.
- Verified for collateral damage by generating the full reference before and after against the same installed `supy`: exactly 140 lines differ, every one of them the intended `:Default:` to `:Status:` change, and nothing else.
- `pytest test/docs/test_generate_datamodel_rst.py` passes 18/18; `make test-smoke` green.

No schema-version implications: this touches `docs/` and `test/docs/` only.

## Incidental finding, not fixed here

`RSTGenerator.generate_all_rst` has a default argument `style="collapsible"`, which is not a valid style and raises `KeyError` if the default is ever used. Production calls pass `"hybrid"`. Left alone as unrelated to this change.
