### PR TITLE
Point the database card at database.suews.io

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -660,7 +660,7 @@
                     <p class="card-description">GitHub repository, issue tracking, and development</p>
                 </a>
 
-                <a href="https://umep-dev.github.io/SUEWS-database/" class="resource-card" style="--card-accent: var(--sky-blue); --card-accent-soft: rgba(93,173,226,0.14);">
+                <a href="https://database.suews.io" class="resource-card" style="--card-accent: var(--sky-blue); --card-accent-soft: rgba(93,173,226,0.14);">
                     <div class="card-icon">
                         <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>
                     </div>


### PR DESCRIPTION
The SUEWS parameter database now answers at **https://database.suews.io**, next
to `docs.suews.io`, `community.suews.io` and `code.suews.io`. The Parameter
Database card on the front page still pointed at the GitHub Pages hosting
address, so it now points at the subdomain instead — matching how the
Documentation, Community and Source Code cards are written.

One line in `site/index.html`; nothing else changes.

## What was checked

- the subdomain is a DNS-only CNAME to `umep-dev.github.io` on the `suews.io`
  zone, configured the same way as `docs` and `community`
- the certificate is issued and HTTPS is enforced; the root and a deep page both
  return 200
- the old address returns 301 to the new one, so the link would have kept
  working either way — this is about the address readers see, not about a
  breakage
- no script on the page keys a selector on this card's `href` (the docs card is
  the only one treated that way)

A companion change on `UMEP-dev/SUEWS-database` updates that repository's own
README and issue-form placeholder.
