### PR TITLE
Run MCP protocol handshake tests against built artifacts

### DIFF
--- a/.github/ci-metrics-needs.json
+++ b/.github/ci-metrics-needs.json
@@ -1,5 +1,6 @@
 {
   "API cross-CPython tests / *": [
+    "Build MCP package",
     "Determine build matrix",
     "Build standard wheels / *"
   ],

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -470,8 +470,11 @@ jobs:
 
   test_api_cross_python:
     name: API cross-CPython tests
-    needs: [determine_matrix, build_wheels]
-    if: always() && needs.build_wheels.result == 'success'
+    needs: [determine_matrix, build_wheels, build_mcp]
+    if: >-
+      always() &&
+      needs.build_wheels.result == 'success' &&
+      needs.build_mcp.result == 'success'
     uses: ./.github/workflows/test-api-cross-python-reusable.yml
     with:
       # Fall back to the full buildplat when api_buildplat is empty: the

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -72,6 +72,12 @@ jobs:
           name: cp312-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
           path: wheelhouse/
 
+      - name: Download MCP distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: suews-mcp-dist
+          path: mcp-dist/
+
       - name: Compose pytest marker expression for api tier
         id: marker
         shell: bash
@@ -99,7 +105,30 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest==9.1.1 pytest-xdist==3.8.0
-          python -m pip install wheelhouse/*.whl
+          python -m pip install wheelhouse/*.whl mcp-dist/*.whl
+          # These imports and the interpreter-local executable are the two
+          # conditions that otherwise skip the protocol test at collection or
+          # setup time. Make either packaging regression fail this lane first.
+          python - <<'PY'
+          from pathlib import Path
+          import shutil
+          import sys
+
+          from mcp.client.session import ClientSession
+          from mcp.client.stdio import StdioServerParameters, stdio_client
+
+          active_bin_dir = Path(sys.executable).parent
+          command = shutil.which("suews-mcp", path=str(active_bin_dir))
+          if command is None:
+              raise SystemExit(
+                  f"suews-mcp is not installed beside {sys.executable}"
+              )
+          print(f"Protocol dependencies available; suews-mcp={command}")
+          PY
+          # A focused collection pass makes marker drift or deletion of the
+          # protocol file fail with pytest's no-tests-collected exit code.
+          python -m pytest --collect-only test/mcp/test_protocol_handshake.py \
+            -m "$MARKER_EXPR" -q
           # Run in one process. xdist duplicates every session fixture per
           # worker; the API lane contains simulation outputs large enough to
           # exhaust hosted-runner memory even with two workers.

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -113,15 +113,17 @@ jobs:
           from pathlib import Path
           import shutil
           import sys
+          import sysconfig
 
           from mcp.client.session import ClientSession
           from mcp.client.stdio import StdioServerParameters, stdio_client
 
-          active_bin_dir = Path(sys.executable).parent
+          active_bin_dir = Path(sysconfig.get_path("scripts"))
           command = shutil.which("suews-mcp", path=str(active_bin_dir))
           if command is None:
               raise SystemExit(
-                  f"suews-mcp is not installed beside {sys.executable}"
+                  f"suews-mcp is not installed in {active_bin_dir} "
+                  f"for {sys.executable}"
               )
           print(f"Protocol dependencies available; suews-mcp={command}")
           PY

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -14,7 +14,9 @@ authors = [
 ]
 dependencies = [
     "supy",
-    "mcp>=1.2",
+    # MCP 2 removed the ``mcp.server.fastmcp`` API used by this server. Keep
+    # installs on the supported SDK major until the server is migrated.
+    "mcp>=1.2,<2",
     # Directly consumed by `server._async_offload` to push blocking CLI calls
     # off the FastMCP event loop (gh#1412). It is already a transitive dep of
     # `mcp`, but the server uses it as a first-class import so we declare it

--- a/mcp/src/suews_mcp/backend/cli.py
+++ b/mcp/src/suews_mcp/backend/cli.py
@@ -1,12 +1,13 @@
 """Subprocess wrapper around the unified ``suews`` CLI.
 
 Every MCP tool that needs to invoke a SUEWS subcommand goes through
-``run_suews_cli`` here. The wrapper enforces three things:
+``run_suews_cli`` here. The wrapper enforces four things:
 
 1. The subcommand must be in ``ALLOWED_SUBCOMMANDS``. No arbitrary shell.
 2. The subprocess is bounded by a timeout (env-configurable).
 3. ``stdout`` is parsed as the standard SUEWS JSON envelope; both success
    and error envelopes are returned to the caller.
+4. The child cannot read the MCP server's JSON-RPC stdin transport.
 """
 
 from __future__ import annotations
@@ -136,6 +137,7 @@ def run_suews_cli(
             cmd,
             cwd=str(project_root) if project_root else None,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             timeout=timeout,
             check=False,

--- a/test/core/test_ci_run_metrics.py
+++ b/test/core/test_ci_run_metrics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from fnmatch import fnmatchcase
+import json
 from pathlib import Path
 import re
 
@@ -141,6 +142,56 @@ def test_api_lane_installs_xdist_contract_without_parallelising_main_suite() -> 
     )
     assert main_invocation is not None
     assert re.search(r"(?:^|\s)-n(?:\s|$)", main_invocation.group()) is None
+
+
+@pytest.mark.smoke
+def test_api_lane_consumes_mcp_artifact_after_build() -> None:
+    """The API matrix installs the MCP wheel only after both builds succeed."""
+    root = Path(__file__).resolve().parents[2]
+    caller = yaml.safe_load(
+        (root / ".github/workflows/build-publish_to_pypi.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    api_job = caller["jobs"]["test_api_cross_python"]
+    assert {"determine_matrix", "build_wheels", "build_mcp"} <= set(api_job["needs"])
+    assert "needs.build_mcp.result == 'success'" in api_job["if"]
+
+    api_workflow = (
+        root / ".github/workflows/test-api-cross-python-reusable.yml"
+    ).read_text(encoding="utf-8")
+    assert "name: suews-mcp-dist" in api_workflow
+    assert "path: mcp-dist/" in api_workflow
+    assert "python -m pip install wheelhouse/*.whl mcp-dist/*.whl" in api_workflow
+
+    declared_needs = json.loads(
+        (root / ".github/ci-metrics-needs.json").read_text(encoding="utf-8")
+    )
+    assert "Build MCP package" in declared_needs["API cross-CPython tests / *"]
+
+
+@pytest.mark.smoke
+def test_api_lane_requires_nonempty_mcp_protocol_collection() -> None:
+    """Missing SDK, executable or protocol nodes cannot silently pass CI."""
+    root = Path(__file__).resolve().parents[2]
+    api_workflow = (
+        root / ".github/workflows/test-api-cross-python-reusable.yml"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        "from mcp.client.session import ClientSession",
+        "from mcp.client.stdio import StdioServerParameters, stdio_client",
+        "active_bin_dir = Path(sys.executable).parent",
+        'shutil.which("suews-mcp", path=str(active_bin_dir))',
+        "python -m pytest --collect-only test/mcp/test_protocol_handshake.py",
+        '-m "$MARKER_EXPR" -q',
+    ):
+        assert required in api_workflow
+
+    protocol_test = (root / "test/mcp/test_protocol_handshake.py").read_text(
+        encoding="utf-8"
+    )
+    assert "pytestmark = [pytest.mark.api, pytest.mark.smoke]" in protocol_test
 
 
 @pytest.mark.core

--- a/test/core/test_ci_run_metrics.py
+++ b/test/core/test_ci_run_metrics.py
@@ -181,7 +181,8 @@ def test_api_lane_requires_nonempty_mcp_protocol_collection() -> None:
     for required in (
         "from mcp.client.session import ClientSession",
         "from mcp.client.stdio import StdioServerParameters, stdio_client",
-        "active_bin_dir = Path(sys.executable).parent",
+        "import sysconfig",
+        'active_bin_dir = Path(sysconfig.get_path("scripts"))',
         'shutil.which("suews-mcp", path=str(active_bin_dir))',
         "python -m pytest --collect-only test/mcp/test_protocol_handshake.py",
         '-m "$MARKER_EXPR" -q',
@@ -192,6 +193,7 @@ def test_api_lane_requires_nonempty_mcp_protocol_collection() -> None:
         encoding="utf-8"
     )
     assert "pytestmark = [pytest.mark.api, pytest.mark.smoke]" in protocol_test
+    assert '_ACTIVE_BIN_DIR = Path(sysconfig.get_path("scripts"))' in protocol_test
 
 
 @pytest.mark.core

--- a/test/mcp/test_backend_cli.py
+++ b/test/mcp/test_backend_cli.py
@@ -34,6 +34,37 @@ def test_appends_format_json_when_missing(monkeypatch: pytest.MonkeyPatch) -> No
     assert captured["cmd"] == ["suews", "validate", "config.yml", "--format", "json"]
 
 
+def test_detaches_child_stdin_from_mcp_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nested CLIs must not inherit the MCP server's JSON-RPC stdin pipe.
+
+    On Windows an inherited pipe keeps the nested ``suews`` process alive,
+    leaving ``subprocess.run`` blocked in ``communicate`` indefinitely.
+    """
+    from suews_mcp.backend import cli as cli_mod
+
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        out = json.dumps({
+            "status": "success",
+            "data": {},
+            "errors": [],
+            "warnings": [],
+            "meta": {},
+        })
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout=out, stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    cli_mod.run_suews_cli("validate", ["config.yml"], suews_executable="suews")
+
+    assert captured["stdin"] is subprocess.DEVNULL
+
+
 def test_passes_through_when_format_already_set(monkeypatch: pytest.MonkeyPatch) -> None:
     from suews_mcp.backend import cli as cli_mod
 

--- a/test/mcp/test_protocol_handshake.py
+++ b/test/mcp/test_protocol_handshake.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 import shutil
-import sys
+import sysconfig
 
 import pytest
 
@@ -46,14 +46,15 @@ StdioServerParameters = _mcp_stdio.StdioServerParameters
 stdio_client = _mcp_stdio.stdio_client
 
 
-_ACTIVE_BIN_DIR = Path(sys.executable).parent
+_ACTIVE_BIN_DIR = Path(sysconfig.get_path("scripts"))
 _SUEWS_MCP_COMMAND = shutil.which("suews-mcp", path=str(_ACTIVE_BIN_DIR))
 
 
 pytestmark_skipif = pytest.mark.skipif(
     _SUEWS_MCP_COMMAND is None,
     reason=(
-        "`suews-mcp` is not installed beside the active Python interpreter. "
+        "`suews-mcp` is not installed in the active Python environment's "
+        "scripts directory. "
         "Run `uv pip install --python .venv/bin/python -e mcp/` from the "
         "repo root before running this test."
     ),

--- a/test/mcp/test_protocol_handshake.py
+++ b/test/mcp/test_protocol_handshake.py
@@ -21,7 +21,7 @@ import sys
 
 import pytest
 
-pytestmark = pytest.mark.api
+pytestmark = [pytest.mark.api, pytest.mark.smoke]
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -46,7 +46,7 @@ StdioServerParameters = _mcp_stdio.StdioServerParameters
 stdio_client = _mcp_stdio.stdio_client
 
 
-_ACTIVE_BIN_DIR = Path(sys.executable).resolve().parent
+_ACTIVE_BIN_DIR = Path(sys.executable).parent
 _SUEWS_MCP_COMMAND = shutil.which("suews-mcp", path=str(_ACTIVE_BIN_DIR))
 
 
@@ -140,10 +140,16 @@ async def _run_handshake() -> dict:
             }
 
 
+@pytest.fixture(scope="module")
+def handshake_result() -> dict:
+    """Run protocol discovery once for the six immutable contract assertions."""
+    return asyncio.run(_run_handshake())
+
+
 @pytestmark_skipif
-def test_initialize_advertises_suews_mcp() -> None:
+def test_initialize_advertises_suews_mcp(handshake_result: dict) -> None:
     """Server identifies itself as `suews-mcp` after the JSON-RPC handshake."""
-    result = asyncio.run(_run_handshake())
+    result = handshake_result
     assert result["server_name"] == "suews-mcp", (
         f"Expected serverInfo.name == 'suews-mcp', got {result['server_name']!r}. "
         "Check FastMCP server name in mcp/src/suews_mcp/server.py."
@@ -151,9 +157,9 @@ def test_initialize_advertises_suews_mcp() -> None:
 
 
 @pytestmark_skipif
-def test_tools_list_advertises_all_fourteen() -> None:
+def test_tools_list_advertises_all_fourteen(handshake_result: dict) -> None:
     """All 14 tools registered in `server.py` are advertised through MCP."""
-    result = asyncio.run(_run_handshake())
+    result = handshake_result
     advertised = result["tool_names"]
 
     missing = EXPECTED_TOOLS - advertised
@@ -170,7 +176,7 @@ def test_tools_list_advertises_all_fourteen() -> None:
 
 
 @pytestmark_skipif
-def test_resources_advertise_all_six() -> None:
+def test_resources_advertise_all_six(handshake_result: dict) -> None:
     """All 6 resources registered in `server.py` surface through MCP.
 
     FastMCP routes URI patterns with `{var}` placeholders to
@@ -178,7 +184,7 @@ def test_resources_advertise_all_six() -> None:
     `resources/list`. The total advertised across both endpoints must
     equal the registered set.
     """
-    result = asyncio.run(_run_handshake())
+    result = handshake_result
     expected_all = EXPECTED_RESOURCE_TEMPLATES | EXPECTED_STATIC_RESOURCES
     advertised_all = result["resource_templates"] | result["static_resources"]
 
@@ -197,7 +203,7 @@ def test_resources_advertise_all_six() -> None:
 
 
 @pytestmark_skipif
-def test_initialize_advertises_instructions() -> None:
+def test_initialize_advertises_instructions(handshake_result: dict) -> None:
     """The `initialize` result carries the server instructions so a client
     that reads only `serverInfo.instructions` still sees the contract.
 
@@ -205,7 +211,7 @@ def test_initialize_advertises_instructions() -> None:
     energy-balance contract; if FastMCP stops forwarding `instructions=` the
     field comes back empty and Codex / Claude Desktop sessions lose it.
     """
-    result = asyncio.run(_run_handshake())
+    result = handshake_result
     instructions = result["instructions"]
     assert instructions, (
         "initialize result advertised no instructions. Check that "
@@ -219,14 +225,14 @@ def test_initialize_advertises_instructions() -> None:
 
 
 @pytestmark_skipif
-def test_prompts_advertise_all_three() -> None:
+def test_prompts_advertise_all_three(handshake_result: dict) -> None:
     """All 3 prompts registered in `server.py` are advertised through MCP.
 
     The prompts carry the fresh-site / parameter-importance / evaluation
     procedures to non-Claude-Code clients; a dropped registration silently
     removes them from `prompts/list`.
     """
-    result = asyncio.run(_run_handshake())
+    result = handshake_result
     advertised = result["prompt_names"]
 
     missing = EXPECTED_PROMPTS - advertised
@@ -434,7 +440,7 @@ def test_concurrent_query_knowledge_and_search_schema() -> None:
 
 
 @pytestmark_skipif
-def test_read_knowledge_manifest_returns_provenance() -> None:
+def test_read_knowledge_manifest_returns_provenance(handshake_result: dict) -> None:
     """Calling `read_knowledge_manifest` over MCP returns pack provenance.
 
     The Layer-3 evidence contract requires `pack_version`, `schema_version`,
@@ -444,7 +450,7 @@ def test_read_knowledge_manifest_returns_provenance() -> None:
     """
     import json
 
-    result = asyncio.run(_run_handshake())
+    result = handshake_result
     envelope = result["manifest_envelope"]
 
     # The MCP SDK wraps the tool's return value in `content[].text` for

--- a/test/mcp/test_protocol_handshake.py
+++ b/test/mcp/test_protocol_handshake.py
@@ -15,6 +15,7 @@ the install is a separate concern owned by ``test_version.py`` and the
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from pathlib import Path
 import shutil
 import sysconfig
@@ -25,6 +26,7 @@ pytestmark = [pytest.mark.api, pytest.mark.smoke]
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+_HANDSHAKE_REQUEST_TIMEOUT = timedelta(seconds=30)
 
 
 _mcp_session = pytest.importorskip(
@@ -113,7 +115,11 @@ async def _run_handshake() -> dict:
     )
 
     async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
+        async with ClientSession(
+            read,
+            write,
+            read_timeout_seconds=_HANDSHAKE_REQUEST_TIMEOUT,
+        ) as session:
             init_result = await session.initialize()
 
             tools_result = await session.list_tools()

--- a/test/mcp/test_version.py
+++ b/test/mcp/test_version.py
@@ -45,6 +45,15 @@ def test_mcp_pyproject_uses_generated_dynamic_version() -> None:
     assert 'version = { attr = "suews_mcp.__version__" }' in text
 
 
+@pytest.mark.smoke
+def test_mcp_pyproject_caps_supported_sdk_major() -> None:
+    """Wheel installs cannot resolve MCP 2, which removed FastMCP's API path."""
+    pyproject = REPO_ROOT / "mcp" / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+
+    assert '"mcp>=1.2,<2"' in text
+
+
 def test_version_script_writes_supy_and_mcp_version_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- install the built `suews-mcp` distribution alongside each cross-Python SuPy wheel
- fail CI when the MCP SDK, interpreter-local executable, or protocol test collection is missing
- include the fast stdio discovery and tool-call contract in smoke coverage while retaining slow concurrency coverage for the full suite
- constrain the MCP SDK to the supported 1.x API and keep the CI metrics DAG aligned with the new artefact dependency

## Validation

All Python commands used the uv-managed worktree environment at `/Users/tingsun/.codex/worktrees/fdf1/suews/.venv` with `/Users/tingsun/.codex/worktrees/fdf1/suews/.venv/bin/python` (Python 3.13.0).

- `make dev` — passed
- `.venv/bin/python -m pytest test/mcp/test_protocol_handshake.py -m "not slow" -v --tb=short` — 6 passed, 2 deselected
- `.venv/bin/python -m pytest test/mcp -m "not slow" -v --tb=short` — 131 passed, 23 skipped, 2 deselected
- `make test-smoke` — 18 passed, 2040 deselected
- `make test` — 1627 passed, 6 skipped, 32 deselected
- `.venv/bin/python -m pytest test/core/test_ci_run_metrics.py -v` — 9 passed
- marker lint — 129 directly marked test files and 5 files covered by conftest auto-apply
- workflow YAML and CI metrics DAG JSON parsing — passed
- built MCP wheel metadata — `Requires-Dist: mcp<2,>=1.2`
- focused Ruff checks and `git diff --check` — passed

Fixes #1698