### PR TITLE
Pass the Rust output block to Python as bytes to cut run() peak memory ~3x

### DIFF
--- a/src/suews_bridge/src/lib.rs
+++ b/src/suews_bridge/src/lib.rs
@@ -126,9 +126,9 @@ pub use phenology::*;
 pub use roughness::*;
 #[cfg(feature = "physics")]
 pub use sim::{
-    run_from_config_str_and_forcing, run_from_config_str_and_forcing_with_state,
-    run_simulation, SimulationInput, SimulationOutput,
-    SiteScalars, OUTPUT_SUEWS_COLS, OUTPUT_ALL_COLS, OUTPUT_GROUP_LAYOUT,
+    run_from_config_str_and_forcing, run_from_config_str_and_forcing_with_state, run_simulation,
+    SimulationInput, SimulationOutput, SiteScalars, OUTPUT_ALL_COLS, OUTPUT_GROUP_LAYOUT,
+    OUTPUT_SUEWS_COLS,
 };
 pub use snow::*;
 pub use snow_prm::*;
@@ -152,10 +152,25 @@ mod python_bindings {
     use crate::*;
     use pyo3::exceptions::{PyRuntimeError, PyValueError};
     use pyo3::prelude::*;
+    use pyo3::types::PyBytes;
     use std::collections::{BTreeMap, HashMap};
 
     fn map_bridge_error(err: BridgeError) -> PyErr {
         PyRuntimeError::new_err(err.to_string())
+    }
+
+    /// View a `[f64]` slice as native-endian bytes and hand it to Python as a
+    /// `bytes` object. Returning bytes instead of `Vec<f64>` avoids PyO3
+    /// boxing every element into a Python float (a ~4x memory blow-up for a
+    /// grid-year output block, GH-1718); the Python side reconstructs the
+    /// array zero-copy with `np.frombuffer(..., dtype=np.float64)`.
+    fn f64s_to_pybytes(py: Python<'_>, values: &[f64]) -> Py<PyBytes> {
+        // SAFETY: f64 has no padding and any byte pattern is a valid u8;
+        // the slice length in bytes is exactly `size_of_val(values)`.
+        let bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(values.as_ptr() as *const u8, std::mem::size_of_val(values))
+        };
+        PyBytes::new(py, bytes).unbind()
     }
 
     #[pyclass(name = "OhmModel")]
