### PR TITLE
ci: adopt self-repository uses syntax and pin zizmor

### DIFF
--- a/.github/scripts/check_action_pins.py
+++ b/.github/scripts/check_action_pins.py
@@ -2,7 +2,9 @@
 """Enforce commit-SHA pinning for external GitHub Actions.
 
 This blocks floating refs like ``@v4``, ``@main``, ``@beta``, and branch names in
-workflow definitions. Local actions (``./...``) are allowed.
+workflow definitions. Same-repository actions are allowed in both forms: the
+workspace-relative ``./...`` form and GitHub's self-repository ``$/...`` form,
+which resolves to the running commit and is itself a form of pinning.
 """
 
 from __future__ import annotations
@@ -34,7 +36,7 @@ def main() -> int:
                 continue
 
             action_ref = match.group(1)
-            if action_ref.startswith("./") or action_ref.startswith("docker://"):
+            if action_ref.startswith(("./", "$/", "docker://")):
                 continue
             if SHA_REF_PATTERN.match(action_ref):
                 continue

--- a/.github/workflows/benchmark-checkout-provenance.yml
+++ b/.github/workflows/benchmark-checkout-provenance.yml
@@ -226,7 +226,11 @@ jobs:
           SUEWS_CI_PHASES: ${{ runner.temp }}/suews-ci-metrics/physics-cp312-win-AMD64-phases.json
         run: python scripts/suews/ci_phase_metrics.py stop checkout
 
-      - name: Build and smoke-test one blob-filtered Windows wheel
+      # Deliberately workspace-relative: this harness reproduces the wheel built
+      # at `expected_sha`, so it must build with that commit's own build action,
+      # not the action from whatever commit is running the workflow. `$/...`
+      # would resolve against the running commit and break the comparison.
+      - name: Build and smoke-test one blob-filtered Windows wheel # zizmor: ignore[self-repository]
         uses: ./.github/actions/build-suews
         with:
           buildplat: windows-2025

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build current SUEWS (Fortran + Rust) + install supy
-        uses: ./.github/actions/build-suews
+        uses: $/.github/actions/build-suews
         with:
           metrics_host_dir: ${{ runner.temp }}/suews-ci-metrics
       - name: Install benchmark requirements

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -426,7 +426,7 @@ jobs:
       (needs.create_nightly_tag.result == 'success' || needs.create_nightly_tag.result == 'skipped') &&
       (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.needs-build == 'true') &&
       (needs.verify-release-tag.result == 'skipped' || needs.verify-release-tag.outputs.on-master == 'true')
-    uses: ./.github/workflows/build-wheels-reusable.yml
+    uses: $/.github/workflows/build-wheels-reusable.yml
     with:
       buildplat_json: ${{ needs.determine_matrix.outputs.buildplat }}
       python_json: ${{ needs.determine_matrix.outputs.python }}
@@ -475,7 +475,7 @@ jobs:
       always() &&
       needs.build_wheels.result == 'success' &&
       needs.build_mcp.result == 'success'
-    uses: ./.github/workflows/test-api-cross-python-reusable.yml
+    uses: $/.github/workflows/test-api-cross-python-reusable.yml
     with:
       # Fall back to the full buildplat when api_buildplat is empty: the
       # determine_matrix job runs determine-matrix.sh from the BASE branch

--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -67,7 +67,7 @@ jobs:
         run: python scripts/suews/ci_phase_metrics.py stop checkout
 
       - name: Build SUEWS wheels
-        uses: ./.github/actions/build-suews
+        uses: $/.github/actions/build-suews
         with:
           buildplat: ${{ matrix.buildplat[0] }}
           buildplat_name: ${{ matrix.buildplat[1] }}

--- a/.github/workflows/ci-metrics-overhead.yml
+++ b/.github/workflows/ci-metrics-overhead.yml
@@ -29,7 +29,7 @@ jobs:
   build_wheel:
     name: Build controlled wheel
     needs: [default_branch_guard]
-    uses: ./.github/workflows/build-wheels-reusable.yml
+    uses: $/.github/workflows/build-wheels-reusable.yml
     with:
       buildplat_json: '[["ubuntu-latest","manylinux","x86_64"]]'
       python_json: '["cp312"]'

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -43,9 +43,13 @@ jobs:
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Run zizmor
+        # Pinned deliberately: each zizmor release can add audits, which silently
+        # moves this advisory baseline (v1.30.0 introduced `self-repository`).
+        # Dependabot does not update versions inside `run:` lines, so bump this by
+        # hand and review the new findings in the same PR.
         run: |
           set -o pipefail
-          uv tool run zizmor --no-online-audits --format=plain .github/workflows .github/actions | tee zizmor.txt
+          uv tool run zizmor@1.30.0 --no-online-audits --format=plain .github/workflows .github/actions | tee zizmor.txt
 
       - name: Add zizmor summary
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ EXAMPLES:
 
 | Year | Features | Bugfixes | Changes | Maintenance | Docs | Total |
 |------|----------|----------|---------|-------------|------|-------|
