### PR TITLE
fix: align supy licence metadata with MPL-2.0

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -277,6 +277,10 @@ runs:
         if-no-files-found: error
         retention-days: 14
 
+    - name: Verify wheel licence metadata
+      shell: bash
+      run: python scripts/suews/check_dist_license.py wheelhouse/*.whl
+
     - name: Upload wheels
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "SUEWS: Surface Urban Energy and Water Balance Scheme",
   "description": "SUEWS (Surface Urban Energy and Water balance Scheme) is a state-of-the-art urban land surface model for simulating the urban surface energy balance, water balance, and anthropogenic heat flux.",
-  "license": "GPL-3.0",
+  "license": "MPL-2.0",
   "upload_type": "software",
   "creators": [
     {

--- a/dev-ref/RELEASE_MANUAL.md
+++ b/dev-ref/RELEASE_MANUAL.md
@@ -70,6 +70,7 @@ From a single tag push:
    - Builds one `cp312-abi3` wheel per (OS, arch) via cibuildwheel
    - The Rust bridge uses PyO3 `abi3-py312`, so the wheel installs on cp312..cp3xx
    - Creates version `2024.10.7`
+   - Verifies the PEP 639 licence expression and bundled MPL/Apache licence files
 
 2. **Cross-CPython API tests** (`test_api_cross_python` job)
    - Installs the single wheel into each test CPython (BOOKEND for PRs, ALL for tags)
@@ -830,7 +831,7 @@ Integration is now active. The setup included:
        {"name": "Ward, Helen"},
        {"name": "Omidvar, Hamidreza"}
      ],
-     "license": "GPL-3.0",
+     "license": "MPL-2.0",
      "title": "SUEWS: Surface Urban Energy and Water Balance Scheme",
      "keywords": ["urban climate", "energy balance", "hydrology", "meteorology"]
    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "meson-python>=0.17",
+    "meson-python>=0.18",
     "meson>=1.3.0",  # required for tool.meson-python.limited-api support
 ]
 build-backend = 'mesonpy'
@@ -23,7 +23,12 @@ authors = [
 ]
 dynamic = ["version"]
 requires-python = ">=3.12"
-license = { text = "GPL-V3.0" }
+license = "MPL-2.0 AND Apache-2.0"
+license-files = [
+    "LICENSE",
+    "src/suews/ext_lib/spartacus-surface/LICENSE",
+    "src/suews/ext_lib/spartacus-surface/NOTICE",
+]
 readme = "README.md"
 
 # Core runtime dependencies only

--- a/scripts/suews/check_dist_license.py
+++ b/scripts/suews/check_dist_license.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Validate the licence metadata and files in SUEWS wheel archives."""
+
+from __future__ import annotations
+
+import argparse
+from email.parser import BytesParser
+from pathlib import Path, PurePosixPath
+import zipfile
+
+EXPECTED_EXPRESSION = "MPL-2.0 AND Apache-2.0"
+EXPECTED_LICENSE_FILES = {
+    "LICENSE",
+    "src/suews/ext_lib/spartacus-surface/LICENSE",
+    "src/suews/ext_lib/spartacus-surface/NOTICE",
+}
+
+
+def _one(candidates: list[str], description: str, archive: Path) -> str:
+    if len(candidates) != 1:
+        raise ValueError(
+            f"{archive}: expected one {description}, found {len(candidates)}: "
+            f"{candidates}"
+        )
+    return candidates[0]
+
+
+def _validate_metadata(metadata_bytes: bytes, archive: Path) -> None:
+    metadata = BytesParser().parsebytes(metadata_bytes)
+    if metadata["Metadata-Version"] != "2.4":
+        raise ValueError(
+            f"{archive}: expected Metadata-Version 2.4, "
+            f"found {metadata['Metadata-Version']!r}"
+        )
+    if metadata["License-Expression"] != EXPECTED_EXPRESSION:
+        raise ValueError(
+            f"{archive}: expected License-Expression {EXPECTED_EXPRESSION!r}, "
+            f"found {metadata['License-Expression']!r}"
+        )
+    if metadata["License"] is not None:
+        raise ValueError(
+            f"{archive}: legacy License field is still present: {metadata['License']!r}"
+        )
+
+    actual_files = set(metadata.get_all("License-File", []))
+    if actual_files != EXPECTED_LICENSE_FILES:
+        raise ValueError(
+            f"{archive}: expected License-File entries "
+            f"{sorted(EXPECTED_LICENSE_FILES)!r}, found {sorted(actual_files)!r}"
+        )
+
+
+def _validate_wheel(archive: Path) -> None:
+    with zipfile.ZipFile(archive) as wheel:
+        names = wheel.namelist()
+        metadata_name = _one(
+            [name for name in names if name.endswith(".dist-info/METADATA")],
+            "wheel METADATA file",
+            archive,
+        )
+        _validate_metadata(wheel.read(metadata_name), archive)
+
+        dist_info = PurePosixPath(metadata_name).parent
+        expected_members = {
+            str(dist_info / "licenses" / relative)
+            for relative in EXPECTED_LICENSE_FILES
+        }
+        missing = expected_members.difference(names)
+        if missing:
+            raise ValueError(
+                f"{archive}: missing licence archive members: {sorted(missing)!r}"
+            )
+
+
+def validate_archive(archive: Path) -> None:
+    """Validate one wheel archive."""
+    if archive.suffix != ".whl":
+        raise ValueError(f"{archive}: expected a .whl archive")
+    _validate_wheel(archive)
+
+
+def main() -> None:
+    """Validate every wheel archive supplied on the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archives", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    for archive in args.archives:
+        validate_archive(archive)
+        print(f"licence metadata OK: {archive}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/suews_bridge/Cargo.toml
+++ b/src/suews_bridge/Cargo.toml
@@ -3,7 +3,7 @@ name = "suews_bridge"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
-license = "GPL-3.0-or-later"
+license = "MPL-2.0"
 description = "Rust bridge MVP for SUEWS OHM Fortran C API"
 
 [lib]

--- a/test/core/test_distribution_license.py
+++ b/test/core/test_distribution_license.py
@@ -1,0 +1,54 @@
+"""Regression checks for the licence signals shipped by the supy package."""
+
+from __future__ import annotations
+
+from importlib.metadata import distribution
+import json
+from pathlib import Path
+import tomllib
+
+import pytest
+
+pytestmark = [pytest.mark.physics, pytest.mark.smoke]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_EXPRESSION = "MPL-2.0 AND Apache-2.0"
+EXPECTED_LICENSE_FILES = {
+    "LICENSE",
+    "src/suews/ext_lib/spartacus-surface/LICENSE",
+    "src/suews/ext_lib/spartacus-surface/NOTICE",
+}
+
+
+def test_source_licence_signals_are_consistent() -> None:
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as stream:
+        pyproject = tomllib.load(stream)
+    with (PROJECT_ROOT / "src/suews_bridge/Cargo.toml").open("rb") as stream:
+        cargo = tomllib.load(stream)
+    with (PROJECT_ROOT / ".zenodo.json").open(encoding="utf-8") as stream:
+        zenodo = json.load(stream)
+
+    assert pyproject["project"]["license"] == EXPECTED_EXPRESSION
+    assert set(pyproject["project"]["license-files"]) == EXPECTED_LICENSE_FILES
+    assert "meson-python>=0.18" in pyproject["build-system"]["requires"]
+    assert cargo["package"]["license"] == "MPL-2.0"
+    assert zenodo["license"] == "MPL-2.0"
+    assert "license: MPL-2.0" in (PROJECT_ROOT / "CITATION.cff").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_installed_wheel_exposes_pep639_licence_metadata() -> None:
+    installed = distribution("supy")
+    metadata = installed.metadata
+
+    assert metadata["Metadata-Version"] == "2.4"
+    assert metadata["License-Expression"] == EXPECTED_EXPRESSION
+    assert metadata["License"] is None
+    assert set(metadata.get_all("License-File", [])) == EXPECTED_LICENSE_FILES
+
+    installed_paths = {str(path) for path in installed.files or []}
+    for relative in EXPECTED_LICENSE_FILES:
+        assert any(
+            path.endswith(f".dist-info/licenses/{relative}") for path in installed_paths
+        )


### PR DESCRIPTION
## Summary

- replace the stale GPLv3 package declaration with the PEP 639 expression `MPL-2.0 AND Apache-2.0`
- include the repository MPL licence plus SPARTACUS-Surface's Apache licence and NOTICE in built wheels
- align the Rust crate, Zenodo metadata, and release documentation with MPL-2.0
- require `meson-python>=0.18` for PEP 639 support
- validate wheel metadata and bundled licence files before upload, with a smoke regression for both source signals and installed metadata

SPARTACUS-Surface is compiled into the extension, so the `supy` wheel uses the compound expression. SUEWS itself remains MPL-2.0.

## Scope

This keeps the existing wheel-only release path. It does not add, build, validate, or publish an sdist, and it does not alter historical tags or previously published PyPI artefacts.

## Verification

- built a real `cp312-abi3` wheel
- confirmed `Metadata-Version: 2.4`
- confirmed `License-Expression: MPL-2.0 AND Apache-2.0`
- confirmed there is no legacy `License:` field
- confirmed all three declared licence files exist under `.dist-info/licenses/`
- installed the wheel and passed the metadata regression
- passed Ruff and `git diff --check`

## Review note

This PR corrects current metadata only. Repository history shows the root licence changed from GPLv3 to MPL-2.0 in February 2020; maintainers should retain or confirm the corresponding relicensing authority for substantive pre-2020 contributions. That provenance question cannot be resolved by packaging metadata.

Closes #1716