### PR TITLE
Show the stopping phase in validator reports

### DIFF
--- a/docs/source/inputs/yaml/validation.rst
+++ b/docs/source/inputs/yaml/validation.rst
@@ -101,6 +101,13 @@ Reports use stable action sections:
   applied because ``--science-fixes apply`` was selected.
 - **INFO**: non-blocking notes and successful validation summaries.
 
+When validation stops on a blocking failure, the header names the first failed
+stage recorded in the structured phase results: **Completeness Check** (A),
+**Scientific Validation** (B), or **Model Compatibility** (C). Public and
+developer reports use the same stage names. Reports that complete successfully,
+including warning-only reports, omit this line. Input and command errors that
+occur before a validation phase starts do not claim an A, B, or C stage.
+
 Example excerpt:
 
 .. code-block:: text
@@ -108,6 +115,7 @@ Example excerpt:
     # SUEWS Validation Report
     # ==================================================
     # Mode: Public
+    # Validation stopped at: Scientific Validation
     # ==================================================
 
     ## ACTION NEEDED

--- a/src/supy/cmd/validate_config.py
+++ b/src/supy/cmd/validate_config.py
@@ -22,7 +22,10 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.progress import track
 
-from ..data_model.validation.pipeline.report_writer import REPORT_WRITER
+from ..data_model.validation.pipeline.report_writer import (
+    REPORT_WRITER,
+    sync_text_report_stopping_phase,
+)
 
 # Import the new JSON output formatter
 try:
@@ -1103,6 +1106,8 @@ def _emit_pipeline_result(
                 phase_report.yaml_in = None
             if phase_report.yaml_out and not Path(phase_report.yaml_out).exists():
                 phase_report.yaml_out = None
+
+        sync_text_report_stopping_phase(report_path, phases)
 
     # gh#1467: persist the consolidated multi-phase ValidationReport as the
     # JSON sidecar next to the final text report, in BOTH table and json

--- a/src/supy/data_model/validation/pipeline/orchestrator.py
+++ b/src/supy/data_model/validation/pipeline/orchestrator.py
@@ -23,7 +23,7 @@ import io
 from contextlib import redirect_stdout, redirect_stderr
 from pathlib import Path
 
-from .report_writer import REPORT_WRITER
+from .report_writer import REPORT_WRITER, sync_text_report_stopping_phase
 from ...core.physics_families import flatten_physics_in_config
 
 # Import Phase A and B functions
@@ -772,6 +772,7 @@ def run_phase_a(
         ))
 
     if report_file:
+        sync_text_report_stopping_phase(report_file, [phase_report])
         json_path = Path(report_file).with_suffix(".json")
         phase_report.json_report_path = str(json_path)
         JSON_REPORT_WRITER.write(json_path, phase_report)
@@ -858,6 +859,7 @@ def run_phase_b(
         ))
 
     if science_report_file:
+        sync_text_report_stopping_phase(science_report_file, [phase_report])
         json_path = Path(science_report_file).with_suffix(".json")
         phase_report.json_report_path = str(json_path)
         JSON_REPORT_WRITER.write(json_path, phase_report)
@@ -935,6 +937,7 @@ def run_phase_c(
     )
 
     if pydantic_report_file:
+        sync_text_report_stopping_phase(pydantic_report_file, [phase_report])
         json_path = Path(pydantic_report_file).with_suffix(".json")
         phase_report.json_report_path = str(json_path)
         JSON_REPORT_WRITER.write(json_path, phase_report)

--- a/src/supy/data_model/validation/pipeline/report_schema.py
+++ b/src/supy/data_model/validation/pipeline/report_schema.py
@@ -11,10 +11,11 @@ Phase B (see ``phase_b_rules/rules_core.py``); both share the same
 ``Issue.severity`` strings so consumers do not need to special-case
 which phase produced the issue.
 