-| 2026 | 80       | 86       | 32 | 81 | 41 | 321   |
+| 2026 | 80       | 86       | 32 | 82 | 41 | 322   |
 | 2025 | 60       | 68       | 22 | 71 | 36 | 256   |
 | 2024 | 12       | 17       | 1 | 12 | 1 | 43    |
 | 2023 | 11       | 14       | 3 | 9 | 1 | 38    |
@@ -53,6 +53,11 @@ EXAMPLES:
 | 2017 | 9        | 0        | 3 | 2 | 0 | 14    |
 
 ## 2026
+
+### 1 Sep 2026
+
+- [maintenance] CI: adopted GitHub's self-repository `uses: $/...` syntax for same-repository actions and reusable workflows, and pinned `zizmor` to 1.30.0 so a new release cannot silently move the advisory audit baseline (#1728)
+  - The checkout-provenance harness keeps the workspace-relative `./` form, which it needs to build a historical commit with that commit's own action.
 
 ### 21 Aug 2026
 


### PR DESCRIPTION
## What changed

Two related CI changes.

**1. Same-repository `uses:` references move to `$/...`.** GitHub added the
self-repository form on 2026-07-30; it resolves to the workflow's own repository
at the exact commit that is running, with no checkout involved. Five references
were converted:

- `build-publish_to_pypi.yml:429` and `:478` -- job-level reusable-workflow calls
- `ci-metrics-overhead.yml:32` -- job-level reusable-workflow call
- `build-wheels-reusable.yml:70` -- step-level composite action
- `benchmark-regression.yml:83` -- step-level composite action, in the `if: false`
  stage-2 job (zizmor suppresses disabled jobs, so this was not among the reported
  findings; converting it now avoids a re-flag when that job is enabled)

**2. `zizmor` is pinned to 1.30.0.** The audit ran the tool unpinned, so a release
could change the advisory baseline with no repository change -- which is what
happened. See "How this surfaced" below.

## One reference deliberately not converted

`benchmark-checkout-provenance.yml:230` keeps `uses: ./...` with an inline
`zizmor: ignore[self-repository]` and a rationale comment.

This is not a blanket exemption -- the two forms are genuinely not equivalent
there. That harness checks out an arbitrary historical commit
(`ref: ${{ steps.source.outputs.sha }}`, from the required `expected_sha` input)
in order to reproduce the wheel built at that commit and compare provenance.
`./` resolves against the workspace, so it builds with that commit's own
`build-suews` action, which is what the comparison requires. `$/` would resolve
against whatever commit is running the workflow and would silently build with a
different recipe. Converting it would be a behaviour change dressed as a lint fix.

The other five sites do not have this property: job-level reusable-workflow calls
are resolved by the Actions service from the caller's commit either way, and the
two step-level sites follow a plain `actions/checkout` of the triggering commit.

## The pin checker had to move too

`.github/scripts/check_action_pins.py` treated only `./` and `docker://` as
same-repository. Left alone it would have classified every converted reference as
an unpinned external action and failed the blocking `enforce-sha-pins` job. It now
accepts `$/` as well. The regression is intact -- a floating ref such as
`actions/checkout@v4` is still rejected (verified locally by re-introducing one).

## Runner requirement, verified

The self-repository form requires GitHub Actions runner 2.336.0 or newer. Rather
than assume, this was read off live job logs from recent runs on this repository:

- `ubuntu-latest` -- 2.337.0
- `macos-15` x86_64 -- 2.337.0
- `macos-15` arm64 -- 2.336.0
- `windows-2025` -- 2.336.0

All at or above the floor, though the two arm64/Windows images sit exactly on it.

## How this surfaced

The "Advisory workflow audit" job began failing on master at `fea3adebf`
(2026-08-31); it passed at `0b3d64e23` (2026-08-24). No workflow changed in
between. `uv tool run zizmor` was unpinned, and v1.30.0 introduced the
`self-repository` audit, producing 5 low-severity findings. Because the job is
`continue-on-error: true`, the workflow run still reported success and the
failure was visible only in the job-level conclusion.

The pin closes that specific silent-drift path. Whether the job should also stop
being `continue-on-error` is a separate call and is left alone here.

## Verification

Both gates run clean locally against this branch, using the exact CI commands:

- `python3 .github/scripts/check_action_pins.py` -> passes
- `uv tool run zizmor@1.30.0 --no-online-audits --format=plain .github/workflows .github/actions`
  -> `No findings to report. Good job! (3 ignored, 65 suppressed)`, exit 0

All six touched workflows also parse under `yaml.safe_load`, and `$/...` needs no
quoting -- it survives as a plain scalar.

### What this PR's CI does and does not exercise

Exercised: `workflow-security.yml` triggers on the changed `.github/**` paths, and
`build-publish_to_pypi.yml` runs on pull requests, so it resolves both job-level
`$/` reusable-workflow calls and, through them, the step-level `$/` reference in
`build-wheels-reusable.yml`.

Not exercised here: `ci-metrics-overhead.yml` (`workflow_dispatch` only, behind a
default-branch guard), the `if: false` job in `benchmark-regression.yml`, and
`benchmark-checkout-provenance.yml` (`workflow_dispatch` only, and unchanged in
substance).

## Scope

Unrelated to #1727, which fixes the interaction-limits workflow and leaves these
findings untouched.
