### PR TITLE
Reach packaged data through importlib.resources, not __file__

### DIFF
--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -214,7 +214,8 @@ sample_dir = Path(supy.__file__).parent / "sample_data"
 sample_dir = Path(sp.__file__).parent / "sample_data"
 ```
 
-Use the package's own resource handle instead:
+Use `importlib.resources` instead. In SUEWS tests, prefer the package's existing
+resource handle:
 
 ```python
 # RIGHT - what supy itself uses, in src/supy/_env.py
@@ -223,11 +224,14 @@ from supy._env import trv_supy_module
 sample_dir = trv_supy_module / "sample_data"
 ```
 
-`trv_supy_module` is `importlib.resources.files("supy")`. It returns an
-object satisfying `Traversable`. It is **not guaranteed** to be a `Path`: a
-filesystem-backed loader may well hand you a real `pathlib.Path`, which is why
-`Path`-only calls appear to work locally, but nothing promises that. Write
-against the protocol rather than against what your install happens to return.
+`trv_supy_module` is the project's shared `importlib.resources.files("supy")`
+handle. Calling `files("supy")` directly is equally resource-safe and is not
+forbidden; reusing the existing handle is simply the in-tree convention. Both
+forms return an object satisfying `Traversable`. It is **not guaranteed** to be
+a `Path`: a filesystem-backed loader may well hand you a real `pathlib.Path`,
+which is why `Path`-only calls appear to work locally, but nothing promises
+that. Write against the protocol rather than against what your install happens
+to return.
 
 The protocol guarantees exactly: `joinpath` (and so `/`), `name`, `is_dir`,
 `is_file`, `iterdir`, `open`, `read_bytes`, `read_text`. Use those:
@@ -264,8 +268,10 @@ obvious reach and is *not* in the protocol.
 **Materialise the directory whenever the resource has siblings it depends on.**
 `as_file()` on a single file extracts *only that file* under a non-filesystem
 loader. `sample_config.yml` names its forcing file as a bare sibling
-(`Kc_2012_data_60.txt`), so anything that loads forcing — `load_forcing_grid`,
-`init_supy`, `SUEWSSimulation` — needs the directory, not the file:
+(`Kc_2012_data_60.txt`), so anything that loads forcing —
+`load_forcing_grid` or `SUEWSSimulation` — needs the directory, not the file.
+`init_supy` only parses the config into initial state, so file materialisation
+is sufficient there:
 
 ```python
 with as_file(trv_supy_module / "sample_data") as path_sample_dir:
@@ -290,8 +296,8 @@ with as_file(trv_supy_module / "sample_data") as path_sample_dir:
 test around a `with` block.
 
 In a `unittest.TestCase`, `self.enterContext()` (3.11+) binds it for the
-lifetime of the test and unwinds it on cleanup, so `setUp` stays one line and
-every downstream use in the class is unchanged:
+lifetime of the test and unwinds it on cleanup. A parse-only class can
+materialise just the file:
 
 ```python
 def setUp(self):
@@ -300,14 +306,14 @@ def setUp(self):
     )
 ```
 
-In pytest, use a yield fixture. Consumers then receive a real `Path` and need
-no changes at all:
+In pytest, use a yield fixture. If any fixture consumer loads forcing,
+materialise the directory so the sibling file remains available:
 
 ```python
 @pytest.fixture(scope="session")
 def sample_yaml_path() -> Iterator[Path]:
-    with as_file(trv_supy_module / "sample_data" / "sample_config.yml") as path_sample:
-        yield path_sample
+    with as_file(trv_supy_module / "sample_data") as path_sample_dir:
+        yield path_sample_dir / "sample_config.yml"
 ```
 
 ### Worked examples already in the tree
@@ -363,17 +369,20 @@ compiled extensions cannot zip-import. Verify a conversion by reading the
 protocol, not by running the suite. Green tests are necessary, never sufficient.
 
 Until a public accessor exists, importing `trv_supy_module` from `supy._env` is
-the correct thing for a test to do: a test importing a private helper is normal,
-and matching the package's own convention is what stops the two drifting apart.
-If you are adding a new test that needs packaged data, use it rather than
-inventing a twenty-fourth variant.
+the project convention: a test importing a private helper is normal, and
+matching the package's own convention stops the two drifting apart. Direct
+`files("supy")` use remains valid and the lint does not forbid it. If you are
+adding a new test that needs packaged data, use one of these resource forms
+rather than inventing a `__file__` reach.
 
 ### What is and is not mechanically enforced
 
-`scripts/lint/check_packaged_data_paths.py` fails CI on any `<module>.__file__`
-access under `test/` (bare `__file__` stays legal, so fixture-relative
-`Path(__file__).parent` is unaffected). It runs as a step of the
-`check_test_markers` job — static AST, no build required.
+`scripts/lint/check_packaged_data_paths.py` fails CI on any imported-module
+`<module>.__file__` access under `test/`. This is deliberately a syntax-wide
+test policy: the lint does not try to infer whether a particular reach is for
+packaged data or module provenance. Bare `__file__` stays legal, so
+fixture-relative `Path(__file__).parent` is unaffected. The lint runs as a step
+of the `check_test_markers` job — static AST, no build required.
 
 It does **not** catch Traversable misuse: calling `.exists()`, passing the
 handle to builtin `open()`, or handing `str(...)` to something that opens the

--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -261,6 +261,21 @@ is 3.12). Reach for that when a test needs both a config and the directory
 holding it: one context gives you both, and it avoids `.parent`, which is the
 obvious reach and is *not* in the protocol.
 
+**Materialise the directory whenever the resource has siblings it depends on.**
+`as_file()` on a single file extracts *only that file* under a non-filesystem
+loader. `sample_config.yml` names its forcing file as a bare sibling
+(`Kc_2012_data_60.txt`), so anything that loads forcing — `load_forcing_grid`,
+`init_supy`, `SUEWSSimulation` — needs the directory, not the file:
+
+```python
+with as_file(trv_supy_module / "sample_data") as path_sample_dir:
+    yield path_sample_dir / "sample_config.yml"
+```
+
+This is the one mistake that survives the `__file__` sweep: it is still a
+layout assumption, just a subtler one, and like the rest of them it passes
+locally.
+
 ```python
 with as_file(trv_supy_module / "sample_data") as path_sample_dir:
     env = assess_readiness(

--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -241,20 +241,73 @@ with sample_config.open(encoding="utf-8") as f: # NOT builtin open(...)
 text = sample_config.read_text(encoding="utf-8")
 ```
 
-Anything that requires `os.PathLike` — builtin `open()`, `shutil.copy()`,
-subprocess arguments — needs a real filesystem path, which means
-`importlib.resources.as_file()`:
+Anything that requires `os.PathLike` needs a real filesystem path, which means
+`importlib.resources.as_file()`. That covers more than it first appears:
+builtin `open()`, `shutil.copy()`, subprocess arguments, `str(...)` used as a
+path, and **any library function that opens the file itself** — including
+`SUEWSConfig.from_yaml()`, `init_config_from_yaml()`, `sp.init_supy()` and
+`SUEWSSimulation(...)`.
 
 ```python
 from importlib.resources import as_file
 
-with as_file(sample_config) as real_path:
-    shutil.copy(real_path, destination)
+with as_file(sample_config) as path_config:
+    shutil.copy(path_config, destination)
+    config = SUEWSConfig.from_yaml(str(path_config))
 ```
 
-Under an editable install these all appear to work regardless, because the
-Traversable happens to wrap a real path. That is what makes the mistake easy: it
-passes locally and only fails where the abstraction was supposed to help.
+`as_file()` also accepts a **directory** (Python 3.12+, and the project floor
+is 3.12). Reach for that when a test needs both a config and the directory
+holding it: one context gives you both, and it avoids `.parent`, which is the
+obvious reach and is *not* in the protocol.
+
+```python
+with as_file(trv_supy_module / "sample_data") as path_sample_dir:
+    env = assess_readiness(
+        str(path_sample_dir / "sample_config.yml"),
+        project_root=str(path_sample_dir),
+    )
+```
+
+### Binding the real path for a test's lifetime
+
+`as_file()` is a context manager, but it does not force you to restructure a
+test around a `with` block.
+
+In a `unittest.TestCase`, `self.enterContext()` (3.11+) binds it for the
+lifetime of the test and unwinds it on cleanup, so `setUp` stays one line and
+every downstream use in the class is unchanged:
+
+```python
+def setUp(self):
+    self.sample_config = self.enterContext(
+        as_file(trv_supy_module / "sample_data" / "sample_config.yml")
+    )
+```
+
+In pytest, use a yield fixture. Consumers then receive a real `Path` and need
+no changes at all:
+
+```python
+@pytest.fixture(scope="session")
+def sample_yaml_path() -> Iterator[Path]:
+    with as_file(trv_supy_module / "sample_data" / "sample_config.yml") as path_sample:
+        yield path_sample
+```
+
+### Worked examples already in the tree
+
+Two helpers in `test/cmd/test_validate_config.py` are the reference
+implementations. Copy those rather than reinventing:
+
+- `_sample_yaml_path()` — the `as_file` context-manager helper, for handing a
+  real path to Click.
+- `_copy_sample_data()` — copies the whole `sample_data` directory using
+  `iterdir()` / `is_file()` / `read_bytes()` / `write_bytes()`, all protocol
+  methods, so it needs no `as_file()` at all. Note it guards with
+  `.is_file()`, not `.exists()`.
+
+`test/conftest.py::sample_yaml_path` is the yield-fixture shape.
 
 ### Why
 
