### PR TITLE
Separate test importance from execution cost

### DIFF
--- a/.claude/rules/ci/conventions.md
+++ b/.claude/rules/ci/conventions.md
@@ -228,14 +228,18 @@ Mitigate by:
 
 Test tiers control which pytest markers run during CI builds. Defined via pytest markers in `pyproject.toml`; consumed by `.github/actions/build-suews/action.yml` (`CIBW_TEST_COMMAND`).
 
-- **smoke** (`-m smoke`) -- minimal wheel validation (~6 tests, ~60s)
-- **core** (`-m "smoke or core"`) -- core physics and logic, includes smoke (~2-3 min)
-- **cfg** (`-m "smoke or cfg"`) -- config/schema validation, includes smoke (~2-3 min)
-- **standard** (`-m "not slow"`) -- all tests except slow-marked ones (~5-10 min)
+- **smoke** (`-m "smoke and not (medium or slow)"`) -- minimal wheel validation (~6 tests, ~60s)
+- **core** (`-m "(smoke or core) and not slow"`) -- core physics and logic, includes smoke (~2-3 min)
+- **cfg** (`-m "(smoke or cfg) and not slow"`) -- config/schema validation, includes smoke (~2-3 min)
+- **standard** (`-m "core or not slow"`) -- all non-slow tests plus essential core regressions (~5-10 min)
 - **physics-full** (physics axis `-m physics`, incl. `slow`; api axis identical to `standard`) -- the physics-change tier (gh#1576). Widens only the physics axis to include `slow` so an output shift surfaces in the PR/merge queue rather than in the nightly; the api axis stays as `standard`.
 - **all** (no filter) -- full suite including slow tests (~15-30 min)
 
-Each higher tier is a superset of smoke. The `standard` tier excludes only `slow`-marked tests (>30s each).
+Importance and cost are independent: `medium` means roughly 30-60 seconds on
+the slowest normal CI platform, while `slow` means over 60 seconds or otherwise
+unsuitable for routine PR runs. Absence of either cost marker means fast. Each
+higher tier is a superset of smoke. The `standard` tier excludes non-core
+`slow` tests but retains tests marked both `core` and `slow`.
 
 ---
 
@@ -332,13 +336,13 @@ The merge queue deliberately uses a reduced matrix rather than the full matrix. 
 
 - 3 platforms: Linux x86_64, macOS ARM64, Windows AMD64
 - 1 Python version: 3.12 (the abi3 floor and oldest supported)
-- standard test tier: all tests except `slow`-marked
+- standard test tier: all non-slow tests plus essential `core` regressions
 
 **What merge queue omits:**
 
 - macOS Intel x86_64 (legacy platform, declining user base)
 - Python 3.13 and 3.14 (covered by ready-PR bookends and nightly/release CI)
-- `slow`-marked tests (>30s each) -- **except** for PRs labelled `0-physics:change`, which run the **physics-full** tier so the `slow` physics regression gates the merge (gh#1576)
+- non-core `slow` tests -- **except** for PRs labelled `0-physics:change`, which run the **physics-full** tier so every `slow` physics regression gates the merge (gh#1576)
 
 **Rationale:** Full matrix (4 platforms x 3 Python = 12 jobs), or even
 repeating both bookends on all three queue platforms, duplicates work already

--- a/.claude/rules/physics-change-evidence.md
+++ b/.claude/rules/physics-change-evidence.md
@@ -20,9 +20,9 @@ building-energy outputs (indoor temperature +~0.5 K, cooling-load peak 28 W vs
 19 W), but two things went wrong:
 
 - The stale STEBBS regression fixture only failed in the **nightly full-physics
-  build**, not in the PR or merge-queue checks. The merge queue runs a reduced
-  matrix (`test_tier=standard`) whose pytest expression excludes `slow`, so a
-  known-output-changing PR merged without the change being caught.
+  build**, not in the PR or merge-queue checks. At the time, the merge queue's
+  reduced `standard` matrix excluded every `slow` test, so a known-output-
+  changing PR merged without the change being caught.
 - There was **no recorded scientific justification** for the new numbers. The
   physical reasoning (longwave cascade -> indoor temperature -> threshold-driven
   cooling) had to be reconstructed after the fact in #1575 to update the
@@ -171,10 +171,11 @@ When reviewing a PR whose diff matches the physics-change triggers:
 
 ## CI gate (the second PR of gh#1576)
 
-`.github/scripts/determine-matrix.sh` currently selects `test_tier=standard` for
-both `pull_request` (ready) and `merge_group`, and `standard` excludes `slow`.
-Only `schedule` (nightly) and tag/full-dispatch use `test_tier=all`, which is why
-the stale STEBBS fixture only failed overnight.
+`.github/scripts/determine-matrix.sh` selects `test_tier=standard` for both
+`pull_request` (ready) and `merge_group`. Standard now retains `core` + `slow`
+regressions while excluding non-core `slow` tests. Only `schedule` (nightly)
+and tag/full-dispatch use `test_tier=all`, which is why the physics-full label
+override remains necessary for all physics regressions.
 
 The CI wiring bumps the tier to include the `slow` physics tests when a PR
 carries `0-physics:change`, making the full physics regression a required check

--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -103,30 +103,37 @@ that introduces a test file without a nature marker.** If you see the
 lint fire, add a `pytestmark = pytest.mark.api` (or physics) line — do
 not bypass.
 
-### Tier axis — per-test decorators
+### Importance and cost — independent per-test decorators
 
 ```python
 @pytest.mark.smoke   # Critical, fast tests (~60s total)
-@pytest.mark.core    # Core physics/logic tests
-@pytest.mark.slow    # Tests taking >30s individually
+@pytest.mark.core    # Essential physics/logic contract
+@pytest.mark.medium  # Roughly 30-60s on the slowest normal CI platform
+@pytest.mark.slow    # Over 60s, or unsuitable for routine PR runs
 @pytest.mark.util    # Utility function tests (non-critical)
 @pytest.mark.cfg     # Config/schema validation tests
 ```
 
-The tier axis composes with the nature axis. CI expressions like
-`-m "api and smoke"` and `-m "physics and not slow"` select the right
+Importance and cost compose independently with the nature axis. Absence of a
+cost marker means fast. CI expressions such as `-m "api and smoke and not
+(medium or slow)"` and `-m "physics and (core or not slow)"` select the right
 subset per matrix cell.
 
 ### PR/CR placement
 
 - `smoke`: minimal fail-fast checks only. Keep this tier small enough for quick
-  wheel validation.
-- `core`: essential guardrails that are fast enough for draft PRs and merge
-  queue. Do not mark a test `core` merely because the feature matters; use
-  `slow` if the regression is important but expensive.
-- `standard`: all non-slow tests for the relevant nature axis.
-- `slow`: long regressions and reproductions. These belong in `make test-all`,
-  scheduled/release builds, or explicit manual validation, not normal PR/CR.
+  wheel validation; smoke selection excludes both `medium` and `slow`.
+- `core`: essential guardrails, independently of cost. Draft `core` selection
+  still excludes `slow`; ready PRs and merge queue use `(core or not slow)`, so
+  an essential expensive regression is honestly marked `core` + `slow`.
+- `standard`: all non-slow tests plus essential `core` tests for the relevant
+  nature axis.
+- `medium`: roughly 30-60 seconds on the slowest normal CI platform. These stay
+  eligible for `standard` and for any importance tier they also carry.
+- `slow`: over 60 seconds individually, or otherwise unsuitable for routine PR
+  runs. A slow test runs before merge only when it also carries `core`; other
+  slow tests belong in `make test-all`, scheduled/release builds, or explicit
+  manual validation.
 - `qgis`: UMEP/QGIS tests only. These target Windows + Python 3.12, which
   matches the current Windows runtime line for both QGIS 3 LTR and QGIS 4.
   They should stay out of local `make test` and normal PR/CR tiers unless

--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -244,10 +244,10 @@ runs:
         CIBW_TEST_COMMAND: >-
           python {project}/scripts/suews/run_ci_tests.py {project}
           -v --tb=short --durations=10 -n auto --maxprocesses=4 --dist worksteal
-          ${{ inputs.test_tier == 'smoke' && '-m "physics and smoke and not slow"' ||
+          ${{ inputs.test_tier == 'smoke' && '-m "physics and smoke and not (medium or slow)"' ||
               inputs.test_tier == 'core' && '-m "physics and (smoke or core) and not slow"' ||
               inputs.test_tier == 'cfg' && '-m "physics and (smoke or cfg) and not slow"' ||
-              inputs.test_tier == 'standard' && '-m "physics and not slow"' ||
+              inputs.test_tier == 'standard' && '-m "physics and (core or not slow)"' ||
               inputs.test_tier == 'physics-full' && '-m physics' ||
               inputs.test_tier == 'all' && '-m physics' ||
               '-m physics' }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,9 +71,10 @@ Python line. Both use Python 3.12 on Windows; the runtime pin is
 - Wheel-build jobs run `physics` tests once per selected platform/architecture.
 - API cross-CPython jobs install the built wheel and run `api` tests across the
   selected Python versions.
-- `smoke`, `core`, `cfg`, and `standard` all exclude `slow` and `qgis`; `all`
-  is reserved for scheduled builds, tagged releases, and explicit manual
-  validation.
+- `smoke` excludes both `medium` and `slow`; `core` and `cfg` exclude `slow`.
+  `standard` includes non-slow tests plus essential `core` regressions even
+  when they are slow. All normal tiers exclude `qgis`; `all` is reserved for
+  scheduled builds, tagged releases, and explicit manual validation.
 - UMEP/QGIS tests are `api + qgis`: they are not physics backend tests, and
   run only when `all` reaches the Windows + Python 3.12 compatibility cell or
   when selected explicitly.

--- a/.github/workflows/benchmark-pytest-scheduler.yml
+++ b/.github/workflows/benchmark-pytest-scheduler.yml
@@ -118,7 +118,7 @@ jobs:
           SUEWS_CI_METRICS: scheduler-abba/loadscope-a.json
         run: >-
           python -m pytest -p scripts.suews.pytest_ci_metrics test
-          -m "physics and not slow" -v --tb=short --durations=10
+          -m "physics and (core or not slow)" -v --tb=short --durations=10
           -n auto --maxprocesses=4 --dist loadscope
           -p no:cacheprovider --basetemp="$RUNNER_TEMP/pytest-loadscope-a"
 
@@ -129,7 +129,7 @@ jobs:
           SUEWS_CI_METRICS: scheduler-abba/worksteal-a.json
         run: >-
           python -m pytest -p scripts.suews.pytest_ci_metrics test
-          -m "physics and not slow" -v --tb=short --durations=10
+          -m "physics and (core or not slow)" -v --tb=short --durations=10
           -n auto --maxprocesses=4 --dist worksteal
           -p no:cacheprovider --basetemp="$RUNNER_TEMP/pytest-worksteal-a"
 
@@ -140,7 +140,7 @@ jobs:
           SUEWS_CI_METRICS: scheduler-abba/worksteal-b.json
         run: >-
           python -m pytest -p scripts.suews.pytest_ci_metrics test
-          -m "physics and not slow" -v --tb=short --durations=10
+          -m "physics and (core or not slow)" -v --tb=short --durations=10
           -n auto --maxprocesses=4 --dist worksteal
           -p no:cacheprovider --basetemp="$RUNNER_TEMP/pytest-worksteal-b"
 
@@ -151,7 +151,7 @@ jobs:
           SUEWS_CI_METRICS: scheduler-abba/loadscope-b.json
         run: >-
           python -m pytest -p scripts.suews.pytest_ci_metrics test
-          -m "physics and not slow" -v --tb=short --durations=10
+          -m "physics and (core or not slow)" -v --tb=short --durations=10
           -n auto --maxprocesses=4 --dist loadscope
           -p no:cacheprovider --basetemp="$RUNNER_TEMP/pytest-loadscope-b"
 

--- a/.github/workflows/ci-metrics-overhead.yml
+++ b/.github/workflows/ci-metrics-overhead.yml
@@ -90,7 +90,7 @@ jobs:
           --source-sha "${{ github.sha }}"
           --wheel "$CONTROLLED_WHEEL"
           -- python -m pytest test
-          -m "physics and not slow"
+          -m "physics and (core or not slow)"
           -q --tb=short
           -n 4 --maxprocesses=4 --dist worksteal
 

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -79,13 +79,13 @@ jobs:
           TIER: ${{ inputs.test_tier }}
         run: |
           case "$TIER" in
-            smoke)    EXPR='api and smoke and not slow and not qgis' ;;
+            smoke)    EXPR='api and smoke and not (medium or slow) and not qgis' ;;
             core)     EXPR='api and (smoke or core) and not slow and not qgis' ;;
             cfg)      EXPR='api and (smoke or cfg) and not slow and not qgis' ;;
-            standard) EXPR='api and not slow and not qgis' ;;
+            standard) EXPR='api and (core or not slow) and not qgis' ;;
             # physics-full (gh#1576): expand only the physics axis to include
             # slow; the api axis stays identical to standard.
