### PR TITLE
Repoint the landing schema card at the parameter database

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -660,12 +660,12 @@
                     <p class="card-description">GitHub repository, issue tracking, and development</p>
                 </a>
 
-                <a href="schemas/suews-config/" class="resource-card" style="--card-accent: var(--sky-blue); --card-accent-soft: rgba(93,173,226,0.14);">
+                <a href="https://umep-dev.github.io/SUEWS-database/" class="resource-card" style="--card-accent: var(--sky-blue); --card-accent-soft: rgba(93,173,226,0.14);">
                     <div class="card-icon">
                         <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>
                     </div>
-                    <h3 class="card-title">Schema Registry</h3>
-                    <p class="card-description">YAML configuration schemas for model input validation</p>
+                    <h3 class="card-title">Parameter Database</h3>
+                    <p class="card-description">Curated parameter values with a citation on every one, ready to paste into a configuration</p>
                 </a>
 
                 <a href="/benchmark/" class="resource-card" style="--card-accent: var(--water-blue); --card-accent-soft: rgba(0,119,182,0.12);">


### PR DESCRIPTION
The landing page's "Schema Registry" card links `schemas/suews-config/`,
which has 404'd since schema hosting was removed from the Pages deployment
(the pages-deploy workflow notes validation moved to Pydantic at runtime).

The SUEWS parameter database now has a browsable site generated from its
record format — every value with its citation, exportable as a fragment
that pastes into a SUEWS YAML configuration — so the dead card becomes the
**Parameter Database** entry pointing at
https://umep-dev.github.io/SUEWS-database/.

Companion PRs: UMEP-dev/SUEWS-database#3 (the record format) and
UMEP-dev/SUEWS-database#4 (the browser site). The PR preview here renders
the card change; the target link goes live once those merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
