### PR TITLE
Fix interaction-limit enforcement: GITHUB_TOKEN cannot set interaction limits

### DIFF
--- a/.github/workflows/interaction-limits.yml
+++ b/.github/workflows/interaction-limits.yml
@@ -1,25 +1,106 @@
 name: Enforce Interaction Limits
 
+# Repository interaction limits always expire -- the GitHub API caps `expiry`
+# at `six_months` and offers no permanent setting. This workflow re-applies the
+# `contributors_only` limit monthly so the contribution policy documented in
+# CONTRIBUTING.md and .github/ISSUE_TEMPLATE/config.yml never lapses.
+#
+# `secrets.GITHUB_TOKEN` CANNOT drive this endpoint. PUT
+# /repos/{owner}/{repo}/interaction-limits requires the "Administration"
+# repository permission (write), and `administration` is not among the scopes a
+# workflow `permissions:` block can grant to GITHUB_TOKEN. A separate token is
+# required -- see the error message in the guard step below for how to mint it.
+
 on:
   schedule:
     # 1st of each month at 09:00 UTC
     - cron: "0 9 1 * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   set-limits:
+    name: Apply contributors_only interaction limit
     runs-on: ubuntu-latest
     steps:
+      - name: Check enforcement token is configured
+        env:
+          ADMIN_TOKEN: ${{ secrets.INTERACTION_LIMITS_TOKEN }}
+        run: |
+          if [ -z "${ADMIN_TOKEN}" ]; then
+            echo "::error::Secret INTERACTION_LIMITS_TOKEN is not configured, so the interaction limit cannot be re-applied."
+            echo "::error::Remedy: a repository admin mints a fine-grained personal access token scoped to this repository with the 'Administration' repository permission set to 'Read and write', stores it as the repository secret INTERACTION_LIMITS_TOKEN, then runs this workflow once via workflow_dispatch."
+            exit 1
+          fi
+
       - name: Apply contributors_only interaction limit
