### PR TITLE
Curate the everyday make test selection

### DIFF
--- a/.claude/rules/00-project-essentials.md
+++ b/.claude/rules/00-project-essentials.md
@@ -68,10 +68,15 @@ Fused legacy identifiers (e.g. `netradiationmethod`, `storageheatmethod`, `soild
 ## Before Committing
 
 - **Default**: Run `make test-smoke` before committing (fast, critical tests)
-- **Full test**: Run `make test` only when changes affect:
+- **Everyday suite**: Run `make test` (core, data model, physics, I/O; excludes
+  slow tests and peripheral surfaces) when changes affect:
   - Test files in `test/`
   - Core physics modules
   - Data model changes
+- **Peripheral surfaces**: `make test` deliberately skips `test/cmd`,
+  `test/mcp`, `test/docs`, `test/knowledge`, and `test/umep`. When you touch
+  one of those, run its directory directly (e.g. `pytest test/cmd`) or
+  `make test-all`
 - Include new source files in `meson.build`:
   - Python files (.py) in `src/supy/`
   - Fortran files (.f90, .f95) in `src/suews/src/`

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ help:
 	@echo "  setup      - Create virtual environment (if using uv)"
 	@echo "  dev        - Build and install in editable mode"
 	@echo "  docs-setup - Install documentation dependencies and strip legacy .pth hooks"
-	@echo "  test       - Run standard tests (excludes slow, ~2-3 min)"
+	@echo "  test       - Everyday dev tests (core/data_model/physics/io, no slow)"
 	@echo "  test-smoke - Run smoke tests only (fast CI validation, ~30-60 sec)"
-	@echo "  test-all   - Run ALL tests including slow (~4-5 min)"
+	@echo "  test-all   - Run ALL tests including slow and peripheral surfaces"
 	@echo "  audit-deps - Audit Python dependencies and startup hooks"
 	@echo "  docs       - Build documentation"
 	@echo "  clean      - Smart clean (keeps .venv if active)"
@@ -197,15 +197,23 @@ rebuild-meson:
 
 # Run tests - Four local entry points available:
 # - test-smoke: Fast critical tests (~30-60 sec) - used in CI wheel validation
-# - test: Standard tests excluding slow (~2-3 min) - default for development
-# - test-all: All tests including slow (~4-5 min) - comprehensive validation
+# - test: Everyday development tests (model, data model, physics, I/O;
+#         excludes slow and the peripheral surfaces below)
+# - test-all: All tests including slow - comprehensive validation
 # - test-qgis: UMEP/QGIS compatibility tests (Windows + Python 3.12 target)
+#
+# The everyday `test` selection deliberately leaves out peripheral surfaces
+# (test/cmd, test/mcp, test/docs, test/knowledge, test/umep). When you touch
+# one of those, run its directory directly (`pytest test/cmd`) or `make
+# test-all`. CI selects by markers and is unaffected by this default.
+TEST_DEFAULT_PATHS := test/test_api_surface.py test/core test/data_model test/physics test/io_tests
 test:
-	@echo "Running standard tests (excluding slow tests)..."
-	@echo "NOTE: Long-running regression tests are skipped."
-	@echo "      Run 'make test-all' for comprehensive testing."
+	@echo "Running everyday development tests (core, data model, physics, I/O)..."
+	@echo "NOTE: slow regressions and peripheral surfaces (cmd, mcp, docs,"
+	@echo "      knowledge, umep) are excluded - run 'make test-all' or the"
+	@echo "      relevant directory (e.g. 'pytest test/cmd') when touched."
 	@echo ""
-	$(PYTHON) -m pytest test -m "not slow and not qgis" -v --tb=short --durations=10
+	$(PYTHON) -m pytest $(TEST_DEFAULT_PATHS) -m "not slow and not qgis" -v --tb=short --durations=10
 
 # Smoke tests - fast critical path tests for CI
 test-smoke:
@@ -216,8 +224,7 @@ test-smoke:
 
 # All tests including slow tests
 test-all:
-	@echo "Running ALL tests including slow tests..."
-	@echo "This may take 4-5 minutes."
+	@echo "Running ALL tests including slow tests and peripheral surfaces..."
 	@echo ""
 	$(PYTHON) -m pytest test -v --tb=short --durations=10
 

--- a/test/README.md
+++ b/test/README.md
@@ -59,14 +59,20 @@ Test data and resources:
 ## Running Tests
 
 ```bash
-# Run all tests
-pytest test/ -v
+# Everyday development default: core, data_model, physics, io_tests
+# (excludes slow tests and the peripheral surfaces cmd/mcp/docs/knowledge/umep)
+make test
+
+# Everything, including slow tests and peripheral surfaces
+make test-all
 
 # Run tests by category
 pytest test/core/ -v              # Core functionality
 pytest test/data_model/ -v        # Data model tests
 pytest test/physics/ -v           # Physics validation
 pytest test/io_tests/ -v          # I/O tests
+pytest test/cmd/ -v               # CLI entry points (run when touched)
+pytest test/mcp/ -v               # MCP server (run when touched)
 pytest test/umep/ -v -m qgis      # UMEP/QGIS tests (Windows + Python 3.12 target)
 make test-qgis                    # Same QGIS/UMEP lane via Makefile
 


### PR DESCRIPTION
## Summary

Make `make test` a focused everyday development suite while keeping the complete repository test suite available through `make test-all` and unchanged GitHub Actions test selections.

This is a standalone extraction of the coherent test-selection concern from #1683, rebased onto current `master`. The original stacked PR remains open pending a separate disposition.

## Changes

- select core, data-model, physics, I/O, and API-surface tests for the everyday `make test` target
- retain every test under `make test-all`
- document direct execution for peripheral `cmd`, `mcp`, `docs`, `knowledge`, and `umep` surfaces
- remove stale wall-clock promises from the Make target descriptions

## Current measurement

Measured after rebasing onto `daf7219d8d965e8c24724803274fe1a77efc59e4` using collection-only runs:

- previous default (`pytest test -m "not slow and not qgis"`): 1,976 selected tests
- proposed everyday paths with the same marker expression: 1,642 selected tests
- difference: 334 peripheral tests omitted from the local default

These are collection measurements, not a wall-clock claim; runtime savings remain environment-dependent.

## Safety and scope

- no tests are deleted or changed
- `make test-all` still executes the entire `test` tree
- GitHub Actions test jobs select whole-tree tests by markers rather than using this Make target
- the MCP handshake coverage gap and sample-config SPARTACUS inconsistency remain tracked separately in #1698 and #1699

## Validation

Exact reviewed commit: `75aeebe7994771fe18764cc303654da5e35eb0d8`

- clean rebuild with `make dev`: passed
- `make test-smoke`: 9 passed, 1 skipped
- `.venv/bin/python .claude/scripts/validate-claude-md.py`: passed
- `scripts/lint/check_schema_version_bump.py --base origin/master`: passed
- `make -n test` and `make -n test-all`: expected selections
- `git diff --check origin/master...HEAD`: passed
- simplify pass: no safe reduction identified
- exact-SHA correctness review: clean, no block or major findings

## Overlap audit

No non-stack open PR now overlaps these files. The previous `test/README.md` overlap was incorporated when #1689 merged before this rebase.
