### PR TITLE
Preserve elapsed model time across chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ EXAMPLES:
 
 ### 12 Aug 2026
 
+- [bugfix] Preserved elapsed model time across chunk and restart boundaries (#1692)
+  - Checkpoint schema version 2 stores `dt_since_start`, `dt_since_start_prev`, the new-day flag, and the model timestep alongside each grid state, making one-day chunks numerically equivalent to an uninterrupted run within a relative and absolute tolerance of `1e-12` across the 24-hour averaging boundary.
+  - State-only version-1 checkpoints are rejected with an actionable compatibility error because their missing elapsed timer cannot be reconstructed reliably.
+
 - [bugfix] Restored chunk checkpoints containing non-finite state sentinels (#1691)
   - Checkpoint generation now preserves `NaN` using the existing JSON `null` representation and rejects infinities with their exact state member and array index.
   - State-aware continuation restores `null` as `NaN`, so existing checkpoints no longer fail with only `invalid state payload`; other invalid JSON values report their exact path and type.

--- a/docs/source/api/io-data-structures.rst
+++ b/docs/source/api/io-data-structures.rst
@@ -181,13 +181,17 @@ than ``df_state_final`` as the restart artefact.
 ``SUEWSCheckpoint``: typed restart state
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``SUEWSCheckpoint`` carries typed backend runtime state keyed by grid ID. It is
-the preferred restart artefact for new object-oriented workflows.
+``SUEWSCheckpoint`` carries typed backend runtime state, elapsed model-time
+metadata, and schema versions keyed by grid ID. It is the preferred restart
+artefact for new object-oriented workflows.
 
-The checkpoint is intentionally only the typed runtime state. It does not
-contain the full YAML configuration or forcing data. To continue a run, load the
-same YAML configuration, attach the next forcing period, and run from
-``SUEWSSimulation.from_checkpoint(...)``:
+The checkpoint does not contain the full YAML configuration or forcing data. To
+continue a run, load the same YAML configuration, attach the next forcing
+period, and run from ``SUEWSSimulation.from_checkpoint(...)``. State-only
+checkpoint schema version 1 lacks the elapsed timer metadata required for
+correct continuation and must be regenerated with schema version 2. Chunked
+and restarted outputs are expected to match uninterrupted outputs within
+relative and absolute tolerances of ``1e-12``.
 
 .. code-block:: python
 

--- a/docs/source/outputs/index.rst
+++ b/docs/source/outputs/index.rst
@@ -38,11 +38,14 @@ Restart Checkpoint
 
 Object-oriented SUEWS runs save ``{site}_SUEWS_checkpoint.json`` as the
 preferred restart artefact. It contains typed runtime state from the backend,
-keyed by grid ID.
+elapsed model-time metadata, and schema versions, keyed by grid ID.
 
-The checkpoint is intentionally only the typed runtime state. To continue a run,
-load the same YAML configuration, attach the next forcing period, and run from
-``SUEWSSimulation.from_checkpoint(...)``.
+The checkpoint does not contain the YAML configuration or forcing data. To
+continue a run, load the same YAML configuration, attach the next forcing
+period, and run from ``SUEWSSimulation.from_checkpoint(...)``. State-only
+checkpoint schema version 1 must be regenerated with schema version 2 before it
+can provide timer continuity. Chunked and restarted outputs are expected to match
+uninterrupted outputs within relative and absolute tolerances of ``1e-12``.
 
 Legacy ``df_state_SSss.csv`` and state parquet files remain documented for
 backwards compatibility and developer inspection, but they are not the preferred

--- a/docs/source/outputs/text_format.rst
+++ b/docs/source/outputs/text_format.rst
@@ -224,6 +224,8 @@ At the end of each object-oriented simulation, ``sim.run()`` exposes
 ``{site}_SUEWS_checkpoint.json``. The checkpoint contains:
 
 - Backend runtime state keyed by grid ID
+- Elapsed model-time metadata needed for exact continuation
+- Checkpoint and backend-state schema versions
 - SUEWS/SuPy version metadata
 - The last forcing timestamp represented by the checkpoint
 
@@ -233,9 +235,14 @@ This file can be used to:
 2. **Chain simulations** - Use end state as input for subsequent runs
 3. **Preserve typed backend state** - Avoid lossy DataFrame restart conversion
 
-The checkpoint is intentionally only the typed runtime state. To continue a run,
-load the same YAML configuration, attach the next forcing period, and run from
-``SUEWSSimulation.from_checkpoint(...)``.
+The checkpoint contains typed runtime state and elapsed timer metadata, but not
+the YAML configuration or forcing data. To continue a run, load the same YAML
+configuration, attach the next forcing period, and run from
+``SUEWSSimulation.from_checkpoint(...)``. State-only checkpoint schema version 1
+cannot preserve timer continuity and must be regenerated with schema version 2.
+Chunked and restarted outputs are expected to match uninterrupted outputs within
+relative and absolute tolerances of ``1e-12``; JSON and bridge round-trips may
+otherwise differ in the final floating-point bits.
 
 ``df_state_SSss.csv`` and ``df_state_final`` remain legacy/developer-facing
 DataFrame structures for backwards compatibility and state inspection. They are

--- a/src/suews_bridge/src/checkpoint.rs
+++ b/src/suews_bridge/src/checkpoint.rs
@@ -1,0 +1,191 @@
+use crate::error::BridgeError;
+use crate::suews_state::{
+    suews_state_from_nested_payload, suews_state_to_checkpoint_value, SuewsState,
+};
+use crate::timer::SuewsTimer;
+use serde_json::{json, Map, Value};
+
+pub const SUEWS_CHECKPOINT_SCHEMA_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckpointTimer {
+    pub dt_since_start: i32,
+    pub dt_since_start_prev: i32,
+    pub tstep: i32,
+    pub new_day: i32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SuewsCheckpointData {
+    pub state: SuewsState,
+    pub timer: CheckpointTimer,
+}
+
+fn invalid_envelope(message: impl Into<String>) -> BridgeError {
+    BridgeError::InvalidCheckpointEnvelope {
+        message: message.into(),
+    }
+}
+
+fn parse_i32_field(object: &Map<String, Value>, name: &str) -> Result<i32, BridgeError> {
+    let value = object
+        .get(name)
+        .and_then(Value::as_i64)
+        .ok_or_else(|| invalid_envelope(format!("timer.{name} must be an integer")))?;
+    i32::try_from(value)
+        .map_err(|_| invalid_envelope(format!("timer.{name} is outside the i32 range")))
+}
+
+fn validate_timer(timer: CheckpointTimer) -> Result<CheckpointTimer, BridgeError> {
+    if timer.dt_since_start < 0 {
+        return Err(invalid_envelope(
+            "timer.dt_since_start must be non-negative",
+        ));
+    }
+    if timer.dt_since_start_prev < 0 {
+        return Err(invalid_envelope(
+            "timer.dt_since_start_prev must be non-negative",
+        ));
+    }
+    if timer.dt_since_start_prev > timer.dt_since_start {
+        return Err(invalid_envelope(
+            "timer.dt_since_start_prev cannot exceed timer.dt_since_start",
+        ));
+    }
+    if timer.tstep <= 0 {
+        return Err(invalid_envelope("timer.tstep must be positive"));
+    }
+    if !matches!(timer.new_day, 0 | 1) {
+        return Err(invalid_envelope("timer.new_day must be 0 or 1"));
+    }
+    Ok(timer)
+}
+
+pub fn suews_checkpoint_to_json(
+    state: &SuewsState,
+    timer: &SuewsTimer,
+) -> Result<String, BridgeError> {
+    let checkpoint_timer = validate_timer(CheckpointTimer {
+        dt_since_start: timer.dt_since_start,
+        dt_since_start_prev: timer.dt_since_start_prev,
+        tstep: timer.tstep,
+        new_day: timer.new_day,
+    })?;
+    let state_value = suews_state_to_checkpoint_value(state)?;
+    let checkpoint = json!({
+        "checkpoint_schema_version": SUEWS_CHECKPOINT_SCHEMA_VERSION,
+        "timer": {
+            "dt_since_start": checkpoint_timer.dt_since_start,
+            "dt_since_start_prev": checkpoint_timer.dt_since_start_prev,
+            "tstep": checkpoint_timer.tstep,
+            "new_day": checkpoint_timer.new_day,
+        },
+        "state": state_value,
+    });
+
+    serde_json::to_string(&checkpoint).map_err(|error| BridgeError::CheckpointSerialization {
+        message: error.to_string(),
+    })
+}
+
+pub fn suews_checkpoint_from_json(json_text: &str) -> Result<SuewsCheckpointData, BridgeError> {
+    let checkpoint: Value = serde_json::from_str(json_text)
+        .map_err(|error| invalid_envelope(format!("invalid JSON: {error}")))?;
+    let object = checkpoint
+        .as_object()
+        .ok_or_else(|| invalid_envelope("top-level value must be an object"))?;
+
+    if !object.contains_key("checkpoint_schema_version")
+        && object.contains_key("schema_version")
+        && object.contains_key("members")
+    {
+        return Err(BridgeError::LegacyCheckpointMissingTimer);
+    }
+
+    let version = object
+        .get("checkpoint_schema_version")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_envelope("checkpoint_schema_version must be an integer"))?;
+    if version != u64::from(SUEWS_CHECKPOINT_SCHEMA_VERSION) {
+        return Err(BridgeError::UnsupportedCheckpointVersion {
+            found: version,
+            expected: SUEWS_CHECKPOINT_SCHEMA_VERSION,
+        });
+    }
+
+    let timer_object = object
+        .get("timer")
+        .and_then(Value::as_object)
+        .ok_or_else(|| invalid_envelope("timer must be an object"))?;
+    let timer = validate_timer(CheckpointTimer {
+        dt_since_start: parse_i32_field(timer_object, "dt_since_start")?,
+        dt_since_start_prev: parse_i32_field(timer_object, "dt_since_start_prev")?,
+        tstep: parse_i32_field(timer_object, "tstep")?,
+        new_day: parse_i32_field(timer_object, "new_day")?,
+    })?;
+
+    let state_value = object
+        .get("state")
+        .ok_or_else(|| invalid_envelope("state is required"))?;
+    let state = suews_state_from_nested_payload(state_value)?;
+
+    Ok(SuewsCheckpointData { state, timer })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::suews_state::{suews_state_default_from_fortran, suews_state_to_nested_payload};
+
+    #[test]
+    fn checkpoint_roundtrip_preserves_elapsed_timer() {
+        let state = suews_state_default_from_fortran().expect("default state should be available");
+        let timer = SuewsTimer {
+            dt_since_start: 90_300,
+            dt_since_start_prev: 90_000,
+            tstep: 300,
+            new_day: 1,
+            ..SuewsTimer::default()
+        };
+
+        let checkpoint_json =
+            suews_checkpoint_to_json(&state, &timer).expect("checkpoint should serialise");
+        let restored =
+            suews_checkpoint_from_json(&checkpoint_json).expect("checkpoint should restore");
+
+        assert_eq!(restored.state, state);
+        assert_eq!(
+            restored.timer,
+            CheckpointTimer {
+                dt_since_start: 90_300,
+                dt_since_start_prev: 90_000,
+                tstep: 300,
+                new_day: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_state_payload_reports_missing_timer() {
+        let state = suews_state_default_from_fortran().expect("default state should be available");
+        let legacy_json = serde_json::to_string(&suews_state_to_nested_payload(&state))
+            .expect("legacy state should serialise");
+
+        let error = suews_checkpoint_from_json(&legacy_json)
+            .expect_err("legacy checkpoints should require timer metadata");
+        assert_eq!(error, BridgeError::LegacyCheckpointMissingTimer);
+    }
+
+    #[test]
+    fn unsupported_checkpoint_version_is_actionable() {
+        let error = suews_checkpoint_from_json(r#"{"checkpoint_schema_version":3}"#)
+            .expect_err("future checkpoint versions should be rejected");
+        assert_eq!(
+            error,
+            BridgeError::UnsupportedCheckpointVersion {
+                found: 3,
+                expected: SUEWS_CHECKPOINT_SCHEMA_VERSION,
+            }
+        );
+    }
+}

--- a/src/suews_bridge/src/error.rs
+++ b/src/suews_bridge/src/error.rs
@@ -17,6 +17,14 @@ pub enum BridgeError {
     InvalidCheckpointValue { path: String, found: String },
     #[error("failed to serialise checkpoint state: {message}")]
     CheckpointSerialization { message: String },
+    #[error(
+        "legacy checkpoint schema version 1 has no elapsed timer metadata; rerun the preceding segment with checkpoint schema version 2"
+    )]
+    LegacyCheckpointMissingTimer,
+    #[error("unsupported checkpoint schema version {found}; expected version {expected}")]
+    UnsupportedCheckpointVersion { found: u64, expected: u32 },
+    #[error("invalid checkpoint envelope: {message}")]
+    InvalidCheckpointEnvelope { message: String },
     #[error("simulation failed (code {code}): {message}")]
     SimulationError { code: i32, message: String },
     #[error("unknown Fortran bridge error code: {0}")]

--- a/src/suews_bridge/src/lib.rs
+++ b/src/suews_bridge/src/lib.rs
@@ -23,6 +23,7 @@ mod anthroemis;
 mod atm;
 mod bioco2;
 mod building_archetype_prm;
+mod checkpoint;
 mod codec;
 mod conductance;
 mod config;
@@ -86,6 +87,7 @@ pub use anthroemis::*;
 pub use atm::*;
 pub use bioco2::*;
 pub use building_archetype_prm::*;
+pub use checkpoint::*;
 pub use codec::*;
 pub use conductance::*;
 pub use config::*;
@@ -4096,10 +4098,10 @@ mod python_bindings {
         forcing_block: Vec<f64>,
         len_sim: usize,
     ) -> PyResult<(Vec<f64>, String, usize)> {
-        let (output_block, state, actual_len) =
+        let (output_block, state, timer, actual_len) =
             run_from_config_str_and_forcing(config_yaml, forcing_block, len_sim)
                 .map_err(map_bridge_error)?;
-        let state_json = suews_state_to_checkpoint_json(&state).map_err(map_bridge_error)?;
+        let state_json = suews_checkpoint_to_json(&state, &timer).map_err(map_bridge_error)?;
         Ok((output_block, state_json, actual_len))
     }
 
@@ -4111,14 +4113,14 @@ mod python_bindings {
         len_sim: usize,
         state_json: &str,
     ) -> PyResult<(Vec<f64>, String, usize)> {
-        let (output_block, state, actual_len) = run_from_config_str_and_forcing_with_state(
+        let (output_block, state, timer, actual_len) = run_from_config_str_and_forcing_with_state(
             config_yaml,
             forcing_block,
             len_sim,
             state_json,
         )
         .map_err(map_bridge_error)?;
-        let state_json_out = suews_state_to_checkpoint_json(&state).map_err(map_bridge_error)?;
+        let state_json_out = suews_checkpoint_to_json(&state, &timer).map_err(map_bridge_error)?;
         Ok((output_block, state_json_out, actual_len))
     }
 
@@ -4151,11 +4153,11 @@ mod python_bindings {
                 .map(|(idx, config_json)| {
                     // Each thread gets its own copy of forcing (Fortran mutates it)
                     let forcing_copy = forcing_block.clone();
-                    let (output_block, state, actual_len) =
+                    let (output_block, state, timer, actual_len) =
                         run_from_config_str_and_forcing(config_json, forcing_copy, len_sim)
                             .map_err(|e| e.to_string())?;
                     let state_json =
-                        suews_state_to_checkpoint_json(&state).map_err(|e| e.to_string())?;
+                        suews_checkpoint_to_json(&state, &timer).map_err(|e| e.to_string())?;
                     Ok((idx, output_block, state_json, actual_len))
                 })
                 .collect()
@@ -4214,7 +4216,7 @@ mod python_bindings {
                 .map(|(idx, (config_json, state_json_in))| {
                     // Each thread gets its own copy of forcing (Fortran mutates it)
                     let forcing_copy = forcing_block.clone();
-                    let (output_block, state, actual_len) =
+                    let (output_block, state, timer, actual_len) =
                         run_from_config_str_and_forcing_with_state(
                             config_json,
                             forcing_copy,
@@ -4223,7 +4225,7 @@ mod python_bindings {
                         )
                         .map_err(|e| e.to_string())?;
                     let state_json =
-                        suews_state_to_checkpoint_json(&state).map_err(|e| e.to_string())?;
+                        suews_checkpoint_to_json(&state, &timer).map_err(|e| e.to_string())?;
                     Ok((idx, output_block, state_json, actual_len))
                 })
                 .collect()

--- a/src/suews_bridge/src/main.rs
+++ b/src/suews_bridge/src/main.rs
@@ -766,7 +766,7 @@ fn run_physics_command(config_path: &str) -> Result<(), String> {
     let raw_forcing = read_forcing_block(&run_cfg.forcing_path)?;
     let forcing = interpolate_forcing(&raw_forcing, run_cfg.timer.tstep)?;
 
-    let (output_block, _state, len_sim) =
+    let (output_block, _state, _timer, len_sim) =
         run_from_config_str_and_forcing(&config_yaml, forcing.block, forcing.len_sim)
             .map_err(|e| e.to_string())?;
 

--- a/src/suews_bridge/src/sim.rs
+++ b/src/suews_bridge/src/sim.rs
@@ -2,6 +2,7 @@ use crate::anthro_emis_prm::anthro_emis_prm_from_ordered_values;
 use crate::anthroemis::anthroemis_state_from_ordered_values;
 use crate::atm::atm_state_from_ordered_values;
 use crate::building_archetype_prm::building_archetype_prm_from_ordered_values;
+use crate::checkpoint::suews_checkpoint_from_json;
 use crate::conductance::conductance_prm_from_ordered_values;
 use crate::config::SuewsConfig;
 use crate::core::{ohm_state_from_ordered_values, SURFACE_NAMES};
@@ -31,7 +32,7 @@ use crate::spartacus_prm::SpartacusPrm;
 use crate::stebbs_prm::stebbs_prm_from_ordered_values;
 use crate::stebbs_state::stebbs_state_from_ordered_values;
 use crate::suews_site::SuewsSite;
-use crate::suews_state::{suews_state_from_nested_payload, SuewsState};
+use crate::suews_state::SuewsState;
 use crate::surf_store::surf_store_prm_from_ordered_values;
 use crate::timer::{SuewsTimer, SUEWS_TIMER_FLAT_LEN};
 use crate::yaml_config::{load_run_config_from_str, RunConfig};
@@ -655,7 +656,7 @@ pub fn run_from_config_str_and_forcing(
     config_yaml: &str,
     forcing_block: Vec<f64>,
     len_sim: usize,
-) -> Result<(Vec<f64>, SuewsState, usize), BridgeError> {
+) -> Result<(Vec<f64>, SuewsState, SuewsTimer, usize), BridgeError> {
     let mut run_cfg = load_run_config_from_str(config_yaml).map_err(simulation_error)?;
 
     if len_sim == 0 {
@@ -753,18 +754,17 @@ pub fn run_from_config_str_and_forcing(
         ndepth: run_cfg.ndepth,
     })?;
 
-    Ok((sim_out.output_block, sim_out.state, len_sim))
+    Ok((sim_out.output_block, sim_out.state, sim_out.timer, len_sim))
 }
 
 /// Like [`run_from_config_str_and_forcing`] but replaces the config-derived
-/// initial state with a state decoded from *state_json* (the nested-payload
-/// JSON produced by a previous run).
+/// initial state and elapsed timer with a checkpoint decoded from *state_json*.
 pub fn run_from_config_str_and_forcing_with_state(
     config_yaml: &str,
     forcing_block: Vec<f64>,
     len_sim: usize,
     state_json: &str,
-) -> Result<(Vec<f64>, SuewsState, usize), BridgeError> {
+) -> Result<(Vec<f64>, SuewsState, SuewsTimer, usize), BridgeError> {
     let mut run_cfg = load_run_config_from_str(config_yaml).map_err(simulation_error)?;
 
     if len_sim == 0 {
@@ -784,10 +784,15 @@ pub fn run_from_config_str_and_forcing_with_state(
         )));
     }
 
-    // Decode state from previous chunk's JSON output.
-    let state_value: serde_json::Value = serde_json::from_str(state_json)
-        .map_err(|e| simulation_error(format!("invalid state JSON: {e}")))?;
-    run_cfg.state = suews_state_from_nested_payload(&state_value)?;
+    // Decode state and elapsed timer from the previous chunk's checkpoint.
+    let checkpoint = suews_checkpoint_from_json(state_json)?;
+    if checkpoint.timer.tstep != run_cfg.timer.tstep {
+        return Err(simulation_error(format!(
+            "checkpoint timestep {} s does not match configuration timestep {} s",
+            checkpoint.timer.tstep, run_cfg.timer.tstep
+        )));
+    }
+    run_cfg.state = checkpoint.state;
 
     // Set timer fields from the first forcing row.
     let first_row = &forcing_block[..MET_FORCING_COLS];
@@ -800,9 +805,9 @@ pub fn run_from_config_str_and_forcing_with_state(
     run_cfg.timer.tstep_real = run_cfg.timer.tstep as f64;
     run_cfg.timer.nsh_real = 3600.0 / run_cfg.timer.tstep as f64;
     run_cfg.timer.nsh = (3600 / run_cfg.timer.tstep).max(1);
-    // Keep first-step timing consistent with non-state run path.
-    run_cfg.timer.dt_since_start = run_cfg.timer.tstep;
-    run_cfg.timer.dt_since_start_prev = 0;
+    run_cfg.timer.dt_since_start = checkpoint.timer.dt_since_start;
+    run_cfg.timer.dt_since_start_prev = checkpoint.timer.dt_since_start_prev;
+    run_cfg.timer.new_day = checkpoint.timer.new_day;
     run_cfg.timer.dectime = (run_cfg.timer.id - 1) as f64
         + run_cfg.timer.it as f64 / 24.0
         + run_cfg.timer.imin as f64 / (60.0 * 24.0)
@@ -857,7 +862,7 @@ pub fn run_from_config_str_and_forcing_with_state(
         ndepth: run_cfg.ndepth,
     })?;
 
-    Ok((sim_out.output_block, sim_out.state, len_sim))
+    Ok((sim_out.output_block, sim_out.state, sim_out.timer, len_sim))
 }
 
 pub fn run_simulation(input: SimulationInput) -> Result<SimulationOutput, BridgeError> {

--- a/src/suews_bridge/src/suews_state.rs
+++ b/src/suews_bridge/src/suews_state.rs
@@ -860,14 +860,10 @@ fn validate_suews_state_for_checkpoint(state: &SuewsState) -> Result<(), BridgeE
     Ok(())
 }
 
-/// Serialise checkpoint state while preserving NaN as JSON null and rejecting infinities.
-pub fn suews_state_to_checkpoint_json(state: &SuewsState) -> Result<String, BridgeError> {
+/// Prepare checkpoint state while preserving NaN as JSON null and rejecting infinities.
+pub(crate) fn suews_state_to_checkpoint_value(state: &SuewsState) -> Result<Value, BridgeError> {
     validate_suews_state_for_checkpoint(state)?;
-    serde_json::to_string(&suews_state_to_nested_payload(state)).map_err(|error| {
-        BridgeError::CheckpointSerialization {
-            message: error.to_string(),
-        }
-    })
+    Ok(suews_state_to_nested_payload(state))
 }
 
 pub fn suews_state_from_nested_payload(payload: &Value) -> Result<SuewsState, BridgeError> {
@@ -926,15 +922,13 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_json_preserves_nan_and_reports_infinities() {
+    fn checkpoint_value_preserves_nan_and_reports_infinities() {
         let mut state =
             suews_state_default_from_fortran().expect("default state should be available");
         state.ohm_state.qn_av = f64::NAN;
 
-        let checkpoint_json = suews_state_to_checkpoint_json(&state)
+        let checkpoint_value = suews_state_to_checkpoint_value(&state)
             .expect("NaN should use the checkpoint null marker");
-        let checkpoint_value: Value =
-            serde_json::from_str(&checkpoint_json).expect("checkpoint should be valid JSON");
         assert!(checkpoint_value["members"][MEMBER_OHM_STATE]["values"][0].is_null());
 
         let restored = suews_state_from_nested_payload(&checkpoint_value)
@@ -946,7 +940,7 @@ mod tests {
                 suews_state_default_from_fortran().expect("default state should be available");
             state.ohm_state.qn_av = value;
 
-            let err = suews_state_to_checkpoint_json(&state)
+            let err = suews_state_to_checkpoint_value(&state)
                 .expect_err("non-finite checkpoint state should fail before JSON conversion");
             assert_eq!(
                 err,

--- a/src/supy/suews_checkpoint.py
+++ b/src/supy/suews_checkpoint.py
@@ -12,6 +12,9 @@ import pandas as pd
 
 from ._version_scm import __version__
 
+CURRENT_CHECKPOINT_SCHEMA_VERSION = 2
+LEGACY_CHECKPOINT_SCHEMA_VERSION = 1
+
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -52,8 +55,14 @@ def _infer_state_schema_version(grid_states: Mapping[int, str]) -> int | None:
     versions: set[int] = set()
     for state_json in grid_states.values():
         payload = _state_to_object(state_json)
-        if isinstance(payload, dict) and payload.get("schema_version") is not None:
-            versions.add(int(payload["schema_version"]))
+        if not isinstance(payload, dict):
+            continue
+        state_payload = payload.get("state", payload)
+        if (
+            isinstance(state_payload, dict)
+            and state_payload.get("schema_version") is not None
+        ):
+            versions.add(int(state_payload["schema_version"]))
 
     if len(versions) > 1:
         raise ValueError(
@@ -63,21 +72,66 @@ def _infer_state_schema_version(grid_states: Mapping[int, str]) -> int | None:
     return next(iter(versions), None)
 
 
+def _infer_checkpoint_schema_version(grid_states: Mapping[int, str]) -> int | None:
+    versions: set[int] = set()
+    for state_json in grid_states.values():
+        payload = _state_to_object(state_json)
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("checkpoint_schema_version") is not None:
+            versions.add(int(payload["checkpoint_schema_version"]))
+        elif "schema_version" in payload and "members" in payload:
+            versions.add(LEGACY_CHECKPOINT_SCHEMA_VERSION)
+
+    if len(versions) > 1:
+        raise ValueError(
+            "SUEWSCheckpoint grid states contain multiple checkpoint schema "
+            f"versions: {sorted(versions)}"
+        )
+    return next(iter(versions), None)
+
+
 @dataclass(frozen=True)
 class SUEWSCheckpoint:
-    """Typed restart artifact carrying Rust SUEWS state JSON by grid ID."""
+    """Typed restart artifact carrying Rust state and timer JSON by grid ID."""
 
     grid_states: dict[int, str]
     supy_version: str = __version__
     state_schema_version: int | None = None
     created_at: str = field(default_factory=_utc_now_iso)
     last_timestamp: str | None = None
+    checkpoint_schema_version: int | None = None
 
     def __post_init__(self) -> None:
         normalised_states = _normalise_grid_states(self.grid_states)
         object.__setattr__(self, "grid_states", normalised_states)
         object.__setattr__(self, "supy_version", self.supy_version or __version__)
         object.__setattr__(self, "created_at", self.created_at or _utc_now_iso())
+
+        inferred_checkpoint_version = _infer_checkpoint_schema_version(
+            normalised_states
+        )
+        if self.checkpoint_schema_version is None:
+            object.__setattr__(
+                self,
+                "checkpoint_schema_version",
+                inferred_checkpoint_version,
+            )
+        else:
+            checkpoint_schema_version = int(self.checkpoint_schema_version)
+            if (
+                inferred_checkpoint_version is not None
+                and checkpoint_schema_version != inferred_checkpoint_version
+            ):
+                raise ValueError(
+                    "SUEWSCheckpoint checkpoint_schema_version does not match "
+                    f"grid state version {inferred_checkpoint_version}."
+                )
+            object.__setattr__(
+                self,
+                "checkpoint_schema_version",
+                checkpoint_schema_version,
+            )
 
         if self.state_schema_version is None:
             object.__setattr__(
@@ -100,6 +154,7 @@ class SUEWSCheckpoint:
         grid_states: Mapping[Any, Any],
         *,
         supy_version: str | None = None,
+        checkpoint_schema_version: int | None = None,
         state_schema_version: int | None = None,
         created_at: str | None = None,
         last_timestamp: Any | None = None,
@@ -108,6 +163,7 @@ class SUEWSCheckpoint:
         return cls(
             grid_states=dict(grid_states),
             supy_version=supy_version or __version__,
+            checkpoint_schema_version=checkpoint_schema_version,
             state_schema_version=state_schema_version,
             created_at=created_at or _utc_now_iso(),
             last_timestamp=_normalise_timestamp(last_timestamp),
@@ -121,6 +177,7 @@ class SUEWSCheckpoint:
         return cls(
             grid_states=dict(payload["grid_states"]),
             supy_version=str(payload.get("supy_version") or __version__),
+            checkpoint_schema_version=payload.get("checkpoint_schema_version"),
             state_schema_version=payload.get("state_schema_version"),
             created_at=str(payload.get("created_at") or _utc_now_iso()),
             last_timestamp=payload.get("last_timestamp"),
@@ -138,6 +195,7 @@ class SUEWSCheckpoint:
         """Return a JSON-serialisable checkpoint payload."""
         return {
             "supy_version": self.supy_version,
+            "checkpoint_schema_version": self.checkpoint_schema_version,
             "state_schema_version": self.state_schema_version,
             "created_at": self.created_at,
             "last_timestamp": self.last_timestamp,
@@ -155,3 +213,19 @@ class SUEWSCheckpoint:
             json.dump(self.to_dict(), checkpoint_file, indent=2)
             checkpoint_file.write("\n")
         return path
+
+    def validate_for_continuation(self) -> None:
+        """Raise an actionable error when restart timer metadata is unavailable."""
+        if self.checkpoint_schema_version == CURRENT_CHECKPOINT_SCHEMA_VERSION:
+            return
+        if self.checkpoint_schema_version == LEGACY_CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError(
+                "Checkpoint schema version 1 has no elapsed timer metadata. "
+                "Rerun the preceding segment with checkpoint schema version 2 "
+                "before continuing."
+            )
+        raise ValueError(
+            "Unsupported checkpoint schema version "
+            f"{self.checkpoint_schema_version!r}; expected "
+            f"{CURRENT_CHECKPOINT_SCHEMA_VERSION}."
+        )

--- a/src/supy/suews_sim.py
+++ b/src/supy/suews_sim.py
@@ -1038,7 +1038,9 @@ class SUEWSSimulation:
                 "call update_config() before continue_from()."
             )
 
-        self._checkpoint = self._coerce_checkpoint(checkpoint)
+        checkpoint_value = self._coerce_checkpoint(checkpoint)
+        checkpoint_value.validate_for_continuation()
+        self._checkpoint = checkpoint_value
         self._df_output = None
         self._df_state_final = None
         self._run_completed = False

--- a/test/core/test_checkpoint.py
+++ b/test/core/test_checkpoint.py
@@ -4,7 +4,6 @@ import importlib
 import json
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -19,11 +18,37 @@ from supy.suews_sim import SUEWSSimulation
 pytestmark = pytest.mark.api
 
 SAMPLE_BUILDING_DYOHM_PROFILE_INDEX = 70
+TIMESTEPS_PER_DAY = 288
+CHECKPOINT_RTOL = 1e-12
+CHECKPOINT_ATOL = 1e-12
+TIMER_SENSITIVE_OUTPUTS = {
+    ("SUEWS", "QS"),
+    ("SUEWS", "T2"),
+    ("debug", "dqndt"),
+}
+
+
+def _checkpoint_payload(state_schema_version=1):
+    """Build the smallest version-2 envelope needed by API validation tests."""
+    return {
+        "checkpoint_schema_version": 2,
+        "timer": {
+            "dt_since_start": 600,
+            "dt_since_start_prev": 300,
+            "tstep": 300,
+            "new_day": 0,
+        },
+        "state": {
+            "schema_version": state_schema_version,
+            "members": {},
+        },
+    }
 
 
 def test_checkpoint_json_roundtrip(tmp_path):
     """Checkpoint files preserve typed Rust state by grid ID."""
-    payload = {"schema_version": 3, "members": {"demo_state": {"value": 1}}}
+    payload = _checkpoint_payload(state_schema_version=3)
+    payload["state"]["members"] = {"demo_state": {"value": 1}}
     checkpoint = SUEWSCheckpoint.from_grid_states(
         {1: json.dumps(payload)},
         last_timestamp=pd.Timestamp("2012-01-01 00:55:00"),
@@ -34,6 +59,7 @@ def test_checkpoint_json_roundtrip(tmp_path):
 
     assert loaded.grid_states.keys() == {1}
     assert json.loads(loaded.grid_states[1]) == payload
+    assert loaded.checkpoint_schema_version == 2
     assert loaded.state_schema_version == 3
     assert loaded.last_timestamp == "2012-01-01T00:55:00"
 
@@ -49,7 +75,15 @@ def test_run_stores_non_empty_checkpoint():
     assert isinstance(sim.checkpoint, SUEWSCheckpoint)
     assert output.checkpoint == sim.checkpoint
     assert sim.checkpoint.grid_states
+    assert sim.checkpoint.checkpoint_schema_version == 2
     assert sim.checkpoint.last_timestamp == forcing.index.max().isoformat()
+    checkpoint_payload = json.loads(next(iter(sim.checkpoint.grid_states.values())))
+    assert checkpoint_payload["timer"] == {
+        "dt_since_start": 3900,
+        "dt_since_start_prev": 0,
+        "tstep": 300,
+        "new_day": 0,
+    }
 
 
 def test_checkpoint_continuation_calls_rust_state_path(monkeypatch):
@@ -93,7 +127,7 @@ def test_checkpoint_continuation_restores_legacy_null_marker():
         for grid_id, state_json in sim_first.checkpoint.grid_states.items()
     }
     first_grid_id = next(iter(dict_grid_states))
-    dict_grid_states[first_grid_id]["members"]["heat_state"]["values"][
+    dict_grid_states[first_grid_id]["state"]["members"]["heat_state"]["values"][
         SAMPLE_BUILDING_DYOHM_PROFILE_INDEX
     ] = None
     checkpoint = SUEWSCheckpoint.from_grid_states(
@@ -121,7 +155,9 @@ def test_checkpoint_continuation_reports_invalid_value_path():
         for grid_id, state_json in sim_first.checkpoint.grid_states.items()
     }
     first_grid_id = next(iter(dict_grid_states))
-    dict_grid_states[first_grid_id]["members"]["atm_state"]["values"][0] = "NaN"
+    dict_grid_states[first_grid_id]["state"]["members"]["atm_state"]["values"][0] = (
+        "NaN"
+    )
     checkpoint = SUEWSCheckpoint.from_grid_states(
         dict_grid_states,
         last_timestamp=sim_first.checkpoint.last_timestamp,
@@ -140,47 +176,54 @@ def test_checkpoint_continuation_reports_invalid_value_path():
         sim_second.run()
 
 
-def test_split_run_matches_continuous_run_with_checkpoint():
-    """A checkpoint continuation matches key continuous-run outputs."""
+def test_external_checkpoint_matches_continuous_run_across_day_boundary():
+    """External continuation agrees to 1e-12 across a 24-hour boundary."""
     sim_full = SUEWSSimulation.from_sample_data()
-    forcing = sim_full.forcing.df.iloc[:48]
+    forcing = sim_full.forcing.df.iloc[:300]
     sim_full.update_forcing(forcing)
     output_full = sim_full.run()
 
     sim_first = SUEWSSimulation.from_sample_data()
-    sim_first.update_forcing(forcing.iloc[:24])
+    sim_first.update_forcing(forcing.iloc[:TIMESTEPS_PER_DAY])
     sim_first.run()
 
     sim_second = SUEWSSimulation.from_checkpoint(
         sim_first.config,
         sim_first.checkpoint,
     )
-    sim_second.update_forcing(forcing.iloc[24:48])
+    sim_second.update_forcing(forcing.iloc[TIMESTEPS_PER_DAY:])
     output_second = sim_second.run()
 
     expected_second = output_full.df.loc[output_second.df.index]
-    tolerances = {
-        "QN": {"rtol": 0.008, "atol": 0.1},
-        "QF": {"rtol": 0.008, "atol": 0.1},
-        "QS": {"rtol": 0.010, "atol": 0.2},
-        "QE": {"rtol": 0.010, "atol": 0.2},
-        "QH": {"rtol": 0.010, "atol": 0.2},
-        "T2": {"rtol": 0.005, "atol": 0.05},
-        "RH2": {"rtol": 0.010, "atol": 0.5},
-        "U10": {"rtol": 0.010, "atol": 0.05},
-    }
+    assert TIMER_SENSITIVE_OUTPUTS.issubset(output_second.df.columns)
+    pd.testing.assert_frame_equal(
+        output_second.df,
+        expected_second,
+        check_exact=False,
+        rtol=CHECKPOINT_RTOL,
+        atol=CHECKPOINT_ATOL,
+    )
 
-    for var_name, tolerance in tolerances.items():
-        column = ("SUEWS", var_name)
-        if column not in output_second.df.columns:
-            continue
-        assert np.allclose(
-            output_second.df[column],
-            expected_second[column],
-            rtol=tolerance["rtol"],
-            atol=tolerance["atol"],
-            equal_nan=True,
-        ), f"{var_name} differs outside tolerance"
+
+def test_chunked_run_matches_uninterrupted_run_across_day_boundary():
+    """Internal one-day chunks agree to 1e-12 with an uninterrupted run."""
+    sim_full = SUEWSSimulation.from_sample_data()
+    forcing = sim_full.forcing.df.iloc[:300]
+    sim_full.update_forcing(forcing)
+    output_full = sim_full.run(chunk_day=3660, n_jobs=1)
+
+    sim_chunked = SUEWSSimulation.from_sample_data()
+    sim_chunked.update_forcing(forcing)
+    output_chunked = sim_chunked.run(chunk_day=1, n_jobs=1)
+
+    assert TIMER_SENSITIVE_OUTPUTS.issubset(output_chunked.df.columns)
+    pd.testing.assert_frame_equal(
+        output_chunked.df,
+        output_full.df,
+        check_exact=False,
+        rtol=CHECKPOINT_RTOL,
+        atol=CHECKPOINT_ATOL,
+    )
 
 
 def test_from_checkpoint_requires_config():
@@ -202,13 +245,46 @@ def test_checkpoint_grid_ids_must_match_config():
     sim = SUEWSSimulation(str(config_path))
     forcing = sim.forcing.df.iloc[:12]
     sim.update_forcing(forcing)
-    checkpoint = SUEWSCheckpoint.from_grid_states({
-        2: {"schema_version": 1, "members": {}}
-    })
+    checkpoint = SUEWSCheckpoint.from_grid_states({2: _checkpoint_payload()})
     sim.continue_from(checkpoint)
 
     with pytest.raises(ValueError, match=r"missing checkpoint states.*unexpected"):
         sim.run()
+
+
+def test_legacy_checkpoint_requires_timer_metadata():
+    """Version-1 state-only checkpoints fail with an actionable migration error."""
+    sim = SUEWSSimulation.from_sample_data()
+    checkpoint = SUEWSCheckpoint.from_grid_states({
+        1: {"schema_version": 1, "members": {}}
+    })
+
+    with pytest.raises(ValueError, match="has no elapsed timer metadata"):
+        sim.continue_from(checkpoint)
+
+
+def test_checkpoint_timestep_must_match_config():
+    """Continuation rejects timer metadata from a different model timestep."""
+    sim_first = SUEWSSimulation.from_sample_data()
+    forcing = sim_first.forcing.df.iloc[:24]
+    sim_first.update_forcing(forcing.iloc[:12])
+    sim_first.run()
+
+    grid_states = {
+        grid_id: json.loads(state_json)
+        for grid_id, state_json in sim_first.checkpoint.grid_states.items()
+    }
+    first_grid_id = next(iter(grid_states))
+    grid_states[first_grid_id]["timer"]["tstep"] = 600
+    checkpoint = SUEWSCheckpoint.from_grid_states(
+        grid_states,
+        last_timestamp=sim_first.checkpoint.last_timestamp,
+    )
+    sim_second = SUEWSSimulation.from_checkpoint(sim_first.config, checkpoint)
+    sim_second.update_forcing(forcing.iloc[12:])
+
+    with pytest.raises(RuntimeError, match="does not match configuration timestep"):
+        sim_second.run()
 
 
 def test_checkpoint_file_continuation_roundtrip(tmp_path):


### PR DESCRIPTION
Fixes #1692

## Summary
- add checkpoint schema version 2 with elapsed-time, timestep, and new-day metadata
- restore that timer for internal chunks and external restart, and reject timestep mismatches or state-only v1 checkpoints with actionable errors
- add 24-hour boundary parity tests and document the compatibility/tolerance contract

## Scientific evidence
Only chunked/restarted runs change. Uninterrupted physics and existing reference fixtures are unchanged. The timer controls the OHM running-mean/spin-up path and atmospheric temperature averaging.

For a 300-row public sample split after 288 five-minute steps:

| Quantity | Unit | Before timer restoration | After timer restoration |
|---|---:|---:|---:|
| All finite output cells differing | count | 2778 | 71 final-bit differences |
| Maximum absolute difference, all outputs | native output units | 0.0511291168 | 3.5527137e-14 |
| SUEWS `QS` | W m-2 | 0.0082726150 | 0 |
| SUEWS `T2` | degC | 5.9366343e-05 | 0 |
| debug `dqndt` | W m-2 h-1 | 0.0273285158 | 0 |

The remaining final-bit differences are within the documented `rtol=1e-12`, `atol=1e-12` JSON/bridge round-trip contract.

**Domain-owner sign-off:** @sunt05 authorised proceeding with this physics change on 12 August 2026.

## Compatibility
State-only checkpoint schema version 1 cannot reconstruct elapsed model time reliably. Continuation therefore gives an actionable instruction to rerun the preceding segment and emit schema version 2.

## Validation
- `make test-smoke`: 9 passed, 1 skipped
- `make test`: 1961 passed, 8 skipped, 66 deselected
- full physics suite including slow tests: 143 passed, 1 skipped, 1891 deselected
- checkpoint API tests: 12 passed
- Rust checkpoint tests and Clippy: passed
- Ruff checks and formatting: passed
- isolated HTML documentation build: passed
- data-interface, output/forcing contract, schema, encoding, and diff checks: passed
