### PR TITLE
Preserve NaN state across chunk checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ EXAMPLES:
 
 ### 12 Aug 2026
 
+- [bugfix] Restored chunk checkpoints containing non-finite state sentinels (#1691)
+  - Checkpoint generation now preserves `NaN` using the existing JSON `null` representation and rejects infinities with their exact state member and array index.
+  - State-aware continuation restores `null` as `NaN`, so existing checkpoints no longer fail with only `invalid state payload`; other invalid JSON values report their exact path and type.
+
 - [bugfix] Stopped the YAML config reference describing parameters without a default as optional (#1677)
   - Every parameter carrying no default previously rendered as `Default: None (optional)`, which asserted the opposite of the truth for parameters such as `store_cap` and `base_temperature_senescence`; these are declared `Optional[...] = None` only so a partial configuration still loads and the validation layer can then report what is missing.
   - Such parameters now render under a `Configuration Note` label stating that no default exists and that a value may be required depending on which physics options and surface types are active. A `Default` label therefore always introduces a real default value, and `Status` stays reserved for the short state token `Required`.

--- a/src/suews_bridge/src/error.rs
+++ b/src/suews_bridge/src/error.rs
@@ -11,6 +11,12 @@ pub enum BridgeError {
     BadBuffer,
     #[error("invalid state payload")]
     BadState,
+    #[error("checkpoint state contains {value_kind} at {path}")]
+    NonFiniteCheckpointValue { path: String, value_kind: String },
+    #[error("invalid checkpoint state value at {path}: expected a JSON number or null NaN marker, found {found}")]
+    InvalidCheckpointValue { path: String, found: String },
+    #[error("failed to serialise checkpoint state: {message}")]
+    CheckpointSerialization { message: String },
     #[error("simulation failed (code {code}): {message}")]
     SimulationError { code: i32, message: String },
     #[error("unknown Fortran bridge error code: {0}")]

--- a/src/suews_bridge/src/lib.rs
+++ b/src/suews_bridge/src/lib.rs
@@ -4099,8 +4099,7 @@ mod python_bindings {
         let (output_block, state, actual_len) =
             run_from_config_str_and_forcing(config_yaml, forcing_block, len_sim)
                 .map_err(map_bridge_error)?;
-        let state_json = serde_json::to_string(&suews_state_to_nested_payload(&state))
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        let state_json = suews_state_to_checkpoint_json(&state).map_err(map_bridge_error)?;
         Ok((output_block, state_json, actual_len))
     }
 
@@ -4112,13 +4111,14 @@ mod python_bindings {
         len_sim: usize,
         state_json: &str,
     ) -> PyResult<(Vec<f64>, String, usize)> {
-        let (output_block, state, actual_len) =
-            run_from_config_str_and_forcing_with_state(
-                config_yaml, forcing_block, len_sim, state_json,
-            )
-            .map_err(map_bridge_error)?;
-        let state_json_out = serde_json::to_string(&suews_state_to_nested_payload(&state))
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        let (output_block, state, actual_len) = run_from_config_str_and_forcing_with_state(
+            config_yaml,
+            forcing_block,
+            len_sim,
+            state_json,
+        )
+        .map_err(map_bridge_error)?;
+        let state_json_out = suews_state_to_checkpoint_json(&state).map_err(map_bridge_error)?;
         Ok((output_block, state_json_out, actual_len))
     }
 
@@ -4154,8 +4154,8 @@ mod python_bindings {
                     let (output_block, state, actual_len) =
                         run_from_config_str_and_forcing(config_json, forcing_copy, len_sim)
                             .map_err(|e| e.to_string())?;
-                    let state_json = serde_json::to_string(&suews_state_to_nested_payload(&state))
-                        .map_err(|e| e.to_string())?;
+                    let state_json =
+                        suews_state_to_checkpoint_json(&state).map_err(|e| e.to_string())?;
                     Ok((idx, output_block, state_json, actual_len))
                 })
                 .collect()
@@ -4222,8 +4222,8 @@ mod python_bindings {
                             state_json_in,
                         )
                         .map_err(|e| e.to_string())?;
-                    let state_json = serde_json::to_string(&suews_state_to_nested_payload(&state))
-                        .map_err(|e| e.to_string())?;
+                    let state_json =
+                        suews_state_to_checkpoint_json(&state).map_err(|e| e.to_string())?;
                     Ok((idx, output_block, state_json, actual_len))
                 })
                 .collect()

--- a/src/suews_bridge/src/suews_state.rs
+++ b/src/suews_bridge/src/suews_state.rs
@@ -127,12 +127,60 @@ fn is_known_member(name: &str) -> bool {
     SUEWS_STATE_MEMBER_ORDER.contains(&name)
 }
 
