### PR TITLE
Render the condition under which a configuration parameter is required

### DIFF
--- a/docs/generate_datamodel_rst.py
+++ b/docs/generate_datamodel_rst.py
@@ -26,6 +26,26 @@ except ImportError:
     sys.path.insert(0, str(SRC_PATH))
     from supy.data_model.doc_utils import ModelDocExtractor
 
+try:
+    from supy.data_model.validation.required_fields import required_when
+except ImportError:
+    # The installed supy predates the conditionally-required field registry.
+    # Degrade to the wording used for parameters whose requirement nothing
+    # records, rather than aborting the whole docs build, but say so plainly:
+    # silently shipping pages that omit the conditions is the failure mode this
+    # registry exists to end.
+    print(
+        "WARNING: the installed supy has no conditionally-required field "
+        "registry, so requirement conditions will be omitted from the "
+        "generated configuration reference. Rebuild supy from this checkout "
+        "(make dev) to include them.",
+        file=sys.stderr,
+    )
+
+    def required_when(model_name: str, field_name: str) -> str:
+        """Fall back to recording no condition."""
+        return ""
+
 
 # Shown for any parameter that carries no default value. Such parameters are
 # typically declared Optional so that a partial configuration still loads and
@@ -550,7 +570,7 @@ class RSTGenerator:
             lines.append(f"   :Unit: {formatted_unit}")
 
         # Add default/sample value
-        default_label, default_value = self._format_default(field_doc)
+        default_label, default_value = self._format_default(field_doc, model_name)
         if default_label is not None and default_value is not None:
             lines.append(f"   :{default_label}: {default_value}")
 
@@ -733,24 +753,32 @@ class RSTGenerator:
         return " ".join(formatted)
 
     @staticmethod
-    def _format_default(field_doc: dict[str, Any]) -> tuple[str, str]:
+    def _format_default(
+        field_doc: dict[str, Any], model_name: str = ""
+    ) -> tuple[str, str]:
         """Format default value for display with consistent labeling.
 
         Returns appropriate label-value pair based on field characteristics:
         - Required fields: ("Status", "Required")
+        - Conditionally required fields: ("Status", "Required when ...")
         - Fields with defaults: ("Default", "value") or ("Example", "value")
-        - Fields with no default: (NO_DEFAULT_NOTE_LABEL, NO_DEFAULT_NOTE)
+        - Fields with no default and no known condition:
+          (NO_DEFAULT_NOTE_LABEL, NO_DEFAULT_NOTE)
         - Nested models: (None, None) to skip display
 
         A ``Default`` label therefore always introduces a real default value.
-        Absence of a value is reported under ``Status``, alongside the
-        unconditionally required case.
+        ``Status`` carries what the validator demands, conditionally or not,
+        and the configuration note carries advice for the parameters whose
+        requirement no validator records.
 
         Site-specific fields (detected by doc_utils.py pattern matching) show
         "Example" instead of "Default" to indicate values are illustrative.
 
         Args:
             field_doc: Field documentation dictionary with is_site_specific flag
+            model_name: Name of the model declaring the field, used to look up
+                a conditional requirement. Omitted for callers that have no
+                model context, which simply skips that lookup.
         """
         nested_model = field_doc.get("nested_model")
 
@@ -765,13 +793,18 @@ class RSTGenerator:
         if str(default) == "PydanticUndefined":
             return "Status", "Required"
 
-        # No default value to report. Most such parameters are declared
-        # Optional purely so a partial configuration still loads and the
-        # validation layer can then report what is missing; whether a value
-        # must be supplied depends on which physics options and surface types
-        # are active. State the absence of a default without claiming that the
-        # parameter itself is optional.
         if default is None:
+            # The validation layer may record the exact condition under which
+            # this parameter must be supplied. Prefer it: it tells the reader
+            # something specific rather than leaving them to guess.
+            condition = required_when(model_name, field_doc.get("name", ""))
+            if condition:
+                return "Status", f"Required when {condition}"
+
+            # Otherwise say only what is certain. Most such parameters are
+            # declared Optional purely so a partial configuration still loads
+            # and the validation layer can then report what is missing, which
+            # is not the same as the parameter being optional to the science.
             return NO_DEFAULT_NOTE_LABEL, NO_DEFAULT_NOTE
 
         # We have a non-None default value - format it

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -38,6 +38,17 @@ from .site import Site, SiteProperties, InitialStates, LandCover, LAIParams
 from .type import SurfaceType
 
 from ..validation.core.yaml_helpers import unwrap_value as _unwrap_value