@@ -270,15 +323,49 @@ passes locally and only fails where the abstraction was supposed to help.
 
 There is no public accessor for the sample-data path. `dir(supy)` exposes nothing
 for it and `trv_supy_module` is private, so a test author who needs the directory
-has no supported route and reaches for the obvious one. As of August 2026 there
-are around two dozen occurrences across roughly ten test modules, each invented
-independently.
+has no supported route and reaches for the obvious one. In August 2026 there were
+23 occurrences across eleven test modules, each invented independently. All 23
+have since been converted, and `scripts/lint/check_packaged_data_paths.py` fails
+CI on a reintroduction.
+
+The second half of the trap is mechanical, and worth stating precisely rather
+than as "the Traversable happens to wrap a real path". Under the editable
+(meson-python) install the two levels differ:
+
+```python
+trv_supy_module / "sample_data"                        # MesonpyTraversable — no .parent
+trv_supy_module / "sample_data" / "sample_config.yml"  # plain pathlib.PosixPath
+```
+
+The loader returns a real `Path` one level down. So `.exists()`, builtin
+`open()`, `shutil.copy()` and `str()`-as-a-path all succeed on the *file*, and a
+full green test run says nothing about whether the code is correct. Under a
+wheel, `files("supy")` returns a real `Path` throughout, so that mode passes
+too. Both of supy's real install modes hide the error.
+
+This means the non-filesystem branch cannot be exercised for supy at all —
+compiled extensions cannot zip-import. Verify a conversion by reading the
+protocol, not by running the suite. Green tests are necessary, never sufficient.
 
 Until a public accessor exists, importing `trv_supy_module` from `supy._env` is
 the correct thing for a test to do: a test importing a private helper is normal,
 and matching the package's own convention is what stops the two drifting apart.
-If you are adding a new test that needs packaged data, use it rather than adding
-a twenty-fifth variant.
+If you are adding a new test that needs packaged data, use it rather than
+inventing a twenty-fourth variant.
+
+### What is and is not mechanically enforced
+
+`scripts/lint/check_packaged_data_paths.py` fails CI on any `<module>.__file__`
+access under `test/` (bare `__file__` stays legal, so fixture-relative
+`Path(__file__).parent` is unaffected). It runs as a step of the
+`check_test_markers` job — static AST, no build required.
+
+It does **not** catch Traversable misuse: calling `.exists()`, passing the
+handle to builtin `open()`, or handing `str(...)` to something that opens the
+file. That class is not statically catchable at reasonable cost, and every
+instance of it passes locally. This section is what owns it. Do not read a
+green lint as "the problem is now mechanically prevented" — only the first half
+of it is.
 
 ## Skipping Tests
 

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -497,8 +497,8 @@ jobs:
   #     runtime counterpart is a pytest_collection_finish hook in
   #     test/conftest.py, which catches the same thing during normal
   #     full-tree pytest runs.
-  #  2. No test may reach packaged data through `<module>.__file__`; use
-  #     `supy._env.trv_supy_module` instead. See
+  #  2. No test may inspect an imported module through `<module>.__file__`;
+  #     use `importlib.resources` for packaged data instead. See
   #     `.claude/rules/tests/patterns.md` ("Locating packaged data").
   #
   # The job id and display name are unchanged so nothing that references

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -489,12 +489,20 @@ jobs:
         ${{ github.event_name == 'merge_group' && needs.determine_matrix.outputs.python || needs.determine_matrix.outputs.api_python }}
       test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
 
-  # Standalone lint: every test file must declare `physics` or `api`
-  # (gh#1300). Uses a static AST-based script so CI can verify marker
-  # coverage without building supy — keeps the check cheap for
-  # test-only PRs. The runtime counterpart is a pytest_collection_finish
-  # hook in test/conftest.py, which catches the same thing during normal
-  # full-tree pytest runs.
+  # Standalone static lints over the test tree. Both use AST-based scripts
+  # that never import supy, so CI can run them without building — that is
+  # what keeps the check cheap for test-only PRs.
+  #
+  #  1. Every test file must declare `physics` or `api` (gh#1300). The
+  #     runtime counterpart is a pytest_collection_finish hook in
+  #     test/conftest.py, which catches the same thing during normal
+  #     full-tree pytest runs.
+  #  2. No test may reach packaged data through `<module>.__file__`; use
+  #     `supy._env.trv_supy_module` instead. See
+  #     `.claude/rules/tests/patterns.md` ("Locating packaged data").
+  #
+  # The job id and display name are unchanged so nothing that references
+  # them (needs:, .github/scripts/pr-gate.sh, branch protection) breaks.
   check_test_markers:
     name: Check pytest marker axis
     runs-on: ubuntu-latest
@@ -516,6 +524,13 @@ jobs:
       - name: Lint physics/api marker coverage
         shell: bash
         run: python scripts/lint/check_test_markers.py
+
+      # `always()` so a marker failure does not mask a packaged-data
+      # failure: a contributor should see both in one run, not one per push.
+      - name: Lint packaged-data path access
+        if: always()
+        shell: bash
+        run: python scripts/lint/check_packaged_data_paths.py
 
   # Single consolidated check for branch protection (always runs for PRs/merge queue)
   pr-gate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ EXAMPLES:
   - Checkpoint generation now preserves `NaN` using the existing JSON `null` representation and rejects infinities with their exact state member and array index.
   - State-aware continuation restores `null` as `NaN`, so existing checkpoints no longer fail with only `invalid state payload`; other invalid JSON values report their exact path and type.
 