-fn parse_values_array(value: &Value) -> Result<Vec<f64>, BridgeError> {
+fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number outside the supported f64 range",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn parse_values_array(value: &Value, path: &str) -> Result<Vec<f64>, BridgeError> {
     let items = value.as_array().ok_or(BridgeError::BadState)?;
     items
         .iter()
-        .map(|item| item.as_f64().ok_or(BridgeError::BadState))
+        .enumerate()
+        .map(|(index, item)| {
+            if item.is_null() {
+                return Ok(f64::NAN);
+            }
+            item.as_f64()
+                .ok_or_else(|| BridgeError::InvalidCheckpointValue {
+                    path: format!("{path}[{index}]"),
+                    found: json_value_kind(item).to_string(),
+                })
+        })
         .collect()
+}
+
+fn non_finite_value_kind(value: f64) -> &'static str {
+    if value.is_nan() {
+        "NaN"
+    } else if value.is_sign_positive() {
+        "+Inf"
+    } else {
+        "-Inf"
+    }
+}
+
+fn validate_checkpoint_values(values: &[f64], path: &str) -> Result<(), BridgeError> {
+    for (index, value) in values.iter().enumerate() {
+        // serde_json already writes NaN as null. Treat that representation as
+        // the checkpoint's backward-compatible inactive-state sentinel.
+        if value.is_nan() {
+            continue;
+        }
+        if value.is_infinite() {
+            return Err(BridgeError::NonFiniteCheckpointValue {
+                path: format!("{path}[{index}]"),
+                value_kind: non_finite_value_kind(*value).to_string(),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn payload_dims_to_value(dims: &PayloadDims) -> Value {
@@ -176,7 +224,10 @@ fn scalar_values_payload_to_value(payload: &ValuesPayload) -> Value {
     Value::Object(obj)
 }
 
-fn scalar_values_payload_from_value(value: &Value) -> Result<ValuesPayload, BridgeError> {
+fn scalar_values_payload_from_value(
+    value: &Value,
+    path: &str,
+) -> Result<ValuesPayload, BridgeError> {
     let obj = value.as_object().ok_or(BridgeError::BadState)?;
     if obj.len() != 2 || !obj.contains_key("schema_version") || !obj.contains_key("values") {
         return Err(BridgeError::BadState);
@@ -188,7 +239,10 @@ fn scalar_values_payload_from_value(value: &Value) -> Result<ValuesPayload, Brid
         .ok_or(BridgeError::BadState)
         .and_then(|v| u32::try_from(v).map_err(|_| BridgeError::BadState))?;
 
-    let values = parse_values_array(obj.get("values").ok_or(BridgeError::BadState)?)?;
+    let values = parse_values_array(
+        obj.get("values").ok_or(BridgeError::BadState)?,
+        &format!("{path}.values"),
+    )?;
 
     Ok(ValuesPayload {
         schema_version,
@@ -212,6 +266,7 @@ fn values_payload_with_dims_to_value(payload: &ValuesPayloadWithDims) -> Value {
 
 fn values_payload_with_dims_from_value(
     value: &Value,
+    path: &str,
 ) -> Result<ValuesPayloadWithDims, BridgeError> {
     let obj = value.as_object().ok_or(BridgeError::BadState)?;
     if obj.len() != 3
@@ -228,7 +283,10 @@ fn values_payload_with_dims_from_value(
         .ok_or(BridgeError::BadState)
         .and_then(|v| u32::try_from(v).map_err(|_| BridgeError::BadState))?;
 
-    let values = parse_values_array(obj.get("values").ok_or(BridgeError::BadState)?)?;
+    let values = parse_values_array(
+        obj.get("values").ok_or(BridgeError::BadState)?,
+        &format!("{path}.values"),
+    )?;
     let dims = payload_dims_from_value(obj.get("dims").ok_or(BridgeError::BadState)?)?;
 
     Ok(ValuesPayloadWithDims {
@@ -263,7 +321,10 @@ fn error_entry_payload_to_value(payload: &ErrorEntryValuesPayload) -> Value {
     Value::Object(obj)
 }
 
-fn error_entry_payload_from_value(value: &Value) -> Result<ErrorEntryValuesPayload, BridgeError> {
+fn error_entry_payload_from_value(
+    value: &Value,
+    path: &str,
+) -> Result<ErrorEntryValuesPayload, BridgeError> {
     let obj = value.as_object().ok_or(BridgeError::BadState)?;
     if obj.len() != 5
         || !obj.contains_key("schema_version")
@@ -281,7 +342,10 @@ fn error_entry_payload_from_value(value: &Value) -> Result<ErrorEntryValuesPaylo
         .ok_or(BridgeError::BadState)
         .and_then(|v| u32::try_from(v).map_err(|_| BridgeError::BadState))?;
 
-    let timer_values = parse_values_array(obj.get("timer_values").ok_or(BridgeError::BadState)?)?;
+    let timer_values = parse_values_array(
+        obj.get("timer_values").ok_or(BridgeError::BadState)?,
+        &format!("{path}.timer_values"),
+    )?;
     let message = obj
         .get("message")
         .and_then(Value::as_str)
@@ -385,8 +449,11 @@ fn error_state_payload_from_value(value: &Value) -> Result<ErrorStateValuesPaylo
         .and_then(Value::as_array)
         .ok_or(BridgeError::BadState)?;
     let mut log = Vec::with_capacity(log_values.len());
-    for entry in log_values {
-        log.push(error_entry_payload_from_value(entry)?);
+    for (index, entry) in log_values.iter().enumerate() {
+        log.push(error_entry_payload_from_value(
+            entry,
+            &format!("members.{MEMBER_ERROR_STATE}.log[{index}]"),
+        )?);
     }
 
     let dims = payload_dims_from_value(obj.get("dims").ok_or(BridgeError::BadState)?)?;
@@ -657,30 +724,54 @@ pub fn suews_state_from_values_payload(
 
     let error_state_payload =
         error_state_payload_from_value(member_value(&payload.members, MEMBER_ERROR_STATE)?)?;
-    let flag_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_FLAG_STATE)?)?;
-    let anthroemis_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_ANTHROEMIS_STATE)?)?;
-    let ohm_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_OHM_STATE)?)?;
-    let solar_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_SOLAR_STATE)?)?;
-    let atm_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_ATM_STATE)?)?;
-    let phenology_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_PHENOLOGY_STATE)?)?;
-    let snow_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_SNOW_STATE)?)?;
-    let hydro_payload =
-        values_payload_with_dims_from_value(member_value(&payload.members, MEMBER_HYDRO_STATE)?)?;
-    let heat_payload =
-        values_payload_with_dims_from_value(member_value(&payload.members, MEMBER_HEAT_STATE)?)?;
-    let roughness_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_ROUGHNESS_STATE)?)?;
-    let stebbs_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_STEBBS_STATE)?)?;
-    let nhood_payload =
-        scalar_values_payload_from_value(member_value(&payload.members, MEMBER_NHOOD_STATE)?)?;
+    let flag_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_FLAG_STATE)?,
+        "members.flag_state",
+    )?;
+    let anthroemis_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_ANTHROEMIS_STATE)?,
+        "members.anthroemis_state",
+    )?;
+    let ohm_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_OHM_STATE)?,
+        "members.ohm_state",
+    )?;
+    let solar_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_SOLAR_STATE)?,
+        "members.solar_state",
+    )?;
+    let atm_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_ATM_STATE)?,
+        "members.atm_state",
+    )?;
+    let phenology_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_PHENOLOGY_STATE)?,
+        "members.phenology_state",
+    )?;
+    let snow_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_SNOW_STATE)?,
+        "members.snow_state",
+    )?;
+    let hydro_payload = values_payload_with_dims_from_value(
+        member_value(&payload.members, MEMBER_HYDRO_STATE)?,
+        "members.hydro_state",
+    )?;
+    let heat_payload = values_payload_with_dims_from_value(
+        member_value(&payload.members, MEMBER_HEAT_STATE)?,
+        "members.heat_state",
+    )?;
+    let roughness_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_ROUGHNESS_STATE)?,
+        "members.roughness_state",
+    )?;
+    let stebbs_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_STEBBS_STATE)?,
+        "members.stebbs_state",
+    )?;
+    let nhood_payload = scalar_values_payload_from_value(
+        member_value(&payload.members, MEMBER_NHOOD_STATE)?,
+        "members.nhood_state",
+    )?;
 
     Ok(SuewsState {
         error_state: error_state_from_values_payload(&error_state_payload)?,
@@ -701,6 +792,82 @@ pub fn suews_state_from_values_payload(
 
 pub fn suews_state_to_nested_payload(state: &SuewsState) -> Value {
     payload_to_nested_value(&suews_state_to_values_payload(state))
+}
+
+fn validate_suews_state_for_checkpoint(state: &SuewsState) -> Result<(), BridgeError> {
+    let error_payload = error_state_to_values_payload(&state.error_state);
+    for (index, entry) in error_payload.log.iter().enumerate() {
+        validate_checkpoint_values(
+            &entry.timer_values,
+            &format!("members.error_state.log[{index}].timer_values"),
+        )?;
+    }
+
+    let scalar_payloads = [
+        (
+            "members.flag_state.values",
+            flag_state_to_values_payload(&state.flag_state),
+        ),
+        (
+            "members.anthroemis_state.values",
+            anthroemis_state_to_values_payload(&state.anthroemis_state),
+        ),
+        (
+            "members.ohm_state.values",
+            ohm_state_to_values_payload(&state.ohm_state),
+        ),
+        (
+            "members.solar_state.values",
+            solar_state_to_values_payload(&state.solar_state),
+        ),
+        (
+            "members.atm_state.values",
+            atm_state_to_values_payload(&state.atm_state),
+        ),
+        (
+            "members.phenology_state.values",
+            phenology_state_to_values_payload(&state.phenology_state),
+        ),
+        (
+            "members.snow_state.values",
+            snow_state_to_values_payload(&state.snow_state),
+        ),
+        (
+            "members.roughness_state.values",
+            roughness_state_to_values_payload(&state.roughness_state),
+        ),
+        (
+            "members.stebbs_state.values",
+            stebbs_state_to_values_payload(&state.stebbs_state),
+        ),
+        (
+            "members.nhood_state.values",
+            nhood_state_to_values_payload(&state.nhood_state),
+        ),
+    ];
+    for (path, payload) in scalar_payloads {
+        validate_checkpoint_values(&payload.values, path)?;
+    }
+
+    validate_checkpoint_values(
+        &hydro_state_to_values_payload(&state.hydro_state).values,
+        "members.hydro_state.values",
+    )?;
+    validate_checkpoint_values(
+        &heat_state_to_values_payload(&state.heat_state).values,
+        "members.heat_state.values",
+    )?;
+    Ok(())
+}
+
+/// Serialise checkpoint state while preserving NaN as JSON null and rejecting infinities.
+pub fn suews_state_to_checkpoint_json(state: &SuewsState) -> Result<String, BridgeError> {
+    validate_suews_state_for_checkpoint(state)?;
+    serde_json::to_string(&suews_state_to_nested_payload(state)).map_err(|error| {
+        BridgeError::CheckpointSerialization {
+            message: error.to_string(),
+        }
+    })
 }
 
 pub fn suews_state_from_nested_payload(payload: &Value) -> Result<SuewsState, BridgeError> {
@@ -756,6 +923,67 @@ mod tests {
         let err = suews_state_from_nested_payload(&payload)
             .expect_err("unknown member payload should fail");
         assert_eq!(err, BridgeError::BadState);
+    }
+
+    #[test]
+    fn checkpoint_json_preserves_nan_and_reports_infinities() {
+        let mut state =
+            suews_state_default_from_fortran().expect("default state should be available");
+        state.ohm_state.qn_av = f64::NAN;
+
+        let checkpoint_json = suews_state_to_checkpoint_json(&state)
+            .expect("NaN should use the checkpoint null marker");
+        let checkpoint_value: Value =
+            serde_json::from_str(&checkpoint_json).expect("checkpoint should be valid JSON");
+        assert!(checkpoint_value["members"][MEMBER_OHM_STATE]["values"][0].is_null());
+
+        let restored = suews_state_from_nested_payload(&checkpoint_value)
+            .expect("checkpoint null marker should restore as NaN");
+        assert!(restored.ohm_state.qn_av.is_nan());
+
+        for (value, value_kind) in [(f64::INFINITY, "+Inf"), (f64::NEG_INFINITY, "-Inf")] {
+            let mut state =
+                suews_state_default_from_fortran().expect("default state should be available");
+            state.ohm_state.qn_av = value;
+
+            let err = suews_state_to_checkpoint_json(&state)
+                .expect_err("non-finite checkpoint state should fail before JSON conversion");
+            assert_eq!(
+                err,
+                BridgeError::NonFiniteCheckpointValue {
+                    path: "members.ohm_state.values[0]".to_string(),
+                    value_kind: value_kind.to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn nested_payload_restores_legacy_null_as_nan() {
+        let state = suews_state_default_from_fortran().expect("default state should be available");
+        let mut payload = suews_state_to_nested_payload(&state);
+        payload["members"][MEMBER_ATM_STATE]["values"][0] = Value::Null;
+
+        let restored = suews_state_from_nested_payload(&payload)
+            .expect("legacy null checkpoint value should restore as NaN");
+        assert!(restored.atm_state.fcld.is_nan());
+    }
+
+    #[test]
+    fn nested_payload_reports_invalid_value_path() {
+        let state = suews_state_default_from_fortran().expect("default state should be available");
+        let mut payload = suews_state_to_nested_payload(&state);
+        payload["members"][MEMBER_ATM_STATE]["values"][0] = Value::String("NaN".to_string());
+
+        let err = suews_state_from_nested_payload(&payload)
+            .expect_err("unsupported checkpoint markers should report their path");
+        assert_eq!(
+            err,
+            BridgeError::InvalidCheckpointValue {
+                path: "members.atm_state.values[0]".to_string(),
+                found: "string".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/test/core/test_checkpoint.py
+++ b/test/core/test_checkpoint.py
@@ -18,6 +18,8 @@ from supy.suews_sim import SUEWSSimulation
 
 pytestmark = pytest.mark.api
 
+SAMPLE_BUILDING_DYOHM_PROFILE_INDEX = 70
+
 
 def test_checkpoint_json_roundtrip(tmp_path):
     """Checkpoint files preserve typed Rust state by grid ID."""
@@ -77,6 +79,65 @@ def test_checkpoint_continuation_calls_rust_state_path(monkeypatch):
     sim2.run()
 
     assert calls["count"] >= 1
+
+
+def test_checkpoint_continuation_restores_legacy_null_marker():
+    """A legacy null state value is restored as a NaN sentinel."""
+    sim_first = SUEWSSimulation.from_sample_data()
+    forcing = sim_first.forcing.df.iloc[:24]
+    sim_first.update_forcing(forcing.iloc[:12])
+    sim_first.run()
+
+    dict_grid_states = {
+        grid_id: json.loads(state_json)
+        for grid_id, state_json in sim_first.checkpoint.grid_states.items()
+    }
+    first_grid_id = next(iter(dict_grid_states))
+    dict_grid_states[first_grid_id]["members"]["heat_state"]["values"][
+        SAMPLE_BUILDING_DYOHM_PROFILE_INDEX
+    ] = None
+    checkpoint = SUEWSCheckpoint.from_grid_states(
+        dict_grid_states,
+        last_timestamp=sim_first.checkpoint.last_timestamp,
+    )
+
+    sim_second = SUEWSSimulation.from_checkpoint(sim_first.config, checkpoint)
+    sim_second.update_forcing(forcing.iloc[12:24])
+
+    output = sim_second.run()
+
+    assert not output.df.empty
+
+
+def test_checkpoint_continuation_reports_invalid_value_path():
+    """An unsupported state value reports its exact checkpoint path."""
+    sim_first = SUEWSSimulation.from_sample_data()
+    forcing = sim_first.forcing.df.iloc[:24]
+    sim_first.update_forcing(forcing.iloc[:12])
+    sim_first.run()
+
+    dict_grid_states = {
+        grid_id: json.loads(state_json)
+        for grid_id, state_json in sim_first.checkpoint.grid_states.items()
+    }
+    first_grid_id = next(iter(dict_grid_states))
+    dict_grid_states[first_grid_id]["members"]["atm_state"]["values"][0] = "NaN"
+    checkpoint = SUEWSCheckpoint.from_grid_states(
+        dict_grid_states,
+        last_timestamp=sim_first.checkpoint.last_timestamp,
+    )
+
+    sim_second = SUEWSSimulation.from_checkpoint(sim_first.config, checkpoint)
+    sim_second.update_forcing(forcing.iloc[12:24])
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"invalid checkpoint state value at members\.atm_state\.values\[0\]: "
+            r"expected a JSON number or null NaN marker, found string"
+        ),
+    ):
+        sim_second.run()
 
 
 def test_split_run_matches_continuous_run_with_checkpoint():


### PR DESCRIPTION
Fixes #1691

## Summary

- treat JSON null in checkpoint value arrays as the existing NaN sentinel representation
- reject positive and negative infinity before serialisation with the exact member/index path
- report exact paths and JSON types for unsupported checkpoint values
- cover state-aware continuation and legacy conversion cases that naturally produce NaN state

## Compatibility

No state schema bump is needed because the Rust writer already emitted NaN as JSON null. This change makes the reader accept that existing wire representation. Historical null values are restored as NaN; older checkpoints cannot distinguish an infinity because the previous writer had already erased that distinction. New checkpoints reject infinities before that loss occurs.

## Validation

- make test-smoke: 9 passed, 1 skipped
- make test: 1958 passed, 8 skipped
- checkpoint regression tests: 9 passed
- legacy single- and multi-layer conversion regressions: passed
- Rust checkpoint unit tests: 8 passed
- cargo clippy with all features and targets, warnings denied: passed
- targeted rustfmt, ruff, docstring, marker, schema-sync, and diff checks: passed