@@ -4086,33 +4101,35 @@ mod python_bindings {
         lon: f64,
         alt: f64,
     ) -> PyResult<(f64, f64)> {
-        let (az, zen) = sunposition_calc(year, idectime, utc, lat, lon, alt)
-            .map_err(map_bridge_error)?;
+        let (az, zen) =
+            sunposition_calc(year, idectime, utc, lat, lon, alt).map_err(map_bridge_error)?;
         Ok((az, zen))
     }
 
     #[cfg(feature = "physics")]
     #[pyfunction(name = "run_suews")]
     fn run_suews_py(
+        py: Python<'_>,
         config_yaml: &str,
         forcing_block: Vec<f64>,
         len_sim: usize,
-    ) -> PyResult<(Vec<f64>, String, usize)> {
+    ) -> PyResult<(Py<PyBytes>, String, usize)> {
         let (output_block, state, timer, actual_len) =
             run_from_config_str_and_forcing(config_yaml, forcing_block, len_sim)
                 .map_err(map_bridge_error)?;
         let state_json = suews_checkpoint_to_json(&state, &timer).map_err(map_bridge_error)?;
-        Ok((output_block, state_json, actual_len))
+        Ok((f64s_to_pybytes(py, &output_block), state_json, actual_len))
     }
 
     #[cfg(feature = "physics")]
     #[pyfunction(name = "run_suews_with_state")]
     fn run_suews_with_state_py(
+        py: Python<'_>,
         config_yaml: &str,
         forcing_block: Vec<f64>,
         len_sim: usize,
         state_json: &str,
-    ) -> PyResult<(Vec<f64>, String, usize)> {
+    ) -> PyResult<(Py<PyBytes>, String, usize)> {
         let (output_block, state, timer, actual_len) = run_from_config_str_and_forcing_with_state(
             config_yaml,
             forcing_block,
@@ -4121,7 +4138,11 @@ mod python_bindings {
         )
         .map_err(map_bridge_error)?;
         let state_json_out = suews_checkpoint_to_json(&state, &timer).map_err(map_bridge_error)?;
-        Ok((output_block, state_json_out, actual_len))
+        Ok((
+            f64s_to_pybytes(py, &output_block),
+            state_json_out,
+            actual_len,
+        ))
     }
 
     /// Run multiple grid cells in parallel using Rayon thread pool.
@@ -4133,11 +4154,12 @@ mod python_bindings {
     #[pyfunction(name = "run_suews_multi")]
     #[pyo3(signature = (config_jsons, forcing_block, len_sim, max_workers=None))]
     fn run_suews_multi_py(
+        py: Python<'_>,
         config_jsons: Vec<String>,
         forcing_block: Vec<f64>,
         len_sim: usize,
         max_workers: Option<usize>,
-    ) -> PyResult<Vec<(usize, Vec<f64>, String, usize)>> {
+    ) -> PyResult<Vec<(usize, Py<PyBytes>, String, usize)>> {
         use rayon::prelude::*;
 
         if max_workers == Some(0) {
@@ -4174,11 +4196,23 @@ mod python_bindings {
                 run_parallel()
             };
 
-        // Convert errors to PyResult
+        // Convert errors to PyResult, then box each output block as bytes
         results
             .into_iter()
             .collect::<Result<Vec<_>, String>>()
             .map_err(pyo3::exceptions::PyRuntimeError::new_err)
+            .map(|list| {
+                list.into_iter()
+                    .map(|(idx, output_block, state_json, actual_len)| {
+                        (
+                            idx,
+                            f64s_to_pybytes(py, &output_block),
+                            state_json,
+                            actual_len,
+                        )
+                    })
+                    .collect()
+            })
     }
 
     /// Run multiple grid cells in parallel using injected previous states.
@@ -4189,12 +4223,13 @@ mod python_bindings {
     #[pyfunction(name = "run_suews_multi_with_state")]
     #[pyo3(signature = (config_jsons, forcing_block, len_sim, state_jsons, max_workers=None))]
     fn run_suews_multi_with_state_py(
+        py: Python<'_>,
         config_jsons: Vec<String>,
         forcing_block: Vec<f64>,
         len_sim: usize,
         state_jsons: Vec<String>,
         max_workers: Option<usize>,
-    ) -> PyResult<Vec<(usize, Vec<f64>, String, usize)>> {
+    ) -> PyResult<Vec<(usize, Py<PyBytes>, String, usize)>> {
         use rayon::prelude::*;
 
         if max_workers == Some(0) {
@@ -4246,6 +4281,18 @@ mod python_bindings {
             .into_iter()
             .collect::<Result<Vec<_>, String>>()
             .map_err(pyo3::exceptions::PyRuntimeError::new_err)
+            .map(|list| {
+                list.into_iter()
+                    .map(|(idx, output_block, state_json, actual_len)| {
+                        (
+                            idx,
+                            f64s_to_pybytes(py, &output_block),
+                            state_json,
+                            actual_len,
+                        )
+                    })
+                    .collect()
+            })
     }
 
     /// Return the output group layout as a list of (name, ncols) tuples.
@@ -4289,11 +4336,7 @@ mod python_bindings {
         let mut n_groups = 0i32;
         let mut err = 0i32;
         unsafe {
-            ffi::suews_output_group_ncolumns(
-                ncols_arr.as_mut_ptr(),
-                &mut n_groups,
-                &mut err,
-            );
+            ffi::suews_output_group_ncolumns(ncols_arr.as_mut_ptr(), &mut n_groups, &mut err);
         }
         if err != 0 {
             return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(

--- a/src/supy/_run_rust.py
+++ b/src/supy/_run_rust.py
@@ -236,7 +236,7 @@ def _prepare_forcing_block(df_forcing: pd.DataFrame) -> np.ndarray:
 
 
 def _parse_output_block(
-    output_flat: list[float],
+    output_flat: bytes | list[float],
     len_sim: int,
     grid_id: int,
 ) -> pd.DataFrame:
@@ -245,10 +245,18 @@ def _parse_output_block(
     The flat buffer contains *len_sim* rows of ``OUTPUT_ALL_COLS`` columns.
     Each of the 11 output groups occupies a contiguous slice and carries its
     own 5-column datetime prefix.  We extract the datetime from the first
-    group (SUEWS), then for every group strip its datetime prefix and build
-    a ``(group, var)`` MultiIndex column set via :func:`gen_index`.
+    group (SUEWS), then strip every group's datetime prefix and build one
+    frame with ``(group, var)`` MultiIndex columns via :func:`gen_index`.
+
+    The bridge hands the buffer over as native-endian ``bytes`` so that no
+    boxed Python floats are created at the FFI boundary (GH-1718);
+    ``np.frombuffer`` reconstructs the array zero-copy. A plain sequence is
+    still accepted for older bridge builds.
     """
-    output_array = np.asarray(output_flat, dtype=np.float64)
+    if isinstance(output_flat, (bytes, bytearray, memoryview)):
+        output_array = np.frombuffer(output_flat, dtype=np.float64)
+    else:
+        output_array = np.asarray(output_flat, dtype=np.float64)
     expected = len_sim * OUTPUT_ALL_COLS
     if output_array.size != expected:
         if len_sim > 0 and output_array.size % len_sim == 0:
@@ -270,31 +278,47 @@ def _parse_output_block(
     # Datetime from the first group (SUEWS)
     datetime_index = _build_datetime_index(output_block)
 
-    list_df_group: list[pd.DataFrame] = []
+    # Column bookkeeping for all groups up front, so the data columns can be
+    # gathered in ONE fancy-index copy (writable) instead of building eleven
+    # per-group frames and concatenating them - the frame pipeline previously
+    # held several whole-year copies at peak (GH-1718).
+    list_col_idx: list[np.ndarray] = []
+    list_group_cols: list[pd.MultiIndex] = []
     col_offset = 0
     for group_name, ncols in OUTPUT_GROUP_LAYOUT:
-        group_data = output_block[:, col_offset + OUTPUT_TIME_COLS : col_offset + ncols]
+        n_data = ncols - OUTPUT_TIME_COLS
         idx = gen_index(f"dataoutline{group_name.lower()}")
-        try:
-            df_group = pd.DataFrame(group_data, columns=idx, index=datetime_index)
-        except ValueError as exc:
+        if len(idx) != n_data:
             raise RuntimeError(
                 f"Failed to parse Rust backend output group '{group_name}': "
-                f"received {group_data.shape[1]} data columns, but the Python "
+                f"received {n_data} data columns, but the Python "
                 f"registry expects {len(idx)}. "
-                f"{_output_layout_update_hint(group_name)} "
-                f"Original pandas error: {exc}"
-            ) from exc
-        # SUEWS uses -999 as missing-data sentinel; expose these as NaN in
-        # Python outputs so downstream filtering/resampling behaves correctly.
-        df_group = df_group.mask(df_group == -999.0)
-        list_df_group.append(df_group)
+                f"{_output_layout_update_hint(group_name)}"
+            )
+        list_col_idx.append(
+            np.arange(col_offset + OUTPUT_TIME_COLS, col_offset + ncols)
+        )
+        list_group_cols.append(idx)
         col_offset += ncols
 
-    df_output = pd.concat(list_df_group, axis=1)
-    df_output.index = pd.MultiIndex.from_product(
-        [[_normalise_grid_id(grid_id)], datetime_index],
-        names=["grid", "datetime"],
+    ar_data = output_block[:, np.concatenate(list_col_idx)]
+    # SUEWS uses -999 as missing-data sentinel; expose these as NaN in
+    # Python outputs so downstream filtering/resampling behaves correctly.
+    # In-place on the freshly copied array: no further whole-year copy.
+    ar_data[ar_data == -999.0] = np.nan
+
+    cols_all = list_group_cols[0]
+    for idx in list_group_cols[1:]:
+        cols_all = cols_all.append(idx)
+
+    df_output = pd.DataFrame(
+        ar_data,
+        columns=cols_all,
+        index=pd.MultiIndex.from_product(
+            [[_normalise_grid_id(grid_id)], datetime_index],
+            names=["grid", "datetime"],
+        ),
+        copy=False,
     )
     return df_output
 
@@ -451,6 +475,9 @@ def run_suews_rust_multi(
             (list_grid_ids[idx], output_flat, state_json, len_sim)
             for idx, output_flat, state_json, len_sim in raw_results
         ]
+        # Drop the duplicate references so each buffer is owned only by
+        # `results` and freed as soon as its grid is parsed below (GH-1718).
+        del raw_results
     else:
         results = []
         for idx, config_json in enumerate(list_config_jsons):
@@ -465,7 +492,12 @@ def run_suews_rust_multi(
     list_df_output = []
     dict_state_json: dict[int, str] = {}
 
-    for grid_id, output_flat, state_json, len_sim in results:
+    # Consume from the tail so each grid's output buffer is released as soon
+    # as it has been parsed, instead of all buffers living until the loop ends
+    # (one whole-year block per grid, GH-1718).
+    results.reverse()
+    while results:
+        grid_id, output_flat, state_json, len_sim = results.pop()
         if len_sim != len_forcing:
             raise RuntimeError(
                 f"Rust backend length mismatch: forcing={len_forcing}, output={len_sim}"
@@ -567,6 +599,9 @@ def run_suews_rust_multi_with_state(
             (list_grid_ids[idx], output_flat, state_json, len_sim)
             for idx, output_flat, state_json, len_sim in raw_results
         ]
+        # Drop the duplicate references so each buffer is owned only by
+        # `results` and freed as soon as its grid is parsed below (GH-1718).
+        del raw_results
     else:
         results = []
         for idx, config_json in enumerate(list_config_jsons):
@@ -581,7 +616,12 @@ def run_suews_rust_multi_with_state(
     list_df_output = []
     dict_state_json: dict[int, str] = {}
 
-    for grid_id, output_flat, state_json, len_sim in results:
+    # Consume from the tail so each grid's output buffer is released as soon
+    # as it has been parsed, instead of all buffers living until the loop ends
+    # (one whole-year block per grid, GH-1718).
+    results.reverse()
+    while results:
+        grid_id, output_flat, state_json, len_sim = results.pop()
         if len_sim != len_forcing:
             raise RuntimeError(
                 f"Rust backend length mismatch: forcing={len_forcing}, output={len_sim}"

--- a/test/core/test_forcing_timestamp_reference.py
+++ b/test/core/test_forcing_timestamp_reference.py
@@ -45,7 +45,12 @@ def _run(rust_module, config, forcing, state_json=None):
 
 
 def _output_datetimes(output, length):
-    block = np.asarray(output).reshape(length, -1)
+    # The bridge returns the block as native-endian bytes (GH-1718); older
+    # builds returned a list of floats. Accept both.
+    if isinstance(output, (bytes, bytearray, memoryview)):
+        block = np.frombuffer(output, dtype=np.float64).reshape(length, -1)
+    else:
+        block = np.asarray(output).reshape(length, -1)
     return (
         pd.to_datetime({
             "year": block[:, 0].astype(int),

--- a/test/core/test_fortran_state_persistence.py
+++ b/test/core/test_fortran_state_persistence.py
@@ -25,6 +25,7 @@ pytestmark = pytest.mark.physics
 
 _RESULT_PREFIX = "__SUEWS_NATIVE_RESULT__"
 _NATIVE_SEQUENCE_RUNNER = f"""
+import array
 import json
 import os
 import sys
@@ -44,7 +45,11 @@ for case_name in payload["sequence"]:
     results.append(
         {{
             "actual_len": actual_len,
-            "output_flat": output_flat,
+            # The bridge returns bytes (GH-1718); decode to a plain list so the
+            # payload stays JSON-serialisable (older list output passes through).
+            "output_flat": list(array.array("d", output_flat))
+            if isinstance(output_flat, (bytes, bytearray))
+            else output_flat,
             "state_json": state_json,
         }}
     )


### PR DESCRIPTION
Fixes #1718.

A grid-year output block returned as `Vec<f64>` is boxed by PyO3 into ~142M Python float objects (~4.5 GB) before `np.asarray` copies it out again; per-group `.mask()` and `pd.concat` then add further whole-year copies. A single-grid one-year run peaked at ~8.2 GB RSS for a ~1.1 GB output frame, which exceeds the 7 GB macOS CI runners outright and is why the #1675 merge-queue attempts timed out.

Changes:
- the four `run_suews*` bridge wrappers return the block as native-endian bytes (`PyBytes`)
- `_parse_output_block` decodes with `np.frombuffer` (zero-copy), gathers the data columns in one fancy-index copy, replaces the -999 sentinel in place, and builds a single DataFrame instead of 11 per-group frames + concat
- multi-grid paths release each grid's buffer as soon as it is parsed
- the two tests that consume the raw FFI buffer directly now accept bytes (and still accept the legacy list)

Validation:
- peak RSS on the bundled sample year: 8.2 GB -> 3.0 GB
- outputs bit-identical to master at 17 significant digits across 10 configurations (both hemispheres, LAIType variants, laimethod=0, shifted forcing) and the chunked state-chained path
- `test/core` 448 passed, `test/io_tests` 132 passed locally on macOS arm64