+- [maintenance] Guarded tests against locating bundled package data through imported modules' `__file__` (#1697)
+  - Reached SuPy's packaged sample data through `importlib.resources`, materialising the whole directory where the YAML config depends on its sibling forcing file.
+  - Added an AST-based CI lint, regression coverage, and test guidance to prevent the fragile path pattern from returning.
+
 - [bugfix] Stopped the YAML config reference describing parameters without a default as optional (#1677)
   - Every parameter carrying no default previously rendered as `Default: None (optional)`, which asserted the opposite of the truth for parameters such as `store_cap` and `base_temperature_senescence`; these are declared `Optional[...] = None` only so a partial configuration still loads and the validation layer can then report what is missing.
   - Such parameters now render under a `Configuration Note` label stating that no default exists and that a value may be required depending on which physics options and surface types are active. A `Default` label therefore always introduces a real default value, and `Status` stays reserved for the short state token `Required`.

--- a/scripts/lint/check_packaged_data_paths.py
+++ b/scripts/lint/check_packaged_data_paths.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Static lint: tests must not reach packaged data through ``<module>.__file__``.
+
+``Path(supy.__file__).parent / "sample_data"`` assumes the package is an
+unpacked directory on disk. The import system does not guarantee that, and it
+couples the test to supy's internal layout. supy resolves its own data with
+``importlib.resources`` (``src/supy/_env.py``: ``trv_supy_module =
+files("supy")``); tests should do the same.
+
+This is a supy-free static pass, so CI can run it without building -- the same
+reasoning as ``check_test_markers.py``, which this script is modelled on.
+
+What it flags: any ``<something>.__file__`` attribute access under ``test/``.
+Bare ``__file__`` (the test module's own location, used for fixture paths) is
+an ``ast.Name`` rather than an ``ast.Attribute``, so it is never flagged.
+
+Exits 0 when the tree is clean, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# Files exempted from the check, each with the reason it is exempt.
+#
+# Deliberately empty: the sweep was complete, so nothing needs exempting. Keep
+# it that way. An allowlist that carries one entry tends to acquire a second,
+# and the check is only worth having while it covers the whole tree. If you
+# think you need an entry here, the bar is a file another in-flight branch owns
+# -- and it comes with a note saying when to delete it.
+ALLOWLIST: dict[str, str] = {}
+
+REMEDIATION = """\
+Reach packaged data through the package's own resource handle instead:
+
+    from supy._env import trv_supy_module
+
+    sample_dir = trv_supy_module / "sample_data"
+    config = sample_dir / "sample_config.yml"
+
+`trv_supy_module` is `importlib.resources.files("supy")`, which returns a
+Traversable. The protocol guarantees only `/` (joinpath), `name`, `is_dir`,
+`is_file`, `iterdir`, `open`, `read_bytes` and `read_text` -- so:
+
+  - existence check      ->  `config.is_file()`, NOT `config.exists()`
+  - read text            ->  `config.open(encoding="utf-8")` / `.read_text(...)`
+  - a real path is needed (a str() path, subprocess, or any API that opens the
+    file itself) ->  materialise it:
+
+        from importlib.resources import as_file
+
+        with as_file(config) as path_config:
+            SUEWSConfig.from_yaml(str(path_config))
+
+    In a unittest.TestCase, `self.enterContext(as_file(config))` binds it for
+    the lifetime of the test.
+
+All of the wrong forms happen to work under an editable install, where the
+Traversable wraps a real filesystem path -- so a passing test run is NOT
+evidence that a conversion is correct.
+
+See `.claude/rules/tests/patterns.md` ("Locating packaged data") and the
+existing `_sample_yaml_path` helper in `test/cmd/test_validate_config.py`.\
+"""
+
+
+class PackagedFileVisitor(ast.NodeVisitor):
+    """Collect ``<something>.__file__`` attribute accesses."""
+
+    def __init__(self) -> None:
+        self.hits: list[tuple[int, str]] = []
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr == "__file__":
+            self.hits.append((node.lineno, ast.unparse(node)))
+        self.generic_visit(node)
+
+
+def find_hits(source: str) -> list[tuple[int, str]]:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # A file that does not parse is not this lint's problem; pytest and
+        # ruff both surface it far more usefully.
+        return []
+    visitor = PackagedFileVisitor()
+    visitor.visit(tree)
+    return visitor.hits
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(argv[1]).resolve() if len(argv) > 1 else Path.cwd()
+    test_root = repo_root / "test"
+    if not test_root.is_dir():
+        print(f"[X] test/ not found under {repo_root}", file=sys.stderr)
+        return 1
+
+    offenders: list[str] = []
+    checked = 0
+    exempted: list[str] = []
+
+    # Every .py file, not just `test_*.py` -- conftest.py and test helpers reach
+    # for packaged data too, and a glob restricted to `test_*.py` would let a
+    # reintroduction land there unseen.
+    for path in sorted(test_root.rglob("*.py")):
+        rel = path.relative_to(repo_root).as_posix()
+        if rel in ALLOWLIST:
+            exempted.append(rel)
+            continue
+        checked += 1
+        for lineno, expr in find_hits(path.read_text(encoding="utf-8")):
+            offenders.append(f"{rel}:{lineno}: {expr}")
+
+    for rel in exempted:
+        print(f"[!] EXEMPT {rel} -- {ALLOWLIST[rel]}")
+
+    if offenders:
+        print(
+            "[X] packaged-data lint: tests reaching package data via `<module>.__file__`:",
+            file=sys.stderr,
+        )
+        for offender in offenders:
+            print(f"  - {offender}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(REMEDIATION, file=sys.stderr)
+        return 1
+
+    print(
+        f"[OK] {checked} files under test/ reach packaged data without "
+        f"`<module>.__file__`; {len(exempted)} exempted."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lint/check_packaged_data_paths.py
+++ b/scripts/lint/check_packaged_data_paths.py
@@ -14,6 +14,11 @@ What it flags: any ``<something>.__file__`` attribute access under ``test/``.
 Bare ``__file__`` (the test module's own location, used for fixture paths) is
 an ``ast.Name`` rather than an ``ast.Attribute``, so it is never flagged.
 
+Scope is deliberately ``test/`` only. Do not widen it to ``src/``:
+``src/supy/cmd/json_envelope.py`` reads ``supy.__file__`` legitimately, to
+find the install root when walking up for a ``.git`` directory. That is
+locating the package, not reaching into its data, and it is correct.
+
 Exits 0 when the tree is clean, 1 otherwise.
 """
 
@@ -23,71 +28,44 @@ import ast
 import sys
 from pathlib import Path
 
-# Files exempted from the check, each with the reason it is exempt.
-#
-# Deliberately empty: the sweep was complete, so nothing needs exempting. Keep
-# it that way. An allowlist that carries one entry tends to acquire a second,
-# and the check is only worth having while it covers the whole tree. If you
-# think you need an entry here, the bar is a file another in-flight branch owns
-# -- and it comes with a note saying when to delete it.
-ALLOWLIST: dict[str, str] = {}
-
 REMEDIATION = """\
-Reach packaged data through the package's own resource handle instead:
+Reach packaged data through the package's own resource handle:
 
     from supy._env import trv_supy_module
 
-    sample_dir = trv_supy_module / "sample_data"
-    config = sample_dir / "sample_config.yml"
+    config = trv_supy_module / "sample_data" / "sample_config.yml"
 
-`trv_supy_module` is `importlib.resources.files("supy")`, which returns a
-Traversable. The protocol guarantees only `/` (joinpath), `name`, `is_dir`,
-`is_file`, `iterdir`, `open`, `read_bytes` and `read_text` -- so:
+That returns a Traversable, not a Path, so:
 
-  - existence check      ->  `config.is_file()`, NOT `config.exists()`
-  - read text            ->  `config.open(encoding="utf-8")` / `.read_text(...)`
-  - a real path is needed (a str() path, subprocess, or any API that opens the
-    file itself) ->  materialise it:
+  - existence check  ->  `config.is_file()`, NOT `config.exists()`
+  - read text        ->  `config.open(encoding="utf-8")` / `.read_text(...)`
+  - a real path (a str() path, subprocess, or any API that opens the file
+    itself)          ->  `importlib.resources.as_file(config)`
 
-        from importlib.resources import as_file
+Every wrong form passes under an editable install, so a green test run is not
+evidence the conversion is right.
 
-        with as_file(config) as path_config:
-            SUEWSConfig.from_yaml(str(path_config))
-
-    In a unittest.TestCase, `self.enterContext(as_file(config))` binds it for
-    the lifetime of the test.
-
-All of the wrong forms happen to work under an editable install, where the
-Traversable wraps a real filesystem path -- so a passing test run is NOT
-evidence that a conversion is correct.
-
-See `.claude/rules/tests/patterns.md` ("Locating packaged data") and the
-existing `_sample_yaml_path` helper in `test/cmd/test_validate_config.py`.\
+Full guidance, including how to bind a real path for a test's lifetime:
+`.claude/rules/tests/patterns.md` ("Locating packaged data"). Worked examples:
+`_sample_yaml_path` / `_copy_sample_data` in `test/cmd/test_validate_config.py`.\
 """
 
 
-class PackagedFileVisitor(ast.NodeVisitor):
-    """Collect ``<something>.__file__`` attribute accesses."""
-
-    def __init__(self) -> None:
-        self.hits: list[tuple[int, str]] = []
-
-    def visit_Attribute(self, node: ast.Attribute) -> None:
-        if node.attr == "__file__":
-            self.hits.append((node.lineno, ast.unparse(node)))
-        self.generic_visit(node)
-
-
 def find_hits(source: str) -> list[tuple[int, str]]:
+    """Return (line, expression) for each ``<something>.__file__`` access."""
     try:
         tree = ast.parse(source)
     except SyntaxError:
         # A file that does not parse is not this lint's problem; pytest and
         # ruff both surface it far more usefully.
         return []
-    visitor = PackagedFileVisitor()
-    visitor.visit(tree)
-    return visitor.hits
+    # sorted() because ast.walk is breadth-first, so hits would otherwise be
+    # reported in tree order rather than line order.
+    return sorted(
+        (node.lineno, ast.unparse(node))
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == "__file__"
+    )
 
 
 def main(argv: list[str]) -> int:
@@ -99,22 +77,15 @@ def main(argv: list[str]) -> int:
 
     offenders: list[str] = []
     checked = 0
-    exempted: list[str] = []
 
     # Every .py file, not just `test_*.py` -- conftest.py and test helpers reach
     # for packaged data too, and a glob restricted to `test_*.py` would let a
     # reintroduction land there unseen.
     for path in sorted(test_root.rglob("*.py")):
         rel = path.relative_to(repo_root).as_posix()
-        if rel in ALLOWLIST:
-            exempted.append(rel)
-            continue
         checked += 1
         for lineno, expr in find_hits(path.read_text(encoding="utf-8")):
             offenders.append(f"{rel}:{lineno}: {expr}")
-
-    for rel in exempted:
-        print(f"[!] EXEMPT {rel} -- {ALLOWLIST[rel]}")
 
     if offenders:
         print(
@@ -129,7 +100,7 @@ def main(argv: list[str]) -> int:
 
     print(
         f"[OK] {checked} files under test/ reach packaged data without "
-        f"`<module>.__file__`; {len(exempted)} exempted."
+        f"`<module>.__file__`."
     )
     return 0
 

--- a/scripts/lint/check_packaged_data_paths.py
+++ b/scripts/lint/check_packaged_data_paths.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
-"""Static lint: tests must not reach packaged data through ``<module>.__file__``.
+"""Static lint: tests must not inspect imported modules via ``__file__``.
 
 ``Path(supy.__file__).parent / "sample_data"`` assumes the package is an
 unpacked directory on disk. The import system does not guarantee that, and it
 couples the test to supy's internal layout. supy resolves its own data with
 ``importlib.resources`` (``src/supy/_env.py``: ``trv_supy_module =
-files("supy")``); tests should do the same.
+files("supy")``); tests should do the same for packaged resources.
 
 This is a supy-free static pass, so CI can run it without building -- the same
 reasoning as ``check_test_markers.py``, which this script is modelled on.
 
 What it flags: any ``<something>.__file__`` attribute access under ``test/``.
-Bare ``__file__`` (the test module's own location, used for fixture paths) is
-an ``ast.Name`` rather than an ``ast.Attribute``, so it is never flagged.
+This is deliberately syntax-wide: the lint does not guess whether a reach is
+for packaged data or module provenance. Bare ``__file__`` (the test module's
+own location, used for fixture paths) is an ``ast.Name`` rather than an
+``ast.Attribute``, so it is never flagged.
 
 Scope is deliberately ``test/`` only. Do not widen it to ``src/``:
 ``src/supy/cmd/json_envelope.py`` reads ``supy.__file__`` legitimately, to
@@ -25,17 +27,20 @@ Exits 0 when the tree is clean, 1 otherwise.
 from __future__ import annotations
 
 import ast
-import sys
 from pathlib import Path
+import sys
 
 REMEDIATION = """\
-Reach packaged data through the package's own resource handle:
+Do not inspect an imported module's `__file__` in tests. For packaged data,
+use `importlib.resources`. supy's in-tree convention is its shared handle:
 
     from supy._env import trv_supy_module
 
     config = trv_supy_module / "sample_data" / "sample_config.yml"
 
-That returns a Traversable, not a Path, so:
+Calling `importlib.resources.files("supy")` directly is equally resource-safe;
+the lint forbids the `__file__` reach, not a particular resource-handle name.
+Either form returns a Traversable, not a Path, so:
 
   - existence check  ->  `config.is_file()`, NOT `config.exists()`
   - read text        ->  `config.open(encoding="utf-8")` / `.read_text(...)`
@@ -69,6 +74,7 @@ def find_hits(source: str) -> list[tuple[int, str]]:
 
 
 def main(argv: list[str]) -> int:
+    """Check every Python file under the repository's test directory."""
     repo_root = Path(argv[1]).resolve() if len(argv) > 1 else Path.cwd()
     test_root = repo_root / "test"
     if not test_root.is_dir():
@@ -78,8 +84,8 @@ def main(argv: list[str]) -> int:
     offenders: list[str] = []
     checked = 0
 
-    # Every .py file, not just `test_*.py` -- conftest.py and test helpers reach
-    # for packaged data too, and a glob restricted to `test_*.py` would let a
+    # Every .py file, not just `test_*.py` -- conftest.py and test helpers can
+    # inspect imported modules too, and a restricted glob would let a
     # reintroduction land there unseen.
     for path in sorted(test_root.rglob("*.py")):
         rel = path.relative_to(repo_root).as_posix()
@@ -89,7 +95,7 @@ def main(argv: list[str]) -> int:
 
     if offenders:
         print(
-            "[X] packaged-data lint: tests reaching package data via `<module>.__file__`:",
+            "[X] module-location lint: tests inspecting imported modules via `__file__`:",
             file=sys.stderr,
         )
         for offender in offenders:
@@ -99,8 +105,7 @@ def main(argv: list[str]) -> int:
         return 1
 
     print(
-        f"[OK] {checked} files under test/ reach packaged data without "
-        f"`<module>.__file__`."
+        f"[OK] {checked} files under test/ avoid imported-module `__file__`."
     )
     return 0
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,11 @@
 """pytest configuration for SUEWS test suite."""
 
-from pathlib import Path
 import subprocess
 import sys
 import warnings
+from importlib.resources import as_file
+from pathlib import Path
+from typing import Iterator
 
 # Make the standalone suews_mcp package importable when it is not pip-installed
 # (e.g. wheel CI installs only the supy wheel). Done at the root conftest rather
@@ -19,6 +21,7 @@ from click.testing import CliRunner
 import pytest
 
 import supy
+from supy._env import trv_supy_module
 
 # =============================================================================
 # Debug Decorators - Centralised to avoid duplication in test files
@@ -380,12 +383,15 @@ def pytest_collection_finish(session):
 
 
 @pytest.fixture(scope="session")
-def sample_yaml_path() -> Path:
+def sample_yaml_path() -> Iterator[Path]:
     """Path to the bundled SUEWS sample YAML configuration.
 
     Session-scoped since the path is fixed for the process lifetime.
+    ``as_file`` materialises the packaged resource as a real filesystem
+    path, which is what the consumers below hand to ``str()``-taking APIs.
     """
-    return Path(supy.__file__).parent / "sample_data" / "sample_config.yml"
+    with as_file(trv_supy_module / "sample_data" / "sample_config.yml") as path_sample:
+        yield path_sample
 
 
 @pytest.fixture(scope="session")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,11 @@
 """pytest configuration for SUEWS test suite."""
 
+from collections.abc import Iterator
+from importlib.resources import as_file
+from pathlib import Path
 import subprocess
 import sys
 import warnings
-from importlib.resources import as_file
-from pathlib import Path
-from typing import Iterator
 
 # Make the standalone suews_mcp package importable when it is not pip-installed
 # (e.g. wheel CI installs only the supy wheel). Done at the root conftest rather

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -389,9 +389,14 @@ def sample_yaml_path() -> Iterator[Path]:
     Session-scoped since the path is fixed for the process lifetime.
     ``as_file`` materialises the packaged resource as a real filesystem
     path, which is what the consumers below hand to ``str()``-taking APIs.
+
+    The **directory** is materialised, not just the config: the config names
+    its forcing file as a bare sibling (``Kc_2012_data_60.txt``), so a
+    file-only ``as_file`` would hand back a config whose forcing cannot
+    resolve under any non-filesystem loader.
     """
-    with as_file(trv_supy_module / "sample_data" / "sample_config.yml") as path_sample:
-        yield path_sample
+    with as_file(trv_supy_module / "sample_data") as path_sample_dir:
+        yield path_sample_dir / "sample_config.yml"
 
 
 @pytest.fixture(scope="session")

--- a/test/core/test_check_packaged_data_paths.py
+++ b/test/core/test_check_packaged_data_paths.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/lint/check_packaged_data_paths.py.
+
+A lint that has only been seen to pass is not tested, so this exercises
+both directions: a tree carrying the anti-pattern must fail, and a swept
+tree must pass.
+
+Three properties matter beyond the basic pass/fail:
+
+- ``conftest.py`` is covered. The sibling ``check_test_markers.py`` globs
+  ``test_*.py``, which would miss it -- and ``test/conftest.py`` was one of
+  the files carrying the anti-pattern, so a reintroduction there has to be
+  caught.
+- Bare ``__file__`` stays legal. Dozens of tests locate their own fixtures
+  with ``Path(__file__).parent``; flagging those would make the lint
+  unusable.
+- The allowlist is honoured, so the one file owned by another branch can be
+  exempted without disabling the check everywhere.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.api
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "lint"
+    / "check_packaged_data_paths.py"
+)
+SCRIPT_SPEC = importlib.util.spec_from_file_location(
+    "check_packaged_data_paths", SCRIPT_PATH
+)
+assert SCRIPT_SPEC is not None
+assert SCRIPT_SPEC.loader is not None
+check_packaged_data_paths = importlib.util.module_from_spec(SCRIPT_SPEC)
+sys.modules[SCRIPT_SPEC.name] = check_packaged_data_paths
+SCRIPT_SPEC.loader.exec_module(check_packaged_data_paths)
+
+
+CLEAN_SOURCE = '''\
+"""A test module that locates packaged data correctly."""
+
+from importlib.resources import as_file
+from pathlib import Path
+
+from supy._env import trv_supy_module
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def test_something():
+    config = trv_supy_module / "sample_data" / "sample_config.yml"
+    assert config.is_file()
+    with as_file(config) as path_config:
+        assert str(path_config)
+'''
+
+OFFENDING_SOURCE = '''\
+"""A test module reaching packaged data through the module file."""
+
+from pathlib import Path
+
+import supy as sp
+
+
+def test_something():
+    sample_dir = Path(sp.__file__).parent / "sample_data"
+    assert (sample_dir / "sample_config.yml").exists()
+'''
+
+
+def _make_repo(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Build a throwaway repo root containing ``test/`` with ``files``."""
+    for rel, source in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+    return tmp_path
+
+
+def _run(repo_root: Path) -> int:
+    return check_packaged_data_paths.main(["check_packaged_data_paths", str(repo_root)])
+
+
+def test_clean_tree_passes(tmp_path):
+    """A tree using trv_supy_module and bare __file__ exits 0."""
+    repo = _make_repo(tmp_path, {"test/test_clean.py": CLEAN_SOURCE})
+
+    assert _run(repo) == 0
+
+
+def test_offending_test_file_fails(tmp_path):
+    """`Path(sp.__file__)` in a test module exits 1."""
+    repo = _make_repo(tmp_path, {"test/test_offender.py": OFFENDING_SOURCE})
+
+    assert _run(repo) == 1
+
+
+def test_offending_conftest_fails(tmp_path):
+    """The check must cover conftest.py, not only `test_*.py`.
+
+    `check_test_markers.py` globs `test_*.py`; copying that glob here would
+    leave `test/conftest.py` -- itself one of the swept files -- unguarded.
+    """
+    repo = _make_repo(tmp_path, {"test/conftest.py": OFFENDING_SOURCE})
+
+    assert _run(repo) == 1
+
+
+def test_bare_dunder_file_is_not_flagged(tmp_path):
+    """`Path(__file__)` locates the test's own fixtures and stays legal."""
+    source = (
+        "from pathlib import Path\n"
+        "\n"
+        "FIXTURES = Path(__file__).resolve().parents[1] / 'fixtures'\n"
+        "OWN_DIR = Path(__file__).parent\n"
+    )
+    repo = _make_repo(tmp_path, {"test/test_fixture_paths.py": source})
+
+    assert _run(repo) == 0
+
+
+def test_indirect_reach_is_flagged(tmp_path):
+    """A reach that never calls `Path()` is still the same anti-pattern."""
+    source = (
+        "import os.path\n"
+        "\n"
+        "import supy\n"
+        "\n"
+        "SAMPLE = os.path.join(os.path.dirname(supy.__file__), 'sample_data')\n"
+    )
+    repo = _make_repo(tmp_path, {"test/test_indirect.py": source})
+
+    assert _run(repo) == 1
+
+
+def test_allowlisted_file_is_exempt(tmp_path, monkeypatch, capsys):
+    """An allowlisted offender passes, and says loudly that it was skipped."""
+    repo = _make_repo(tmp_path, {"test/core/test_owned_elsewhere.py": OFFENDING_SOURCE})
+    monkeypatch.setattr(
+        check_packaged_data_paths,
+        "ALLOWLIST",
+        {"test/core/test_owned_elsewhere.py": "owned by another branch"},
+    )
+
+    assert _run(repo) == 0
+    assert "EXEMPT test/core/test_owned_elsewhere.py" in capsys.readouterr().out
+
+
+def test_missing_test_dir_fails(tmp_path):
+    """Pointed at a tree with no `test/`, the lint fails rather than passing."""
+    assert _run(tmp_path) == 1
+
+
+def test_repo_tree_is_clean():
+    """The real repository passes -- the sweep is complete."""
+    repo_root = Path(__file__).resolve().parents[2]
+
+    assert _run(repo_root) == 0

--- a/test/core/test_check_packaged_data_paths.py
+++ b/test/core/test_check_packaged_data_paths.py
@@ -13,8 +13,9 @@ Three properties matter beyond the basic pass/fail:
 - Bare ``__file__`` stays legal. Dozens of tests locate their own fixtures
   with ``Path(__file__).parent``; flagging those would make the lint
   unusable.
-- The allowlist is honoured, so the one file owned by another branch can be
-  exempted without disabling the check everywhere.
+- Offenders are reported in line order. ``find_hits`` walks the AST
+  breadth-first, so without an explicit sort the report would come out in
+  tree order, which reads as noise in a CI log.
 """
 
 from __future__ import annotations
@@ -141,17 +142,32 @@ def test_indirect_reach_is_flagged(tmp_path):
     assert _run(repo) == 1
 
 
-def test_allowlisted_file_is_exempt(tmp_path, monkeypatch, capsys):
-    """An allowlisted offender passes, and says loudly that it was skipped."""
-    repo = _make_repo(tmp_path, {"test/core/test_owned_elsewhere.py": OFFENDING_SOURCE})
-    monkeypatch.setattr(
-        check_packaged_data_paths,
-        "ALLOWLIST",
-        {"test/core/test_owned_elsewhere.py": "owned by another branch"},
-    )
+def test_offenders_are_reported_in_line_order(tmp_path, capsys):
+    """Offenders are listed by line number, not AST walk order.
 
-    assert _run(repo) == 0
-    assert "EXEMPT test/core/test_owned_elsewhere.py" in capsys.readouterr().out
+    `find_hits` uses `ast.walk`, which is breadth-first, so a shallow late
+    hit would otherwise be printed before a deeply nested early one.
+    """
+    source = (
+        "import supy\n"
+        "\n"
+        "def f():\n"
+        "    if True:\n"
+        "        if True:\n"
+        "            early = supy.__file__\n"
+        "\n"
+        "late = supy.__file__\n"
+    )
+    repo = _make_repo(tmp_path, {"test/test_order.py": source})
+
+    assert _run(repo) == 1
+    reported = [
+        line for line in capsys.readouterr().err.splitlines() if "test_order.py:" in line
+    ]
+    assert reported == [
+        "  - test/test_order.py:6: supy.__file__",
+        "  - test/test_order.py:8: supy.__file__",
+    ], reported
 
 
 def test_missing_test_dir_fails(tmp_path):

--- a/test/core/test_load.py
+++ b/test/core/test_load.py
@@ -5,6 +5,7 @@ This module tests all data loading and initialization functions in supy,
 including state initialization, forcing data loading, and configuration loading.
 """
 
+from importlib.resources import as_file
 from pathlib import Path
 import tempfile
 from unittest import TestCase
@@ -15,6 +16,7 @@ import pytest
 import yaml
 
 import supy as sp
+from supy._env import trv_supy_module
 from supy.data_model import SUEWSConfig
 from supy.util.converter import convert_table, detect_table_version
 
@@ -27,8 +29,8 @@ class TestSimulationLoading(TestCase):
     def setUp(self):
         """Set up test environment."""
         # Get the sample config path
-        self.sample_config = (
-            Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        self.sample_config = self.enterContext(
+            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
         )
         self.benchmark_config = (
             Path(__file__).parent.parent / "fixtures" / "benchmark1" / "benchmark1.yml"
@@ -86,8 +88,8 @@ class TestLoadForcing(TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        self.sample_config = (
-            Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        self.sample_config = self.enterContext(
+            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
         )
         self.benchmark_config = (
             Path(__file__).parent.parent / "fixtures" / "benchmark1" / "benchmark1.yml"
@@ -178,8 +180,8 @@ class TestConfigLoading(TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        self.sample_config = (
-            Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        self.sample_config = self.enterContext(
+            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
         )
 
     def test_init_config_from_yaml(self):

--- a/test/core/test_load.py
+++ b/test/core/test_load.py
@@ -29,9 +29,10 @@ class TestSimulationLoading(TestCase):
     def setUp(self):
         """Set up test environment."""
         # Get the sample config path
-        self.sample_config = self.enterContext(
-            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
-        )
+        # The directory, not just the config: the config names its forcing
+        # file as a bare sibling, so a file-only as_file() would not carry it.
+        sample_dir = self.enterContext(as_file(trv_supy_module / "sample_data"))
+        self.sample_config = sample_dir / "sample_config.yml"
         self.benchmark_config = (
             Path(__file__).parent.parent / "fixtures" / "benchmark1" / "benchmark1.yml"
         )
@@ -88,9 +89,10 @@ class TestLoadForcing(TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        self.sample_config = self.enterContext(
-            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
-        )
+        # The directory, not just the config: the config names its forcing
+        # file as a bare sibling, so a file-only as_file() would not carry it.
+        sample_dir = self.enterContext(as_file(trv_supy_module / "sample_data"))
+        self.sample_config = sample_dir / "sample_config.yml"
         self.benchmark_config = (
             Path(__file__).parent.parent / "fixtures" / "benchmark1" / "benchmark1.yml"
         )
@@ -180,9 +182,10 @@ class TestConfigLoading(TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        self.sample_config = self.enterContext(
-            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
-        )
+        # The directory, not just the config: the config names its forcing
+        # file as a bare sibling, so a file-only as_file() would not carry it.
+        sample_dir = self.enterContext(as_file(trv_supy_module / "sample_data"))
+        self.sample_config = sample_dir / "sample_config.yml"
 
     def test_init_config_from_yaml(self):
         """Test loading configuration from YAML."""

--- a/test/core/test_load.py
+++ b/test/core/test_load.py
@@ -182,8 +182,8 @@ class TestConfigLoading(TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        # The directory, not just the config: the config names its forcing
-        # file as a bare sibling, so a file-only as_file() would not carry it.
+        # The object-oriented state conversion below constructs a simulation,
+        # which auto-loads the forcing file named as a sibling of the config.
         sample_dir = self.enterContext(as_file(trv_supy_module / "sample_data"))
         self.sample_config = sample_dir / "sample_config.yml"
 

--- a/test/data_model/test_data_model.py
+++ b/test/data_model/test_data_model.py
@@ -8,6 +8,7 @@ This file combines:
 """
 
 # Import section will be combined from all relevant files
+from importlib.resources import as_file
 from pathlib import Path
 import unittest
 
@@ -16,6 +17,7 @@ import pandas as pd
 import pytest
 
 import supy as sp
+from supy._env import trv_supy_module
 from supy._load import trim_df_state
 from supy.data_model import (
     InitialStates,
@@ -37,8 +39,8 @@ pytestmark = pytest.mark.api
 class TestSUEWSConfig(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
-        self.path_sample_config = (
-            Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        self.path_sample_config = self.enterContext(
+            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
         )
         self.config = SUEWSConfig.from_yaml(self.path_sample_config)
 
@@ -361,7 +363,9 @@ class TestLegacyDfStateStebbsDefaults(unittest.TestCase):
     """
 
     def setUp(self):
-        path = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        path = self.enterContext(
+            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
+        )
         self.df_physics = SUEWSConfig.from_yaml(path).model.physics.to_df_state(
             grid_id=1
         )
@@ -392,7 +396,9 @@ class TestLegacyDfStateStebbsDefaults(unittest.TestCase):
     def test_issue_minimal_repro_via_suews_config(self):
         """The gh#1500 symptom at config level: drop ``setpointmethod`` from a
         full df_state and round-trip through ``SUEWSConfig.from_df_state``."""
-        path = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        path = self.enterContext(
+            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
+        )
         df = SUEWSConfig.from_yaml(path).to_df_state()
         df_legacy = df.drop(columns=[("setpointmethod", "0")])
         config = SUEWSConfig.from_df_state(df_legacy)

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -11,13 +11,10 @@ machine-readable representation of the validator's findings.
 from __future__ import annotations
 
 import json
-from importlib.resources import as_file
 from pathlib import Path
-from typing import Iterator
 
 import pytest
 
-from supy._env import trv_supy_module
 from supy.data_model.validation.pipeline.orchestrator import (
     run_phase_a,
     run_phase_b,
@@ -28,25 +25,14 @@ from supy.data_model.validation.pipeline.report_schema import PhaseReport
 pytestmark = pytest.mark.api
 
 
-@pytest.fixture
-def sample_config_path() -> Iterator[Path]:
-    """The bundled sample config as a real filesystem path.
-
-    The pipeline entry points below take ``str`` paths, so the
-    packaged resource is materialised with ``as_file``.
-    """
-    with as_file(trv_supy_module / "sample_data" / "sample_config.yml") as path_sample:
-        yield path_sample
-
-
-def test_phase_a_emits_json_sidecar(tmp_path, sample_config_path):
+def test_phase_a_emits_json_sidecar(tmp_path, sample_yaml_path):
     """Phase A writes a JSON sidecar alongside its text report."""
     uptodate_file = tmp_path / "uptodate.yml"
     report_file = tmp_path / "report.txt"
 
     report = run_phase_a(
-        user_yaml_file=str(sample_config_path),
-        standard_yaml_file=str(sample_config_path),
+        user_yaml_file=str(sample_yaml_path),
+        standard_yaml_file=str(sample_yaml_path),
         uptodate_file=str(uptodate_file),
         report_file=str(report_file),
         silent=True,
@@ -71,15 +57,15 @@ def test_phase_a_emits_json_sidecar(tmp_path, sample_config_path):
         assert issue["code"].startswith("A.")
 
 
-def test_phase_b_emits_json_sidecar(tmp_path, sample_config_path):
+def test_phase_b_emits_json_sidecar(tmp_path, sample_yaml_path):
     """Phase B writes a JSON sidecar alongside its text report."""
     science_yaml = tmp_path / "science.yml"
     science_report = tmp_path / "science_report.txt"
 
     report = run_phase_b(
-        user_yaml_file=str(sample_config_path),
-        uptodate_file=str(sample_config_path),  # Skip Phase A
-        standard_yaml_file=str(sample_config_path),
+        user_yaml_file=str(sample_yaml_path),
+        uptodate_file=str(sample_yaml_path),  # Skip Phase A
+        standard_yaml_file=str(sample_yaml_path),
         science_yaml_file=str(science_yaml),
         science_report_file=str(science_report),
         phase_a_report_file=str(tmp_path / "phase_a_report.txt"),
@@ -105,13 +91,13 @@ def test_phase_b_emits_json_sidecar(tmp_path, sample_config_path):
         assert "message" in issue
 
 
-def test_phase_c_emits_json_for_passing_config(tmp_path, sample_config_path):
+def test_phase_c_emits_json_for_passing_config(tmp_path, sample_yaml_path):
     """Phase C writes a JSON sidecar even on the success path."""
     pydantic_yaml = tmp_path / "pydantic.yml"
     pydantic_report = tmp_path / "pydantic_report.txt"
 
     report = run_phase_c(
-        input_yaml_file=str(sample_config_path),
+        input_yaml_file=str(sample_yaml_path),
         pydantic_yaml_file=str(pydantic_yaml),
         pydantic_report_file=str(pydantic_report),
         phases_run=["C"],
@@ -161,15 +147,15 @@ def test_phase_c_emits_structured_pydantic_errors_for_bad_config(tmp_path):
     assert pydantic_codes, "Expected at least one C.PYDANTIC.* issue"
 
 
-def test_phase_b_text_report_unchanged(tmp_path, sample_config_path):
+def test_phase_b_text_report_unchanged(tmp_path, sample_yaml_path):
     """Confirm the text report still exists and is non-empty (no regression)."""
     science_yaml = tmp_path / "science.yml"
     science_report = tmp_path / "science_report.txt"
 
     run_phase_b(
-        user_yaml_file=str(sample_config_path),
-        uptodate_file=str(sample_config_path),
-        standard_yaml_file=str(sample_config_path),
+        user_yaml_file=str(sample_yaml_path),
+        uptodate_file=str(sample_yaml_path),
+        standard_yaml_file=str(sample_yaml_path),
         science_yaml_file=str(science_yaml),
         science_report_file=str(science_report),
         phase_a_report_file=str(tmp_path / "phase_a_report.txt"),
@@ -185,7 +171,7 @@ def test_phase_b_text_report_unchanged(tmp_path, sample_config_path):
     assert "SUEWS" in text or "Phase B" in text or "Science" in text
 
 
-def test_pipeline_writes_json_sidecars_alongside_text_reports(tmp_path, sample_config_path):
+def test_pipeline_writes_json_sidecars_alongside_text_reports(tmp_path, sample_yaml_path):
     """Running A then B then C produces a JSON sidecar for every text report.
 
     This is the end-to-end machine-format contract: any tool that wants the
@@ -200,17 +186,17 @@ def test_pipeline_writes_json_sidecars_alongside_text_reports(tmp_path, sample_c
     pydantic_report = tmp_path / "pydantic_report.txt"
 
     a_report = run_phase_a(
-        user_yaml_file=str(sample_config_path),
-        standard_yaml_file=str(sample_config_path),
+        user_yaml_file=str(sample_yaml_path),
+        standard_yaml_file=str(sample_yaml_path),
         uptodate_file=str(uptodate_file),
         report_file=str(report_file),
         silent=True,
         forcing="off",
     )
     b_report = run_phase_b(
-        user_yaml_file=str(sample_config_path),
+        user_yaml_file=str(sample_yaml_path),
         uptodate_file=str(uptodate_file),
-        standard_yaml_file=str(sample_config_path),
+        standard_yaml_file=str(sample_yaml_path),
         science_yaml_file=str(science_yaml),
         science_report_file=str(science_report),
         phase_a_report_file=str(report_file),
@@ -218,7 +204,7 @@ def test_pipeline_writes_json_sidecars_alongside_text_reports(tmp_path, sample_c
         silent=True,
     )
     c_report = run_phase_c(
-        input_yaml_file=str(sample_config_path),
+        input_yaml_file=str(sample_yaml_path),
         pydantic_yaml_file=str(pydantic_yaml),
         pydantic_report_file=str(pydantic_report),
         phases_run=["A", "B", "C"],

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -11,11 +11,13 @@ machine-readable representation of the validator's findings.
 from __future__ import annotations
 
 import json
+from importlib.resources import as_file
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 
-import supy as sp
+from supy._env import trv_supy_module
 from supy.data_model.validation.pipeline.orchestrator import (
     run_phase_a,
     run_phase_b,
@@ -27,8 +29,14 @@ pytestmark = pytest.mark.api
 
 
 @pytest.fixture
-def sample_config_path() -> Path:
-    return Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+def sample_config_path() -> Iterator[Path]:
+    """The bundled sample config as a real filesystem path.
+
+    The pipeline entry points below take ``str`` paths, so the
+    packaged resource is materialised with ``as_file``.
+    """
+    with as_file(trv_supy_module / "sample_data" / "sample_config.yml") as path_sample:
+        yield path_sample
 
 
 def test_phase_a_emits_json_sidecar(tmp_path, sample_config_path):

--- a/test/data_model/test_validation.py
+++ b/test/data_model/test_validation.py
@@ -10,6 +10,7 @@ This file combines:
 """
 
 import io
+from importlib.resources import as_file
 import logging
 from pathlib import Path
 import tempfile
@@ -21,7 +22,6 @@ import copy
 import pytest
 import yaml
 
-import supy as sp
 from supy._env import trv_supy_module
 from supy.data_model.core import SUEWSConfig
 from supy.data_model.core.site import (
@@ -3552,10 +3552,10 @@ def test_nlayer_height_array_dimension_error():
     from supy.data_model.validation.pipeline.phase_a import validate_nlayer_dimensions
     import yaml
 
-    sample_data_dir = Path(sp.__file__).parent / "sample_data"
+    sample_data_dir = trv_supy_module / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r", encoding="utf-8") as f:
+    with config_path.open("r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Set nlayer=3 but truncate height array to 2 elements
@@ -3593,10 +3593,10 @@ def test_nlayer_veg_frac_array_dimension_error():
     from supy.data_model.validation.pipeline.phase_a import validate_nlayer_dimensions
     import yaml
 
-    sample_data_dir = Path(sp.__file__).parent / "sample_data"
+    sample_data_dir = trv_supy_module / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r", encoding="utf-8") as f:
+    with config_path.open("r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Set nlayer=5 but truncate veg_frac to 3 elements
@@ -3634,10 +3634,10 @@ def test_nlayer_multiple_arrays_dimension_errors():
     from supy.data_model.validation.pipeline.phase_a import validate_nlayer_dimensions
     import yaml
 
-    sample_data_dir = Path(sp.__file__).parent / "sample_data"
+    sample_data_dir = trv_supy_module / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r", encoding="utf-8") as f:
+    with config_path.open("r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Set nlayer=4 but truncate multiple arrays
@@ -3669,10 +3669,10 @@ def test_nlayer_no_errors_when_correct():
     from supy.data_model.validation.pipeline.phase_a import validate_nlayer_dimensions
     import yaml
 
-    sample_data_dir = Path(sp.__file__).parent / "sample_data"
+    sample_data_dir = trv_supy_module / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r", encoding="utf-8") as f:
+    with config_path.open("r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Detect nlayer from the config
@@ -3699,10 +3699,10 @@ def test_nlayer_roofs_walls_dimension_error_with_templates():
     from supy.data_model.validation.pipeline.phase_a import validate_nlayer_dimensions
     import yaml
 
-    sample_data_dir = Path(sp.__file__).parent / "sample_data"
+    sample_data_dir = trv_supy_module / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
-    with open(config_path, "r", encoding="utf-8") as f:
+    with config_path.open("r", encoding="utf-8") as f:
         user_data = yaml.safe_load(f)
 
     # Set nlayer to 2 but keep only 1 roof and 1 wall element
@@ -3984,7 +3984,7 @@ def test_forcing_validation_can_be_disabled():
         annotate_missing_parameters,
     )
 
-    sample_data_dir = Path(sp.__file__).parent / "sample_data"
+    sample_data_dir = trv_supy_module / "sample_data"
     config_path = sample_data_dir / "sample_config.yml"
 
     # Create temporary output files
@@ -3994,17 +3994,20 @@ def test_forcing_validation_can_be_disabled():
         report_path = report_f.name
 
     try:
-        # Run Phase A validation with forcing="off"
-        annotate_missing_parameters(
-            user_file=str(config_path),
-            standard_file=str(config_path),
-            uptodate_file=uptodate_path,
-            report_file=report_path,
-            mode="public",
-            phase="A",
-            nlayer=3,
-            forcing="off",
-        )
+        # Run Phase A validation with forcing="off".
+        # `annotate_missing_parameters` takes str paths, so the packaged
+        # resource is materialised as a real file first.
+        with as_file(config_path) as config_file:
+            annotate_missing_parameters(
+                user_file=str(config_file),
+                standard_file=str(config_file),
+                uptodate_file=uptodate_path,
+                report_file=report_path,
+                mode="public",
+                phase="A",
+                nlayer=3,
+                forcing="off",
+            )
 
         # Verify report does not contain forcing validation errors
         with open(report_path, "r", encoding="utf-8") as f:
@@ -4248,11 +4251,11 @@ def test_forcing_validation_cli_integration(cli_runner):
     import pandas as pd
     from supy.cmd.validate_config import cli as validate_cli
 
-    sample_data_dir = Path(sp.__file__).parent / "sample_data"
+    sample_data_dir = trv_supy_module / "sample_data"
     sample_config = sample_data_dir / "sample_config.yml"
 
     # Read sample config and get forcing file path
-    with open(sample_config, "r", encoding="utf-8") as f:
+    with sample_config.open("r", encoding="utf-8") as f:
         config_data = yaml.safe_load(f)
 
     # Create a temporary config with invalid forcing data
@@ -4341,7 +4344,7 @@ def test_validate_cli_success_removes_temp_report_json_sidecars(cli_runner):
     """Successful ABC validation should not leak intermediate JSON reports."""
     from supy.cmd.validate_config import cli as validate_cli
 
-    sample_config = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+    sample_config = trv_supy_module / "sample_data" / "sample_config.yml"
 
     with cli_runner.isolated_filesystem() as tmpdir:
         tmpdir_path = Path(tmpdir)
@@ -4766,7 +4769,7 @@ class TestSparseYmlCriticalMissing:
     SPARSE_FIXTURE = (
         Path(__file__).parent.parent / "fixtures" / "sparse_site.yml"
     )
-    SAMPLE_CONFIG = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+    SAMPLE_CONFIG = trv_supy_module / "sample_data" / "sample_config.yml"
 
     def test_sparse_yml_raises_validation_error(self):
         """Sparse config raises on load, naming each missing block.
@@ -4803,16 +4806,18 @@ class TestSparseYmlCriticalMissing:
 
     def test_sample_config_still_loads(self):
         """Packaged sample config is complete and must not trigger the new check."""
-        assert self.SAMPLE_CONFIG.exists(), (
+        assert self.SAMPLE_CONFIG.is_file(), (
             f"Sample config missing: {self.SAMPLE_CONFIG}"
         )
         # Must not raise; a successful load is the assertion.
-        config = SUEWSConfig.from_yaml(str(self.SAMPLE_CONFIG))
+        with as_file(self.SAMPLE_CONFIG) as sample_path:
+            config = SUEWSConfig.from_yaml(str(sample_path))
         assert config is not None
 
     def test_site_params_check_returns_empty_on_complete_config(self):
         """Direct method check — complete config yields no critical issues."""
-        config = SUEWSConfig.from_yaml(str(self.SAMPLE_CONFIG))
+        with as_file(self.SAMPLE_CONFIG) as sample_path:
+            config = SUEWSConfig.from_yaml(str(sample_path))
         assert config._check_critical_null_site_params() == []
 
     def test_partial_land_cover_still_checks_omitted_active_defaults(self, tmp_path):

--- a/test/mcp/test_tool_readiness.py
+++ b/test/mcp/test_tool_readiness.py
@@ -8,6 +8,8 @@ once a value is customised, it must move out of the assumed list.
 from __future__ import annotations
 
 import shutil
+from importlib.resources import as_file
+from importlib.resources.abc import Traversable
 from pathlib import Path
 
 import pytest
@@ -21,10 +23,16 @@ _requires_suews_cli = pytest.mark.skipif(
 )
 
 
-def _sample() -> Path:
-    import supy
+def _sample_dir() -> Traversable:
+    """The bundled ``sample_data`` directory as a packaged resource."""
+    from supy._env import trv_supy_module
 
-    return Path(supy.__file__).resolve().parent / "sample_data" / "sample_config.yml"
+    return trv_supy_module / "sample_data"
+
+
+def _sample() -> Traversable:
+    """The bundled sample config as a packaged resource (read-only)."""
+    return _sample_dir() / "sample_config.yml"
 
 
 @_requires_suews_cli
@@ -32,7 +40,12 @@ def test_fresh_sample_is_all_assumed() -> None:
     """The bundled sample, unedited, flags location / land_cover / forcing as assumed."""
     from suews_mcp.tools import assess_readiness
 
-    env = assess_readiness(str(_sample()), project_root=str(_sample().parent))
+    # `assess_readiness` shells out to the `suews` CLI, so both the
+    # config and the project root must be real filesystem paths.
+    with as_file(_sample_dir()) as sample_dir:
+        env = assess_readiness(
+            str(sample_dir / "sample_config.yml"), project_root=str(sample_dir)
+        )
     assert env["status"] == "success", env.get("errors")
     data = env["data"]
     assert data["ready"] is False

--- a/test/physics/test_macdonald_roughness.py
+++ b/test/physics/test_macdonald_roughness.py
@@ -10,14 +10,13 @@ fraction are all constant over the run and the MacDonald relations can be
 asserted in closed form.
 """
 
-import pathlib
-
 from conftest import load_sample_frames, run_simulation
 import numpy as np
 import pytest
 import yaml
 
 import supy as sp
+from supy._env import trv_supy_module
 from supy.data_model import SUEWSConfig
 
 pytestmark = pytest.mark.physics
@@ -44,7 +43,7 @@ def _tree_free_macdonald_config(tmp_path):
     Zeroing the deciduous fraction removes the phenology feedback on porosity,
     so Zh, FAI and PAI stay constant and the closed-form check below is exact.
     """
-    src = pathlib.Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+    src = trv_supy_module / "sample_data" / "sample_config.yml"
     raw = yaml.safe_load(src.read_text(encoding="utf-8"))
 
     raw["model"]["physics"]["roughness_length_momentum"] = "macdonald"

--- a/test/physics/test_macdonald_roughness.py
+++ b/test/physics/test_macdonald_roughness.py
@@ -15,7 +15,6 @@ import numpy as np
 import pytest
 import yaml
 
-import supy as sp
 from supy._env import trv_supy_module
 from supy.data_model import SUEWSConfig
 

--- a/test/umep/test_postprocessor.py
+++ b/test/umep/test_postprocessor.py
@@ -6,10 +6,10 @@ This module tests the output path handling used by UMEP Post-processor:
 See: https://github.com/UMEP-dev/SUEWS/issues/901
 """
 
-from pathlib import Path
+from importlib.resources import as_file
 from unittest import TestCase
 
-import supy as sp
+from supy._env import trv_supy_module
 
 
 class TestOutputPathHandling(TestCase):
@@ -23,12 +23,15 @@ class TestOutputPathHandling(TestCase):
         """Test that config structure includes output directory."""
         from supy.data_model import init_config_from_yaml
 
-        sample_config = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        sample_resource = trv_supy_module / "sample_data" / "sample_config.yml"
 
-        if not sample_config.exists():
+        if not sample_resource.is_file():
             self.skipTest("Sample config not available")
 
-        config = init_config_from_yaml(sample_config)
+        # `init_config_from_yaml` opens the path itself, so hand it a
+        # real file rather than a packaged-resource handle.
+        with as_file(sample_resource) as sample_config:
+            config = init_config_from_yaml(sample_config)
 
         # Navigate to output dir as UMEP does
         self.assertTrue(hasattr(config, "model"))

--- a/test/umep/test_preprocessor.py
+++ b/test/umep/test_preprocessor.py
@@ -8,11 +8,12 @@ This module tests the functions used by UMEP Pre-processor plugins:
 See: https://github.com/UMEP-dev/SUEWS/issues/901
 """
 
+from importlib.resources import as_file
 import tempfile
 from pathlib import Path
 from unittest import TestCase
 
-import supy as sp
+from supy._env import trv_supy_module
 
 
 class TestDatabaseManagerAPI(TestCase):
@@ -82,10 +83,14 @@ class TestDatabasePrepareAPI(TestCase):
         from supy.data_model.configuration.publisher import generate_json_schema
 
         # Get sample config path
-        sample_config = Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        sample_resource = trv_supy_module / "sample_data" / "sample_config.yml"
 
-        if not sample_config.exists():
+        if not sample_resource.is_file():
             self.skipTest("Sample config not available")
+
+        # `validate_single_file` opens the path itself, so hand it a
+        # real file rather than a packaged-resource handle.
+        sample_config = self.enterContext(as_file(sample_resource))
 
         # Generate schema
         schema = generate_json_schema()

--- a/test/umep/test_processor.py
+++ b/test/umep/test_processor.py
@@ -12,6 +12,7 @@ https://github.com/UMEP-dev/UMEP-processing/blob/82bc3266d8cb4d04359994b1cae5cf0
 See: https://github.com/UMEP-dev/SUEWS/issues/901
 """
 
+from importlib.resources import as_file
 from pathlib import Path
 import tempfile
 from unittest import TestCase
@@ -20,6 +21,7 @@ from conftest import TIMESTEPS_PER_DAY
 import pandas as pd
 
 import supy as sp
+from supy._env import trv_supy_module
 
 
 class TestSUEWSProcessorAPI(TestCase):
@@ -27,8 +29,10 @@ class TestSUEWSProcessorAPI(TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        self.sample_config = (
-            Path(sp.__file__).parent / "sample_data" / "sample_config.yml"
+        # `as_file` because the UMEP entry points below take real
+        # filesystem paths, not packaged-resource handles.
+        self.sample_config = self.enterContext(
+            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
         )
 
     def test_init_config_from_yaml_import(self):

--- a/test/umep/test_processor.py
+++ b/test/umep/test_processor.py
@@ -29,11 +29,11 @@ class TestSUEWSProcessorAPI(TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        # `as_file` because the UMEP entry points below take real
-        # filesystem paths, not packaged-resource handles.
-        self.sample_config = self.enterContext(
-            as_file(trv_supy_module / "sample_data" / "sample_config.yml")
-        )
+        # `as_file` because the UMEP entry points below take real filesystem
+        # paths, not packaged-resource handles. The whole directory, because
+        # load_forcing_grid resolves the forcing file as a sibling of the config.
+        sample_dir = self.enterContext(as_file(trv_supy_module / "sample_data"))
+        self.sample_config = sample_dir / "sample_config.yml"
 
     def test_init_config_from_yaml_import(self):
         """Test that init_config_from_yaml is importable from expected location."""


### PR DESCRIPTION
Tests located supy's bundled sample data with `Path(supy.__file__).parent / "sample_data"`. That assumes the package is an unpacked directory on disk, which the import system does not guarantee, and it couples the tests to supy's internal layout. supy has resolved its own data correctly since May 2024 (`src/supy/_env.py`: `trv_supy_module = files("supy")`); the tests had drifted because there is no public accessor, so each author invented a route.

There were **23 occurrences across eleven test modules** (counted by AST at the pre-sweep commit, not estimated). #1679 converted the one in `test/core/test_sample_output.py`; this sweeps the remaining 22 across ten modules, so the tree now has none.

## The conversion is not mechanical

`trv_supy_module / ...` is **not** a drop-in for the `Path(...)` expression. `importlib.resources.abc.Traversable` guarantees only `joinpath` / `/` / `name` / `is_dir` / `is_file` / `iterdir` / `open` / `read_bytes` / `read_text`. It does not guarantee `.exists()`, `__fspath__`, `.parent`, or that `str()` yields a filesystem path.

So each site is converted by what it actually needs:

- reads the YAML -> `.open(...)` / `.read_text(...)`
- existence guard -> `.is_file()`
- needs a real path (a `str()` path, a subprocess, or **any API that opens the file itself** -- `SUEWSConfig.from_yaml`, `init_config_from_yaml`, `sp.init_supy`, `SUEWSSimulation`) -> `importlib.resources.as_file`, bound via `self.enterContext(...)` in a `TestCase` and a yield fixture in pytest.

This follows the existing `_sample_yaml_path` helper in `test/cmd/test_validate_config.py`.

## The lint

`scripts/lint/check_packaged_data_paths.py` is a static AST pass (no build required, modelled on `check_test_markers.py`) that fails on any `<module>.__file__` access under `test/`. Bare `__file__` stays legal, so the many fixture-relative `Path(__file__).parent` uses are untouched.

Two design notes:

- It walks every `.py` file rather than `test_*.py`. `test/conftest.py` was one of the offenders, and a `test_*.py` glob would not have seen it.
- AST rather than grep matters concretely: `test/core/test_sample_output.py:104` contains the string `Path(supy.__file__).parent` inside a docstring explaining what not to do. A grep-based lint would false-positive on the very file that documents the fix.

Wired as a second step in the existing `check_test_markers` CI job. Its id and display name are unchanged, so `needs:`, `.github/scripts/pr-gate.sh` and branch protection keep working. The step carries `if: always()` so a marker failure does not hide a packaged-data failure.

## What the lint does not cover

It catches the `<module>.__file__` reach. It does **not** catch Traversable misuse -- calling `.exists()`, passing the handle to builtin `open()`, or handing `str(...)` to something that opens the file. That class is not statically catchable at reasonable cost, so the rule text owns it. Please do not read a green lint as "this problem is now mechanically prevented"; only the first half of it is.

## Rule update

Extends the "Locating packaged data" section of `.claude/rules/tests/patterns.md` (added by #1679) with what the sweep established:

- `as_file()` accepts directories on the 3.12 floor, so one context can yield both a config path and its directory -- and `.parent` is the obvious reach but is not in the protocol.
- `self.enterContext(as_file(...))` and pytest yield fixtures, so binding a real path does not mean restructuring a test around a `with` block.
- Points at `_sample_yaml_path` and `_copy_sample_data` in `test/cmd/test_validate_config.py` as worked in-tree examples. `_copy_sample_data` copies a whole directory using only protocol methods, so it needs no `as_file()` at all.
- States the mechanism behind the trap rather than "it happens to wrap a real path": under the editable install `trv_supy_module / "sample_data"` is a `MesonpyTraversable` with no `.parent`, while `.../sample_config.yml` one level down is a plain `PosixPath`. The loader returns real paths for files, so every wrong form succeeds locally; under a wheel `files("supy")` is a real `Path` throughout. Both real install modes hide the error.

This corrects text added hours earlier in #1679 -- worth a look from that PR's author.

## Testing

- `test/core/test_check_packaged_data_paths.py` covers the lint in **both directions**: offending test module fails, offending conftest fails, an indirect `os.path.dirname(supy.__file__)` reach fails, bare `__file__` passes, offenders are reported in line order, and the real repo tree is clean.
- Suite re-run after rebasing onto current master and rebuilding: 1193 passed (data_model, mcp, umep, physics, test_load, test_laimethod, lint tests) and 598 passed (core, cmd), `-m "not slow"`.
- Both CI lints green: markers 131 files, packaged-data 141 files / 0 exemptions.

## Verification caveat

The non-filesystem branch cannot be exercised for supy at all -- compiled extensions cannot zip-import, and both real install modes hand back filesystem paths. Every wrong form therefore passes locally, so **green tests were necessary, not sufficient**; the conversion was audited against the protocol by inspection. The three `test/umep/` modules skip outside the Windows + Python 3.12 QGIS lane and were covered by that audit only -- they will execute in CI's qgis lane.