### PR TITLE
Worked example values for the config reference, for discussion

### DIFF
--- a/src/supy/data_model/core/hydro.py
+++ b/src/supy/data_model/core/hydro.py
@@ -399,7 +399,15 @@ class StorageDrainParams(BaseModel):
             "storage-capacity values: "
             "https://docs.suews.io/latest/inputs/tables/SUEWS_SiteInfo/Typical_Values.html."
         ),
-        json_schema_extra={"unit": "mm", "display_name": "Storage Capacity"},
+        json_schema_extra={
+            "unit": "mm",
+            "display_name": "Storage Capacity",
+            "default_description": (
+                "Varies by surface type. In the shipped sample configuration the "
+                "values range from 0.25 mm for buildings to 1.9 mm for grass; "
+                "calibrate by site."
+            ),
+        },
     )
     drain_eq: FlexibleRefValue(int) = Field(
         default=0,

--- a/src/supy/data_model/core/surface.py
+++ b/src/supy/data_model/core/surface.py
@@ -247,7 +247,14 @@ class SurfaceProperties(BaseModel):
     soil_depth: Optional[FlexibleRefValue(float)] = Field(
         default=None,
         description="Depth of soil layer below surface for hydrological calculations, controlling sub-surface water storage and drainage processes. Site-specific value typically determined from soil surveys or borehole data",
-        json_schema_extra={"unit": "mm", "display_name": "Soil Depth"},
+        json_schema_extra={
+            "unit": "mm",
+            "display_name": "Soil Depth",
+            "default_description": (
+                "The shipped sample configuration uses 350 mm for every land "
+                "surface and 0 mm for water; calibrate by site."
+            ),
+        },
     )
     soil_store_capacity: Optional[FlexibleRefValue(float)] = Field(
         default=None,


### PR DESCRIPTION
**Draft, for discussion only. Not for merge as it stands.**

Preparation for the parameter-provenance discussion in #1690, and for the call proposed on #1677. The aim is to give that conversation a worked list and a rendered result to react to, rather than starting from an abstract question.

**No value from the jointly maintained parameter database is used here**, and nothing in this branch presumes the outcome of that discussion. The two example values below are lifted from the sample configuration this repository already ships publicly, so they disclose nothing new. If the database supplies better values, they supersede these entirely.

## What the repository currently knows

Seventy scalar parameters are declared with no default. Of those:

- 22 now carry a requirement condition, via the registry in #1693.
- 5 already carry an example value, through `default_description`.
- 66 appear in the shipped `sample_config.yml`.
- **43 have neither a condition nor an example.** That is the gap.

The gap is spread thinly rather than concentrated: 5 in `CO2Params`, 5 in `VegetatedSurfaceProperties`, 4 each in `IrrigationParams`, `LAIPowerCoefficients`, `StorageDrainParams` and `SurfaceProperties`, 3 each in `OHMCoefficients`, `SnowParams` and `ThermalLayers`, and the remainder in ones and twos.

## Two findings that change the shape of the work

**A single example value is wrong for surface-varying parameters.** `store_cap` in the shipped sample ranges from 0.25 mm for buildings to 1.9 mm for grass, an eightfold spread: paved 0.48, bldgs 0.25, evetr 1.3, dectr 0.3, grass 1.9, bsoil 0.8, water 0.5. The five existing `default_description` entries all sit on anthropogenic-emission parameters that do not vary by surface, so the pattern they establish does not carry over unchanged.

**The shipped sample contains sentinels, so values cannot be lifted mechanically.** `drain_coef_1` is 10.0 for paved, buildings and bare soil, 0.013 for the vegetated surfaces, and **-999.0 for water**, which is a missing-data marker rather than a physical value. Any script that harvested sample values into documentation would publish that as an example. This has to be curated by a person.

## The two worked examples

Rendered through the real formatter:

```
=== StorageDrainParams.store_cap ===
   :Unit: mm
   :Configuration Note: No default value. A value may be required depending on which physics options and surface types are active in your configuration.
   :Default Description: Varies by surface type. In the shipped sample configuration the values range from 0.25 mm for buildings to 1.9 mm for grass; calibrate by site.

=== SurfaceProperties.soil_depth ===
   :Unit: mm
   :Configuration Note: No default value. A value may be required depending on which physics options and surface types are active in your configuration.
   :Default Description: The shipped sample configuration uses 350 mm for every land surface and 0 mm for water; calibrate by site.
```

`store_cap` was chosen because it is surface-varying and therefore the harder case; `soil_depth` as the contrasting near-uniform one.

## Questions this is meant to surface

- **What should the label be?** It currently reads `Default Description`, which sits awkwardly next to a line saying there is no default. "Example values" has been suggested as the better term. Note the generator already uses an `Example` label for site-specific fields, so there are three candidate meanings in play and it would be worth settling all of them together.
- **How should a surface-varying parameter be expressed?** A range with named extremes, as above, or a per-surface breakdown, or a link out to a table.
- **What provenance does an example carry?** These two say only "the shipped sample configuration", which is verifiable from this repository alone. Anything drawn from published sources needs both the original reference and the compilation that cited it, per the discussion recorded on #1690.
- **Where does the value live?** Inline in the field declaration, as here, does not scale to 43 parameters and puts the data in the code. The alternative is an external table bound by identifier, which is what #1690 proposes.

## Related

- #1677 - the reported symptom.
- #1690 - persistent identifiers for shipped parameter values; the discussion this prepares for.
- #1693 - the requirement conditions, in flight.
