### PR TITLE
Extract shared version-audit plumbing

### DIFF
--- a/scripts/lint/check_data_interface_version_history.py
+++ b/scripts/lint/check_data_interface_version_history.py
@@ -9,13 +9,18 @@ their machine-readable representations are available.
 from __future__ import annotations
 
 import argparse
-import ast
 import os
 from pathlib import Path
 import re
 import subprocess
 import sys
 from typing import Literal, NamedTuple
+
+from version_audit import (
+    extract_literal_assignments,
+    read_file_at_ref,
+    resolve_merge_base,
+)
 
 type InterfaceKind = Literal["forcing", "output"]
 
@@ -47,32 +52,10 @@ class AuditFailure(RuntimeError):
     """Raised for a version-history violation that a contributor can fix."""
 
 
-def _run(args: list[str]) -> str:
-    result = subprocess.run(args, check=True, capture_output=True, text=True)
-    return result.stdout
-
-
-def _assignment(tree: ast.Module, name: str) -> object:
-    for node in tree.body:
-        if isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name) and target.id == name
-            for target in node.targets
-        ):
-            return ast.literal_eval(node.value)
-        if (
-            isinstance(node, ast.AnnAssign)
-            and isinstance(node.target, ast.Name)
-            and node.target.id == name
-            and node.value is not None
-        ):
-            return ast.literal_eval(node.value)
-    raise ValueError(f"could not read {name}")
-
-
 def _parse_state(source: str, current_name: str, versions_name: str) -> VersionState:
