### PR TITLE
Complete CO2 parameter naming sweep

### DIFF
--- a/.claude/rules/naming-convention.md
+++ b/.claude/rules/naming-convention.md
@@ -163,6 +163,7 @@ written and **not** reordered under Rule 2:
 
 - `ground_depth`
 - `ventilation_rate`
+- `traffic_rate`
 - `lighting_power_density`
 
 The test for membership: the phrase is one a domain reader would say

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 80       | 86       | 31 | 81 | 40 | 319   |
+| 2026 | 80       | 86       | 32 | 81 | 40 | 320   |
 | 2025 | 60       | 68       | 22 | 71 | 36 | 256   |
 | 2024 | 12       | 17       | 1 | 12 | 1 | 43    |
 | 2023 | 11       | 14       | 3 | 9 | 1 | 38    |
@@ -71,6 +71,10 @@ EXAMPLES:
 - [maintenance] Guarded tests against locating bundled package data through imported modules' `__file__` (#1697)
   - Reached SuPy's packaged sample data through `importlib.resources`, materialising the whole directory where the YAML config depends on its sibling forcing file.
   - Added an AST-based CI lint, regression coverage, and test guidance to prevent the fragile path pattern from returning.
+
+- [change][experimental] Completed the naming-convention sweep for CO2 emission parameters (#1688)
+  - Renamed fourteen fused or unit-bearing YAML keys under `anthropogenic_emissions.co2` while preserving old YAML compatibility through the schema migrator and rename registry.
+  - Corrected point-source, metabolic-emission and traffic-rate units against the Fortran physics contract; legacy `df_state` columns remain unchanged.
 
 - [bugfix] Stopped the YAML config reference describing parameters without a default as optional (#1677)
   - Every parameter carrying no default previously rendered as `Default: None (optional)`, which asserted the opposite of the truth for parameters such as `store_cap` and `base_temperature_senescence`; these are declared `Optional[...] = None` only so a partial configuration still loads and the validation layer can then report what is missing.

--- a/docs/source/contributing/schema/schema_versioning.rst
+++ b/docs/source/contributing/schema/schema_versioning.rst
@@ -28,7 +28,7 @@ the structure and format of the configuration file:
   compatibility matrix.
 
 Schema version is distinct from the SUEWS model version. A line such as
-``schema_version: "2026.6.dev2"`` describes the shape of the configuration
+``schema_version: "2026.6.dev3"`` describes the shape of the configuration
 file, while the SUEWS version you installed (for example
 ``2026.4.3``) describes the model code. One schema may validate many
 model releases.
@@ -41,7 +41,7 @@ Add the ``schema_version`` field to the top level of your configuration:
 .. code-block:: yaml
 
    name: my_urban_config
-   schema_version: "2026.6.dev2"
+   schema_version: "2026.6.dev3"
    description: Urban climate simulation for central London
    model:
      # ... model configuration ...
@@ -59,7 +59,8 @@ Schema Version Policy
 Schema labels use **CalVer** (``YYYY.M``, with ``.devN`` labels during
 development), aligned with the SUEWS release in which that shape first
 ships. The next label is chosen from the current month, not incremented
-as a floating-point number — ``2026.6.dev2`` comes after ``2026.6.dev1``,
+as a floating-point number — ``2026.6.dev3`` comes after ``2026.6.dev2``,
+which comes after ``2026.6.dev1``,
 which comes after ``2026.5``,
 which comes after ``2026.4``, which comes after ``2026.1``, which comes
 after ``2025.12``.
@@ -109,7 +110,7 @@ The three outcomes users see:
 **Older schema with a registered migration**
    .. code-block:: text
 
-      Configuration uses schema 2026.5, current is 2026.6.dev2 (compatible)
+      Configuration uses schema 2026.5, current is 2026.6.dev3 (compatible)
 
    The YAML loads via the chained migration. Regenerate the file with
    :doc:`/inputs/converter` if you want to persist the upgrade.
@@ -117,13 +118,13 @@ The three outcomes users see:
 **Older schema with no registered migration**
    .. code-block:: text
 
-      WARNING: Configuration uses older schema 2025.8, current is 2026.6.dev2.
+      WARNING: Configuration uses older schema 2025.8, current is 2026.6.dev3.
       Consider updating your configuration.
 
 **Newer schema than this SUEWS knows about**
    .. code-block:: text
 
-      WARNING: Configuration uses newer schema 2027.1, this version supports 2026.6.dev2.
+      WARNING: Configuration uses newer schema 2027.1, this version supports 2026.6.dev3.
       Please update SUEWS or use an older configuration.
 
 Migration
@@ -173,7 +174,15 @@ The lineage below mirrors ``SCHEMA_VERSIONS`` in
 the schema that shipped with it via
 ``supy.util.converter.yaml_upgrade._PACKAGE_TO_SCHEMA``.
 
-**Schema 2026.6.dev2** (current; development)
+**Schema 2026.6.dev3** (current; development)
+   Development schema completing the naming-convention sweep for
+   ``sites[*].properties.anthropogenic_emissions.co2``. Fourteen fused or
+   unit-bearing keys are replaced with quantity-first or category-prefixed
+   names. The ``(2026.6.dev2 -> 2026.6.dev3)`` handler renames every key and
+   preserves its value; direct loading also accepts the legacy spellings with
+   a deprecation warning. Legacy ``df_state`` columns remain unchanged.
+
+**Schema 2026.6.dev2** (development)
    Development schema adding ``storage_heat=dyohm_building``
    (``StorageHeatMethod=8``). This option uses DyOHM to determine the
    building storage heat flux only; other land-cover surfaces continue to

--- a/docs/source/data-structures/df_state.rst
+++ b/docs/source/data-structures/df_state.rst
@@ -428,7 +428,7 @@
 .. option:: co2pointsource
 
     :Description:
-        CO2 emission factor [kg |km^-1|]
+        Whole-grid CO2 point-source emission expressed as carbon mass [kg C |day^-1|].
     :Dimensionality:
         0
     :Dimensionality Remarks:
@@ -584,7 +584,7 @@
 .. option:: ef_umolco2perj
 
     :Description:
-        Emission factor for fuels used for building heating.
+        CO2 emission factor for fuels used for building energy [|umol| |J^-1|].
     :Dimensionality:
         0
     :Dimensionality Remarks:
@@ -632,7 +632,7 @@
 .. option:: enef_v_jkm
 
     :Description:
-        Emission factor for heat [J k |m^-1| ].
+        Vehicle energy consumption per unit distance [J |km^-1|].
     :Dimensionality:
         0
     :Dimensionality Remarks:
@@ -716,7 +716,7 @@
 .. option:: fcef_v_kgkm
 
     :Description:
-        CO2 emission factor for weekdays [kg |km^-1|];;CO2 emission factor for weekends [kg |km^-1|]
+        Vehicle CO2 emission factor for weekdays [kg CO2 |km^-1|];;vehicle CO2 emission factor for weekends [kg CO2 |km^-1|].
     :Dimensionality:
         (2,)
     :Dimensionality Remarks:
@@ -1176,7 +1176,7 @@
 .. option:: maxfcmetab
 
     :Description:
-        Maximum (day) CO2 from human metabolism. [W |m^-2|]
+        Maximum (day) CO2 emission from human metabolism [|umol| |cap^-1| |s^-1|].
     :Dimensionality:
         0
     :Dimensionality Remarks:
@@ -1188,7 +1188,7 @@
 .. option:: maxqfmetab
 
     :Description:
-        Maximum value for human heat emission. [W |m^-2|]
+        Maximum (day) human heat emission [W |cap^-1|].
     :Dimensionality:
         0
     :Dimensionality Remarks:
@@ -1212,7 +1212,7 @@
 .. option:: minfcmetab
 
     :Description:
-        Minimum (night) CO2 from human metabolism. [W |m^-2|]
+        Minimum (night) CO2 emission from human metabolism [|umol| |cap^-1| |s^-1|].
     :Dimensionality:
         0
     :Dimensionality Remarks:
@@ -1224,7 +1224,7 @@
 .. option:: minqfmetab
 
     :Description:
-        Minimum value for human heat emission. [W |m^-2|]
+        Minimum (night) human heat emission [W |cap^-1|].
     :Dimensionality:
         0
     :Dimensionality Remarks:
@@ -2086,7 +2086,7 @@
 .. option:: trafficrate
 
     :Description:
-        Traffic rate used for CO2 flux calculation.
+        Traffic rate used for CO2 flux calculation: vehicle km |m^-2| |day^-1| for type 1 or vehicle km |cap^-1| |day^-1| for type 2.
     :Dimensionality:
         (2,)
     :Dimensionality Remarks:
@@ -2098,7 +2098,7 @@
 .. option:: trafficunits
 
     :Description:
-        Units for the traffic rate for the study area. Not used in v2018a.
+        Dimensionless traffic-rate basis: 1 for per area, 2 for per capita. Not used in v2018a.
     :Dimensionality:
         0
     :Dimensionality Remarks:
@@ -2305,4 +2305,3 @@
         Scalar
     :SUEWS-related variables:
         `zd`
-

--- a/docs/source/inputs/tables/SUEWS_SiteInfo/csv-table/SUEWS_AnthropogenicEmission.csv
+++ b/docs/source/inputs/tables/SUEWS_SiteInfo/csv-table/SUEWS_AnthropogenicEmission.csv
@@ -25,16 +25,16 @@ No.,Column Name,Use,Description
 24,`TraffProfWE`,`MU` `O`,Code for traffic activity profile (weekends) linking to `Code` of `SUEWS_Profiles.txt`. Not used in v2018a.
 25,`PopProfWD`,`MU` `O`,Code for population density profile (weekdays) linking to `Code` of `SUEWS_Profiles.txt`.
 26,`PopProfWE`,`MU` `O`,Code for population density profile (weekends) linking to `Code` of `SUEWS_Profiles.txt`.
-27,`MinQFMetab`,`MU` `O`,Minimum value for human heat emission. [W |m^-2|]
-28,`MaxQFMetab`,`MU` `O`,Maximum value for human heat emission. [W |m^-2|]
-29,`MinFCMetab`,`MU` `O`,Minimum (night) CO2 from human metabolism. [W |m^-2|]
-30,`MaxFCMetab`,`MU` `O`,Maximum (day) CO2 from human metabolism. [W |m^-2|]
+27,`MinQFMetab`,`MU` `O`,Minimum (night) human heat emission [W |cap^-1|].
+28,`MaxQFMetab`,`MU` `O`,Maximum (day) human heat emission [W |cap^-1|].
+29,`MinFCMetab`,`MU` `O`,Minimum (night) CO2 emission from human metabolism [|umol| |cap^-1| |s^-1|].
+30,`MaxFCMetab`,`MU` `O`,Maximum (day) CO2 emission from human metabolism [|umol| |cap^-1| |s^-1|].
 31,`FrPDDwe`,`MU` `O`,Fraction of weekend population to weekday population. [-]
 32,`FrFossilFuel_Heat`,`MU` `O`,Fraction of fossil fuels used for building heating [-]
 33,`FrFossilFuel_NonHeat`,`MU` `O`,Fraction of fossil fuels used for building energy use [-]
-34,`EF_umolCO2perJ`,`MU` `O`,Emission factor for fuels used for building heating.
-35,`EnEF_v_Jkm`,`MU` `O`,Emission factor for heat [J k |m^-1| ].
-36,`FcEF_v_kgkmWD`,`MU` `O`,CO2 emission factor for weekdays [kg |km^-1|]
-37,`FcEF_v_kgkmWE`,`MU` `O`,CO2 emission factor for weekends [kg |km^-1|]
-38,`CO2PointSource`,`MU` `O`,CO2 emission factor [kg |km^-1|]
-39,`TrafficUnits`,`MU` `O`,Units for the traffic rate for the study area. Not used in v2018a.
+34,`EF_umolCO2perJ`,`MU` `O`,CO2 emission factor for fuels used for building energy [|umol| |J^-1|].
+35,`EnEF_v_Jkm`,`MU` `O`,Vehicle energy consumption per unit distance [J |km^-1|].
+36,`FcEF_v_kgkmWD`,`MU` `O`,Vehicle CO2 emission factor for weekdays [kg CO2 |km^-1|].
+37,`FcEF_v_kgkmWE`,`MU` `O`,Vehicle CO2 emission factor for weekends [kg CO2 |km^-1|].
+38,`CO2PointSource`,`MU` `O`,Whole-grid CO2 point-source emission expressed as carbon mass [kg C |day^-1|].
+39,`TrafficUnits`,`MU` `O`,Traffic-rate basis: 1 for vehicle km |m^-2| |day^-1|; 2 for vehicle km |cap^-1| |day^-1|. Not used in v2018a.

--- a/docs/source/inputs/tables/schema.json
+++ b/docs/source/inputs/tables/schema.json
@@ -2155,7 +2155,7 @@
     "CO2Params": {
       "description": "CO2 emission parameters and profiles.",
       "properties": {
-        "co2pointsource": {
+        "emission_co2_point_source": {
           "anyOf": [
             {
               "$ref": "#/$defs/RefValue_float_"
@@ -2168,12 +2168,12 @@
             }
           ],
           "default": null,
-          "description": "CO2 point source emission factor",
+          "description": "Whole-grid CO2 point-source emission expressed as carbon mass",
           "display_name": "CO2 Point Source",
-          "title": "Co2Pointsource",
-          "unit": "kg m^-2 s^-1"
+          "title": "Emission Co2 Point Source",
+          "unit": "kg C day^-1"
         },
-        "ef_umolco2perj": {
+        "emission_factor_co2_fuel": {
           "anyOf": [
             {
               "$ref": "#/$defs/RefValue_float_"
@@ -2189,10 +2189,10 @@
           "default_description": "Sample benchmark value: 1.159 umol J^-1 (Ward et al. 2016, central London); calibrate by site.",
           "description": "CO2 emission factor per unit of fuel energy",
           "display_name": "Emission Factor (umol CO2/J)",
-          "title": "Ef Umolco2Perj",
+          "title": "Emission Factor Co2 Fuel",
           "unit": "umol J^-1"
         },
-        "enef_v_jkm": {
+        "emission_factor_energy_vehicle": {
           "anyOf": [
             {
               "$ref": "#/$defs/RefValue_float_"
@@ -2205,13 +2205,13 @@
             }
           ],
           "default": null,
-          "description": "Vehicle energy consumption factor",
+          "description": "Vehicle energy consumption per unit distance",
           "display_name": "Energy Emission Factor Vehicles",
           "range_description": "Sample range from benchmark/sample tables: 3.97e6-4.11e6 J km^-1; calibrate by site.",
-          "title": "Enef V Jkm",
+          "title": "Emission Factor Energy Vehicle",
           "unit": "J km^-1"
         },
-        "fcef_v_kgkm": {
+        "emission_factor_co2_vehicle": {
           "anyOf": [
             {
               "$ref": "#/$defs/DayProfile"
@@ -2220,12 +2220,12 @@
               "type": "null"
             }
           ],
-          "default_description": "Sample benchmark value: 0.285 kg km^-1 (Ward et al. 2016, central London); calibrate by site.",
-          "description": "Fuel consumption efficiency for vehicles",
+          "default_description": "Sample benchmark value: 0.285 kg CO2 km^-1 (Ward et al. 2016, central London); calibrate by site.",
+          "description": "Vehicle CO2 emission factor per unit distance",
           "display_name": "Fuel Carbon Emission Factor Vehicles",
-          "unit": "kg km^-1"
+          "unit": "kg CO2 km^-1"
         },
-        "frfossilfuel_heat": {
+        "fraction_fossil_fuel_heating": {
           "anyOf": [
             {
               "anyOf": [
@@ -2247,10 +2247,10 @@
           "description": "Fraction of heating energy from fossil fuels",
           "display_name": "Fossil Fuel Fraction Heating",
           "range_description": "Sample range from benchmark/sample tables: 0.05-0.7 (depends on local energy mix).",
-          "title": "Frfossilfuel Heat",
+          "title": "Fraction Fossil Fuel Heating",
           "unit": "dimensionless"
         },
-        "frfossilfuel_nonheat": {
+        "fraction_fossil_fuel_non_heating": {
           "anyOf": [
             {
               "anyOf": [
@@ -2272,10 +2272,10 @@
           "description": "Fraction of non-heating energy from fossil fuels",
           "display_name": "Fossil Fuel Fraction Non-Heating",
           "range_description": "Sample range from benchmark/sample tables: 0.0-0.7 (depends on local energy mix).",
-          "title": "Frfossilfuel Nonheat",
+          "title": "Fraction Fossil Fuel Non Heating",
           "unit": "dimensionless"
         },
-        "maxfcmetab": {
+        "emission_co2_metabolism_max": {
           "anyOf": [
             {
               "$ref": "#/$defs/RefValue_float_"
@@ -2288,13 +2288,13 @@
             }
           ],
           "default": null,
-          "default_description": "Sample value from benchmark/sample tables: 280.0 umol m^-2 s^-1; calibrate by site.",
-          "description": "Maximum metabolic CO2 flux rate",
+          "default_description": "Sample value from benchmark/sample tables: 280.0 umol cap^-1 s^-1; calibrate by site.",
+          "description": "Maximum daytime metabolic CO2 emission per capita",
           "display_name": "Maximum Metabolic CO2 Flux",
-          "title": "Maxfcmetab",
-          "unit": "umol m^-2 s^-1"
+          "title": "Emission Co2 Metabolism Max",
+          "unit": "umol cap^-1 s^-1"
         },
-        "maxqfmetab": {
+        "emission_heat_metabolism_max": {
           "anyOf": [
             {
               "$ref": "#/$defs/RefValue_float_"
@@ -2307,13 +2307,13 @@
             }
           ],
           "default": null,
-          "default_description": "Sample value from benchmark/sample tables: 175.0 W m^-2; calibrate by site.",
-          "description": "Maximum metabolic heat flux rate",
+          "default_description": "Sample value from benchmark/sample tables: 175.0 W cap^-1; calibrate by site.",
+          "description": "Maximum daytime metabolic heat emission per capita",
           "display_name": "Maximum Metabolic Heat Flux",
-          "title": "Maxqfmetab",
-          "unit": "W m^-2"
+          "title": "Emission Heat Metabolism Max",
+          "unit": "W cap^-1"
         },
-        "minfcmetab": {
+        "emission_co2_metabolism_min": {
           "anyOf": [
             {
               "$ref": "#/$defs/RefValue_float_"
@@ -2326,13 +2326,13 @@
             }
           ],
           "default": null,
-          "default_description": "Sample value from benchmark/sample tables: 120.0 umol m^-2 s^-1; calibrate by site.",
-          "description": "Minimum metabolic CO2 flux rate",
+          "default_description": "Sample value from benchmark/sample tables: 120.0 umol cap^-1 s^-1; calibrate by site.",
+          "description": "Minimum night-time metabolic CO2 emission per capita",
           "display_name": "Minimum Metabolic CO2 Flux",
-          "title": "Minfcmetab",
-          "unit": "umol m^-2 s^-1"
+          "title": "Emission Co2 Metabolism Min",
+          "unit": "umol cap^-1 s^-1"
         },
-        "minqfmetab": {
+        "emission_heat_metabolism_min": {
           "anyOf": [
             {
               "$ref": "#/$defs/RefValue_float_"
@@ -2345,13 +2345,13 @@
             }
           ],
           "default": null,
-          "default_description": "Sample value from benchmark/sample tables: 75.0 W m^-2; calibrate by site.",
-          "description": "Minimum metabolic heat flux rate",
+          "default_description": "Sample value from benchmark/sample tables: 75.0 W cap^-1; calibrate by site.",
+          "description": "Minimum night-time metabolic heat emission per capita",
           "display_name": "Minimum Metabolic Heat Flux",
-          "title": "Minqfmetab",
-          "unit": "W m^-2"
+          "title": "Emission Heat Metabolism Min",
+          "unit": "W cap^-1"
         },
-        "trafficrate": {
+        "traffic_rate": {
           "anyOf": [
             {
               "$ref": "#/$defs/DayProfile"
@@ -2360,11 +2360,11 @@
               "type": "null"
             }
           ],
-          "description": "Traffic rate",
+          "description": "Mean traffic activity; basis selected by type_traffic_rate",
           "display_name": "Traffic Rate",
-          "unit": "vehicle km ha^-1"
+          "unit": "vehicle km m^-2 day^-1 (type 1) or vehicle km cap^-1 day^-1 (type 2)"
         },
-        "trafficunits": {
+        "type_traffic_rate": {
           "anyOf": [
             {
               "$ref": "#/$defs/RefValue_float_"
@@ -2377,12 +2377,12 @@
             }
           ],
           "default": null,
-          "description": "Units for traffic density normalisation",
-          "display_name": "Traffic Units",
-          "title": "Trafficunits",
-          "unit": "vehicle km ha^-1"
+          "description": "Traffic-rate basis: 1 for per area, 2 for per capita",
+          "display_name": "Traffic Rate Type",
+          "title": "Type Traffic Rate",
+          "unit": "dimensionless"
         },
-        "traffprof_24hr": {
+        "profile_traffic_24hr": {
           "anyOf": [
             {
               "$ref": "#/$defs/HourlyProfile"
@@ -2395,7 +2395,7 @@
           "display_name": "Traffic Profile (24hr)",
           "unit": "dimensionless"
         },
-        "humactivity_24hr": {
+        "profile_human_activity_24hr": {
           "anyOf": [
             {
               "$ref": "#/$defs/HourlyProfile"
@@ -12201,7 +12201,7 @@
             0.0,
             0.0
           ],
-          "description": "Fraction of vegetation in each SPARTACUS vertical layer; length must be nlayer",
+          "description": "Fraction of vegetation obstruction in each vertical layer, length must be nlayer. The lowest layer value may represent trunk or near-ground obstruction and is not required to equal total tree land-cover fraction.",
           "display_name": "Vegetation Fraction",
           "title": "Veg Frac",
           "unit": "dimensionless"
@@ -13173,7 +13173,7 @@
     }
   },
   "additionalProperties": true,
-  "description": "JSON Schema for SUEWS YAML configuration files. Schema version 2026.6.dev2. Development schema adding storage_heat=dyohm_building (StorageHeatMethod=8): DyOHM determines building storage heat flux only, ordinary OHM remains active for other land-cover surfaces, and the DyOHM surface-temperature feedback to radiation stays disabled for this method. Existing 2026.6.dev1 YAMLs remain compatible through a no-op migration because the new selector is opt-in.",
+  "description": "JSON Schema for SUEWS YAML configuration files. Schema version 2026.6.dev3. Development schema completing the CO2Params naming-convention sweep (#1688): fourteen fused or unit-bearing anthropogenic-emissions keys renamed to quantity-first or category-prefixed identifiers. Existing 2026.6.dev2 YAMLs remain compatible through an explicit rename migration; legacy df_state column names are unchanged.",
   "properties": {
     "name": {
       "default": "sample config",
@@ -13226,20 +13226,20 @@
       "type": "array"
     }
   },
-  "title": "SUEWS Configuration Schema v2026.6.dev2",
+  "title": "SUEWS Configuration Schema v2026.6.dev3",
   "type": "object",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://umep-dev.github.io/SUEWS/schema/suews-config/2026.6.dev2.json",
-  "version": "2026.6.dev2",
+  "$id": "https://umep-dev.github.io/SUEWS/schema/suews-config/2026.6.dev3.json",
+  "version": "2026.6.dev3",
   "$comment": {
     "generator": "supy.util.schema_publisher",
     "suews_version": "unknown",
-    "schema_version": "2026.6.dev2"
+    "schema_version": "2026.6.dev3"
   },
   "examples": [
     {
       "name": "minimal_config",
-      "schema_version": "2026.6.dev2",
+      "schema_version": "2026.6.dev3",
       "description": "Minimal SUEWS configuration example",
       "model": {
         "control": {

--- a/docs/source/inputs/transition_guide.rst
+++ b/docs/source/inputs/transition_guide.rst
@@ -223,6 +223,55 @@ The sections below summarise what users see change between schemas.
 The authoritative lineage (including release-tag to schema mapping)
 lives in :ref:`schema_version_history`.
 
+Upgrading to Schema 2026.6.dev3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Schema ``2026.6.dev3`` completes the naming-convention sweep for the
+``sites[*].properties.anthropogenic_emissions.co2`` section. The migration
+renames fourteen YAML keys while preserving their values:
+
+.. list-table:: CO2 parameter renames
+   :header-rows: 1
+
+   * - Previous key
+     - Current key
+   * - ``co2pointsource``
+     - ``emission_co2_point_source``
+   * - ``ef_umolco2perj``
+     - ``emission_factor_co2_fuel``
+   * - ``enef_v_jkm``
+     - ``emission_factor_energy_vehicle``
+   * - ``fcef_v_kgkm``
+     - ``emission_factor_co2_vehicle``
+   * - ``frfossilfuel_heat``
+     - ``fraction_fossil_fuel_heating``
+   * - ``frfossilfuel_nonheat``
+     - ``fraction_fossil_fuel_non_heating``
+   * - ``maxfcmetab`` / ``minfcmetab``
+     - ``emission_co2_metabolism_max`` / ``emission_co2_metabolism_min``
+   * - ``maxqfmetab`` / ``minqfmetab``
+     - ``emission_heat_metabolism_max`` / ``emission_heat_metabolism_min``
+   * - ``trafficrate``
+     - ``traffic_rate``
+   * - ``trafficunits``
+     - ``type_traffic_rate``
+   * - ``traffprof_24hr``
+     - ``profile_traffic_24hr``
+   * - ``humactivity_24hr``
+     - ``profile_human_activity_24hr``
+
+``type_traffic_rate`` keeps the existing numeric values: ``1`` selects a
+per-area traffic rate and ``2`` selects a per-capita rate. The point-source
+input is a whole-grid CO2 emission expressed as kg C |day^-1|; the
+metabolic inputs are per capita. Legacy ``df_state`` column names do not
+change.
+
+Upgrade a ``2026.6.dev2`` YAML with:
+
+.. code-block:: bash
+
+   suews schema migrate your_config.yml
+
 Upgrading to Schema 2026.6.dev2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/suews_bridge/src/field_renames.rs
+++ b/src/suews_bridge/src/field_renames.rs
@@ -38,9 +38,7 @@ use serde_yaml::Value;
 /// wrote in legacy YAMLs). The preprocessor's downstream
 /// `normalise_field_name` then lowercases/fuses before the hand-written
 /// parser reads the Fortran-indexed key.
-/// Total: 174 pairs (gh#1334 full STEBBS + Snow snake_case sweep; building_type
-/// and the two hot_water_tank view-factor params dropped per the Reading STEBBS
-/// team review, gh#1392).
+/// Total: 188 pairs (including the gh#1688 CO2Params naming completion).
 pub const FIELD_RENAMES: &[(&str, &str)] = &[
     // ModelPhysics (17) — fused -> final (Cat 2+3, gh#1321) + flags
     ("net_radiation", "netradiationmethod"),
@@ -319,6 +317,21 @@ pub const FIELD_RENAMES: &[(&str, &str)] = &[
     ("tau_refreezing_snow", "tau_r"),
     ("snow_profile_24hr", "snowprof_24hr"),
     ("narp_emissivity_snow", "narp_emis_snow"),
+    // CO2Params (14) — user-facing names omitted from the original #1256 sweep.
+    ("emission_co2_point_source", "co2pointsource"),
+    ("emission_factor_co2_fuel", "ef_umolco2perj"),
+    ("emission_factor_energy_vehicle", "enef_v_jkm"),
+    ("emission_factor_co2_vehicle", "fcef_v_kgkm"),
+    ("fraction_fossil_fuel_heating", "frfossilfuel_heat"),
+    ("fraction_fossil_fuel_non_heating", "frfossilfuel_nonheat"),
+    ("emission_co2_metabolism_max", "maxfcmetab"),
+    ("emission_heat_metabolism_max", "maxqfmetab"),
+    ("emission_co2_metabolism_min", "minfcmetab"),
+    ("emission_heat_metabolism_min", "minqfmetab"),
+    ("traffic_rate", "trafficrate"),
+    ("type_traffic_rate", "trafficunits"),
+    ("profile_traffic_24hr", "traffprof_24hr"),
+    ("profile_human_activity_24hr", "humactivity_24hr"),
 ];
 
 /// Additional compatibility aliases for short-lived schema-intermediate
@@ -2203,7 +2216,7 @@ mod tests {
     fn field_renames_registry_has_expected_size() {
         // Matches the Python ALL_FIELD_RENAMES total (see field_renames.py).
         // Bump when ModelPhysics / SurfaceProperties / ... dicts change.
-        assert_eq!(FIELD_RENAMES.len(), 174);
+        assert_eq!(FIELD_RENAMES.len(), 188);
     }
 
     #[test]
@@ -2254,6 +2267,38 @@ mod tests {
         assert!(physics.get("netradiationmethod").is_some());
         assert!(physics.get("storageheatmethod").is_some());
         assert!(physics.get("net_radiation").is_none());
+    }
+
+    #[test]
+    fn normalises_co2_param_names() {
+        let renames = [
+            ("emission_co2_point_source", "co2pointsource"),
+            ("emission_factor_co2_fuel", "ef_umolco2perj"),
+            ("emission_factor_energy_vehicle", "enef_v_jkm"),
+            ("emission_factor_co2_vehicle", "fcef_v_kgkm"),
+            ("fraction_fossil_fuel_heating", "frfossilfuel_heat"),
+            ("fraction_fossil_fuel_non_heating", "frfossilfuel_nonheat"),
+            ("emission_co2_metabolism_max", "maxfcmetab"),
+            ("emission_heat_metabolism_max", "maxqfmetab"),
+            ("emission_co2_metabolism_min", "minfcmetab"),
+            ("emission_heat_metabolism_min", "minqfmetab"),
+            ("traffic_rate", "trafficrate"),
+            ("type_traffic_rate", "trafficunits"),
+            ("profile_traffic_24hr", "traffprof_24hr"),
+            ("profile_human_activity_24hr", "humactivity_24hr"),
+        ];
+        let mut co2 = serde_yaml::Mapping::new();
+        for (new_name, _) in renames {
+            co2.insert(Value::String(new_name.to_string()), Value::Null);
+        }
+        let mut root = Value::Mapping(co2);
+
+        normalize_field_names(&mut root).unwrap();
+
+        for (new_name, old_name) in renames {
+            assert!(root.get(old_name).is_some(), "missing {old_name}");
+            assert!(root.get(new_name).is_none(), "retained {new_name}");
+        }
     }
 
     #[test]

--- a/src/supy/data_model/configuration/version.py
+++ b/src/supy/data_model/configuration/version.py
@@ -23,7 +23,7 @@ import warnings
 # between releases bumps the dev counter instead of consuming a new
 # CalVer label. The 2026.5 cycle (dev1..dev14) was collapsed to the
 # plain `2026.5` label in the 2026.6.5 release PR.
-CURRENT_SCHEMA_VERSION = "2026.6.dev2"
+CURRENT_SCHEMA_VERSION = "2026.6.dev3"
 
 # Schema version history and descriptions.
 #
@@ -129,6 +129,13 @@ SCHEMA_VERSIONS: dict[str, str] = {
         "the DyOHM surface-temperature feedback to radiation stays disabled "
         "for this method. Existing 2026.6.dev1 YAMLs remain compatible through "
         "a no-op migration because the new selector is opt-in."
+    ),
+    "2026.6.dev3": (
+        "Development schema completing the CO2Params naming-convention sweep "
+        "(#1688): fourteen fused or unit-bearing anthropogenic-emissions keys "
+        "renamed to quantity-first or category-prefixed identifiers. Existing "
+        "2026.6.dev2 YAMLs remain compatible through an explicit rename "
+        "migration; legacy df_state column names are unchanged."
     ),
 }
 

--- a/src/supy/data_model/core/config.py
+++ b/src/supy/data_model/core/config.py
@@ -1326,20 +1326,20 @@ class SUEWSConfig(BaseModel):
         Notes
         -----
         The following parameters are checked:
-        - co2pointsource: CO2 point source emission factor
-        - ef_umolco2perj: CO2 emission factor per unit of fuel energy
-        - frfossilfuel_heat: Fraction of heating energy from fossil fuels
-        - frfossilfuel_nonheat: Fraction of non-heating energy from fossil fuels
+        - emission_co2_point_source: CO2 point source emission factor
+        - emission_factor_co2_fuel: CO2 emission factor per unit of fuel energy
+        - fraction_fossil_fuel_heating: Fraction of heating energy from fossil fuels
+        - fraction_fossil_fuel_non_heating: Fraction of non-heating energy from fossil fuels
 
         Any missing parameters are added to the validation summary.
         """
         from ..validation.core.utils import check_missing_params
 
         critical_params = {
-            "co2pointsource": "CO2 point source emission factor",
-            "ef_umolco2perj": "CO2 emission factor per unit of fuel energy",
-            "frfossilfuel_heat": "Fraction of heating energy from fossil fuels",
-            "frfossilfuel_nonheat": "Fraction of non-heating energy from fossil fuels",
+            "emission_co2_point_source": "CO2 point source emission factor",
+            "emission_factor_co2_fuel": "CO2 emission factor per unit of fuel energy",
+            "fraction_fossil_fuel_heating": "Fraction of heating energy from fossil fuels",
+            "fraction_fossil_fuel_non_heating": "Fraction of non-heating energy from fossil fuels",
         }
 
         missing_params = check_missing_params(
@@ -3466,10 +3466,10 @@ class SUEWSConfig(BaseModel):
             from ..validation.core.utils import check_missing_params
 
             critical_params = {
-                "co2pointsource": "CO2 point source emission factor",
-                "ef_umolco2perj": "CO2 emission factor per unit of fuel energy",
-                "frfossilfuel_heat": "Fraction of heating energy from fossil fuels",
-                "frfossilfuel_nonheat": "Fraction of non-heating energy from fossil fuels",
+                "emission_co2_point_source": "CO2 point source emission factor",
+                "emission_factor_co2_fuel": "CO2 emission factor per unit of fuel energy",
+                "fraction_fossil_fuel_heating": "Fraction of heating energy from fossil fuels",
+                "fraction_fossil_fuel_non_heating": "Fraction of non-heating energy from fossil fuels",
             }
 
             missing_params = check_missing_params(
@@ -4078,12 +4078,12 @@ class SUEWSConfig(BaseModel):
                 anthro_co2 = site.properties.anthropogenic_emissions.co2
                 hourly_profiles.extend([
                     (
-                        "anthropogenic_emissions.co2.traffprof_24hr",
-                        anthro_co2.traffprof_24hr,
+                        "anthropogenic_emissions.co2.profile_traffic_24hr",
+                        anthro_co2.profile_traffic_24hr,
                     ),
                     (
-                        "anthropogenic_emissions.co2.humactivity_24hr",
-                        anthro_co2.humactivity_24hr,
+                        "anthropogenic_emissions.co2.profile_human_activity_24hr",
+                        anthro_co2.profile_human_activity_24hr,
                     ),
                 ])
 

--- a/src/supy/data_model/core/df_column_renames.py
+++ b/src/supy/data_model/core/df_column_renames.py
@@ -33,6 +33,7 @@ import pandas as pd
 
 from .field_renames import (
     ARCHETYPEPROPERTIES_DEV7_TO_PASCAL,
+    CO2PARAMS_RENAMES,
     DECTRPROPERTIES_RENAMES,
     EVETRPROPERTIES_RENAMES,
     LAIPARAMS_RENAMES,
@@ -64,6 +65,7 @@ VEGETATEDSURFACEPROPERTIES_DF_RENAMES: Dict[str, str] = dict(
 EVETRPROPERTIES_DF_RENAMES: Dict[str, str] = dict(EVETRPROPERTIES_RENAMES)
 DECTRPROPERTIES_DF_RENAMES: Dict[str, str] = dict(DECTRPROPERTIES_RENAMES)
 SNOWPARAMS_DF_RENAMES: Dict[str, str] = dict(SNOWPARAMS_RENAMES)
+CO2PARAMS_DF_RENAMES: Dict[str, str] = dict(CO2PARAMS_RENAMES)
 
 # ``ArchetypeProperties``: ``to_df_state`` lowercases the Pydantic
 # attribute name before writing it into the DataFrame (see ``site.py``
@@ -125,6 +127,7 @@ ALL_DF_COLUMN_RENAMES: Dict[str, str] = {
     **ARCHETYPEPROPERTIES_DF_RENAMES,
     **STEBBSPROPERTIES_DF_RENAMES,
     **SNOWPARAMS_DF_RENAMES,
+    **CO2PARAMS_DF_RENAMES,
 }
 
 # Reverse map: new -> legacy. Required by ``read_df_column`` when the
@@ -151,6 +154,7 @@ def _assert_registry_invariants() -> None:
         + len(ARCHETYPEPROPERTIES_DF_RENAMES)
         + len(STEBBSPROPERTIES_DF_RENAMES)
         + len(SNOWPARAMS_DF_RENAMES)
+        + len(CO2PARAMS_DF_RENAMES)
     )
     if len(ALL_DF_COLUMN_RENAMES) != per_class_total:
         raise RuntimeError(

--- a/src/supy/data_model/core/field_renames.py
+++ b/src/supy/data_model/core/field_renames.py
@@ -291,6 +291,28 @@ ARCHETYPEPROPERTIES_PASCAL_RENAMES: Dict[str, str] = {
     "RoofExternalCp": "specific_heat_capacity_roof_outer",
 }
 
+# -- CO2Params (gh#1688) -----------------------------------------------------
+#
+# User-facing anthropogenic-emissions fields omitted from the original #1256
+# naming inventory. The final names follow the adopted quantity-first and
+# category-prefix rules; units remain schema metadata rather than identifiers.
+CO2PARAMS_RENAMES: Dict[str, str] = {
+    "co2pointsource": "emission_co2_point_source",
+    "ef_umolco2perj": "emission_factor_co2_fuel",
+    "enef_v_jkm": "emission_factor_energy_vehicle",
+    "fcef_v_kgkm": "emission_factor_co2_vehicle",
+    "frfossilfuel_heat": "fraction_fossil_fuel_heating",
+    "frfossilfuel_nonheat": "fraction_fossil_fuel_non_heating",
+    "maxfcmetab": "emission_co2_metabolism_max",
+    "maxqfmetab": "emission_heat_metabolism_max",
+    "minfcmetab": "emission_co2_metabolism_min",
+    "minqfmetab": "emission_heat_metabolism_min",
+    "trafficrate": "traffic_rate",
+    "trafficunits": "type_traffic_rate",
+    "traffprof_24hr": "profile_traffic_24hr",
+    "humactivity_24hr": "profile_human_activity_24hr",
+}
+
 # Schema 2026.5.dev3 `water_tank_water_volume` -> unified `hot_water_tank_volume`
 # (drop the double-`water` redundancy and fold under the `hot_water_tank_*`
 # component prefix). NOT spread into ALL_FIELD_RENAMES — keeping the
@@ -1153,6 +1175,7 @@ ALL_FIELD_RENAMES: Dict[str, str] = {
     **ARCHETYPEPROPERTIES_RENAMES,
     **STEBBSPROPERTIES_RENAMES,
     **SNOWPARAMS_RENAMES,
+    **CO2PARAMS_RENAMES,
 }
 
 # -- Fortran-internal rename registry (gh#1326 Tier D) ------------------------

--- a/src/supy/data_model/core/human_activity.py
+++ b/src/supy/data_model/core/human_activity.py
@@ -5,6 +5,7 @@ import pandas as pd
 import warnings
 from .type import RefValue, Reference, FlexibleRefValue, df_from_cols
 from .profile import HourlyProfile, WeeklyProfile, DayProfile
+from .field_renames import CO2PARAMS_RENAMES, apply_field_renames
 from ..validation.core.utils import (
     warn_missing_params,
     check_missing_params,
@@ -409,15 +410,22 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
 
     model_config = ConfigDict(title="CO2 Emissions")
 
+    @model_validator(mode="before")
+    @classmethod
+    def _rename_co2_fields(cls, values):
+        if isinstance(values, dict):
+            return apply_field_renames(values, CO2PARAMS_RENAMES, cls.__name__)
+        return values
+
     # Sample/range metadata values below are derived from:
     # - test/fixtures/benchmark1/benchmark1.yml (Ward et al. 2016 benchmark setup)
     # - docs/source/inputs/tables/SUEWS_SiteInfo/sample-table/SUEWS_AnthropogenicEmission.txt
-    co2pointsource: Optional[FlexibleRefValue(float)] = Field(
+    emission_co2_point_source: Optional[FlexibleRefValue(float)] = Field(
         default=None,
-        description="CO2 point source emission factor",
-        json_schema_extra={"unit": "kg m^-2 s^-1", "display_name": "CO2 Point Source"},
+        description="Whole-grid CO2 point-source emission expressed as carbon mass",
+        json_schema_extra={"unit": "kg C day^-1", "display_name": "CO2 Point Source"},
     )
-    ef_umolco2perj: Optional[FlexibleRefValue(float)] = Field(
+    emission_factor_co2_fuel: Optional[FlexibleRefValue(float)] = Field(
         default=None,
         description="CO2 emission factor per unit of fuel energy",
         json_schema_extra={
@@ -426,29 +434,29 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
             "default_description": "Sample benchmark value: 1.159 umol J^-1 (Ward et al. 2016, central London); calibrate by site.",
         },
     )
-    enef_v_jkm: Optional[FlexibleRefValue(float)] = Field(
+    emission_factor_energy_vehicle: Optional[FlexibleRefValue(float)] = Field(
         default=None,
-        description="Vehicle energy consumption factor",
+        description="Vehicle energy consumption per unit distance",
         json_schema_extra={
             "unit": "J km^-1",
             "display_name": "Energy Emission Factor Vehicles",
             "range_description": "Sample range from benchmark/sample tables: 3.97e6-4.11e6 J km^-1; calibrate by site.",
         },
     )
-    fcef_v_kgkm: Optional[DayProfile] = Field(
-        description="Fuel consumption efficiency for vehicles",
+    emission_factor_co2_vehicle: Optional[DayProfile] = Field(
+        description="Vehicle CO2 emission factor per unit distance",
         default_factory=DayProfile,
         json_schema_extra={
-            "unit": "kg km^-1",
+            "unit": "kg CO2 km^-1",
             "display_name": "Fuel Carbon Emission Factor Vehicles",
-            "default_description": "Sample benchmark value: 0.285 kg km^-1 (Ward et al. 2016, central London); calibrate by site.",
+            "default_description": "Sample benchmark value: 0.285 kg CO2 km^-1 (Ward et al. 2016, central London); calibrate by site.",
         },
     )
     # Field is Optional[DayProfile] but has default_factory=DayProfile,
     # so it will never actually be None unless explicitly set during
     # validation preprocessing.
 
-    frfossilfuel_heat: Optional[FlexibleRefValue(float)] = Field(
+    fraction_fossil_fuel_heating: Optional[FlexibleRefValue(float)] = Field(
         default=None,
         description="Fraction of heating energy from fossil fuels",
         json_schema_extra={
@@ -459,7 +467,7 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
         ge=0.0,
         le=1.0,
     )
-    frfossilfuel_nonheat: Optional[FlexibleRefValue(float)] = Field(
+    fraction_fossil_fuel_non_heating: Optional[FlexibleRefValue(float)] = Field(
         default=None,
         description="Fraction of non-heating energy from fossil fuels",
         json_schema_extra={
@@ -470,57 +478,65 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
         ge=0.0,
         le=1.0,
     )
-    maxfcmetab: Optional[FlexibleRefValue(float)] = Field(
+    emission_co2_metabolism_max: Optional[FlexibleRefValue(float)] = Field(
         default=None,
-        description="Maximum metabolic CO2 flux rate",
+        description="Maximum daytime metabolic CO2 emission per capita",
         json_schema_extra={
-            "unit": "umol m^-2 s^-1",
+            "unit": "umol cap^-1 s^-1",
             "display_name": "Maximum Metabolic CO2 Flux",
-            "default_description": "Sample value from benchmark/sample tables: 280.0 umol m^-2 s^-1; calibrate by site.",
+            "default_description": "Sample value from benchmark/sample tables: 280.0 umol cap^-1 s^-1; calibrate by site.",
         },
     )
-    maxqfmetab: Optional[FlexibleRefValue(float)] = Field(
+    emission_heat_metabolism_max: Optional[FlexibleRefValue(float)] = Field(
         default=None,
-        description="Maximum metabolic heat flux rate",
+        description="Maximum daytime metabolic heat emission per capita",
         json_schema_extra={
-            "unit": "W m^-2",
+            "unit": "W cap^-1",
             "display_name": "Maximum Metabolic Heat Flux",
-            "default_description": "Sample value from benchmark/sample tables: 175.0 W m^-2; calibrate by site.",
+            "default_description": "Sample value from benchmark/sample tables: 175.0 W cap^-1; calibrate by site.",
         },
     )
-    minfcmetab: Optional[FlexibleRefValue(float)] = Field(
+    emission_co2_metabolism_min: Optional[FlexibleRefValue(float)] = Field(
         default=None,
-        description="Minimum metabolic CO2 flux rate",
+        description="Minimum night-time metabolic CO2 emission per capita",
         json_schema_extra={
-            "unit": "umol m^-2 s^-1",
+            "unit": "umol cap^-1 s^-1",
             "display_name": "Minimum Metabolic CO2 Flux",
-            "default_description": "Sample value from benchmark/sample tables: 120.0 umol m^-2 s^-1; calibrate by site.",
+            "default_description": "Sample value from benchmark/sample tables: 120.0 umol cap^-1 s^-1; calibrate by site.",
         },
     )
-    minqfmetab: Optional[FlexibleRefValue(float)] = Field(
+    emission_heat_metabolism_min: Optional[FlexibleRefValue(float)] = Field(
         default=None,
-        description="Minimum metabolic heat flux rate",
+        description="Minimum night-time metabolic heat emission per capita",
         json_schema_extra={
-            "unit": "W m^-2",
+            "unit": "W cap^-1",
             "display_name": "Minimum Metabolic Heat Flux",
-            "default_description": "Sample value from benchmark/sample tables: 75.0 W m^-2; calibrate by site.",
+            "default_description": "Sample value from benchmark/sample tables: 75.0 W cap^-1; calibrate by site.",
         },
     )
-    trafficrate: Optional[DayProfile] = Field(
-        description="Traffic rate",
+    traffic_rate: Optional[DayProfile] = Field(
+        description="Mean traffic activity; basis selected by type_traffic_rate",
         default_factory=DayProfile,
-        json_schema_extra={"unit": "vehicle km ha^-1", "display_name": "Traffic Rate"},
+        json_schema_extra={
+            "unit": (
+                "vehicle km m^-2 day^-1 (type 1) or vehicle km cap^-1 day^-1 (type 2)"
+            ),
+            "display_name": "Traffic Rate",
+        },
     )
     # Field is Optional[DayProfile] but has default_factory=DayProfile,
     # so it will never actually be None unless explicitly set during
     # validation preprocessing.
 
-    trafficunits: Optional[FlexibleRefValue(float)] = Field(
+    type_traffic_rate: Optional[FlexibleRefValue(float)] = Field(
         default=None,
-        description="Units for traffic density normalisation",
-        json_schema_extra={"unit": "vehicle km ha^-1", "display_name": "Traffic Units"},
+        description="Traffic-rate basis: 1 for per area, 2 for per capita",
+        json_schema_extra={
+            "unit": "dimensionless",
+            "display_name": "Traffic Rate Type",
+        },
     )
-    traffprof_24hr: Optional[HourlyProfile] = Field(
+    profile_traffic_24hr: Optional[HourlyProfile] = Field(
         description="24-hour profile of traffic rate",
         default_factory=HourlyProfile,
         json_schema_extra={
@@ -532,7 +548,7 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
     # so it will never actually be None unless explicitly set during
     # validation preprocessing.
 
-    humactivity_24hr: Optional[HourlyProfile] = Field(
+    profile_human_activity_24hr: Optional[HourlyProfile] = Field(
         description="24-hour profile of human activity",
         default_factory=HourlyProfile,
         json_schema_extra={
@@ -559,55 +575,55 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
         """
 
         scalar_params = {
-            "co2pointsource": self.co2pointsource.value
-            if isinstance(self.co2pointsource, RefValue)
-            else self.co2pointsource
-            if self.co2pointsource is not None
+            "co2pointsource": self.emission_co2_point_source.value
+            if isinstance(self.emission_co2_point_source, RefValue)
+            else self.emission_co2_point_source
+            if self.emission_co2_point_source is not None
             else 0.0,
-            "ef_umolco2perj": self.ef_umolco2perj.value
-            if isinstance(self.ef_umolco2perj, RefValue)
-            else self.ef_umolco2perj
-            if self.ef_umolco2perj is not None
+            "ef_umolco2perj": self.emission_factor_co2_fuel.value
+            if isinstance(self.emission_factor_co2_fuel, RefValue)
+            else self.emission_factor_co2_fuel
+            if self.emission_factor_co2_fuel is not None
             else 0.0,
-            "enef_v_jkm": self.enef_v_jkm.value
-            if isinstance(self.enef_v_jkm, RefValue)
-            else self.enef_v_jkm
-            if self.enef_v_jkm is not None
+            "enef_v_jkm": self.emission_factor_energy_vehicle.value
+            if isinstance(self.emission_factor_energy_vehicle, RefValue)
+            else self.emission_factor_energy_vehicle
+            if self.emission_factor_energy_vehicle is not None
             else 0.0,
-            "frfossilfuel_heat": self.frfossilfuel_heat.value
-            if isinstance(self.frfossilfuel_heat, RefValue)
-            else self.frfossilfuel_heat
-            if self.frfossilfuel_heat is not None
+            "frfossilfuel_heat": self.fraction_fossil_fuel_heating.value
+            if isinstance(self.fraction_fossil_fuel_heating, RefValue)
+            else self.fraction_fossil_fuel_heating
+            if self.fraction_fossil_fuel_heating is not None
             else 0.0,
-            "frfossilfuel_nonheat": self.frfossilfuel_nonheat.value
-            if isinstance(self.frfossilfuel_nonheat, RefValue)
-            else self.frfossilfuel_nonheat
-            if self.frfossilfuel_nonheat is not None
+            "frfossilfuel_nonheat": self.fraction_fossil_fuel_non_heating.value
+            if isinstance(self.fraction_fossil_fuel_non_heating, RefValue)
+            else self.fraction_fossil_fuel_non_heating
+            if self.fraction_fossil_fuel_non_heating is not None
             else 0.0,
-            "maxfcmetab": self.maxfcmetab.value
-            if isinstance(self.maxfcmetab, RefValue)
-            else self.maxfcmetab
-            if self.maxfcmetab is not None
+            "maxfcmetab": self.emission_co2_metabolism_max.value
+            if isinstance(self.emission_co2_metabolism_max, RefValue)
+            else self.emission_co2_metabolism_max
+            if self.emission_co2_metabolism_max is not None
             else 0.0,
-            "maxqfmetab": self.maxqfmetab.value
-            if isinstance(self.maxqfmetab, RefValue)
-            else self.maxqfmetab
-            if self.maxqfmetab is not None
+            "maxqfmetab": self.emission_heat_metabolism_max.value
+            if isinstance(self.emission_heat_metabolism_max, RefValue)
+            else self.emission_heat_metabolism_max
+            if self.emission_heat_metabolism_max is not None
             else 0.0,
-            "minfcmetab": self.minfcmetab.value
-            if isinstance(self.minfcmetab, RefValue)
-            else self.minfcmetab
-            if self.minfcmetab is not None
+            "minfcmetab": self.emission_co2_metabolism_min.value
+            if isinstance(self.emission_co2_metabolism_min, RefValue)
+            else self.emission_co2_metabolism_min
+            if self.emission_co2_metabolism_min is not None
             else 0.0,
-            "minqfmetab": self.minqfmetab.value
-            if isinstance(self.minqfmetab, RefValue)
-            else self.minqfmetab
-            if self.minqfmetab is not None
+            "minqfmetab": self.emission_heat_metabolism_min.value
+            if isinstance(self.emission_heat_metabolism_min, RefValue)
+            else self.emission_heat_metabolism_min
+            if self.emission_heat_metabolism_min is not None
             else 0.0,
-            "trafficunits": self.trafficunits.value
-            if isinstance(self.trafficunits, RefValue)
-            else self.trafficunits
-            if self.trafficunits is not None
+            "trafficunits": self.type_traffic_rate.value
+            if isinstance(self.type_traffic_rate, RefValue)
+            else self.type_traffic_rate
+            if self.type_traffic_rate is not None
             else 0.0,
         }
         cols = {("gridiv", "0"): grid_id}
@@ -616,16 +632,16 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
         df_state = df_from_cols(cols, index=pd.Index([grid_id], name="grid"))
 
         day_profiles = {
-            "fcef_v_kgkm": self.fcef_v_kgkm,
-            "trafficrate": self.trafficrate,
+            "fcef_v_kgkm": self.emission_factor_co2_vehicle,
+            "trafficrate": self.traffic_rate,
         }
         for param_name, profile in day_profiles.items():
             df_day_profile = profile.to_df_state(grid_id, param_name)
             df_state = df_state.combine_first(df_day_profile)
 
         hourly_profiles = {
-            "traffprof_24hr": self.traffprof_24hr,
-            "humactivity_24hr": self.humactivity_24hr,
+            "traffprof_24hr": self.profile_traffic_24hr,
+            "humactivity_24hr": self.profile_human_activity_24hr,
         }
         for param_name, profile in hourly_profiles.items():
             df_hourly_profile = profile.to_df_state(grid_id, param_name)
@@ -648,16 +664,18 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
 
         # Extract scalar attributes
         scalar_params = {
-            "co2pointsource": df.loc[grid_id, ("co2pointsource", "0")],
-            "ef_umolco2perj": df.loc[grid_id, ("ef_umolco2perj", "0")],
-            "enef_v_jkm": df.loc[grid_id, ("enef_v_jkm", "0")],
-            "frfossilfuel_heat": df.loc[grid_id, ("frfossilfuel_heat", "0")],
-            "frfossilfuel_nonheat": df.loc[grid_id, ("frfossilfuel_nonheat", "0")],
-            "maxfcmetab": df.loc[grid_id, ("maxfcmetab", "0")],
-            "maxqfmetab": df.loc[grid_id, ("maxqfmetab", "0")],
-            "minfcmetab": df.loc[grid_id, ("minfcmetab", "0")],
-            "minqfmetab": df.loc[grid_id, ("minqfmetab", "0")],
-            "trafficunits": df.loc[grid_id, ("trafficunits", "0")],
+            "emission_co2_point_source": df.loc[grid_id, ("co2pointsource", "0")],
+            "emission_factor_co2_fuel": df.loc[grid_id, ("ef_umolco2perj", "0")],
+            "emission_factor_energy_vehicle": df.loc[grid_id, ("enef_v_jkm", "0")],
+            "fraction_fossil_fuel_heating": df.loc[grid_id, ("frfossilfuel_heat", "0")],
+            "fraction_fossil_fuel_non_heating": df.loc[
+                grid_id, ("frfossilfuel_nonheat", "0")
+            ],
+            "emission_co2_metabolism_max": df.loc[grid_id, ("maxfcmetab", "0")],
+            "emission_heat_metabolism_max": df.loc[grid_id, ("maxqfmetab", "0")],
+            "emission_co2_metabolism_min": df.loc[grid_id, ("minfcmetab", "0")],
+            "emission_heat_metabolism_min": df.loc[grid_id, ("minqfmetab", "0")],
+            "type_traffic_rate": df.loc[grid_id, ("trafficunits", "0")],
         }
 
         # Convert scalar attributes to RefValue
@@ -665,16 +683,18 @@ class CO2Params(BaseModel):  # TODO: May need to add the RefValue to the profile
 
         # Extract DayProfile attributes
         day_profiles = {
-            "fcef_v_kgkm": DayProfile.from_df_state(df, grid_id, "fcef_v_kgkm"),
-            "trafficrate": DayProfile.from_df_state(df, grid_id, "trafficrate"),
+            "emission_factor_co2_vehicle": DayProfile.from_df_state(
+                df, grid_id, "fcef_v_kgkm"
+            ),
+            "traffic_rate": DayProfile.from_df_state(df, grid_id, "trafficrate"),
         }
 
         # Extract HourlyProfile attributes
         hourly_profiles = {
-            "traffprof_24hr": HourlyProfile.from_df_state(
+            "profile_traffic_24hr": HourlyProfile.from_df_state(
                 df, grid_id, "traffprof_24hr"
             ),
-            "humactivity_24hr": HourlyProfile.from_df_state(
+            "profile_human_activity_24hr": HourlyProfile.from_df_state(
                 df, grid_id, "humactivity_24hr"
             ),
         }

--- a/src/supy/data_model/validation/pipeline/yaml_annotator.py
+++ b/src/supy/data_model/validation/pipeline/yaml_annotator.py
@@ -136,16 +136,16 @@ class ValidationIssue:
                 "value": 12.0,
                 "_comment": "deciduous tree height in meters",
             },
-            "co2pointsource": {"value": 0.0, "_comment": "point source CO2 emissions"},
-            "ef_umolco2perj": {
+            "emission_co2_point_source": {"value": 0.0, "_comment": "point source CO2 emissions"},
+            "emission_factor_co2_fuel": {
                 "value": 1.159,
                 "_comment": "CO2 emission factor (μmol/J)",
             },
-            "frfossilfuel_heat": {
+            "fraction_fossil_fuel_heating": {
                 "value": 0.7,
                 "_comment": "fossil fuel fraction for heating",
             },
-            "frfossilfuel_nonheat": {
+            "fraction_fossil_fuel_non_heating": {
                 "value": 0.7,
                 "_comment": "fossil fuel fraction for non-heating",
             },

--- a/src/supy/sample_data/sample_config.yml
+++ b/src/supy/sample_data/sample_config.yml
@@ -1,5 +1,5 @@
 name: sample_config
-schema_version: '2026.6.dev2'
+schema_version: '2026.6.dev3'
 description: Sample configuration built from benchmark 1a (Ward et al. 2016) model configuration
 model:
   control:
@@ -2100,33 +2100,33 @@ sites:
             '23': 0.87
             '24': 0.74
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.285
           holiday: 0.285
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.05
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.0
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.57
             '2': 0.45
@@ -2177,7 +2177,7 @@ sites:
             '22': 0.85
             '23': 0.8
             '24': 0.7
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 0.57
             '2': 0.45

--- a/src/supy/util/converter/yaml_upgrade.py
+++ b/src/supy/util/converter/yaml_upgrade.py
@@ -32,6 +32,7 @@ from ...data_model.core.field_renames import (
     ARCHETYPEPROPERTIES_DEV6_RENAMES,
     ARCHETYPEPROPERTIES_DEV7_RENAMES,
     ARCHETYPEPROPERTIES_DEV12_RENAMES,
+    CO2PARAMS_RENAMES,
     STEBBSPROPERTIES_DEV3_RENAMES,
     STEBBSPROPERTIES_DEV8_RENAMES,
     STEBBSPROPERTIES_DEV12_RENAMES,
@@ -174,6 +175,16 @@ def _rename_field(arch: dict, old_name: str, new_name: str) -> bool:
     arch[new_name] = value
     _log(f"[yaml-upgrade]   renamed {old_name!r} -> {new_name!r}")
     return True
+
+
+def _apply_co2params_renames(cfg: dict) -> None:
+    """Apply the gh#1688 CO2Params naming-convention completion."""
+    for emissions in _walk_site_container(cfg, "anthropogenic_emissions"):
+        co2 = emissions.get("co2")
+        if not isinstance(co2, dict):
+            continue
+        for old_name, new_name in CO2PARAMS_RENAMES.items():
+            _rename_field(co2, old_name, new_name)
 
 
 def _drop_obsolete_field(arch: dict, name: str, reason: str) -> bool:
@@ -1202,6 +1213,8 @@ def _migrate_2026_5_to_current(cfg: dict) -> dict:
     * 2026.5.dev8 -> 2026.5.dev9 (gh#1372): cumulative model.control
       restructure - forcing_file -> forcing.file, then output_file ->
       output (with inner path -> dir, legacy string form dropped).
+    * 2026.6.dev2 -> 2026.6.dev3 (gh#1688): the omitted CO2Params fields
+      renamed to convention-compliant identifiers while preserving values.
 
     Each rename flows through ``_rename_field`` so a dedicated log line
     is emitted per field - ``TestNoSilentFieldDrops`` enforces that. The
@@ -1225,6 +1238,7 @@ def _migrate_2026_5_to_current(cfg: dict) -> dict:
     _apply_stebbs_straggler_renames(cfg)
     _apply_stebbs_physics_fold(cfg)
     _apply_fai_alias_canonicalisation(cfg)
+    _apply_co2params_renames(cfg)
     return cfg
 
 
@@ -1245,6 +1259,18 @@ def _migrate_2026_6_dev1_to_2026_6_dev2(cfg: dict) -> dict:
     selector. Existing 2026.6.dev1 YAML content does not need reshaping.
     """
     return cfg
+
+
+def _migrate_2026_6_dev2_to_2026_6_dev3(cfg: dict) -> dict:
+    """Rename the fourteen CO2Params fields omitted from the #1256 sweep."""
+    _apply_co2params_renames(cfg)
+    return cfg
+
+
+def _migrate_2026_6_dev1_to_current(cfg: dict) -> dict:
+    """Chain the dev2 identity delta and the dev3 CO2Params renames."""
+    cfg = _migrate_2026_6_dev1_to_2026_6_dev2(cfg)
+    return _migrate_2026_6_dev2_to_2026_6_dev3(cfg)
 
 
 def _migrate_2026_4_to_current(cfg: dict) -> dict:
@@ -1311,8 +1337,9 @@ _HANDLERS: dict[tuple[str, str], Handler] = {
     # gh#1456 STEBBS physics fold, and gh#1495 frontal_area_index selector.
     # _migrate_2026_4_to_current chains _migrate_2026_4_to_2026_5 (Category 1)
     # then _migrate_2026_5_to_current (the remaining dev-cycle union).
-    ("2026.6.dev1", CURRENT_SCHEMA_VERSION): _migrate_2026_6_dev1_to_2026_6_dev2,
-    ("2026.5", CURRENT_SCHEMA_VERSION): _migrate_2026_5_to_2026_6_dev1,
+    ("2026.6.dev2", CURRENT_SCHEMA_VERSION): _migrate_2026_6_dev2_to_2026_6_dev3,
+    ("2026.6.dev1", CURRENT_SCHEMA_VERSION): _migrate_2026_6_dev1_to_current,
+    ("2026.5", CURRENT_SCHEMA_VERSION): _migrate_2026_5_to_current,
     ("2026.4", CURRENT_SCHEMA_VERSION): _migrate_2026_4_to_current,
     ("2026.1", CURRENT_SCHEMA_VERSION): _migrate_2026_1_to_current,
     ("2025.12", CURRENT_SCHEMA_VERSION): _migrate_2025_12_to_current,

--- a/test/core/data/issue_1097/yaml_setup.yml
+++ b/test/core/data/issue_1097/yaml_setup.yml
@@ -1180,33 +1180,33 @@ sites:
             '23': 1.5
             '24': 1.0
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.2069
           holiday: 0.2069
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.7
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.7
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.19
             '2': 0.14
@@ -1257,7 +1257,7 @@ sites:
             '22': 0.75
             '23': 0.58
             '24': 0.5
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 1.0
             '2': 1.0

--- a/test/data_model/test_df_column_renames.py
+++ b/test/data_model/test_df_column_renames.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.api
 from supy.data_model.core.df_column_renames import (
     ALL_DF_COLUMN_RENAMES,
     ARCHETYPEPROPERTIES_DF_RENAMES,
+    CO2PARAMS_DF_RENAMES,
     DECTRPROPERTIES_DF_RENAMES,
     EVETRPROPERTIES_DF_RENAMES,
     LAIPARAMS_DF_RENAMES,
@@ -71,6 +72,7 @@ class TestRegistryIntegrity:
             + len(ARCHETYPEPROPERTIES_DF_RENAMES)
             + len(STEBBSPROPERTIES_DF_RENAMES)
             + len(SNOWPARAMS_DF_RENAMES)
+            + len(CO2PARAMS_DF_RENAMES)
         )
         assert len(ALL_DF_COLUMN_RENAMES) == expected
 

--- a/test/data_model/test_field_renames.py
+++ b/test/data_model/test_field_renames.py
@@ -26,6 +26,7 @@ from supy.data_model.core.field_renames import (
     ARCHETYPEPROPERTIES_DEV6_RENAMES,
     ARCHETYPEPROPERTIES_DEV7_RENAMES,
     ARCHETYPEPROPERTIES_DEV12_RENAMES,
+    CO2PARAMS_RENAMES,
     ARCHETYPEPROPERTIES_RENAMES,
     ATMOSPHERE_RENAMES,
     DECTRPROPERTIES_RENAMES,
@@ -52,6 +53,7 @@ from supy.data_model.core.field_renames import (
     rename_keys_recursive,
 )
 from supy.data_model.core.model import ModelPhysics, StebbsPhysics
+from supy.data_model.core.human_activity import CO2Params
 from supy.data_model.core.site import (
     ArchetypeProperties,
     DectrProperties,
@@ -71,6 +73,7 @@ _RENAMED_CLASSES = [
     (EvetrProperties, EVETRPROPERTIES_RENAMES),
     (DectrProperties, DECTRPROPERTIES_RENAMES),
     (SnowParams, SNOWPARAMS_RENAMES),
+    (CO2Params, CO2PARAMS_RENAMES),
     (ArchetypeProperties, ARCHETYPEPROPERTIES_RENAMES),
     (StebbsProperties, STEBBSPROPERTIES_RENAMES),
     # VEGETATEDSURFACEPROPERTIES_RENAMES is covered by subclasses EvetrProperties
@@ -98,6 +101,7 @@ class TestRegistryIntegrity:
             + len(ARCHETYPEPROPERTIES_RENAMES)
             + len(STEBBSPROPERTIES_RENAMES)
             + len(SNOWPARAMS_RENAMES)
+            + len(CO2PARAMS_RENAMES)
         )
         assert len(ALL_FIELD_RENAMES) == expected
 
@@ -220,6 +224,32 @@ class TestNewNamesAccepted:
 
 
 class TestBackwardCompat:
+    def test_old_co2_names_populate_new_attributes(self):
+        with pytest.warns(DeprecationWarning):
+            co2 = CO2Params(
+                co2pointsource=4.0,
+                maxqfmetab=175.0,
+                trafficunits=1.0,
+            )
+
+        assert _unwrap(co2.emission_co2_point_source) == 4.0
+        assert _unwrap(co2.emission_heat_metabolism_max) == 175.0
+        assert _unwrap(co2.type_traffic_rate) == 1.0
+
+    def test_co2_metadata_matches_fortran_units(self):
+        expected_units = {
+            "emission_co2_point_source": "kg C day^-1",
+            "emission_co2_metabolism_min": "umol cap^-1 s^-1",
+            "emission_co2_metabolism_max": "umol cap^-1 s^-1",
+            "emission_heat_metabolism_min": "W cap^-1",
+            "emission_heat_metabolism_max": "W cap^-1",
+            "type_traffic_rate": "dimensionless",
+        }
+
+        for field_name, expected_unit in expected_units.items():
+            metadata = CO2Params.model_fields[field_name].json_schema_extra
+            assert metadata["unit"] == expected_unit
+
     def test_old_name_constructor_populates_new_attribute(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
@@ -1151,6 +1181,15 @@ class TestDataFrameColumnsPreserveLegacyNames:
         flat_cols = {col[0] for col in df.columns}
         for old_name in MODELPHYSICS_RENAMES:
             assert old_name in flat_cols, f"Missing legacy column {old_name!r}"
+
+    def test_co2_params_columns(self):
+        df = CO2Params().to_df_state(grid_id=1)
+        flat_cols = {col[0] for col in df.columns}
+        for old_name, new_name in CO2PARAMS_RENAMES.items():
+            assert old_name in flat_cols, f"Missing legacy column {old_name!r}"
+            assert new_name not in flat_cols, (
+                f"Unexpected new-name column {new_name!r} in bridge output"
+            )
 
     def test_lai_params_columns(self):
         df = LAIParams(base_temperature=5.0).to_df_state(grid_id=1, surf_idx=2)

--- a/test/data_model/test_to_yaml_roundtrip.py
+++ b/test/data_model/test_to_yaml_roundtrip.py
@@ -163,10 +163,10 @@ class TestToYamlRoundTrip:
         # ARRANGE
         co2 = sample_config.sites[0].properties.anthropogenic_emissions.co2
         fields = [
-            "co2pointsource",
-            "ef_umolco2perj",
-            "enef_v_jkm",
-            "trafficunits",
+            "emission_co2_point_source",
+            "emission_factor_co2_fuel",
+            "emission_factor_energy_vehicle",
+            "type_traffic_rate",
         ]
         for field in fields:
             setattr(co2, field, RefValue(None))

--- a/test/data_model/test_yaml_upgrade.py
+++ b/test/data_model/test_yaml_upgrade.py
@@ -20,6 +20,7 @@ import yaml
 
 from supy.cmd.table_converter import convert_table_cmd
 from supy.data_model.core.config import SUEWSConfig
+from supy.data_model.core.field_renames import CO2PARAMS_RENAMES
 from supy.data_model.configuration import CURRENT_SCHEMA_VERSION
 from supy.util.converter.yaml_upgrade import (
     YamlUpgradeError,
@@ -89,6 +90,49 @@ class TestYamlUpgradeModule:
         # ASSERT
         reloaded = SUEWSConfig.from_yaml(str(out))
         assert reloaded.name is not None
+
+    def test_dev2_co2params_renames_preserve_all_values(self, tmp_path: Path, capsys):
+        """The dev2 -> dev3 handler must migrate every gh#1688 field."""
+        legacy_co2 = {
+            "co2pointsource": {"value": 4.0},
+            "ef_umolco2perj": {"value": 1.159},
+            "enef_v_jkm": {"value": 4.1e6},
+            "fcef_v_kgkm": {"working_day": 0.285, "holiday": 0.275},
+            "frfossilfuel_heat": {"value": 0.7},
+            "frfossilfuel_nonheat": {"value": 0.3},
+            "maxfcmetab": {"value": 280.0},
+            "maxqfmetab": {"value": 175.0},
+            "minfcmetab": {"value": 120.0},
+            "minqfmetab": {"value": 75.0},
+            "trafficrate": {"working_day": 0.02, "holiday": 0.01},
+            "trafficunits": {"value": 1.0},
+            "traffprof_24hr": {"working_day": {"1": 0.5}},
+            "humactivity_24hr": {"holiday": {"24": 1.0}},
+            "ref": {"desc": "unchanged"},
+        }
+        payload = {
+            "schema_version": "2026.6.dev2",
+            "sites": [{"properties": {"anthropogenic_emissions": {"co2": legacy_co2}}}],
+        }
+        source = tmp_path / "dev2.yml"
+        output = tmp_path / "dev3.yml"
+        source.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+        upgrade_yaml(input_path=source, output_path=output)
+
+        migrated = yaml.safe_load(output.read_text(encoding="utf-8"))
+        migrated_co2 = migrated["sites"][0]["properties"]["anthropogenic_emissions"][
+            "co2"
+        ]
+        for old_name, new_name in CO2PARAMS_RENAMES.items():
+            assert old_name not in migrated_co2
+            assert migrated_co2[new_name] == legacy_co2[old_name]
+        assert migrated_co2["ref"] == legacy_co2["ref"]
+        assert migrated["schema_version"] == CURRENT_SCHEMA_VERSION
+
+        log = capsys.readouterr().err
+        for old_name, new_name in CO2PARAMS_RENAMES.items():
+            assert f"renamed {old_name!r} -> {new_name!r}" in log
 
     def test_explicit_override_respected(
         self, signed_yaml: Path, tmp_path: Path, capsys

--- a/test/fixtures/benchmark1/benchmark1.yml
+++ b/test/fixtures/benchmark1/benchmark1.yml
@@ -1490,33 +1490,33 @@ sites:
             '23': 0.87
             '24': 0.74
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.285
           holiday: 0.285
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.05
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.0
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.57
             '2': 0.45
@@ -1567,7 +1567,7 @@ sites:
             '22': 0.85
             '23': 0.8
             '24': 0.7
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 0.57
             '2': 0.45

--- a/test/fixtures/benchmark1/benchmark1_short.yml
+++ b/test/fixtures/benchmark1/benchmark1_short.yml
@@ -1490,33 +1490,33 @@ sites:
             '23': 0.87
             '24': 0.74
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.285
           holiday: 0.285
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.05
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.0
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.57
             '2': 0.45
@@ -1567,7 +1567,7 @@ sites:
             '22': 0.85
             '23': 0.8
             '24': 0.7
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 0.57
             '2': 0.45

--- a/test/fixtures/benchmark1/benchmark1b.yml
+++ b/test/fixtures/benchmark1/benchmark1b.yml
@@ -1487,33 +1487,33 @@ sites:
             '23': 0.87
             '24': 0.74
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.285
           holiday: 0.285
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.05
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.0
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.57
             '2': 0.45
@@ -1564,7 +1564,7 @@ sites:
             '22': 0.85
             '23': 0.8
             '24': 0.7
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 0.57
             '2': 0.45

--- a/test/fixtures/data_test/stebbs_test/sample_config.yml
+++ b/test/fixtures/data_test/stebbs_test/sample_config.yml
@@ -2083,33 +2083,33 @@ sites:
             '23': 0.87
             '24': 0.74
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.285
           holiday: 0.285
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.05
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.0
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.57
             '2': 0.45
@@ -2160,7 +2160,7 @@ sites:
             '22': 0.85
             '23': 0.8
             '24': 0.7
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 0.57
             '2': 0.45

--- a/test/fixtures/precheck_testcase/precheck_testcase1.yml
+++ b/test/fixtures/precheck_testcase/precheck_testcase1.yml
@@ -622,33 +622,33 @@ sites:
             '23': 0.8
             '24': 0.7
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.285
           holiday: 0.285
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.05
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.0
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.57
             '2': 0.45
@@ -699,7 +699,7 @@ sites:
             '22': 0.85
             '23': 0.8
             '24': 0.7
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 0.57
             '2': 0.45

--- a/test/fixtures/precheck_testcase/precheck_testcase2.yml
+++ b/test/fixtures/precheck_testcase/precheck_testcase2.yml
@@ -1202,33 +1202,33 @@ sites:
             '23': 0.8
             '24': 0.7
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.285
           holiday: 0.285
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.05
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.0
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.57
             '2': 0.45
@@ -1279,7 +1279,7 @@ sites:
             '22': 0.85
             '23': 0.8
             '24': 0.7
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 0.57
             '2': 0.45

--- a/test/fixtures/precheck_testcase/precheck_testcase3.yml
+++ b/test/fixtures/precheck_testcase/precheck_testcase3.yml
@@ -622,33 +622,33 @@ sites:
             '23': 0.8
             '24': 0.7
       co2:
-        co2pointsource:
+        emission_co2_point_source:
           value: 0.0
-        ef_umolco2perj:
+        emission_factor_co2_fuel:
           value: 1.159
-        enef_v_jkm:
+        emission_factor_energy_vehicle:
           value: 3970000.0
-        fcef_v_kgkm:
+        emission_factor_co2_vehicle:
           working_day: 0.285
           holiday: 0.285
-        frfossilfuel_heat:
+        fraction_fossil_fuel_heating:
           value: 0.05
-        frfossilfuel_nonheat:
+        fraction_fossil_fuel_non_heating:
           value: 0.0
-        maxfcmetab:
+        emission_co2_metabolism_max:
           value: 280.0
-        maxqfmetab:
+        emission_heat_metabolism_max:
           value: 175.0
-        minfcmetab:
+        emission_co2_metabolism_min:
           value: 120.0
-        minqfmetab:
+        emission_heat_metabolism_min:
           value: 75.0
-        trafficrate:
+        traffic_rate:
           working_day: 0.01
           holiday: 0.01
-        trafficunits:
+        type_traffic_rate:
           value: 1.0
-        traffprof_24hr:
+        profile_traffic_24hr:
           working_day:
             '1': 0.57
             '2': 0.45
@@ -699,7 +699,7 @@ sites:
             '22': 0.85
             '23': 0.8
             '24': 0.7
-        humactivity_24hr:
+        profile_human_activity_24hr:
           working_day:
             '1': 0.57
             '2': 0.45


### PR DESCRIPTION
## Summary

- rename the fourteen remaining `CO2Params` YAML fields to convention-compliant names and bump the development schema to `2026.6.dev3`
- preserve legacy YAML loading/migration, legacy `df_state` column names, numeric traffic-rate type values, and the formal `2026.6.5` release fixture
- align CO2 point-source, vehicle, metabolism, and traffic metadata units with the existing Fortran physics contract
- extend the Python and Rust rename registries, current fixtures, generated schema, transition guide, and naming convention documentation

## Scope

This change does not alter Fortran physics, defaults, `AnthropogenicHeat`, or `IrrigationParams`. The Rust change is limited to the field-name compatibility registry.

## Validation

- `make test` (1961 passed, 8 skipped before the latest-master rebase)
- exact-SHA `make test-smoke` (9 passed, 1 skipped)
- exact-SHA CO2/schema/round-trip suite (203 passed)
- schema-version and Python/Rust alias audits
- Rust clippy with all features and targeted CO2 rename test
- `make docs`

Fixes #1688