-            physics-full) EXPR='api and not slow and not qgis' ;;
+            physics-full) EXPR='api and (core or not slow) and not qgis' ;;
             all)      EXPR='api' ;;
             *)        echo "::error::Unknown test_tier: $TIER"; exit 1 ;;
           esac

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ test-smoke:
 	@echo "Running smoke tests (critical path only)..."
 	@echo "This is the fastest test tier for CI wheel validation."
 	@echo ""
-	$(PYTHON) -m pytest test -m "smoke and not slow and not qgis" -v --tb=short --durations=10
+	$(PYTHON) -m pytest test -m "smoke and not (medium or slow) and not qgis" -v --tb=short --durations=10
 
 # All tests including slow tests
 test-all:

--- a/dev-ref/MERGE_QUEUE.md
+++ b/dev-ref/MERGE_QUEUE.md
@@ -209,7 +209,7 @@ Documentation-only PRs skip builds even in merge queue:
 
 UMEP/QGIS tests (the `qgis` tier) do **not** run in the merge queue. The
 merge queue's `standard` test tier explicitly excludes them
-(`api and not slow and not qgis`); `qgis`-tier tests run only under the
+(`api and (core or not slow) and not qgis`); `qgis`-tier tests run only under the
 `all` tier -- nightly schedule, tag push, or manual dispatch (`full`):
 - Windows Python 3.12 only (current QGIS 3 LTR / QGIS 4 runtime)
 - Validates NumPy 1.x compatibility