-    tree = ast.parse(source)
-    current = _assignment(tree, current_name)
-    versions = _assignment(tree, versions_name)
+    assignments = extract_literal_assignments(source, (current_name, versions_name))
+    current = assignments[current_name]
+    versions = assignments[versions_name]
     if current is not None and not isinstance(current, str):
         raise ValueError(f"{current_name} must be a string or None")
     if not isinstance(versions, dict) or any(
@@ -138,15 +121,14 @@ def _state_at_base(
     current_name: str,
     versions_name: str,
 ) -> VersionState:
-    try:
-        source = _run(["git", "show", f"{merge_base}:{path}"])
-    except subprocess.CalledProcessError:
+    source = read_file_at_ref(merge_base, path)
+    if source is None:
         return VersionState(None, ())
     return _parse_state(source, current_name, versions_name)
 
 
 def _audit(base_ref: str) -> list[InterfaceKind]:
-    merge_base = _run(["git", "merge-base", base_ref, "HEAD"]).strip()
+    merge_base = resolve_merge_base(base_ref)
     changed: list[InterfaceKind] = []
     for kind, (path, current_name, versions_name) in _INTERFACES.items():
         base = _state_at_base(merge_base, path, current_name, versions_name)

--- a/scripts/lint/check_schema_version_bump.py
+++ b/scripts/lint/check_schema_version_bump.py
@@ -60,9 +60,15 @@ from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
-import re
 import subprocess
 import sys
+
+from version_audit import (
+    extract_literal_assignments,
+    read_file_at_ref,
+    resolve_merge_base,
+    run_git,
+)
 
 # Paths that own the public YAML configuration shape (relative to repo root).
 # Output registries, forcing contracts and validation implementation are
@@ -93,29 +99,6 @@ _SCHEMA_DOC_PATHS: tuple[str, ...] = (
 )
 
 
-def _run(args: list[str]) -> str:
-    """Run a subprocess and return stdout; raise on non-zero exit."""
-    result = subprocess.run(
-        args,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout
-
-
-def _merge_base(base_ref: str) -> str:
-    """Return the merge-base commit between `base_ref` and `HEAD`.
-
-    The audit cares about what *this branch* did, not about what landed
-    on `base_ref` after the branch diverged. Resolving the merge-base
-    explicitly lets both the changed-file listing and the base-side
-    schema-version lookup compare against the same reference point,
-    even when `base_ref` has advanced with unrelated commits.
-    """
-    return _run(["git", "merge-base", base_ref, "HEAD"]).strip()
-
-
 def _paths_from_name_status(output: str) -> set[str]:
     """Return both paths from NUL-delimited ``git --name-status -z`` output."""
     paths: set[str] = set()
@@ -143,9 +126,10 @@ def _list_changed_files(base_ref: str, include_worktree: bool) -> list[str]:
     against the merge-base so uncommitted edits are included but
     unrelated commits on `base_ref` are still filtered out.
     """
-    comparison = _merge_base(base_ref) if include_worktree else f"{base_ref}...HEAD"
-    output = _run([
-        "git",
+    comparison = (
+        resolve_merge_base(base_ref) if include_worktree else f"{base_ref}...HEAD"
+    )
+    output = run_git([
         "diff",
         "--name-status",
         "-z",
@@ -156,8 +140,7 @@ def _list_changed_files(base_ref: str, include_worktree: bool) -> list[str]:
     if include_worktree:
         paths.update(
             path
-            for path in _run([
-                "git",
+            for path in run_git([
                 "ls-files",
                 "--others",
                 "--exclude-standard",
@@ -175,24 +158,16 @@ def _is_watched(path: str) -> bool:
     )
 
 
-_CURRENT_SCHEMA_VERSION_PATTERN = re.compile(
-    r"^\s*CURRENT_SCHEMA_VERSION\s*=\s*['\"]([^'\"]+)['\"]",
-    re.MULTILINE,
-)
-
-
 def _extract_current_schema_version(source: str) -> str | None:
-    """Return the quoted value of the top-level `CURRENT_SCHEMA_VERSION`.
-
-    Matches the first `CURRENT_SCHEMA_VERSION = "<value>"` assignment in
-    `source`. Returns None when the constant is absent, which lets callers
-    treat "file missing" and "file refactored beyond recognition" as hard
-    failures rather than silent passes.
-    """
-    match = _CURRENT_SCHEMA_VERSION_PATTERN.search(source)
-    if match is None:
+    """Return the string literal assigned to ``CURRENT_SCHEMA_VERSION``."""
+    try:
+        value = extract_literal_assignments(
+            source,
+            ("CURRENT_SCHEMA_VERSION",),
+        )["CURRENT_SCHEMA_VERSION"]
+    except (SyntaxError, ValueError):
         return None
-    return match.group(1)
+    return value if isinstance(value, str) else None
 
 
 def _load_schema_version_at_base(base_ref: str) -> str | None:
@@ -212,15 +187,13 @@ def _load_schema_version_at_base(base_ref: str) -> str | None:
     value counts as a bump from "nothing").
     """
     try:
-        merge_base = _merge_base(base_ref)
+        merge_base = resolve_merge_base(base_ref)
     except subprocess.CalledProcessError:
         return None
-    try:
-        return _extract_current_schema_version(
-            _run(["git", "show", f"{merge_base}:{_SCHEMA_VERSION_FILE}"])
-        )
-    except subprocess.CalledProcessError:
+    source = read_file_at_ref(merge_base, _SCHEMA_VERSION_FILE)
+    if source is None:
         return None
+    return _extract_current_schema_version(source)
 
 
 def _load_schema_version_worktree() -> str | None:

--- a/scripts/lint/version_audit.py
+++ b/scripts/lint/version_audit.py
@@ -1,0 +1,60 @@
+"""Policy-neutral plumbing for repository version audits."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+
+
+def run_git(args: list[str]) -> str:
+    """Run a Git command and return stdout; raise on non-zero exit."""
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def resolve_merge_base(base_ref: str) -> str:
+    """Return the merge-base commit between ``base_ref`` and ``HEAD``."""
+    return run_git(["merge-base", base_ref, "HEAD"]).strip()
+
+
+def read_file_at_ref(ref: str, path: str) -> str | None:
+    """Return ``path`` at ``ref``, or ``None`` when it does not exist there."""
+    entries = run_git(["ls-tree", "-r", "--name-only", "-z", ref, "--", path])
+    if path not in entries.split("\0"):
+        return None
+    return run_git(["show", f"{ref}:{path}"])
+
+
+def extract_literal_assignments(
+    source: str,
+    names: tuple[str, ...],
+) -> dict[str, object]:
+    """Return requested top-level literal assignments from Python source."""
+    tree = ast.parse(source)
+    values: dict[str, object] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            assigned_names = {
+                target.id for target in node.targets if isinstance(target, ast.Name)
+            }
+            for name in names:
+                if name in assigned_names and name not in values:
+                    values[name] = ast.literal_eval(node.value)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id in names
+            and node.target.id not in values
+            and node.value is not None
+        ):
+            values[node.target.id] = ast.literal_eval(node.value)
+
+    missing = [name for name in names if name not in values]
+    if missing:
+        raise ValueError(f"could not read {', '.join(missing)}")
+    return values

--- a/test/core/test_check_data_interface_version_history.py
+++ b/test/core/test_check_data_interface_version_history.py
@@ -11,12 +11,10 @@ import pytest
 
 pytestmark = pytest.mark.api
 
-SCRIPT_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "lint"
-    / "check_data_interface_version_history.py"
-)
+LINT_ROOT = Path(__file__).resolve().parents[2] / "scripts" / "lint"
+if str(LINT_ROOT) not in sys.path:
+    sys.path.insert(0, str(LINT_ROOT))
+SCRIPT_PATH = LINT_ROOT / "check_data_interface_version_history.py"
 SCRIPT_SPEC = importlib.util.spec_from_file_location(
     "check_data_interface_version_history",
     SCRIPT_PATH,

--- a/test/core/test_check_schema_version_bump.py
+++ b/test/core/test_check_schema_version_bump.py
@@ -25,12 +25,10 @@ import pytest
 pytestmark = pytest.mark.api
 
 
-SCRIPT_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "lint"
-    / "check_schema_version_bump.py"
-)
+LINT_ROOT = Path(__file__).resolve().parents[2] / "scripts" / "lint"
+if str(LINT_ROOT) not in sys.path:
+    sys.path.insert(0, str(LINT_ROOT))
+SCRIPT_PATH = LINT_ROOT / "check_schema_version_bump.py"
 SCRIPT_SPEC = importlib.util.spec_from_file_location(
     "check_schema_version_bump", SCRIPT_PATH
 )
@@ -151,6 +149,9 @@ def test_main_entry_chdirs_to_repo_root(branched_repo: Path) -> None:
     target_dir.mkdir(parents=True)
     script_copy = target_dir / SCRIPT_PATH.name
     script_copy.write_text(SCRIPT_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    helper_path = LINT_ROOT / "version_audit.py"
+    helper_copy = target_dir / helper_path.name
+    helper_copy.write_text(helper_path.read_text(encoding="utf-8"), encoding="utf-8")
     nested = branched_repo / "src"
     assert nested.is_dir()
 
@@ -171,7 +172,7 @@ def test_main_entry_chdirs_to_repo_root(branched_repo: Path) -> None:
 
 
 def test_extract_current_schema_version_parses_literal() -> None:
-    """Sanity check on the regex: it must find the quoted value even
+    """Sanity check on literal parsing: it must find the quoted value even
     when other assignments appear above it.
     """
     source = (

--- a/test/core/test_version_audit.py
+++ b/test/core/test_version_audit.py
@@ -1,0 +1,109 @@
+"""Tests for policy-neutral version-audit plumbing."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.api
+
+HELPER_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "lint" / "version_audit.py"
+)
+HELPER_SPEC = importlib.util.spec_from_file_location("version_audit", HELPER_PATH)
+assert HELPER_SPEC is not None
+assert HELPER_SPEC.loader is not None
+version_audit = importlib.util.module_from_spec(HELPER_SPEC)
+sys.modules[HELPER_SPEC.name] = version_audit
+HELPER_SPEC.loader.exec_module(version_audit)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(repo, "add", "-A")
+    _git(
+        repo,
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-qm",
+        message,
+    )
+
+
+def test_extract_literal_assignments_reads_plain_and_annotated_values() -> None:
+    source = """\
+CURRENT = "1.0.0"
+VERSIONS: dict[str, str] = {"1.0.0": "sha256:digest"}
+"""
+
+    assert version_audit.extract_literal_assignments(
+        source,
+        ("CURRENT", "VERSIONS"),
+    ) == {
+        "CURRENT": "1.0.0",
+        "VERSIONS": {"1.0.0": "sha256:digest"},
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "OTHER = 'value'\n",
+        "def nested():\n    CURRENT = '1.0.0'\n",
+    ],
+)
+def test_extract_literal_assignments_requires_top_level_names(source: str) -> None:
+    with pytest.raises(ValueError, match="could not read CURRENT"):
+        version_audit.extract_literal_assignments(source, ("CURRENT",))
+
+
+def test_extract_literal_assignments_rejects_computed_values() -> None:
+    with pytest.raises(ValueError):
+        version_audit.extract_literal_assignments(
+            "CURRENT = make_version()\n",
+            ("CURRENT",),
+        )
+
+
+def test_merge_base_and_ref_file_reading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "master")
+    version_file = repo / "version.py"
+    version_file.write_text('CURRENT = "1.0.0"\n', encoding="utf-8")
+    _commit(repo, "initial")
+    base_commit = _git(repo, "rev-parse", "HEAD").strip()
+
+    _git(repo, "checkout", "-qb", "feature")
+    version_file.write_text('CURRENT = "1.1.0"\n', encoding="utf-8")
+    _commit(repo, "feature")
+    monkeypatch.chdir(repo)
+
+    assert version_audit.resolve_merge_base("master") == base_commit
+    assert (
+        version_audit.read_file_at_ref(base_commit, "version.py")
+        == 'CURRENT = "1.0.0"\n'
+    )
+    assert version_audit.read_file_at_ref(base_commit, "missing.py") is None
+    with pytest.raises(subprocess.CalledProcessError):
+        version_audit.read_file_at_ref("not-a-ref", "version.py")


### PR DESCRIPTION
## Summary

- extract policy-neutral Git, merge-base, Git-ref file reading, and top-level literal-assignment helpers
- keep configuration CalVer/documentation policy separate from forcing/output SemVer and append-only digest-history policy
- retain the existing CI entry points and add focused coverage for the shared mechanics

## Validation

Run in a dedicated worktree-local uv environment with Python 3.12.7 and no system site packages:

- `make dev` — passed
- `python -m pytest -q test/core/test_version_audit.py test/core/test_check_schema_version_bump.py test/core/test_check_data_interface_version_history.py` — 37 passed
- `make test-smoke` — 9 passed, 1 skipped, 2043 deselected
- `make test` — 1630 passed, 6 skipped, 32 deselected
- `ruff format --check` and `ruff check` on all changed Python files — passed
- schema-version and data-interface version-history audit entry points — passed
- forcing/output contract artefact audits and forcing reference freshness check — passed

Fixes #1664