-The text reports written by each phase are unchanged; this module
-adds a JSON sidecar (``<report>.json``) next to every ``<report>.txt``
-so downstream tooling (MCP, agents, CI) can consume the validator
-output without parsing the human-readable form.
+The text reports retain their existing action sections and add a stopping-stage
+line for blocking failures, derived from these structured phase results. This
+module also adds a JSON sidecar (``<report>.json``) next to every
+``<report>.txt`` so downstream tooling (MCP, agents, CI) can consume the
+validator output without parsing the human-readable form.
 
 Two sidecar shapes exist (gh#1467):
 

--- a/src/supy/data_model/validation/pipeline/report_writer.py
+++ b/src/supy/data_model/validation/pipeline/report_writer.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from .report_schema import PhaseReport
 
 PathLike = Union[str, Path]
+
+VALIDATION_PHASE_NAMES = {
+    "A": "Completeness Check",
+    "B": "Scientific Validation",
+    "C": "Model Compatibility",
+}
+STOPPING_PHASE_PREFIX = "# Validation stopped at:"
 
 
 @dataclass(frozen=True)
@@ -30,3 +41,62 @@ class ValidationReportWriter:
 
 
 REPORT_WRITER = ValidationReportWriter()
+
+
+def format_report_stopping_phase(
+    content: str, phase_reports: Iterable[PhaseReport]
+) -> str:
+    """Synchronise a text-report header with structured phase results.
+
+    The first failed ``PhaseReport`` is the sole source of the public stage
+    name. Successful and warning-only results do not carry a stopping-stage
+    line.
+    """
+    failed_phase = next(
+        (report.phase for report in phase_reports if report.has_errors), None
+    )
+    stage_name = VALIDATION_PHASE_NAMES.get(failed_phase)
+
+    lines = content.splitlines(keepends=True)
+    lines = [
+        line
+        for line in lines
+        if not line.rstrip("\r\n").startswith(STOPPING_PHASE_PREFIX)
+    ]
+    if stage_name is None:
+        return "".join(lines)
+
+    for index, line in enumerate(lines):
+        if line.rstrip("\r\n").startswith("# Mode:"):
+            newline = "\r\n" if line.endswith("\r\n") else "\n"
+            if not line.endswith(("\r", "\n")):
+                lines[index] = f"{line}{newline}"
+            lines.insert(
+                index + 1,
+                f"{STOPPING_PHASE_PREFIX} {stage_name}{newline}",
+            )
+            break
+
+    return "".join(lines)
+
+
+def sync_text_report_stopping_phase(
+    report_path: PathLike, phase_reports: Iterable[PhaseReport]
+) -> None:
+    """Apply the structured stopping phase to an existing text report.
+
+    Report I/O must not change validation exit behaviour. Missing or
+    unwritable reports remain the responsibility of the existing pipeline
+    diagnostics.
+    """
+    path = Path(report_path)
+    if not path.exists():
+        return
+
+    try:
+        content = REPORT_WRITER.read(path)
+        updated = format_report_stopping_phase(content, phase_reports)
+        if updated != content:
+            REPORT_WRITER.write(path, updated)
+    except OSError:
+        return

--- a/test/cmd/test_validate_config.py
+++ b/test/cmd/test_validate_config.py
@@ -822,6 +822,165 @@ def test_emit_pipeline_result_warning_status_matches_inner_report(
     assert envelope["data"]["validation_report"]["overall_status"] == "WARNING"
 
 
+@pytest.mark.parametrize("mode", ["public", "dev"])
+@pytest.mark.parametrize(
+    "pipeline, failed_phase",
+    [
+        ("A", "A"),
+        ("B", "B"),
+        ("C", "C"),
+        ("AB", "A"),
+        ("AB", "B"),
+        ("AC", "A"),
+        ("AC", "C"),
+        ("BC", "B"),
+        ("BC", "C"),
+        ("ABC", "A"),
+        ("ABC", "B"),
+        ("ABC", "C"),
+    ],
+)
+def test_final_text_report_matches_failed_structured_phase(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    mode: str,
+    pipeline: str,
+    failed_phase: str,
+) -> None:
+    """Every pipeline selection derives its final header from PhaseReport."""
+    from supy.cmd.validate_config import _emit_pipeline_result
+    from supy.data_model.validation.pipeline.report_schema import (
+        Issue,
+        PhaseReport,
+        SEVERITY_ERROR,
+    )
+    from supy.data_model.validation.pipeline.report_writer import (
+        VALIDATION_PHASE_NAMES,
+    )
+
+    phases = []
+    for phase in pipeline:
+        issues = []
+        if phase == failed_phase:
+            issues.append(
+                Issue(
+                    phase=phase,
+                    severity=SEVERITY_ERROR,
+                    code=f"{phase}.TEST.ERROR",
+                    message="blocking error",
+                )
+            )
+        phases.append(PhaseReport(phase=phase, issues=issues))
+        if issues:
+            break
+
+    report_path = tmp_path / f"report_{pipeline}_{failed_phase}_{mode}.txt"
+    report_path.write_text(
+        "# SUEWS Validation Report\n"
+        "# ==================================================\n"
+        f"# Mode: {'Public' if mode == 'public' else 'Developer'}\n"
+        "# ==================================================\n\n"
+        "## ACTION NEEDED\n"
+        "- Fix the blocking error.\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _emit_pipeline_result(
+        phases=phases,
+        report_path=report_path,
+        yaml_path=tmp_path / "updated.yml",
+        out_format="table",
+        command=f"suews validate --pipeline {pipeline}",
+        started_at="2026-08-19T00:00:00Z",
+    )
+    capsys.readouterr()
+
+    assert exit_code == 1
+    text = report_path.read_text(encoding="utf-8")
+    expected_name = VALIDATION_PHASE_NAMES[failed_phase]
+    assert f"# Validation stopped at: {expected_name}" in text
+    assert text.count("# Validation stopped at:") == 1
+    assert f"# Mode: {'Public' if mode == 'public' else 'Developer'}" in text
+
+    payload = json.loads(
+        report_path.with_suffix(".json").read_text(encoding="utf-8")
+    )
+    failed_entries = [
+        phase for phase in payload["phases"] if phase["status"] == "FAILED"
+    ]
+    assert [phase["phase"] for phase in failed_entries] == [failed_phase]
+    assert expected_name == VALIDATION_PHASE_NAMES[failed_entries[0]["phase"]]
+
+
+@pytest.mark.parametrize("pipeline", ["A", "B", "C", "AB", "AC", "BC", "ABC"])
+@pytest.mark.parametrize("outcome", ["success", "warning"])
+def test_completed_pipeline_reports_omit_stopping_phase(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    pipeline: str,
+    outcome: str,
+) -> None:
+    """Successful and warning-only single/combined reports do not say stopped."""
+    from supy.cmd.validate_config import _emit_pipeline_result
+    from supy.data_model.validation.pipeline.report_schema import (
+        Issue,
+        PhaseReport,
+        SEVERITY_WARNING,
+    )
+
+    phases = [PhaseReport(phase=phase, issues=[]) for phase in pipeline]
+    if outcome == "warning":
+        phase = phases[-1].phase
+        phases[-1].issues.append(
+            Issue(
+                phase=phase,
+                severity=SEVERITY_WARNING,
+                code=f"{phase}.TEST.WARNING",
+                message="review this",
+            )
+        )
+
+    report_path = tmp_path / f"report_{pipeline}_{outcome}.txt"
+    report_path.write_text(
+        "# SUEWS Validation Report\n"
+        "# ==================================================\n"
+        "# Mode: Public\n"
+        "# ==================================================\n\n"
+        "## INFO\n"
+        "- Validation completed.\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _emit_pipeline_result(
+        phases=phases,
+        report_path=report_path,
+        yaml_path=tmp_path / "updated.yml",
+        out_format="table",
+        command=f"suews validate --pipeline {pipeline}",
+        started_at="2026-08-19T00:00:00Z",
+    )
+    capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Validation stopped at:" not in report_path.read_text(encoding="utf-8")
+    payload = json.loads(
+        report_path.with_suffix(".json").read_text(encoding="utf-8")
+    )
+    assert payload["overall_status"] == (
+        "WARNING" if outcome == "warning" else "PASSED"
+    )
+
+
+def test_pre_pipeline_input_error_does_not_claim_stopping_phase(tmp_path: Path) -> None:
+    """A Click input-path failure occurs before any A/B/C result exists."""
+    from supy.cmd.validate_config import cli as validate_cli
+
+    result = CliRunner().invoke(validate_cli, [str(tmp_path / "missing.yml")])
+
+    assert result.exit_code == 2
+    assert "Validation stopped at:" not in result.output
+
+
 def test_validate_passes_when_critical_physics_present(tmp_path: Path) -> None:
     """The bundled sample config declares every critical physics key, so
     the structural-presence check must not fire.

--- a/test/data_model/test_pipeline_structured_output.py
+++ b/test/data_model/test_pipeline_structured_output.py
@@ -56,6 +56,11 @@ def test_phase_a_emits_json_sidecar(tmp_path, sample_yaml_path):
         assert "code" in issue
         # Phase A codes always start with "A."
         assert issue["code"].startswith("A.")
+    text = report_file.read_text(encoding="utf-8")
+    if payload["status"] == "FAILED":
+        assert "# Validation stopped at: Completeness Check" in text
+    else:
+        assert "Validation stopped at:" not in text
 
 
 def test_phase_b_emits_json_sidecar(tmp_path, sample_yaml_path):
@@ -90,6 +95,11 @@ def test_phase_b_emits_json_sidecar(tmp_path, sample_yaml_path):
         assert "severity" in issue
         assert "code" in issue
         assert "message" in issue
+    text = science_report.read_text(encoding="utf-8")
+    if payload["status"] == "FAILED":
+        assert "# Validation stopped at: Scientific Validation" in text
+    else:
+        assert "Validation stopped at:" not in text
 
 
 def test_phase_c_emits_json_for_passing_config(tmp_path, sample_yaml_path):
@@ -114,6 +124,9 @@ def test_phase_c_emits_json_for_passing_config(tmp_path, sample_yaml_path):
     # Sample config should pass; status is PASSED unless there are
     # legitimate warnings in the sample.
     assert payload["status"] in {"PASSED", "WARNING"}
+    assert "Validation stopped at:" not in pydantic_report.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_phase_c_emits_structured_pydantic_errors_for_bad_config(tmp_path):
@@ -143,6 +156,9 @@ def test_phase_c_emits_structured_pydantic_errors_for_bad_config(tmp_path):
     payload = json.loads(pydantic_report.with_suffix(".json").read_text(encoding="utf-8"))
     assert payload["phase"] == "C"
     assert payload["status"] == "FAILED"
+    assert "# Validation stopped at: Model Compatibility" in (
+        pydantic_report.read_text(encoding="utf-8")
+    )
     # At least one issue should be a structured Pydantic error.
     pydantic_codes = [i["code"] for i in payload["issues"] if i["code"].startswith("C.PYDANTIC.")]
     assert pydantic_codes, "Expected at least one C.PYDANTIC.* issue"

--- a/test/data_model/test_report_schema.py
+++ b/test/data_model/test_report_schema.py
@@ -14,6 +14,9 @@ from supy.data_model.validation.pipeline.report_schema import (
     SEVERITY_WARNING,
     ValidationReport,
 )
+from supy.data_model.validation.pipeline.report_writer import (
+    format_report_stopping_phase,
+)
 
 pytestmark = pytest.mark.api
 
@@ -112,3 +115,94 @@ def test_json_report_writer_emits_utf8_with_trailing_newline(tmp_path):
     assert text.endswith("\n")
     payload = json.loads(text)
     assert payload["issues"][0]["message"] == "é"
+
+
+@pytest.mark.parametrize(
+    "failed_phase, expected_name",
+    [
+        ("A", "Completeness Check"),
+        ("B", "Scientific Validation"),
+        ("C", "Model Compatibility"),
+    ],
+)
+def test_report_header_uses_first_failed_structured_phase(
+    failed_phase, expected_name
+):
+    content = (
+        "# SUEWS Validation Report\n"
+        "# ==================================================\n"
+        "# Mode: Public\n"
+        "# ==================================================\n"
+    )
+    phases = [PhaseReport(phase="A", issues=[])] if failed_phase != "A" else []
+    if failed_phase == "C":
+        phases.append(PhaseReport(phase="B", issues=[]))
+    phases.append(
+        PhaseReport(
+            phase=failed_phase,
+            issues=[
+                Issue(
+                    phase=failed_phase,
+                    severity=SEVERITY_ERROR,
+                    code=f"{failed_phase}.TEST.ERROR",
+                    message="blocking error",
+                )
+            ],
+        )
+    )
+
+    formatted = format_report_stopping_phase(content, phases)
+
+    assert f"# Validation stopped at: {expected_name}\n" in formatted
+    assert formatted.count("# Validation stopped at:") == 1
+
+
+def test_report_header_uses_first_failure_when_multiple_phases_failed():
+    content = "# SUEWS Validation Report\n# Mode: Public\n"
+    failed_phases = [
+        PhaseReport(
+            phase=phase,
+            issues=[
+                Issue(
+                    phase=phase,
+                    severity=SEVERITY_ERROR,
+                    code=f"{phase}.TEST.ERROR",
+                    message="blocking error",
+                )
+            ],
+        )
+        for phase in ("B", "C")
+    ]
+
+    formatted = format_report_stopping_phase(content, failed_phases)
+
+    assert "# Validation stopped at: Scientific Validation\n" in formatted
+    assert "Model Compatibility" not in formatted
+
+
+@pytest.mark.parametrize("status", ["success", "warning"])
+def test_report_header_omits_stopping_phase_without_errors(status):
+    content = (
+        "# SUEWS Validation Report\n"
+        "# ==================================================\n"
+        "# Mode: Developer\n"
+        "# Validation stopped at: Completeness Check\n"
+        "# ==================================================\n"
+    )
+    issues = []
+    if status == "warning":
+        issues.append(
+            Issue(
+                phase="A",
+                severity=SEVERITY_WARNING,
+                code="A.TEST.WARNING",
+                message="review this",
+            )
+        )
+
+    formatted = format_report_stopping_phase(
+        content, [PhaseReport(phase="A", issues=issues)]
+    )
+
+    assert "Validation stopped at:" not in formatted
+    assert "# Mode: Developer\n" in formatted


### PR DESCRIPTION
## Summary

- derive the human-readable stopping stage from structured phase results through one shared formatter
- use the public Completeness Check, Scientific Validation, and Model Compatibility names across single and combined pipelines
- omit the stopping-stage line for successful, warning-only, and pre-pipeline failures
- update the public validation documentation while preserving exit codes and structured schemas

## Validation

- `pytest test/data_model/test_pipeline_structured_output.py`
- `pytest test/data_model/test_report_schema.py`
- `pytest test/cmd/test_validate_config.py`
- `make test-smoke`
- `make test`

Closes #1091