+        env:
+          GH_TOKEN: ${{ secrets.INTERACTION_LIMITS_TOKEN }}
+          REPOSITORY_SLUG: ${{ github.repository }}
+        run: |
+          if ! gh api -X PUT "/repos/${REPOSITORY_SLUG}/interaction-limits" \
+            -f limit=contributors_only \
+            -f expiry=six_months; then
+            echo "::error::Could not set the interaction limit. INTERACTION_LIMITS_TOKEN must be unexpired and carry the 'Administration' repository permission (write) for ${REPOSITORY_SLUG}; a 403 here means the permission is missing or the token has lapsed."
+            exit 1
+          fi
+
+      - name: Verify the limit is in force
+        env:
+          GH_TOKEN: ${{ secrets.INTERACTION_LIMITS_TOKEN }}
+          REPOSITORY_SLUG: ${{ github.repository }}
+        run: |
+          gh api "/repos/${REPOSITORY_SLUG}/interaction-limits" > limits.json
+          limit=$(jq -r '.limit // empty' limits.json)
+          expires=$(jq -r '.expires_at // "unknown"' limits.json)
+
+          if [ "${limit}" != "contributors_only" ]; then
+            echo "::error::Read-back check failed: expected limit 'contributors_only', got '${limit:-none}'."
+            exit 1
+          fi
+
+          echo "Interaction limit '${limit}' is in force until ${expires}."
+          {
+            echo "## Interaction limits"
+            echo
+            echo "- Limit: \`${limit}\`"
+            echo "- Expires: \`${expires}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  notify-on-failure:
+    name: Report enforcement failure
+    needs: set-limits
+    # Scheduled runs have no audience, which is how this workflow failed silently
+    # from 2026-04 to 2026-09. Surface a scheduled failure as an issue. A manual
+    # dispatch already reports back to whoever triggered it, so it is excluded.
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY_SLUG: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh api -X PUT "/repos/${REPOSITORY_SLUG}/interaction-limits" \
-            -f limit=contributors_only \
-            -f expiry=six_months
+          title="CI: monthly interaction-limit enforcement failed"
+          body=$(printf '%s\n' \
+            "The scheduled \`Enforce Interaction Limits\` run failed, so the \`contributors_only\` interaction limit was not re-applied." \
+            "" \
+            "The limit expires on its own (the API caps \`expiry\` at six months). If this keeps failing, the repository will silently fall open to non-contributors." \
+            "" \
+            "Failing run: ${RUN_URL}" \
+            "" \
+            "Most likely cause: the \`INTERACTION_LIMITS_TOKEN\` secret is missing, expired, or no longer carries the \"Administration\" repository permission (write). See \`.github/workflows/interaction-limits.yml\`.")
+
+          existing=$(gh issue list --repo "${REPOSITORY_SLUG}" --state open --limit 100 \
+            --search "in:title \"${title}\"" --json number,title \
+            | jq -r --arg t "${title}" 'map(select(.title == $t)) | .[0].number // empty')
+
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --repo "${REPOSITORY_SLUG}" --body "${body}"
+          else
+            gh issue create --repo "${REPOSITORY_SLUG}" --title "${title}" --body "${body}"
+          fi


### PR DESCRIPTION
## Summary

The scheduled `Enforce Interaction Limits` workflow has **never** worked. All six runs since it was added in #1251 have failed with the same error:

```
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration",
 "documentation_url":"https://docs.github.com/rest/interactions/repos#set-interaction-restrictions-for-a-repository","status":"403"}
```

- 2026-09-01 · 2026-08-01 · 2026-07-01 · 2026-06-01 · 2026-05-01 · 2026-04-01 — all `failure`, no successful run on record.

It runs only on a monthly cron against `master`, so it never appears on a PR and the failures went unnoticed.

## Root cause

Not a missing `permissions:` line and not a deprecated action — the workflow uses no actions at all. It is structural:

- `PUT /repos/{owner}/{repo}/interaction-limits` requires the **"Administration" repository permission (write)**. GitHub's docs for this endpoint state it "works with the following fine-grained token types: GitHub App user access tokens, GitHub App installation access tokens, Fine-grained personal access tokens. The fine-grained token must have the following permission set: 'Administration' repository permissions (write)".
- `administration` is **not** among the scopes a workflow `permissions:` block can grant to `GITHUB_TOKEN` (the available set is `actions`, `attestations`, `checks`, `contents`, `deployments`, `discussions`, `id-token`, `issues`, `packages`, `pages`, `pull-requests`, `security-events`, `statuses`, and a few newer additions — no `administration`).

So `secrets.GITHUB_TOKEN` can never call this endpoint. The workflow needed a separate token from day one.

## Why not just delete it

The workflow is doing a necessary job. There is no permanent interaction limit: the API caps `expiry` at `six_months` and every limit expires, so periodic re-application is the only way to keep one in force. The policy is also load-bearing — both `CONTRIBUTING.md` and `.github/ISSUE_TEMPLATE/config.yml` tell new users the limit is enabled and route them to the community forum.

The limit currently in force was applied by hand, not by this workflow. It was re-applied on 2026-09-01 and now expires **2027-03-01**, so there is no immediate deadline; before that re-application it was due to lapse on 2026-09-17.

## Changes

- Drive the API with a new `INTERACTION_LIMITS_TOKEN` secret instead of `GITHUB_TOKEN`.
- Guard step fails with an actionable message naming the exact remedy when the secret is absent, rather than a bare 403 mid-run.
- Read the limit back after setting it and assert it is `contributors_only`, writing the limit and its expiry to the run summary. A silent no-op now fails.
- `permissions: {}` at workflow level. The old `issues: write` / `pull-requests: write` grants were never used.
- New `notify-on-failure` job opens (or comments on) a tracking issue when a **scheduled** run fails. This is the part that would have caught the problem in April. Manual dispatches are excluded — they already report back to whoever triggered them.
- Header comment records why `GITHUB_TOKEN` cannot be used, so this is not "simplified" back later.

Kept as-is: the monthly cron, `limit=contributors_only`, and `expiry=six_months`.

## Merging this does not turn the runs green

The secret has to exist first. Steps for a repository admin, in order:

1. Mint a **fine-grained personal access token** scoped to `UMEP-dev/SUEWS` with the **"Administration" repository permission → Read and write**. (A fine-grained PAT against an organisation-owned repository may need organisation approval; if that path is blocked, a GitHub App installation token with the same permission also works.)
2. Add it as the repository secret **`INTERACTION_LIMITS_TOKEN`**.
3. Run the workflow once via **`workflow_dispatch`**.

Step 3 confirms the token works end to end and completes the "verify workflow runs successfully via manual dispatch after merge" item from #1251, which was never ticked. Note that until the secret exists, each scheduled run will continue to fail and will now open a tracking issue.

The pre-existing `PAT` secret (created 2021, unknown scope) was deliberately **not** reused — an opaque long-lived credential should not be wired into a new admin-level path.

## Test plan

- [x] `python3 .github/scripts/check_action_pins.py` — passes (no actions used, so nothing to SHA-pin).
- [x] `zizmor --no-online-audits` on the changed workflow — no findings.
- [x] YAML parses; `bash -n` clean on all four `run:` blocks.
- [x] Issue-dedup query exercised against the live repo read-only: returns empty for the tracking title, correctly resolves an existing issue title to its number.
- [ ] After the secret is added: `workflow_dispatch` succeeds and the run summary shows `contributors_only` with an expiry about six months out.
- [ ] Confirm on that dispatch that `github-actions[bot]` can open issues while `contributors_only` is active, so the failure notifier is not itself blocked. (Apps are generally exempt from interaction limits, but this has not been verified here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

