### PR TITLE
Point community links at the open forum URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 80       | 86       | 32 | 81 | 40 | 320   |
+| 2026 | 80       | 86       | 32 | 81 | 41 | 321   |
 | 2025 | 60       | 68       | 22 | 71 | 36 | 256   |
 | 2024 | 12       | 17       | 1 | 12 | 1 | 43    |
 | 2023 | 11       | 14       | 3 | 9 | 1 | 38    |
@@ -53,6 +53,10 @@ EXAMPLES:
 | 2017 | 9        | 0        | 3 | 2 | 0 | 14    |
 
 ## 2026
+
+### 21 Aug 2026
+
+- [doc] Replaced the single-use Discourse invite link with the public `community.suews.io` URL across the documentation and the landing page, now that forum registration is open (#1713)
 
 ### 14 Aug 2026
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -438,7 +438,7 @@ rst_prolog = rf"""
       2. Please report issues with the manual on `GitHub Issues`_ (or use `Report Issue for This Page`_ for page-specific feedback).
       3. Please cite SUEWS with proper information from our `Zenodo page`_.
 
-.. _SUEWS Community: https://community.suews.io/invites/bKjzoboyVV
+.. _SUEWS Community: https://community.suews.io
 .. _GitHub Issues: https://github.com/UMEP-dev/SUEWS/issues
 .. _SUEWS download page: https://forms.office.com/r/4qGfYu8LaR
 

--- a/docs/source/contributing/contributing.rst
+++ b/docs/source/contributing/contributing.rst
@@ -14,9 +14,9 @@ We welcome community contributions in the following areas:
 
 - **Bug Reports**: Open an issue on `GitHub Issues <https://github.com/UMEP-dev/SUEWS/issues>`_
 - **Documentation Improvements**: Click the "Suggest an edit" button at the top right of the page (the GitHub icon) and make your changes.
-- **Feature Requests**: Discuss ideas in the `SUEWS Community <https://community.suews.io/invites/bKjzoboyVV>`_
+- **Feature Requests**: Discuss ideas in the `SUEWS Community <https://community.suews.io>`_
 
-.. note:: If you are interested in contributing to the project, please start a discussion in the `SUEWS Community <https://community.suews.io/invites/bKjzoboyVV>`_ to share your ideas.
+.. note:: If you are interested in contributing to the project, please start a discussion in the `SUEWS Community <https://community.suews.io>`_ to share your ideas.
 
 Building SUEWS Locally
 ----------------------
@@ -34,6 +34,6 @@ Getting Help
 ------------
 
 - **Issues**: `GitHub Issues <https://github.com/UMEP-dev/SUEWS/issues>`_
-- **Discussions**: `SUEWS Community <https://community.suews.io/invites/bKjzoboyVV>`_
+- **Discussions**: `SUEWS Community <https://community.suews.io>`_
 - **Documentation**: `ReadTheDocs <https://docs.suews.io>`_
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -173,4 +173,4 @@ How to support SUEWS?
    :hidden:
 
    community_publications
-   Community <https://community.suews.io/invites/bKjzoboyVV>
+   Community <https://community.suews.io>

--- a/docs/source/inputs/yaml/index.rst
+++ b/docs/source/inputs/yaml/index.rst
@@ -299,4 +299,4 @@ Getting Help
 - **Validation issues**: Check the report file (``report_*.txt``)
 - **Parameter documentation**: See the error messages from validation
 - **Examples**: Look in ``sample_data/`` directory
-- **Community support**: `SUEWS Community <https://community.suews.io/invites/bKjzoboyVV>`_
+- **Community support**: `SUEWS Community <https://community.suews.io>`_

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -19,7 +19,7 @@ Please submit your issue via `our GitHub page. <https://github.com/UMEP-dev/SUEW
 2. How to join your email-list?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please join our community `here. <https://community.suews.io/invites/bKjzoboyVV>`_
+Please join our community `here. <https://community.suews.io>`_
 
 3. How to create a directory?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -650,7 +650,7 @@ Getting Support and Community
 **SuPy and SUEWS Community:**
 
 - **GitHub Repository**: `SUEWS on GitHub <https://github.com/UMEP-dev/SUEWS>`__ for issues and contributions
-- **Community**: `Join the SUEWS community <https://community.suews.io/invites/bKjzoboyVV>`__ for discussions
+- **Community**: `Join the SUEWS community <https://community.suews.io>`__ for discussions
 - **Documentation**: :doc:`Complete API reference <inputs/yaml/index>` and parameter guides
 
 **Essential Reading:**

--- a/site/index.html
+++ b/site/index.html
@@ -641,12 +641,12 @@
                     <p class="card-description">User guide, scientific background, tutorials, and API reference</p>
                 </a>
 
-                <a href="https://community.suews.io/invites/bKjzoboyVV" class="resource-card" style="--card-accent: var(--energy-orange); --card-accent-soft: rgba(232,93,4,0.12);">
+                <a href="https://community.suews.io" class="resource-card" style="--card-accent: var(--energy-orange); --card-accent-soft: rgba(232,93,4,0.12);">
                     <div class="card-icon">
                         <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
                     </div>
                     <h3 class="card-title">Community</h3>
-                    <p class="card-description">Invite-only discussion forum &mdash; click to request access</p>
+                    <p class="card-description">Open discussion forum for questions, support, and announcements</p>
                 </a>
             </div>
 


### PR DESCRIPTION
## Summary

Registration on `community.suews.io` is now open, so the single-use Discourse invite link (`/invites/bKjzoboyVV`) embedded across the documentation and the landing page is no longer the right entry point for new users. This replaces every occurrence with the bare forum URL.

## Changes

- `docs/source/conf.py` -- the `SUEWS Community` link target in `rst_prolog` (this one feeds every page's footer).
- `docs/source/index.rst`, `troubleshooting.rst`, `workflow.rst`, `contributing/contributing.rst` (3 occurrences), `inputs/yaml/index.rst`.
- `site/index.html` -- the Community resource card href, plus its description, which still read "Invite-only discussion forum -- click to request access".

`README.md` and `CONTRIBUTING.md` already used the bare URL, so the whole user-facing surface is now consistent.

## Out of scope

The historical release note in `docs/source/version-history/v2026.4.3.rst` and the matching `CHANGELOG.md` line still mention the invite page. Those are records of what shipped in that release and are left untouched.

## Verification

- `https://community.suews.io/site/basic-info.json` reports `"login_required": false`.
- `https://community.suews.io/signup` returns HTTP 200.
- No remaining `community.suews.io/invites/` reference anywhere in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)