+from ..validation.required_fields import (
+    BUILDING_REQUIRED,
+    BUILDING_REQUIRED_PROVIDED_FAI,
+    CONDUCTANCE_REQUIRED,
+    DECIDUOUS_REQUIRED,
+    DECIDUOUS_REQUIRED_PROVIDED_FAI,
+    EVERGREEN_REQUIRED,
+    EVERGREEN_REQUIRED_PROVIDED_FAI,
+    LAI_CALCULATED_ONLY_REQUIRED,
+    LAI_REQUIRED,
+)
 
 from datetime import datetime
 import pytz
@@ -3116,18 +3127,6 @@ class SUEWSConfig(BaseModel):
         # Sourced from the shared registry so the documentation generator can
         # describe the same conditions to readers. Copied rather than aliased,
         # because the FAI entries below are added conditionally per call.
-        from ..validation.required_fields import (
-            BUILDING_REQUIRED,
-            BUILDING_REQUIRED_PROVIDED_FAI,
-            CONDUCTANCE_REQUIRED,
-            DECIDUOUS_REQUIRED,
-            DECIDUOUS_REQUIRED_PROVIDED_FAI,
-            EVERGREEN_REQUIRED,
-            EVERGREEN_REQUIRED_PROVIDED_FAI,
-            LAI_CALCULATED_ONLY_REQUIRED,
-            LAI_REQUIRED,
-        )
-
         lai_required = dict(LAI_REQUIRED)
         lai_calculated_only_required = dict(LAI_CALCULATED_ONLY_REQUIRED)
         conductance_required = dict(CONDUCTANCE_REQUIRED)

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -3113,109 +3113,34 @@ class SUEWSConfig(BaseModel):
             raw_surface = raw_lc.get(surface_name)
             return raw_surface is None or isinstance(raw_surface, dict)
 
-        lai_required = {
-            "lai_max": (
-                "Maximum LAI is required for active vegetation",
-                "Add maximum leaf area index for full leaf-on conditions",
-            ),
-        }
-        lai_calculated_only_required = {
-            "base_temperature": (
-                "Base temperature is required for active vegetation",
-                "Add the base temperature for growing degree day accumulation",
-            ),
-            "base_temperature_senescence": (
-                "Senescence base temperature is required for active vegetation",
-                "Add the base temperature for senescence degree day accumulation",
-            ),
-            "gdd_full": (
-                "Growing degree days for full LAI are required for active vegetation",
-                "Add the growing degree day threshold for full leaf-on conditions",
-            ),
-            "sdd_full": (
-                "Senescence degree days are required for active vegetation",
-                "Add the senescence degree day threshold for leaf-off conditions",
-            ),
-        }
-        conductance_required = {
-            "g_max": (
-                "Maximum surface conductance is required for active vegetation",
-                "Add g_max for evapotranspiration calculations",
-            ),
-            "g_k": (
-                "Solar radiation response parameter is required for active vegetation",
-                "Add g_k for evapotranspiration calculations",
-            ),
-            "g_q_base": (
-                "Vapour pressure deficit base parameter is required for active vegetation",
-                "Add g_q_base for evapotranspiration calculations",
-            ),
-            "g_q_shape": (
-                "Vapour pressure deficit shape parameter is required for active vegetation",
-                "Add g_q_shape for evapotranspiration calculations",
-            ),
-            "g_t": (
-                "Temperature response parameter is required for active vegetation",
-                "Add g_t for evapotranspiration calculations",
-            ),
-            "g_sm": (
-                "Soil moisture response parameter is required for active vegetation",
-                "Add g_sm for evapotranspiration calculations",
-            ),
-            "kmax": (
-                "Maximum shortwave radiation parameter is required for active vegetation",
-                "Add kmax for evapotranspiration calculations",
-            ),
-            "s1": (
-                "Lower soil moisture threshold is required for active vegetation",
-                "Add s1 for evapotranspiration calculations",
-            ),
-            "s2": (
-                "Soil moisture dependence parameter is required for active vegetation",
-                "Add s2 for evapotranspiration calculations",
-            ),
-            "tl": (
-                "Lower temperature threshold is required for active vegetation",
-                "Add tl for evapotranspiration calculations",
-            ),
-            "th": (
-                "Upper temperature threshold is required for active vegetation",
-                "Add th for evapotranspiration calculations",
-            ),
-        }
-        building_required = {
-            "bldgh": (
-                "Building height is required when buildings are active",
-                "Add building height in meters",
-            ),
-        }
+        # Sourced from the shared registry so the documentation generator can
+        # describe the same conditions to readers. Copied rather than aliased,
+        # because the FAI entries below are added conditionally per call.
+        from ..validation.required_fields import (
+            BUILDING_REQUIRED,
+            BUILDING_REQUIRED_PROVIDED_FAI,
+            CONDUCTANCE_REQUIRED,
+            DECIDUOUS_REQUIRED,
+            DECIDUOUS_REQUIRED_PROVIDED_FAI,
+            EVERGREEN_REQUIRED,
+            EVERGREEN_REQUIRED_PROVIDED_FAI,
+            LAI_CALCULATED_ONLY_REQUIRED,
+            LAI_REQUIRED,
+        )
+
+        lai_required = dict(LAI_REQUIRED)
+        lai_calculated_only_required = dict(LAI_CALCULATED_ONLY_REQUIRED)
+        conductance_required = dict(CONDUCTANCE_REQUIRED)
+
+        building_required = dict(BUILDING_REQUIRED)
         if require_provided_fai:
-            building_required["faibldg"] = (
-                "Building frontal area index is required when buildings are active",
-                "Add frontal area index for wind and roughness calculations",
-            )
-        evergreen_required = {
-            "height_evergreen_tree": (
-                "Evergreen tree height is required when evergreen vegetation is active",
-                "Add evergreen tree height in meters",
-            ),
-        }
+            building_required.update(BUILDING_REQUIRED_PROVIDED_FAI)
+        evergreen_required = dict(EVERGREEN_REQUIRED)
         if require_provided_fai:
-            evergreen_required["fai_evergreen_tree"] = (
-                "Evergreen tree frontal area index is required when evergreen vegetation is active",
-                "Add evergreen tree frontal area index",
-            )
-        deciduous_required = {
-            "height_deciduous_tree": (
-                "Deciduous tree height is required when deciduous vegetation is active",
-                "Add deciduous tree height in meters",
-            ),
-        }
+            evergreen_required.update(EVERGREEN_REQUIRED_PROVIDED_FAI)
+        deciduous_required = dict(DECIDUOUS_REQUIRED)
         if require_provided_fai:
-            deciduous_required["fai_deciduous_tree"] = (
-                "Deciduous tree frontal area index is required when deciduous vegetation is active",
-                "Add deciduous tree frontal area index",
-            )
+            deciduous_required.update(DECIDUOUS_REQUIRED_PROVIDED_FAI)
 
         def _add_issue(
             *,

--- a/src/supy/data_model/validation/required_fields.py
+++ b/src/supy/data_model/validation/required_fields.py
@@ -15,19 +15,18 @@ these parameters have no default and leaving the reader to guess.
 Two distinct things live in this module:
 
 - The ``*_REQUIRED`` tables, which map a field name to the
-  ``(message, fix)`` pair the validator emits. These are consumed by
-  ``SUEWSConfig._iter_critical_null_site_param_issues``.
+  ``(message, fix)`` pair emitted in annotated-YAML feedback. These are
+  consumed by ``SUEWSConfig._iter_critical_null_site_param_issues``.
 - ``DOC_REQUIRED_WHEN``, which maps a model class name to a reader-facing
   description of when each field is required. This is consumed by the
   documentation generator.
 
 .. warning::
 
-   The ``message`` strings are load-bearing. ``validation/pipeline/phase_c.py``
-   classifies issues by matching substrings of the emitted text, so rewording a
-   message can silently change how an issue is reported without failing any
-   type check. A freeze test guards the exact strings; if you need to change
-   one, update that test deliberately and check the phase C matchers.
+   The ``message`` and ``fix`` strings are user-facing annotated-YAML output.
+   Rewording either changes validation feedback without failing any type check.
+   A freeze test guards every pair; update it deliberately when changing this
+   public feedback contract.
 """
 
 from __future__ import annotations

--- a/src/supy/data_model/validation/required_fields.py
+++ b/src/supy/data_model/validation/required_fields.py
@@ -1,0 +1,202 @@
+"""Registry of conditionally required configuration fields.
+
+A number of parameters are declared ``Optional[...] = None`` on their Pydantic
+model so that a partial configuration still loads and the validation layer can
+report what is missing. Whether such a parameter must actually be supplied
+depends on the configuration: which surface types have a non-zero fraction, and
+which physics options are selected.
+
+That knowledge used to live only as local dictionary literals inside
+``SUEWSConfig._iter_critical_null_site_param_issues``, where nothing but the
+validator itself could reach it. It is hoisted here so the documentation
+generator can describe the same conditions to readers instead of reporting that
+these parameters have no default and leaving the reader to guess.
+
+Two distinct things live in this module:
+
+- The ``*_REQUIRED`` tables, which map a field name to the
+  ``(message, fix)`` pair the validator emits. These are consumed by
+  ``SUEWSConfig._iter_critical_null_site_param_issues``.
+- ``DOC_REQUIRED_WHEN``, which maps a model class name to a reader-facing
+  description of when each field is required. This is consumed by the
+  documentation generator.
+
+.. warning::
+
+   The ``message`` strings are load-bearing. ``validation/pipeline/phase_c.py``
+   classifies issues by matching substrings of the emitted text, so rewording a
+   message can silently change how an issue is reported without failing any
+   type check. A freeze test guards the exact strings; if you need to change
+   one, update that test deliberately and check the phase C matchers.
+"""
+
+from __future__ import annotations
+
+# (message, fix) keyed by field name.
+RequirementTable = dict[str, tuple[str, str]]
+
+LAI_REQUIRED: RequirementTable = {
+    "lai_max": (
+        "Maximum LAI is required for active vegetation",
+        "Add maximum leaf area index for full leaf-on conditions",
+    ),
+}
+
+# Required only when leaf area index is modelled rather than observed.
+LAI_CALCULATED_ONLY_REQUIRED: RequirementTable = {
+    "base_temperature": (
+        "Base temperature is required for active vegetation",
+        "Add the base temperature for growing degree day accumulation",
+    ),
+    "base_temperature_senescence": (
+        "Senescence base temperature is required for active vegetation",
+        "Add the base temperature for senescence degree day accumulation",
+    ),
+    "gdd_full": (
+        "Growing degree days for full LAI are required for active vegetation",
+        "Add the growing degree day threshold for full leaf-on conditions",
+    ),
+    "sdd_full": (
+        "Senescence degree days are required for active vegetation",
+        "Add the senescence degree day threshold for leaf-off conditions",
+    ),
+}
+
+CONDUCTANCE_REQUIRED: RequirementTable = {
+    "g_max": (
+        "Maximum surface conductance is required for active vegetation",
+        "Add g_max for evapotranspiration calculations",
+    ),
+    "g_k": (
+        "Solar radiation response parameter is required for active vegetation",
+        "Add g_k for evapotranspiration calculations",
+    ),
+    "g_q_base": (
+        "Vapour pressure deficit base parameter is required for active vegetation",
+        "Add g_q_base for evapotranspiration calculations",
+    ),
+    "g_q_shape": (
+        "Vapour pressure deficit shape parameter is required for active vegetation",
+        "Add g_q_shape for evapotranspiration calculations",
+    ),
+    "g_t": (
+        "Temperature response parameter is required for active vegetation",
+        "Add g_t for evapotranspiration calculations",
+    ),
+    "g_sm": (
+        "Soil moisture response parameter is required for active vegetation",
+        "Add g_sm for evapotranspiration calculations",
+    ),
+    "kmax": (
+        "Maximum shortwave radiation parameter is required for active vegetation",
+        "Add kmax for evapotranspiration calculations",
+    ),
+    "s1": (
+        "Lower soil moisture threshold is required for active vegetation",
+        "Add s1 for evapotranspiration calculations",
+    ),
+    "s2": (
+        "Soil moisture dependence parameter is required for active vegetation",
+        "Add s2 for evapotranspiration calculations",
+    ),
+    "tl": (
+        "Lower temperature threshold is required for active vegetation",
+        "Add tl for evapotranspiration calculations",
+    ),
+    "th": (
+        "Upper temperature threshold is required for active vegetation",
+        "Add th for evapotranspiration calculations",
+    ),
+}
+
+BUILDING_REQUIRED: RequirementTable = {
+    "bldgh": (
+        "Building height is required when buildings are active",
+        "Add building height in meters",
+    ),
+}
+
+# Added to BUILDING_REQUIRED only when frontal area index comes from site input.
+BUILDING_REQUIRED_PROVIDED_FAI: RequirementTable = {
+    "faibldg": (
+        "Building frontal area index is required when buildings are active",
+        "Add frontal area index for wind and roughness calculations",
+    ),
+}
+
+EVERGREEN_REQUIRED: RequirementTable = {
+    "height_evergreen_tree": (
+        "Evergreen tree height is required when evergreen vegetation is active",
+        "Add evergreen tree height in meters",
+    ),
+}
+
+EVERGREEN_REQUIRED_PROVIDED_FAI: RequirementTable = {
+    "fai_evergreen_tree": (
+        "Evergreen tree frontal area index is required when evergreen vegetation is active",
+        "Add evergreen tree frontal area index",
+    ),
+}
+
+DECIDUOUS_REQUIRED: RequirementTable = {
+    "height_deciduous_tree": (
+        "Deciduous tree height is required when deciduous vegetation is active",
+        "Add deciduous tree height in meters",
+    ),
+}
+
+DECIDUOUS_REQUIRED_PROVIDED_FAI: RequirementTable = {
+    "fai_deciduous_tree": (
+        "Deciduous tree frontal area index is required when deciduous vegetation is active",
+        "Add deciduous tree frontal area index",
+    ),
+}
+
+
+_VEGETATION_PRESENT = "a vegetated surface using these parameters is present"
+_LAI_MODELLED = "leaf area index is modelled rather than observed"
+_PROVIDED_FAI = "frontal area index is taken from site parameters"
+
+# Reader-facing conditions, keyed by the model class that declares the field.
+# Consumed by the documentation generator; see docs/generate_datamodel_rst.py.
+DOC_REQUIRED_WHEN: dict[str, dict[str, str]] = {
+    "Conductance": dict.fromkeys(CONDUCTANCE_REQUIRED, _VEGETATION_PRESENT),
+    "LAIParams": {
+        **dict.fromkeys(LAI_REQUIRED, _VEGETATION_PRESENT),
+        **dict.fromkeys(
+            LAI_CALCULATED_ONLY_REQUIRED,
+            f"{_VEGETATION_PRESENT} and {_LAI_MODELLED}",
+        ),
+    },
+    "BldgsProperties": {
+        "bldgh": "buildings are present",
+        "faibldg": f"buildings are present and {_PROVIDED_FAI}",
+    },
+    "EvetrProperties": {
+        "height_evergreen_tree": "evergreen trees are present",
+        "fai_evergreen_tree": f"evergreen trees are present and {_PROVIDED_FAI}",
+    },
+    "DectrProperties": {
+        "height_deciduous_tree": "deciduous trees are present",
+        "fai_deciduous_tree": f"deciduous trees are present and {_PROVIDED_FAI}",
+    },
+}
+
+
+def required_when(model_name: str, field_name: str) -> str:
+    """Return the condition under which a field must be supplied.
+
+    Parameters
+    ----------
+    model_name : str
+        Name of the Pydantic model class declaring the field.
+    field_name : str
+        Name of the field.
+
+    Returns
+    -------
+    str
+        A reader-facing condition, or an empty string when the field has no
+        recorded requirement condition.
+    """
+    return DOC_REQUIRED_WHEN.get(model_name, {}).get(field_name, "")

--- a/src/supy/meson.build
+++ b/src/supy/meson.build
@@ -172,6 +172,7 @@ py.install_sources(
             'data_model/validation/core/feedback.py',
             'data_model/validation/core/utils.py',
             'data_model/validation/core/yaml_helpers.py',
+            'data_model/validation/required_fields.py',
             'data_model/validation/pipeline/__init__.py',
             'data_model/validation/pipeline/orchestrator.py',
             'data_model/validation/pipeline/phase_a.py',

--- a/test/data_model/test_required_fields_registry.py
+++ b/test/data_model/test_required_fields_registry.py
@@ -53,6 +53,115 @@ ALL_TABLES = (
     DECIDUOUS_REQUIRED_PROVIDED_FAI,
 )
 
+EXPECTED_TABLES = {
+    "LAI_REQUIRED": {
+        "lai_max": (
+            "Maximum LAI is required for active vegetation",
+            "Add maximum leaf area index for full leaf-on conditions",
+        ),
+    },
+    "LAI_CALCULATED_ONLY_REQUIRED": {
+        "base_temperature": (
+            "Base temperature is required for active vegetation",
+            "Add the base temperature for growing degree day accumulation",
+        ),
+        "base_temperature_senescence": (
+            "Senescence base temperature is required for active vegetation",
+            "Add the base temperature for senescence degree day accumulation",
+        ),
+        "gdd_full": (
+            "Growing degree days for full LAI are required for active vegetation",
+            "Add the growing degree day threshold for full leaf-on conditions",
+        ),
+        "sdd_full": (
+            "Senescence degree days are required for active vegetation",
+            "Add the senescence degree day threshold for leaf-off conditions",
+        ),
+    },
+    "CONDUCTANCE_REQUIRED": {
+        "g_max": (
+            "Maximum surface conductance is required for active vegetation",
+            "Add g_max for evapotranspiration calculations",
+        ),
+        "g_k": (
+            "Solar radiation response parameter is required for active vegetation",
+            "Add g_k for evapotranspiration calculations",
+        ),
+        "g_q_base": (
+            "Vapour pressure deficit base parameter is required for active vegetation",
+            "Add g_q_base for evapotranspiration calculations",
+        ),
+        "g_q_shape": (
+            "Vapour pressure deficit shape parameter is required for active vegetation",
+            "Add g_q_shape for evapotranspiration calculations",
+        ),
+        "g_t": (
+            "Temperature response parameter is required for active vegetation",
+            "Add g_t for evapotranspiration calculations",
+        ),
+        "g_sm": (
+            "Soil moisture response parameter is required for active vegetation",
+            "Add g_sm for evapotranspiration calculations",
+        ),
+        "kmax": (
+            "Maximum shortwave radiation parameter is required for active vegetation",
+            "Add kmax for evapotranspiration calculations",
+        ),
+        "s1": (
+            "Lower soil moisture threshold is required for active vegetation",
+            "Add s1 for evapotranspiration calculations",
+        ),
+        "s2": (
+            "Soil moisture dependence parameter is required for active vegetation",
+            "Add s2 for evapotranspiration calculations",
+        ),
+        "tl": (
+            "Lower temperature threshold is required for active vegetation",
+            "Add tl for evapotranspiration calculations",
+        ),
+        "th": (
+            "Upper temperature threshold is required for active vegetation",
+            "Add th for evapotranspiration calculations",
+        ),
+    },
+    "BUILDING_REQUIRED": {
+        "bldgh": (
+            "Building height is required when buildings are active",
+            "Add building height in meters",
+        ),
+    },
+    "BUILDING_REQUIRED_PROVIDED_FAI": {
+        "faibldg": (
+            "Building frontal area index is required when buildings are active",
+            "Add frontal area index for wind and roughness calculations",
+        ),
+    },
+    "EVERGREEN_REQUIRED": {
+        "height_evergreen_tree": (
+            "Evergreen tree height is required when evergreen vegetation is active",
+            "Add evergreen tree height in meters",
+        ),
+    },
+    "EVERGREEN_REQUIRED_PROVIDED_FAI": {
+        "fai_evergreen_tree": (
+            "Evergreen tree frontal area index is required when evergreen vegetation is active",
+            "Add evergreen tree frontal area index",
+        ),
+    },
+    "DECIDUOUS_REQUIRED": {
+        "height_deciduous_tree": (
+            "Deciduous tree height is required when deciduous vegetation is active",
+            "Add deciduous tree height in meters",
+        ),
+    },
+    "DECIDUOUS_REQUIRED_PROVIDED_FAI": {
+        "fai_deciduous_tree": (
+            "Deciduous tree frontal area index is required when deciduous vegetation is active",
+            "Add deciduous tree frontal area index",
+        ),
+    },
+}
+
 
 def test_documented_fields_exist_on_their_models() -> None:
     """Every documented condition names a field that really exists."""
@@ -74,36 +183,29 @@ def test_every_required_field_has_a_documented_condition() -> None:
     documented = {field for fields in DOC_REQUIRED_WHEN.values() for field in fields}
 
     # ACT
-    undocumented = {
-        field for table in ALL_TABLES for field in table
-    } - documented
+    undocumented = {field for table in ALL_TABLES for field in table} - documented
 
     # ASSERT
     assert not undocumented
 
 
 def test_message_strings_are_frozen() -> None:
-    """phase_c classifies issues by matching message substrings.
+    """Pin every user-facing annotated-YAML message and fix string."""
+    # ARRANGE
+    actual_tables = {
+        "LAI_REQUIRED": LAI_REQUIRED,
+        "LAI_CALCULATED_ONLY_REQUIRED": LAI_CALCULATED_ONLY_REQUIRED,
+        "CONDUCTANCE_REQUIRED": CONDUCTANCE_REQUIRED,
+        "BUILDING_REQUIRED": BUILDING_REQUIRED,
+        "BUILDING_REQUIRED_PROVIDED_FAI": BUILDING_REQUIRED_PROVIDED_FAI,
+        "EVERGREEN_REQUIRED": EVERGREEN_REQUIRED,
+        "EVERGREEN_REQUIRED_PROVIDED_FAI": EVERGREEN_REQUIRED_PROVIDED_FAI,
+        "DECIDUOUS_REQUIRED": DECIDUOUS_REQUIRED,
+        "DECIDUOUS_REQUIRED_PROVIDED_FAI": DECIDUOUS_REQUIRED_PROVIDED_FAI,
+    }
 
-    Rewording a message changes how an issue is reported without failing any
-    type check, so the exact text is pinned. If you intend to change one,
-    update this test deliberately and re-check the matchers in
-    ``validation/pipeline/phase_c.py``.
-    """
-    # ARRANGE / ACT / ASSERT
-    assert LAI_REQUIRED["lai_max"] == (
-        "Maximum LAI is required for active vegetation",
-        "Add maximum leaf area index for full leaf-on conditions",
-    )
-    assert LAI_CALCULATED_ONLY_REQUIRED["base_temperature_senescence"] == (
-        "Senescence base temperature is required for active vegetation",
-        "Add the base temperature for senescence degree day accumulation",
-    )
-    assert BUILDING_REQUIRED_PROVIDED_FAI["faibldg"] == (
-        "Building frontal area index is required when buildings are active",
-        "Add frontal area index for wind and roughness calculations",
-    )
-    assert sum(len(table) for table in ALL_TABLES) == 22
+    # ACT / ASSERT
+    assert actual_tables == EXPECTED_TABLES
 
 
 def test_required_when_returns_condition_or_empty() -> None:

--- a/test/data_model/test_required_fields_registry.py
+++ b/test/data_model/test_required_fields_registry.py
@@ -1,0 +1,118 @@
+"""Guards for the conditionally-required field registry.
+
+The registry is consumed by two unrelated places: the configuration validator,
+which emits its message strings, and the documentation generator, which
+describes its conditions to readers. Neither notices if the other drifts, so
+the coupling is pinned here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from supy.data_model.core.site import (
+    Conductance,
+    DectrProperties,
+    EvetrProperties,
+    LAIParams,
+)
+from supy.data_model.core.surface import BldgsProperties
+from supy.data_model.validation.required_fields import (
+    BUILDING_REQUIRED,
+    BUILDING_REQUIRED_PROVIDED_FAI,
+    CONDUCTANCE_REQUIRED,
+    DECIDUOUS_REQUIRED,
+    DECIDUOUS_REQUIRED_PROVIDED_FAI,
+    DOC_REQUIRED_WHEN,
+    EVERGREEN_REQUIRED,
+    EVERGREEN_REQUIRED_PROVIDED_FAI,
+    LAI_CALCULATED_ONLY_REQUIRED,
+    LAI_REQUIRED,
+    required_when,
+)
+
+pytestmark = pytest.mark.api
+
+MODELS = {
+    "Conductance": Conductance,
+    "LAIParams": LAIParams,
+    "BldgsProperties": BldgsProperties,
+    "EvetrProperties": EvetrProperties,
+    "DectrProperties": DectrProperties,
+}
+
+ALL_TABLES = (
+    LAI_REQUIRED,
+    LAI_CALCULATED_ONLY_REQUIRED,
+    CONDUCTANCE_REQUIRED,
+    BUILDING_REQUIRED,
+    BUILDING_REQUIRED_PROVIDED_FAI,
+    EVERGREEN_REQUIRED,
+    EVERGREEN_REQUIRED_PROVIDED_FAI,
+    DECIDUOUS_REQUIRED,
+    DECIDUOUS_REQUIRED_PROVIDED_FAI,
+)
+
+
+def test_documented_fields_exist_on_their_models() -> None:
+    """Every documented condition names a field that really exists."""
+    # ARRANGE / ACT
+    missing = [
+        f"{model_name}.{field}"
+        for model_name, fields in DOC_REQUIRED_WHEN.items()
+        for field in fields
+        if field not in MODELS[model_name].model_fields
+    ]
+
+    # ASSERT
+    assert not missing
+
+
+def test_every_required_field_has_a_documented_condition() -> None:
+    """A field the validator can demand must be explainable to the reader."""
+    # ARRANGE
+    documented = {field for fields in DOC_REQUIRED_WHEN.values() for field in fields}
+
+    # ACT
+    undocumented = {
+        field for table in ALL_TABLES for field in table
+    } - documented
+
+    # ASSERT
+    assert not undocumented
+
+
+def test_message_strings_are_frozen() -> None:
+    """phase_c classifies issues by matching message substrings.
+
+    Rewording a message changes how an issue is reported without failing any
+    type check, so the exact text is pinned. If you intend to change one,
+    update this test deliberately and re-check the matchers in
+    ``validation/pipeline/phase_c.py``.
+    """
+    # ARRANGE / ACT / ASSERT
+    assert LAI_REQUIRED["lai_max"] == (
+        "Maximum LAI is required for active vegetation",
+        "Add maximum leaf area index for full leaf-on conditions",
+    )
+    assert LAI_CALCULATED_ONLY_REQUIRED["base_temperature_senescence"] == (
+        "Senescence base temperature is required for active vegetation",
+        "Add the base temperature for senescence degree day accumulation",
+    )
+    assert BUILDING_REQUIRED_PROVIDED_FAI["faibldg"] == (
+        "Building frontal area index is required when buildings are active",
+        "Add frontal area index for wind and roughness calculations",
+    )
+    assert sum(len(table) for table in ALL_TABLES) == 22
+
+
+def test_required_when_returns_condition_or_empty() -> None:
+    """The generator lookup answers for known fields and declines otherwise."""
+    # ARRANGE / ACT / ASSERT
+    assert "modelled rather than observed" in required_when(
+        "LAIParams", "base_temperature_senescence"
+    )
+    assert required_when("BldgsProperties", "bldgh") == "buildings are present"
+    # store_cap is in no validator, so nothing may be claimed about it.
+    assert not required_when("StorageDrainParams", "store_cap")
+    assert not required_when("LAIParams", "not_a_field")

--- a/test/docs/test_generate_datamodel_rst.py
+++ b/test/docs/test_generate_datamodel_rst.py
@@ -240,6 +240,45 @@ def test_field_without_default_is_not_described_as_optional() -> None:
     assert label != "Status"
 
 
+def test_conditionally_required_field_reports_its_condition(monkeypatch) -> None:
+    """A recorded condition is preferred over the generic note.
+
+    The lookup is injected rather than relied upon, so this holds whether or
+    not the installed supy carries the registry.
+    """
+    # ARRANGE
+    module = _load_generator_module()
+    monkeypatch.setattr(
+        module,
+        "required_when",
+        lambda model, field: "buildings are present" if field == "bldgh" else "",
+    )
+
+    # ACT
+    label, value = module.RSTGenerator._format_default(
+        {"name": "bldgh", "default": None}, "BldgsProperties"
+    )
+
+    # ASSERT
+    assert (label, value) == ("Status", "Required when buildings are present")
+
+
+def test_field_without_recorded_condition_keeps_the_note(monkeypatch) -> None:
+    """Where nothing records a condition, no requirement may be claimed."""
+    # ARRANGE
+    module = _load_generator_module()
+    monkeypatch.setattr(module, "required_when", lambda model, field: "")
+
+    # ACT
+    label, value = module.RSTGenerator._format_default(
+        {"name": "store_cap", "default": None}, "StorageDrainParams"
+    )
+
+    # ASSERT
+    assert (label, value) == (module.NO_DEFAULT_NOTE_LABEL, module.NO_DEFAULT_NOTE)
+    assert "required" not in value.lower().split("may be required")[0]
+
+
 def test_required_field_still_reports_required() -> None:
     """The unconditionally required rendering must be left intact."""
     # ARRANGE


### PR DESCRIPTION
Follows #1686, which stopped the configuration reference describing parameters without a default as optional. This adds the other half: saying, where the code actually knows, what a parameter's requirement depends on.

Part of #1677.

## The problem it addresses

#1686 could only report that a parameter has no default, because the knowledge of when a parameter must be supplied lived as local dictionary literals inside `SUEWSConfig._iter_critical_null_site_param_issues`, reachable by nothing but the validator that declared them. A reader was left to guess.

## What changed

**Registry.** The six requirement tables move to `src/supy/data_model/validation/required_fields.py` unchanged, and `config.py` consumes them. Alongside them the module records `DOC_REQUIRED_WHEN`, a reader-facing description of each condition keyed by the model class declaring the field.

The tables are copied rather than aliased at the point of use. The frontal-area-index entries are added conditionally per call, so aliasing module-level dictionaries would let one call mutate state seen by the next.

**Generator.** `_format_default` consults the registry. `model_name` was already threaded from `_format_field` through `_format_field_metadata`, so it only had to be passed one level further.

`base_temperature_senescence` now renders as:

```
:Status: Required when a vegetated surface using these parameters is present and leaf area index is modelled rather than observed
```

## What it deliberately does not do

Twenty-two parameters have a recorded condition. Everything else keeps the configuration note from #1686, and that is the point: the registry records nothing for parameters no validator covers, so the generator cannot claim a requirement the code does not hold. `store_cap` remains in that group, and a test pins that it stays there.

`Status` carries what the validator demands, conditionally or not; the configuration note carries advice where the requirement is unknown. One label, one kind of content.

## Behaviour preservation

This is a pure refactor on the validation side. The `(message, fix)` pairs are reproduced byte for byte, verified by parsing the previous revision and comparing all twenty-two entries individually rather than by inspection.

Those strings are user-facing annotated-YAML feedback, so an unintended rewording would change diagnostics without failing any type check. The freeze test now pins every exact `(message, fix)` pair.

## Version skew

A `supy` install predating the registry degrades rather than aborting: the conditions are omitted and a warning goes to stderr. Failing the whole docs build over a version skew would be worse than generating pages without the conditions, but silently shipping pages that leave them out is exactly the failure mode this registry exists to end, so the omission is announced.

## Testing

- Drift guards: every documented condition names a field that exists on its model, and every field the validator can demand has a documented condition.
- Freeze test on every exact `(message, fix)` pair.
- Generator tests inject the lookup rather than importing it, so the conditional path is exercised regardless of what the installed `supy` carries.
- `pytest test/docs/test_generate_datamodel_rst.py` passes 20/20.

The editable `supy` install now resolves to this worktree. Focused registry and generator tests pass locally, `make test-smoke` passes, and CI built and tested this exact HEAD across the supported matrix.

## Schema gate

This touches `src/supy/data_model/**`, so the schema version audit fires by path. No bump is correct: the YAML surface is byte-identical and no field is renamed, removed, retyped or added. This is the internal-refactor case in `.claude/rules/python/schema-versioning.md`, so the `0-ci:schema-audit-ok` label is applied with that justification. Adding a `.devN` bump here would insert a no-op `SCHEMA_VERSIONS` entry and a vacuous migration handler.