--- a/dev-ref/testing/TESTING_GUIDELINES.md
+++ b/dev-ref/testing/TESTING_GUIDELINES.md
@@ -143,9 +143,10 @@ test/physics/
 
 ## 5. pytest Markers and Configuration
 
-### Two-Axis Marker System (gh#1300)
+### Composed Marker Properties (gh#1300, gh#1680)
 
-Markers sit on two orthogonal axes, declared in `pyproject.toml` (see
+Markers compose across orthogonal nature, importance, and cost properties,
+declared in `pyproject.toml` (see
 `.claude/rules/tests/patterns.md` for the full authoring guide):
 
 - **Nature axis** -- what the test actually exercises. Every test file must
@@ -156,8 +157,8 @@ Markers sit on two orthogonal axes, declared in `pyproject.toml` (see
   - `api` -- Python wrapper correctness (pandas/numpy/pydantic, CLI,
     `SUEWSSimulation`); run across `(platform x Python)` because the
     dependency surface varies per interpreter.
-- **Tier axis** -- how fast/expensive the test is, applied as a per-test
-  decorator on top of the nature marker:
+- **Importance and cost** -- independent properties applied as per-test
+  decorators on top of the nature marker; absence of a cost marker means fast:
   - `smoke` -- minimal wheel validation (~6 tests, ~60s)
   - `smoke_bridge` -- bridge-loading subset run across `cp312..cp3xx` after a
     single abi3 build
@@ -166,7 +167,8 @@ Markers sit on two orthogonal axes, declared in `pyproject.toml` (see
   - `util` -- utility function tests (non-critical)
   - `rust` -- Rust bridge backend tests (requires `suews_bridge` built with
     the `physics` feature)
-  - `slow` -- tests taking >30s individually
+  - `medium` -- tests taking roughly 30-60s on the slowest normal CI platform
+  - `slow` -- tests taking over 60s individually, or unsuitable for routine PR runs
   - `qgis` -- UMEP plugin integration tests in `test/umep/`, targeting
     Windows + Python 3.12 (current QGIS 3 LTR / QGIS 4 runtime); auto-applied
     by `test/umep/conftest.py`, stays out of normal PR/merge-queue tiers
@@ -178,20 +180,22 @@ markers = [
     # Nature axis
     "physics: Numerical/binary correctness; sufficient to run once per (OS, arch) on the canonical Python",
     "api: Python wrapper correctness; run across (platform x Python) because pandas/numpy/pydantic surface varies",
-    # Tier axis
+    # Importance markers
     "smoke: Minimal wheel validation (~6 tests, ~60s)",
     "smoke_bridge: Bridge-loading subset run across cp312..cp3xx after a single abi3 build",
     "core: Core physics & logic tests (Fortran, driver)",
     "rust: Rust bridge backend tests (requires suews_bridge with physics feature)",
     "util: Utility function tests (non-critical)",
     "cfg: Config/schema validation tests",
-    "slow: Tests taking >30s individually",
+    # Cost markers
+    "medium: Tests taking roughly 30-60s individually on the slowest normal CI platform",
+    "slow: Tests taking over 60s individually, or unsuitable for routine PR runs",
     "qgis: UMEP plugin integration tests in test/umep/ (Windows + Python 3.12 target)",
 ]
 ```
 
-A CI expression composes the two axes, e.g. `-m "api and smoke"` or
-`-m "physics and not slow"`. A static lint
+A CI expression composes nature, importance, and cost, e.g. `-m "api and smoke
+and not (medium or slow)"` or `-m "physics and (core or not slow)"`. A static lint
 (`scripts/lint/check_test_markers.py`) plus a `pytest_collection_finish` hook
 in `test/conftest.py` fail any PR that adds a test file without a nature
 marker.
@@ -251,7 +255,7 @@ def test_urban_canyon_radiation(self):
 
 ### Tier Structure
 
-CI tiers are driven by the two-axis marker system in Section 5, not a
+CI tiers are driven by the composed marker properties in Section 5, not a
 separate taxonomy. The `determine_matrix` job in
 `.github/workflows/build-publish_to_pypi.yml` assigns a tier per event; see
 `.claude/rules/ci/conventions.md` ("Test Tier Definitions" and "Test Tier
@@ -259,7 +263,8 @@ Assignment by Event") for the authoritative mapping:
 
 - **Draft PR**: `smoke`, `core`, or `cfg` depending on what changed -- fastest
   feedback (~60s-3 min)
-- **Ready PR / merge queue**: `standard` (all non-`slow` tests, ~5-10 min), or
+- **Ready PR / merge queue**: `standard` (all non-`slow` tests plus `core`
+  regressions regardless of cost, ~5-10 min), or
   `physics-full` when the PR carries `0-physics:change` (gh#1576)
 - **Nightly / tag push / manual dispatch (`full`)**: `all` -- the complete
   suite including `slow` and `qgis` (~15-30 min)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,23 +151,25 @@ filterwarnings = [
     "ignore::UserWarning:pydantic.main",
 ]
 # Test markers.
-# Two orthogonal axes (gh#1300):
-#   nature:  physics | api   -- what the test actually exercises
-#   tier:    smoke | core | cfg | slow | util -- how fast/expensive it is
-# Every test file must carry at least one of {physics, api}; tier markers
-# compose with the nature axis.
+# Three orthogonal properties (gh#1300, gh#1680):
+#   nature:     physics | api       -- what the test actually exercises
+#   importance: smoke | core | cfg  -- where the contract must run
+#   cost:       medium | slow       -- absence means fast
+# Every test file must carry at least one of {physics, api}; importance and
+# cost markers compose independently with the nature axis.
 markers = [
-    # Nature axis (gh#1300) -- orthogonal to tier.
+    # Nature axis (gh#1300) -- orthogonal to importance and cost.
     "physics: Numerical/binary correctness; sufficient to run once per (OS, arch) on the canonical Python",
     "api: Python wrapper correctness; run across (platform x Python) because pandas/numpy/pydantic surface varies",
-    # Tier axis
+    # Importance markers
     "smoke: Minimal wheel validation (~6 tests, ~60s)",
     "smoke_bridge: Bridge-loading subset run across cp312..cp3xx after a single abi3 build",
     "core: Core physics & logic tests (Fortran, driver)",
     "rust: Rust bridge backend tests (requires suews_bridge with physics feature)",
     "util: Utility function tests (non-critical)",
     "cfg: Config/schema validation tests",
-    "slow: Tests taking >30s individually",
+    "medium: Tests taking roughly 30-60s individually on the slowest normal CI platform",
+    "slow: Tests taking over 60s individually, or unsuitable for routine PR runs",
     "qgis: UMEP plugin integration tests in test/umep/ (Windows + Python 3.12 target)",
 ]
 

--- a/scripts/suews/README.md
+++ b/scripts/suews/README.md
@@ -104,7 +104,7 @@ worker cap and alternating order.
 
 The manual `CI metrics overhead check` workflow runs only from the default
 branch. It verifies and installs one Linux wheel once, records the source SHA
-and wheel SHA-256, and runs the standard non-slow physics selection in
+and wheel SHA-256, and runs the standard physics selection in
 the fixed order metrics-off/on/on/off. Every run uses four workers,
 `--maxprocesses=4`, work stealing, a unique base temporary directory and no
 pytest cache. It uploads four raw JSON files, captured logs and a comparison
@@ -121,7 +121,7 @@ host load is uncontrolled.
 The manual workflow compares `loadscope` and `worksteal` without changing the
 fixed GitHub-hosted worker budget. It downloads one successful
 `cp312-manylinux-x86_64` wheel, checks out the exact SHA that produced it, and
-runs the same `physics and not slow` nodes four times in A/B/B/A order:
+runs the same `physics and (core or not slow)` nodes four times in A/B/B/A order:
 
 1. `loadscope`
 2. `worksteal`

--- a/test/README.md
+++ b/test/README.md
@@ -130,19 +130,22 @@ are gated to Windows + Python 3.12 by the existing `qgis` marker. This matches
 the current Windows runtime for both QGIS 3 LTR and QGIS 4; the Qt/PyQt
 difference is outside this repository's direct test surface.
 
-### Tier axis — how fast or expensive is the test?
+### Importance and cost — independent properties
 
 - `smoke` — minimal wheel validation (~6 tests, ~60s).
 - `smoke_bridge` — legacy marker for the bridge-loading subset; still
   registered, but CI no longer selects on it directly. Post-gh#1300,
   cross-CPython coverage is driven by `-m "api and <tier>"` in the
   `test_api_cross_python` job.
-- `core` — core physics and logic tests (Fortran, driver).
+- `core` — essential physics and logic contracts (Fortran, driver), independent
+  of cost.
 - `rust` — Rust bridge backend tests (requires `suews_bridge` with the
   `physics` feature).
 - `util` — utility function tests (non-critical).
 - `cfg` — config / schema validation tests.
-- `slow` — tests taking more than 30s individually.
+- `medium` — tests taking roughly 30-60s on the slowest normal CI platform.
+- `slow` — tests taking over 60s individually, or unsuitable for routine PR
+  runs. `core` + `slow` means expensive but essential before merge.
 - `qgis` — UMEP plugin tests in `test/umep/` (Windows + Python 3.12 target).
 
 ### Selecting a subset
@@ -150,22 +153,25 @@ difference is outside this repository's direct test surface.
 ```bash
 pytest -m physics                  # numerical / binary correctness only
 pytest -m api                      # wrapper surface only
-pytest -m "physics and smoke"      # physics tests in the smoke tier
-pytest -m "api and not slow"       # wrapper surface, skip slow tests
+pytest -m "physics and smoke and not (medium or slow)"  # smoke physics
+pytest -m "api and (core or not slow)"  # standard wrapper selection
 pytest -m "physics and api"        # files that straddle both axes
 ```
 
 ### PR/CR placement rules
 
 - Put numerical guardrails in `test/physics/` or a clearly named physics file
-  under `test/core/`, mark them `physics`, and add `core` only when they are
-  fast enough for draft PRs and merge-queue checks.
+  under `test/core/`, mark them `physics`, and add `core` when they are
+  essential before merge. Add `medium` or `slow` independently for cost.
 - Put pandas / numpy / pydantic / CLI / wrapper behaviour in `api` tests. These
   run across the CPython bookends because the dependency surface varies by
   interpreter.
-- Mark long regression or reproduction tests `slow`. Slow tests run in
-  `test-all`, scheduled builds, release builds, or explicit manual validation;
-  they are excluded from smoke, core, cfg, standard, and local `make test`.
+- Mark the measured middle band `medium`; it remains in `standard` but is
+  excluded from `smoke`. Mark long regression or reproduction tests `slow`.
+  Slow tests run in `test-all`, scheduled builds, release builds, or explicit
+  manual validation unless they also carry `core`, in which case ready PR and
+  merge-queue `standard` selection retains them. Draft `core`, `cfg`, and local
+  `make test` still exclude `slow`.
 - Keep UMEP/QGIS tests under `test/umep/` with the auto-applied `api` + `qgis`
   markers. They run in `all` validation on the Windows + Python 3.12 cell or
   through `make test-qgis`; keep them out of normal PR/CR tiers unless a change

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -323,8 +323,8 @@ def _invocation_targets_full_test_tree(config):
 def pytest_collection_finish(session):
     """Enforce that every collected test carries `physics` or `api` (gh#1300).
 
-    Rationale: the two-axis taxonomy only works if every file declares which
-    axis it belongs to. A missing nature marker would silently drop a file
+    Rationale: the composed marker taxonomy only works if every file declares
+    its nature. A missing nature marker would silently drop a file
     out of CI once the matrix is split in a follow-up PR. Fail loudly at
     collection time on full-tree runs so the gap is caught before CI.
     """

--- a/test/core/test_ci_run_metrics.py
+++ b/test/core/test_ci_run_metrics.py
@@ -144,6 +144,34 @@ def test_api_lane_installs_xdist_contract_without_parallelising_main_suite() -> 
 
 
 @pytest.mark.core
+def test_standard_marker_expressions_preserve_core_slow_override() -> None:
+    """All duplicated standard selectors keep importance independent of cost."""
+    root = Path(__file__).resolve().parents[2]
+    action = (root / ".github/actions/build-suews/action.yml").read_text(
+        encoding="utf-8"
+    )
+    api_workflow = (
+        root / ".github/workflows/test-api-cross-python-reusable.yml"
+    ).read_text(encoding="utf-8")
+    overhead = (root / ".github/workflows/ci-metrics-overhead.yml").read_text(
+        encoding="utf-8"
+    )
+    scheduler = (root / ".github/workflows/benchmark-pytest-scheduler.yml").read_text(
+        encoding="utf-8"
+    )
+
+    physics_standard = "physics and (core or not slow)"
+    assert action.count(physics_standard) == 1
+    assert overhead.count(physics_standard) == 1
+    assert scheduler.count(physics_standard) == 4
+
+    api_standard = "EXPR='api and (core or not slow) and not qgis'"
+    assert api_workflow.count(api_standard) == 2  # standard and physics-full
+    assert "physics and smoke and not (medium or slow)" in action
+    assert "api and smoke and not (medium or slow) and not qgis" in api_workflow
+
+
+@pytest.mark.core
 def test_publish_jobs_download_only_cpython_wheel_artifacts() -> None:
     """PyPI publishers must not merge metrics or MCP files into ``dist``."""
     workflow_path = (

--- a/test/core/test_ehc_regression.py
+++ b/test/core/test_ehc_regression.py
@@ -144,6 +144,7 @@ def _run_short_spartacus_ehc_with_building_cp(rho_cp):
 
 
 @pytest.mark.core
+@pytest.mark.medium
 def test_ehc_lumped_storage_is_sensitive_to_surface_rho_cp():
     low_cp_qs = _run_short_ehc_with_surface_cp(1.0e6)
     high_cp_qs = _run_short_ehc_with_surface_cp(4.0e6)
@@ -159,6 +160,7 @@ def test_ehc_lumped_storage_skips_invalid_surface_without_zeroing_grid():
     assert np.max(np.abs(qs)) > 1.0
 
 
+@pytest.mark.medium
 def test_ehc_dual_timescale_lumped_branch_changes_storage_response(monkeypatch):
     env_keys = [
         EHC_EXPERIMENTAL_CONTROLS_KEY,
@@ -186,6 +188,7 @@ def test_ehc_dual_timescale_lumped_branch_changes_storage_response(monkeypatch):
     assert np.max(np.abs(dual_qs - default_qs)) > 0.1
 
 
+@pytest.mark.medium
 def test_ehc_state_admittance_changes_lumped_storage_response(monkeypatch):
     for key in (
         EHC_EXPERIMENTAL_CONTROLS_KEY,
@@ -210,6 +213,7 @@ def test_ehc_state_admittance_changes_lumped_storage_response(monkeypatch):
     assert np.max(np.abs(state_qs - default_qs)) > 0.1
 
 
+@pytest.mark.medium
 def test_ehc_impervious_qf_allocation_changes_lumped_storage_response(monkeypatch):
     monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
@@ -224,6 +228,7 @@ def test_ehc_impervious_qf_allocation_changes_lumped_storage_response(monkeypatc
     assert np.max(np.abs(impervious_qf_qs - default_qs)) > 0.1
 
 
+@pytest.mark.medium
 def test_ehc_direct_air_qf_mode_changes_lumped_storage_response(monkeypatch):
     monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_IMPERVIOUS_ONLY", raising=False)
@@ -253,6 +258,7 @@ def test_ehc_direct_air_qf_mode_changes_coupled_qe_response(monkeypatch):
     assert np.max(np.abs(direct_air_fluxes[:, 1] - default_fluxes[:, 1])) > 0.1
 
 
+@pytest.mark.medium
 def test_ehc_experimental_qf_env_is_ignored_without_gate(monkeypatch):
     monkeypatch.delenv(EHC_EXPERIMENTAL_CONTROLS_KEY, raising=False)
     monkeypatch.delenv("SUEWS_EHC_QF_SURF_MODE", raising=False)
@@ -338,6 +344,7 @@ def test_ehc_converged_lumped_storage_is_nearly_relaxation_invariant(monkeypatch
     assert np.max(np.abs(fast_relax_qs - slow_relax_qs)) < 0.75
 
 
+@pytest.mark.medium
 def test_ehc_ra_heat_factor_changes_lumped_storage_response(monkeypatch):
     for key in EHC_RA_HEAT_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
@@ -386,6 +393,7 @@ def test_ehc_state_dependent_ra_heat_guard_includes_zero_kdown(monkeypatch):
     assert np.max(np.abs(guarded_qs - default_qs)) > 0.1
 
 
+@pytest.mark.medium
 def test_ehc_adaptive_relax_limits_high_relax_response(monkeypatch):
     for key in (
         EHC_EXPERIMENTAL_CONTROLS_KEY,
@@ -431,6 +439,7 @@ def test_ehc_restore_best_iteration_path_runs(monkeypatch):
 
 
 @pytest.mark.core
+@pytest.mark.medium
 def test_ehc_spartacus_facet_storage_is_sensitive_to_building_rho_cp():
     low_cp_qs = _run_short_spartacus_ehc_with_building_cp(1.0e6)
     high_cp_qs = _run_short_spartacus_ehc_with_building_cp(4.0e6)

--- a/test/core/test_laimethod.py
+++ b/test/core/test_laimethod.py
@@ -362,7 +362,6 @@ class TestLAIMethodRuntime:
             minimum_aligned_days=self.SHORT_N_DAYS,
         )
 
-    @pytest.mark.slow
     def test_laimethod_seasonal_integration(self, lai_runtime_inputs):
         """Observed LAI continues to track a 30-day seasonal forcing curve."""
         _, df_forcing_base = lai_runtime_inputs

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -602,6 +602,8 @@ class TestSampleOutput(TestCase):
         """Validate the smoke window (one model day by default) against the reference."""
         self._validate_sample_output()
 
+    @pytest.mark.core
+    @pytest.mark.slow
     @pytest.mark.rust
     def test_sample_output_validation_full_year(self):
         """Validate the whole simulated year against the reference.
@@ -613,21 +615,12 @@ class TestSampleOutput(TestCase):
         GDD and SDD take months to reach the values their branches test, and the
         day-140/170/250/300 gates are never evaluated inside a one-day run.
 
-        Carries no tier marker, which is deliberate. Per the tier definitions,
-        `standard` is "all non-slow tests for the relevant nature axis", so an
-        unmarked test lands in `standard` and the full physics tiers: every ready
-        PR touching code, every merge-queue entry, and the nightly. Since the
-        queue always runs `standard`, nothing merges without this having passed.
-
-        Not `slow`: `standard` resolves to "physics and not slow", so that marker
-        would drop this from ready PRs and the queue too, leaving the coverage
-        dependent on someone applying the 0-physics:change label by hand. That
-        dependency is the mechanism that failed and produced this gap.
-
-        Not `core` or `smoke` either: those tiers are for fast feedback on drafts
-        and narrow changes, and a full year of engine time does not belong in a
-        tier defined as "fast enough for draft PRs". gh#1348 put a full-year run
-        in `smoke` and gh#1382 reverted it six days later over a Windows
+        Carries both `core` and `slow`: the regression is essential before merge
+        and expensive. Ready PRs and merge queue resolve `standard` to "physics
+        and (core or not slow)", so importance overrides cost there. Draft
+        `core` selection still ends in `and not slow`, keeping the full-year run
+        off fast feedback paths. It is deliberately not `smoke`: gh#1348 put a
+        full-year run there and gh#1382 reverted it six days later over a Windows
         per-test timeout.
 
         Measured runtimes, and the case for promoting this to `smoke` should
@@ -745,7 +738,7 @@ if __name__ == "__main__":
 
 
 @pytest.mark.core
-@pytest.mark.slow  # Runs in test-all, scheduled builds, release builds, or manual all-tier validation.
+@pytest.mark.slow  # Expensive, but core keeps it in ready-PR and queue standard tiers.
 class TestSTEBBSOutput(TestCase):
     """Test class for validating STEBBS building energy outputs."""
 

--- a/test/core/test_soil_obs_conversion.py
+++ b/test/core/test_soil_obs_conversion.py
@@ -277,7 +277,6 @@ class TestObservedSoilMoistureIntegration:
     3. Output physics (evaporation) is affected by soil moisture stress
     """
 
-    @pytest.mark.slow
     def test_observed_soil_moisture_affects_evaporation(self):
         """Verify that observed soil moisture affects latent heat flux (QE).
 
@@ -386,7 +385,6 @@ class TestObservedSoilMoistureIntegration:
         print(f"Mean daytime QE (wet, xsmd=0.38):        {mean_qe_wet:.1f} W/m²")
         print(f"QE difference (wet - dry):               {qe_difference:.1f} W/m²")
 
-    @pytest.mark.slow
     def test_smdmethod_config_propagates_to_kernel(self):
         """Verify that SMDMethod setting propagates correctly through the pipeline."""
 


### PR DESCRIPTION
## Summary

- add an independent `medium`/`slow` cost property while keeping `smoke`/`core`/`cfg` as importance
- make ready-PR and merge-queue `standard` selection retain essential `core + slow` regressions; draft `core`/`cfg` still exclude `slow`, and smoke excludes both `medium` and `slow`
- classify the measured nine-test EHC middle band as `medium`, retain the complete full-year regression as `core + slow`, and remove stale `slow` labels from three short core regressions
- keep the six duplicated physics selectors, the parallel API selectors, and their rule/reference text in parity without introducing a CI abstraction

This is stacked directly on #1687 at exact parent `ca840b10707a33b7b21b10238629b42d52a5f7e6`.

## Measured selection effect

Real pytest collection against the exact parent and final tree:

- legacy physics standard: 143 nodes
- final physics standard: 147 nodes
- delta: +4, with no removals — LAI seasonal integration, STEBBS building-energy output, observed-soil-moisture evaporation, and SMD-method propagation
- on the final tree, `physics and (core or not slow)` differs from `physics and not slow` by exactly the two deliberate `core + slow` tests: STEBBS and the full-year sample output
- on the final tree, the API standard expressions both collect 1777 nodes; the selector change itself has zero API-axis delta
- the branch adds one API contract test relative to the parent, which locks the six physics and two API expression copies

The four newly selected physics regressions passed in a 135.95s local sequential measurement. The cost is dominated by STEBBS (88.34s in the final focused run; 159.43s in the latest recorded Windows run). The LAI and two soil tests remain well below 30s. The full-year test remains a complete year and was already in the legacy standard selection, so its `core + slow` classification adds no ready/queue node; its recorded Windows runtime was 75.79s.

The nine EHC tests are `medium` based on the slowest normal CI measurement (34.17-36.13s each). They all passed locally in 27.93s with three workers.

## Validation

- `make test-smoke`: 9 passed, 1 skipped, 1970 deselected in 33.14s
- nine `medium` EHC regressions: 9 passed
- five marker-changed core regressions, including full-year and STEBBS: 5 passed in 125.67s
- CI selector contract tests: 7 passed; exact-commit selector test re-run passed
- marker lint: 128 directly marked files and 5 conftest-auto-marked files, all valid
- `git diff --check`
- exact-SHA review of `295d13b4eb806a56f11410fce31fbd2ee05acf32`

Closes #1680
