### PR TITLE
Correct the diagnose energy-balance check and inspect every output partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ EXAMPLES:
 
 ## 2026
 
+### 7 Sep 2026
+
+- [bugfix] Corrected the `suews diagnose` energy-balance check and made it inspect every output partition (#1734)
+  - The closure residual now follows the model identity `QN + QF + QMRain = QH + QE + QS + QM + QMFreeze`; QF had been placed among the sinks, so balanced runs were flagged and unbalanced ones passed.
+  - All files of the highest-priority output format, and every grid within a multi-grid file, are checked; `-999` sentinels and non-finite rows are treated as missing and counted; an absent optional column no longer raises.
+  - `suews summarise` and `suews compare` keep their existing single-file loader.
+
 ### 1 Sep 2026
 
 - [maintenance] CI: adopted GitHub's self-repository `uses: $/...` syntax for same-repository actions and reusable workflows, and pinned `zizmor` to 1.30.0 so a new release cannot silently move the advisory audit baseline (#1728)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ EXAMPLES:
 
 - [bugfix] Corrected the `suews diagnose` energy-balance check and made it inspect every output partition (#1734)
   - The closure residual now follows the model identity `QN + QF + QMRain = QH + QE + QS + QM + QMFreeze`; QF had been placed among the sinks, so balanced runs were flagged and unbalanced ones passed.
-  - All files of the highest-priority output format, and every grid within a multi-grid file, are checked; `-999` sentinels and non-finite rows are treated as missing and counted; an absent optional column no longer raises.
+  - All files of the highest-priority output format, and every grid within a multi-grid file, are checked and each partition is judged on its own, so a healthy partition cannot mask a broken one; `-999` sentinels and non-finite rows are treated as missing and counted, and a partition with too few evaluable rows is reported; an absent optional column no longer raises.
   - `suews summarise` and `suews compare` keep their existing single-file loader.
 
 ### 1 Sep 2026

--- a/src/supy/_run_output.py
+++ b/src/supy/_run_output.py
@@ -114,11 +114,106 @@ def _flatten_output_columns(df_output: pd.DataFrame) -> pd.DataFrame:
     return df_output
 
 
+def _format_tier(path_output: Path) -> int:
+    """Rank an output file by format: parquet (0), CSV (1), legacy text (2)."""
+    suffix = path_output.suffix.lower()
+    if suffix == ".parquet":
+        return 0
+    if suffix == ".csv":
+        return 1
+    return 2
+
+
+def _select_output_partitions(list_paths: list[Path]) -> list[Path]:
+    """Keep only the files of the highest-priority format present.
+
+    ``SUEWSSimulation.save`` can write the same run as parquet, CSV or
+    legacy text. Reading more than one format would count the same rows
+    twice, so partitions are drawn from a single format tier.
+    """
+    if not list_paths:
+        return []
+    tier_best = min(_format_tier(path) for path in list_paths)
+    return [path for path in list_paths if _format_tier(path) == tier_best]
+
+
+def _select_core_group(df_output: pd.DataFrame) -> pd.DataFrame:
+    """Restrict MultiIndex columns to the core ``SUEWS`` output group.
+
+    The canonical parquet output stacks every output group under one
+    column MultiIndex, and some variable names recur across groups (for
+    example ``QS`` in both ``SUEWS`` and ``ESTM``). Flattening such a
+    frame to the variable level would leave duplicate column labels, so
+    partitions keep only the core group when it is present.
+    """
+    if not isinstance(df_output.columns, pd.MultiIndex):
+        return df_output
+    for level in range(df_output.columns.nlevels):
+        if "SUEWS" in df_output.columns.get_level_values(level):
+            return df_output.xs("SUEWS", axis=1, level=level, drop_level=False)
+    return df_output
+
+
+def _load_run_output_partitions(
+    path: Path,
+    *,
+    include_text: bool = True,
+) -> list[tuple[str, pd.DataFrame]]:
+    """Load every partition of a run output as ``(label, DataFrame)`` pairs.
+
+    A partition is one output file of the highest-priority format present
+    (see :func:`_select_output_partitions`), restricted to the core
+    ``SUEWS`` column group when the file stacks several groups (see
+    :func:`_select_core_group`), and, for files whose row index
+    is a MultiIndex such as the canonical ``(grid, datetime)`` layout, one
+    grid within that file. Legacy text output is already split per grid
+    and per year on disk. Labels are ``"<file name>"`` or
+    ``"<file name>[grid=<grid>]"``.
+
+    Raises ``FileNotFoundError`` when ``path`` is a directory without any
+    recognised output file.
+    """
+    path = Path(path)
+    if path.is_dir():
+        list_paths = _select_output_partitions(
+            _list_run_output_files(path, include_text=include_text)
+        )
+        if not list_paths:
+            patterns = " / ".join(_candidate_patterns(include_text))
+            raise FileNotFoundError(
+                f"No recognised SUEWS output ({patterns}) under {path}"
+            )
+    else:
+        list_paths = [path]
+
+    list_partitions: list[tuple[str, pd.DataFrame]] = []
+    for path_file in list_paths:
+        df_file = _flatten_output_columns(
+            _select_core_group(_read_output_file(path_file))
+        )
+        if isinstance(df_file.index, pd.MultiIndex) and len(df_file.index):
+            level_values = df_file.index.get_level_values(0)
+            for grid in level_values.unique():
+                list_partitions.append((
+                    f"{path_file.name}[grid={grid}]",
+                    df_file.xs(grid, level=0),
+                ))
+        else:
+            list_partitions.append((path_file.name, df_file))
+    return list_partitions
+
+
 def _load_run_output_dataframe(
     path: Path,
     *,
     include_text: bool = True,
 ) -> pd.DataFrame:
+    """Load the first recognised output file under ``path`` (or ``path`` itself).
+
+    ``suews summarise`` / ``suews compare`` operate on a single time series
+    and keep this first-file contract; diagnostics that must see every
+    partition use :func:`_load_run_output_partitions` instead.
+    """
     path = Path(path)
     if path.is_dir():
         list_paths = _list_run_output_files(path, include_text=include_text)

--- a/src/supy/cmd/diagnose_run.py
+++ b/src/supy/cmd/diagnose_run.py
@@ -54,8 +54,10 @@ def _build_recommendations(list_results: list[Any]) -> list[str]:
             )
         elif res.name == "energy_balance_closure":
             list_recommendations.append(
-                "Review storage_heat / emissions physics options and check "
-                "land-cover fractions sum to 1.0."
+                "SUEWS closes QN + QF = QH + QE + QS (plus snow terms) by "
+                "construction; a residual means the saved output is "
+                "internally inconsistent. Check for truncated or mixed "
+                "output files and rows flagged missing before trusting the run."
             )
     return list_recommendations
 

--- a/src/supy/diagnostics/__init__.py
+++ b/src/supy/diagnostics/__init__.py
@@ -16,8 +16,9 @@ Phase-1 checks (intentionally minimal):
 - :func:`check_energy_balance_closure` -- mean
   ``|(QN + QF + QMRain) - (QH + QE + QS + QM + QMFreeze)| / |QN| < 0.10``.
 
-Every partition of the run output is inspected (all files of the
-highest-priority format present, and every grid within a file); the
+Every partition of the run output is inspected and judged on its own
+(all files of the highest-priority format present, and every grid
+within a file); a run passes only when every partition passes. The
 legacy ``-999`` sentinel is treated as missing.
 
 Severity ladder: ``pass`` (passed=True), ``warning`` (passed=False but

--- a/src/supy/diagnostics/__init__.py
+++ b/src/supy/diagnostics/__init__.py
@@ -8,11 +8,17 @@ keeps the checks individually testable and the aggregator trivial.
 Phase-1 checks (intentionally minimal):
 
 - :func:`check_provenance_present` -- ``provenance.json`` sidecar exists.
-- :func:`check_output_files_present` -- at least one ``df_output*.csv``
-  or ``*.parquet`` produced by ``suews run`` is present.
-- :func:`check_nan_proportion` -- NaN fraction in QH/QE/QN below 5%.
+- :func:`check_output_files_present` -- at least one ``df_output*.csv``,
+  ``*.parquet`` or legacy ``*_SUEWS_*.txt`` produced by ``suews run`` is
+  present.
+- :func:`check_nan_proportion` -- missing fraction in QH/QE/QN below 5%
+  in every output partition.
 - :func:`check_energy_balance_closure` -- mean
-  ``|QN - (QH + QE + QS + QF)| / |QN| < 0.10``.
+  ``|(QN + QF + QMRain) - (QH + QE + QS + QM + QMFreeze)| / |QN| < 0.10``.
+
+Every partition of the run output is inspected (all files of the
+highest-priority format present, and every grid within a file); the
+legacy ``-999`` sentinel is treated as missing.
 
 Severity ladder: ``pass`` (passed=True), ``warning`` (passed=False but
 non-fatal), ``fail`` (passed=False and the run is unusable).

--- a/src/supy/diagnostics/_checks.py
+++ b/src/supy/diagnostics/_checks.py
@@ -16,10 +16,11 @@ Phase-1 checks (intentionally minimal):
 - ``check_energy_balance_closure`` -- mean
   ``|(QN + QF + QMRain) - (QH + QE + QS + QM + QMFreeze)| / |QN| < 0.10``.
 
-Every partition of the run output is inspected: all files of the
-highest-priority format present (parquet, then CSV, then legacy text) and
-every grid within a multi-grid file. Values equal to the legacy ``-999``
-sentinel are treated as missing.
+Every partition of the run output is inspected and judged on its own:
+all files of the highest-priority format present (parquet, then CSV,
+then legacy text) and every grid within a multi-grid file. A run passes
+a check only when every partition passes it. Values equal to the legacy
+``-999`` sentinel are treated as missing.
 
 Severity ladder: ``pass`` (passed=True), ``warning`` (passed=False but
 non-fatal), ``fail`` (passed=False and the run is unusable).
@@ -57,8 +58,8 @@ _MISSING_SENTINEL = -999.0
 
 # Energy-balance identity used by the model driver (``qh_residual`` in
 # ``suews_ctrl_driver.f95``): QN + QF + QMRain = QH + QE + QS + QM + QMFreeze.
-# The snow terms and QF are absent from simple configurations and are
-# treated as zero when their column is missing.
+# Current writers emit every term; reduced or older outputs may lack QF
+# or the snow terms, which are then treated as zero and reported.
 _CLOSURE_REQUIRED = ("QN", "QH", "QE", "QS")
 _CLOSURE_SOURCES_OPTIONAL = ("QF", "QMRain")
 _CLOSURE_SINKS_OPTIONAL = ("QM", "QMFreeze")
@@ -152,40 +153,60 @@ def _closure_terms(df_output: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
     return pd.DataFrame(dict_terms), list_missing
 
 
-def _collect_closure_terms(
-    list_partitions: list[tuple[str, pd.DataFrame]],
-) -> tuple[pd.DataFrame, list[str]] | CheckResult:
-    """Concatenate the closure terms of every partition.
+def _missing_required(df_output: pd.DataFrame) -> list[str]:
+    return [name for name in _CLOSURE_REQUIRED if name not in df_output.columns]
 
-    Returns the combined term frame and the sorted list of optional terms
-    absent from any partition, or a ``fail`` result naming the first
-    partition that lacks a required term.
+
+def _evaluate_partition_closure(df_terms: pd.DataFrame) -> dict[str, Any]:
+    """Evaluate closure for one partition and return its statistics.
+
+    Rows enter the evaluation when ``|QN| > 1`` and every term is finite.
+    ``status`` is ``"pass"`` when the mean ratio is below the threshold and
+    at least ``1 - _NAN_THRESHOLD_FRACTION`` of the non-trivial rows were
+    evaluable, ``"no_evaluable_rows"`` when nothing could be evaluated,
+    ``"low_coverage"`` when too many rows were skipped, and
+    ``"residual"`` when the mean ratio exceeds the threshold.
     """
-    list_frames: list[pd.DataFrame] = []
-    set_missing_optional: set[str] = set()
-    for label, df_output in list_partitions:
-        list_missing_required = [
-            name for name in _CLOSURE_REQUIRED if name not in df_output.columns
-        ]
-        if list_missing_required:
-            return CheckResult(
-                name="energy_balance_closure",
-                severity="fail",
-                passed=False,
-                message=(
-                    f"{', '.join(list_missing_required)} missing in {label}; "
-                    "cannot compute energy balance closure."
-                ),
-                details={
-                    "partition": label,
-                    "missing": list_missing_required,
-                    "available_columns": [str(c) for c in df_output.columns][:30],
-                },
-            )
-        df_terms, list_missing_optional = _closure_terms(df_output)
-        set_missing_optional.update(list_missing_optional)
-        list_frames.append(df_terms)
-    return pd.concat(list_frames, ignore_index=True), sorted(set_missing_optional)
+    ser_qn = df_terms["QN"]
+    mask_nontrivial = ser_qn.notna() & (ser_qn.abs() > 1.0)
+    mask_finite = df_terms.notna().all(axis=1)
+    mask_valid = mask_nontrivial & mask_finite
+    n_nontrivial = int(mask_nontrivial.sum())
+    n_evaluated = int(mask_valid.sum())
+    stats: dict[str, Any] = {
+        "n_rows": len(df_terms),
+        "n_rows_evaluated": n_evaluated,
+        "n_rows_skipped_nonfinite": n_nontrivial - n_evaluated,
+        "ratio_mean": None,
+        "status": "no_evaluable_rows",
+    }
+    if n_evaluated == 0:
+        return stats
+
+    ser_sources = df_terms["QN"] + df_terms["QF"] + df_terms["QMRain"]
+    ser_sinks = df_terms["QH"] + df_terms["QE"] + df_terms["QS"]
+    ser_sinks += df_terms["QM"] + df_terms["QMFreeze"]
+    ser_ratio = (ser_sources - ser_sinks).abs()[mask_valid] / ser_qn[mask_valid].abs()
+    ratio_mean = float(ser_ratio.mean())
+    stats["ratio_mean"] = ratio_mean
+    coverage = n_evaluated / n_nontrivial
+    stats["coverage"] = coverage
+    if ratio_mean >= _ENERGY_BALANCE_THRESHOLD:
+        stats["status"] = "residual"
+    elif coverage < 1.0 - _NAN_THRESHOLD_FRACTION:
+        stats["status"] = "low_coverage"
+    else:
+        stats["status"] = "pass"
+    return stats
+
+
+def _describe_partition_problem(label: str, stats: dict[str, Any]) -> str:
+    status = stats["status"]
+    if status == "residual":
+        return f"{label}: residual {stats['ratio_mean']:.3f}"
+    if status == "low_coverage":
+        return f"{label}: only {stats['coverage']:.1%} of rows evaluable"
+    return f"{label}: no evaluable rows"
 
 
 def _read_error(name: str, path_run_dir: Path, exc: Exception) -> CheckResult:
@@ -333,19 +354,25 @@ def check_nan_proportion(path_run_dir: Path) -> CheckResult:
 
 
 def check_energy_balance_closure(path_run_dir: Path) -> CheckResult:
-    """Energy-balance consistency check over every output partition.
+    """Energy-balance consistency check, judged per output partition.
 
-    Computes ``mean(|(QN + QF + QMRain) - (QH + QE + QS + QM + QMFreeze)| /
-    |QN|)`` over rows where every term is finite and ``|QN| > 1``, then
-    flags the run when the ratio exceeds 10%. QN, QH, QE and QS must be
-    present; QF and the snow terms are treated as zero when their column
-    is absent, and the absent terms are listed in ``details``.
+    For every partition (file, and grid within a file) computes
+    ``mean(|(QN + QF + QMRain) - (QH + QE + QS + QM + QMFreeze)| / |QN|)``
+    over rows where every term is finite and ``|QN| > 1``. QN, QH, QE
+    and QS must be present; QF and the snow terms are treated as zero
+    when their column is absent, and the absent terms are listed in
+    ``details``.
+
+    A partition passes when its mean ratio is below 10% and at least 95%
+    of its non-trivial rows could be evaluated. The run passes only when
+    every partition passes: a partition with an excessive residual, too
+    few evaluable rows, or none at all, is reported and blocks the pass,
+    so a healthy partition cannot mask a broken one. ``details`` carries
+    the per-partition statistics and the row-weighted aggregate ratio.
 
     SUEWS closes this identity by construction, so the check is a
     consistency test of the saved output rather than evidence of
-    scientific skill. Legacy text output stores the snow group in a
-    separate file that is not read here, so snow terms read as absent in
-    that format.
+    scientific skill.
     """
     try:
         list_partitions = _load_output_partitions(path_run_dir)
@@ -355,66 +382,82 @@ def check_energy_balance_closure(path_run_dir: Path) -> CheckResult:
     if list_partitions is None:
         return _no_output("energy_balance_closure", path_run_dir)
 
-    collected = _collect_closure_terms(list_partitions)
-    if isinstance(collected, CheckResult):
-        return collected
-    df_all, list_missing_optional = collected
+    dict_partitions: dict[str, dict[str, Any]] = {}
+    set_missing_optional: set[str] = set()
+    list_problems: list[str] = []
+    for label, df_output in list_partitions:
+        list_missing_required = _missing_required(df_output)
+        if list_missing_required:
+            return CheckResult(
+                name="energy_balance_closure",
+                severity="fail",
+                passed=False,
+                message=(
+                    f"{', '.join(list_missing_required)} missing in {label}; "
+                    "cannot compute energy balance closure."
+                ),
+                details={
+                    "partition": label,
+                    "missing": list_missing_required,
+                    "available_columns": [str(c) for c in df_output.columns][:30],
+                },
+            )
+        df_terms, list_missing_optional = _closure_terms(df_output)
+        set_missing_optional.update(list_missing_optional)
+        stats = _evaluate_partition_closure(df_terms)
+        dict_partitions[label] = stats
+        if stats["status"] != "pass":
+            list_problems.append(_describe_partition_problem(label, stats))
 
-    ser_qn = df_all["QN"]
-    mask_nontrivial = ser_qn.notna() & (ser_qn.abs() > 1.0)
-    mask_finite = df_all.notna().all(axis=1)
-    mask_valid = mask_nontrivial & mask_finite
-
-    details: dict[str, Any] = {
-        "n_partitions": len(list_partitions),
-        "n_rows": len(df_all),
-        "n_rows_evaluated": int(mask_valid.sum()),
-        "n_rows_skipped_nonfinite": int((mask_nontrivial & ~mask_finite).sum()),
-        "terms_missing": list_missing_optional,
-    }
-
-    if not mask_valid.any():
-        return CheckResult(
-            name="energy_balance_closure",
-            severity="warning",
-            passed=False,
-            message=(
-                "No rows with finite closure terms and non-trivial QN to evaluate."
-            ),
-            details=details,
+    n_evaluated = sum(st["n_rows_evaluated"] for st in dict_partitions.values())
+    ratio_mean = (
+        sum(
+            st["ratio_mean"] * st["n_rows_evaluated"]
+            for st in dict_partitions.values()
+            if st["ratio_mean"] is not None
         )
-
-    ser_sources = df_all["QN"] + df_all["QF"] + df_all["QMRain"]
-    ser_sinks = df_all["QH"] + df_all["QE"] + df_all["QS"]
-    ser_sinks += df_all["QM"] + df_all["QMFreeze"]
-    ser_residual = (ser_sources - ser_sinks).abs()
-    ser_ratio = ser_residual[mask_valid] / ser_qn[mask_valid].abs()
-    ratio_mean = float(ser_ratio.mean())
-    details["ratio_mean"] = ratio_mean
-
+        / n_evaluated
+        if n_evaluated
+        else None
+    )
+    details: dict[str, Any] = {
+        "threshold_ratio": _ENERGY_BALANCE_THRESHOLD,
+        "n_partitions": len(list_partitions),
+        "n_rows": sum(st["n_rows"] for st in dict_partitions.values()),
+        "n_rows_evaluated": n_evaluated,
+        "n_rows_skipped_nonfinite": sum(
+            st["n_rows_skipped_nonfinite"] for st in dict_partitions.values()
+        ),
+        "ratio_mean": ratio_mean,
+        "terms_missing": sorted(set_missing_optional),
+        "partitions": dict_partitions,
+    }
     note_missing = (
         f" (absent terms treated as zero: {', '.join(details['terms_missing'])})"
         if details["terms_missing"]
         else ""
     )
-    if ratio_mean < _ENERGY_BALANCE_THRESHOLD:
+
+    if list_problems:
         return CheckResult(
             name="energy_balance_closure",
-            severity="pass",
-            passed=True,
+            severity="warning",
+            passed=False,
             message=(
-                f"Mean closure residual {ratio_mean:.3f} < "
-                f"{_ENERGY_BALANCE_THRESHOLD:.2f}{note_missing}."
+                f"Closure not confirmed in {len(list_problems)} of "
+                f"{len(list_partitions)} partition(s): "
+                f"{'; '.join(list_problems)}{note_missing}."
             ),
             details=details,
         )
     return CheckResult(
         name="energy_balance_closure",
-        severity="warning",
-        passed=False,
+        severity="pass",
+        passed=True,
         message=(
-            f"Mean closure residual {ratio_mean:.3f} exceeds "
-            f"{_ENERGY_BALANCE_THRESHOLD:.2f}{note_missing}."
+            f"Mean closure residual {ratio_mean:.3f} < "
+            f"{_ENERGY_BALANCE_THRESHOLD:.2f} in every one of "
+            f"{len(list_partitions)} partition(s){note_missing}."
         ),
         details=details,
     )

--- a/src/supy/diagnostics/_checks.py
+++ b/src/supy/diagnostics/_checks.py
@@ -7,12 +7,19 @@ checks individually testable and the aggregator trivial.
 
 Phase-1 checks (intentionally minimal):
 
-- ``check_provenance_present`` — ``provenance.json`` sidecar exists.
-- ``check_output_files_present`` — at least one ``df_output*.csv`` or
-  ``*.parquet`` produced by ``suews run`` is present.
-- ``check_nan_proportion`` — NaN fraction in QH/QE/QN below 5%.
-- ``check_energy_balance_closure`` — mean
-  ``|QN - (QH + QE + QS + QF)| / |QN| < 0.10``.
+- ``check_provenance_present`` -- ``provenance.json`` sidecar exists.
+- ``check_output_files_present`` -- at least one ``df_output*.csv``,
+  ``*.parquet`` or legacy ``*_SUEWS_*.txt`` produced by ``suews run`` is
+  present.
+- ``check_nan_proportion`` -- missing fraction in QH/QE/QN below 5% in
+  every output partition.
+- ``check_energy_balance_closure`` -- mean
+  ``|(QN + QF + QMRain) - (QH + QE + QS + QM + QMFreeze)| / |QN| < 0.10``.
+
+Every partition of the run output is inspected: all files of the
+highest-priority format present (parquet, then CSV, then legacy text) and
+every grid within a multi-grid file. Values equal to the legacy ``-999``
+sentinel are treated as missing.
 
 Severity ladder: ``pass`` (passed=True), ``warning`` (passed=False but
 non-fatal), ``fail`` (passed=False and the run is unusable).
@@ -25,9 +32,10 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pandas as pd
 
-from .._run_output import _list_run_output_files, _load_run_output_dataframe
+from .._run_output import _list_run_output_files, _load_run_output_partitions
 
 __all__ = [
     "CheckResult",
@@ -43,6 +51,17 @@ __all__ = [
 _NAN_THRESHOLD_FRACTION = 0.05
 _ENERGY_BALANCE_THRESHOLD = 0.10
 _FLUX_VARIABLES = ("QH", "QE", "QN")
+
+# Legacy SUEWS text output marks missing values with -999.
+_MISSING_SENTINEL = -999.0
+
+# Energy-balance identity used by the model driver (``qh_residual`` in
+# ``suews_ctrl_driver.f95``): QN + QF + QMRain = QH + QE + QS + QM + QMFreeze.
+# The snow terms and QF are absent from simple configurations and are
+# treated as zero when their column is missing.
+_CLOSURE_REQUIRED = ("QN", "QH", "QE", "QS")
+_CLOSURE_SOURCES_OPTIONAL = ("QF", "QMRain")
+_CLOSURE_SINKS_OPTIONAL = ("QM", "QMFreeze")
 
 
 @dataclass
@@ -81,24 +100,112 @@ class CheckResult:
 def _list_output_files(path_run_dir: Path) -> list[Path]:
     """Return all candidate output files under ``path_run_dir``.
 
-    Recognises CSV and parquet output produced by ``suews run`` /
-    ``SUEWSSimulation.save``. The current ``save`` implementation may write
-    files at the run-dir root or under a subdirectory keyed by site name —
-    we accept both.
+    Recognises CSV, parquet and legacy text output produced by
+    ``suews run`` / ``SUEWSSimulation.save``. The current ``save``
+    implementation may write files at the run-dir root or under a
+    subdirectory keyed by site name; we accept both.
     """
     return _list_run_output_files(path_run_dir)
 
 
-def _load_output_dataframe(path_run_dir: Path) -> pd.DataFrame | None:
-    """Best-effort load of run output into a single DataFrame.
+def _load_output_partitions(
+    path_run_dir: Path,
+) -> list[tuple[str, pd.DataFrame]] | None:
+    """Best-effort load of every run-output partition.
 
     Returns ``None`` when no recognisable output file is present. Errors
-    during read are deliberately propagated to the caller — the caller
-    decides whether to mark the check as ``fail`` or ``warning``.
+    during read are deliberately propagated to the caller, which decides
+    whether to mark the check as ``fail`` or ``warning``.
     """
     if not _list_output_files(path_run_dir):
         return None
-    return _load_run_output_dataframe(path_run_dir)
+    return _load_run_output_partitions(path_run_dir)
+
+
+def _numeric_series(df_output: pd.DataFrame, name: str) -> pd.Series:
+    """Return column ``name`` as floats with sentinels and infinities as NaN."""
+    column = df_output[name]
+    if isinstance(column, pd.DataFrame):  # duplicate labels: keep the first
+        column = column.iloc[:, 0]
+    ser = pd.to_numeric(column, errors="coerce").astype(float)
+    ser = ser.mask(ser == _MISSING_SENTINEL)
+    return ser.replace([np.inf, -np.inf], np.nan)
+
+
+def _closure_terms(df_output: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
+    """Build the closure terms of one partition.
+
+    Returns the numeric frame of every closure term (absent optional
+    terms filled with zero) and the list of optional terms that were
+    absent from the output.
+    """
+    dict_terms: dict[str, pd.Series] = {}
+    for name in _CLOSURE_REQUIRED:
+        dict_terms[name] = _numeric_series(df_output, name)
+    list_missing: list[str] = []
+    for name in (*_CLOSURE_SOURCES_OPTIONAL, *_CLOSURE_SINKS_OPTIONAL):
+        if name in df_output.columns:
+            dict_terms[name] = _numeric_series(df_output, name)
+        else:
+            list_missing.append(name)
+            dict_terms[name] = pd.Series(0.0, index=df_output.index)
+    return pd.DataFrame(dict_terms), list_missing
+
+
+def _collect_closure_terms(
+    list_partitions: list[tuple[str, pd.DataFrame]],
+) -> tuple[pd.DataFrame, list[str]] | CheckResult:
+    """Concatenate the closure terms of every partition.
+
+    Returns the combined term frame and the sorted list of optional terms
+    absent from any partition, or a ``fail`` result naming the first
+    partition that lacks a required term.
+    """
+    list_frames: list[pd.DataFrame] = []
+    set_missing_optional: set[str] = set()
+    for label, df_output in list_partitions:
+        list_missing_required = [
+            name for name in _CLOSURE_REQUIRED if name not in df_output.columns
+        ]
+        if list_missing_required:
+            return CheckResult(
+                name="energy_balance_closure",
+                severity="fail",
+                passed=False,
+                message=(
+                    f"{', '.join(list_missing_required)} missing in {label}; "
+                    "cannot compute energy balance closure."
+                ),
+                details={
+                    "partition": label,
+                    "missing": list_missing_required,
+                    "available_columns": [str(c) for c in df_output.columns][:30],
+                },
+            )
+        df_terms, list_missing_optional = _closure_terms(df_output)
+        set_missing_optional.update(list_missing_optional)
+        list_frames.append(df_terms)
+    return pd.concat(list_frames, ignore_index=True), sorted(set_missing_optional)
+
+
+def _read_error(name: str, path_run_dir: Path, exc: Exception) -> CheckResult:
+    return CheckResult(
+        name=name,
+        severity="warning",
+        passed=False,
+        message=f"Could not read run output: {exc}",
+        details={"run_dir": str(path_run_dir)},
+    )
+
+
+def _no_output(name: str, path_run_dir: Path) -> CheckResult:
+    return CheckResult(
+        name=name,
+        severity="warning",
+        passed=False,
+        message="No output dataframe to inspect.",
+        details={"run_dir": str(path_run_dir)},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -149,154 +256,157 @@ def check_output_files_present(path_run_dir: Path) -> CheckResult:
 
 
 def check_nan_proportion(path_run_dir: Path) -> CheckResult:
-    """Check NaN proportion in QH / QE / QN flux columns.
+    """Check the missing-value proportion in QH / QE / QN per partition.
+
+    A value is missing when it is NaN, non-finite or equal to the legacy
+    ``-999`` sentinel. Every partition (file, and grid within a file) is
+    judged separately so one broken grid or year cannot hide behind the
+    others.
 
     Severity:
-    - ``pass`` when all three flux columns have NaN fraction below 5%.
-    - ``warning`` when any flux column exceeds the threshold.
+    - ``pass`` when every flux column in every partition is below 5%.
+    - ``warning`` when any flux column in any partition exceeds the threshold.
     - ``fail`` when none of the flux columns are present (cannot judge).
     """
     try:
-        df_output = _load_output_dataframe(path_run_dir)
+        list_partitions = _load_output_partitions(path_run_dir)
     except (OSError, ValueError, pd.errors.ParserError) as exc:
-        return CheckResult(
-            name="nan_proportion",
-            severity="warning",
-            passed=False,
-            message=f"Could not read run output to compute NaN proportions: {exc}",
-            details={"run_dir": str(path_run_dir)},
+        return _read_error("nan_proportion", path_run_dir, exc)
+
+    if list_partitions is None:
+        return _no_output("nan_proportion", path_run_dir)
+
+    dict_fractions: dict[str, dict[str, float]] = {}
+    list_offenders: list[str] = []
+    set_found: set[str] = set()
+    list_columns_seen: list[str] = []
+    for label, df_output in list_partitions:
+        list_columns_seen = [str(col) for col in df_output.columns]
+        dict_partition = {
+            var: float(_numeric_series(df_output, var).isna().mean())
+            for var in _FLUX_VARIABLES
+            if var in df_output.columns
+        }
+        set_found.update(dict_partition)
+        dict_fractions[label] = dict_partition
+        list_offenders.extend(
+            f"{label}:{var}={frac:.3%}"
+            for var, frac in dict_partition.items()
+            if frac > _NAN_THRESHOLD_FRACTION
         )
 
-    if df_output is None:
-        return CheckResult(
-            name="nan_proportion",
-            severity="warning",
-            passed=False,
-            message="No output dataframe to inspect.",
-            details={"run_dir": str(path_run_dir)},
-        )
-
-    # Tolerate MultiIndex columns from the canonical SUEWS output.
-    list_columns = [
-        col[0] if isinstance(col, tuple) else col for col in df_output.columns
-    ]
-    df_output = df_output.copy()
-    df_output.columns = list_columns
-
-    found = {var: var in df_output.columns for var in _FLUX_VARIABLES}
-    if not any(found.values()):
+    if not set_found:
         return CheckResult(
             name="nan_proportion",
             severity="fail",
             passed=False,
             message="None of QH / QE / QN present in output.",
-            details={"available_columns": list_columns[:30]},
+            details={"available_columns": list_columns_seen[:30]},
         )
 
-    dict_fractions = {
-        var: float(df_output[var].isna().mean())
-        for var in _FLUX_VARIABLES
-        if found[var]
+    details = {
+        "threshold_fraction": _NAN_THRESHOLD_FRACTION,
+        "n_partitions": len(list_partitions),
+        "fractions": dict_fractions,
     }
-    list_offenders = [
-        f"{var}={frac:.3%}"
-        for var, frac in dict_fractions.items()
-        if frac > _NAN_THRESHOLD_FRACTION
-    ]
     if list_offenders:
         return CheckResult(
             name="nan_proportion",
             severity="warning",
             passed=False,
             message=(
-                f"NaN fraction exceeds {_NAN_THRESHOLD_FRACTION * 100:.0f}% "
+                f"Missing fraction exceeds {_NAN_THRESHOLD_FRACTION * 100:.0f}% "
                 f"in: {', '.join(list_offenders)}"
             ),
-            details={
-                "threshold_fraction": _NAN_THRESHOLD_FRACTION,
-                "fractions": dict_fractions,
-            },
+            details=details,
         )
     return CheckResult(
         name="nan_proportion",
         severity="pass",
         passed=True,
-        message=f"NaN fractions within {_NAN_THRESHOLD_FRACTION * 100:.0f}% on QH/QE/QN.",
-        details={"fractions": dict_fractions},
+        message=(
+            f"Missing fractions within {_NAN_THRESHOLD_FRACTION * 100:.0f}% "
+            f"on QH/QE/QN across {len(list_partitions)} partition(s)."
+        ),
+        details=details,
     )
 
 
 def check_energy_balance_closure(path_run_dir: Path) -> CheckResult:
-    """Approximate energy balance closure check.
+    """Energy-balance consistency check over every output partition.
 
-    Computes ``mean(|QN - (QH + QE + QS + QF)| / |QN|)`` over rows where
-    ``QN`` is finite and non-zero, then flags the run when the ratio
-    exceeds 10%. ``QF`` and ``QS`` may be missing for very simple
-    configurations — the check treats them as zero in that case rather
-    than refusing to run.
+    Computes ``mean(|(QN + QF + QMRain) - (QH + QE + QS + QM + QMFreeze)| /
+    |QN|)`` over rows where every term is finite and ``|QN| > 1``, then
+    flags the run when the ratio exceeds 10%. QN, QH, QE and QS must be
+    present; QF and the snow terms are treated as zero when their column
+    is absent, and the absent terms are listed in ``details``.
+
+    SUEWS closes this identity by construction, so the check is a
+    consistency test of the saved output rather than evidence of
+    scientific skill. Legacy text output stores the snow group in a
+    separate file that is not read here, so snow terms read as absent in
+    that format.
     """
     try:
-        df_output = _load_output_dataframe(path_run_dir)
+        list_partitions = _load_output_partitions(path_run_dir)
     except (OSError, ValueError, pd.errors.ParserError) as exc:
-        return CheckResult(
-            name="energy_balance_closure",
-            severity="warning",
-            passed=False,
-            message=f"Could not read run output to compute energy balance: {exc}",
-            details={"run_dir": str(path_run_dir)},
-        )
+        return _read_error("energy_balance_closure", path_run_dir, exc)
 
-    if df_output is None:
-        return CheckResult(
-            name="energy_balance_closure",
-            severity="warning",
-            passed=False,
-            message="No output dataframe to inspect.",
-            details={"run_dir": str(path_run_dir)},
-        )
+    if list_partitions is None:
+        return _no_output("energy_balance_closure", path_run_dir)
 
-    list_columns = [
-        col[0] if isinstance(col, tuple) else col for col in df_output.columns
-    ]
-    df_output = df_output.copy()
-    df_output.columns = list_columns
+    collected = _collect_closure_terms(list_partitions)
+    if isinstance(collected, CheckResult):
+        return collected
+    df_all, list_missing_optional = collected
 
-    if "QN" not in df_output.columns:
-        return CheckResult(
-            name="energy_balance_closure",
-            severity="fail",
-            passed=False,
-            message="QN missing — cannot compute energy balance closure.",
-            details={"available_columns": list_columns[:30]},
-        )
+    ser_qn = df_all["QN"]
+    mask_nontrivial = ser_qn.notna() & (ser_qn.abs() > 1.0)
+    mask_finite = df_all.notna().all(axis=1)
+    mask_valid = mask_nontrivial & mask_finite
 
-    ser_qn = pd.to_numeric(df_output["QN"], errors="coerce")
-    ser_qh = pd.to_numeric(df_output.get("QH", 0.0), errors="coerce").fillna(0.0)
-    ser_qe = pd.to_numeric(df_output.get("QE", 0.0), errors="coerce").fillna(0.0)
-    ser_qs = pd.to_numeric(df_output.get("QS", 0.0), errors="coerce").fillna(0.0)
-    ser_qf = pd.to_numeric(df_output.get("QF", 0.0), errors="coerce").fillna(0.0)
+    details: dict[str, Any] = {
+        "n_partitions": len(list_partitions),
+        "n_rows": len(df_all),
+        "n_rows_evaluated": int(mask_valid.sum()),
+        "n_rows_skipped_nonfinite": int((mask_nontrivial & ~mask_finite).sum()),
+        "terms_missing": list_missing_optional,
+    }
 
-    mask_valid = ser_qn.notna() & (ser_qn.abs() > 1.0)
     if not mask_valid.any():
         return CheckResult(
             name="energy_balance_closure",
             severity="warning",
             passed=False,
-            message="QN has no finite, non-trivial values to evaluate closure.",
-            details={"n_rows": len(df_output)},
+            message=(
+                "No rows with finite closure terms and non-trivial QN to evaluate."
+            ),
+            details=details,
         )
 
-    ser_residual = (ser_qn - (ser_qh + ser_qe + ser_qs + ser_qf)).abs()
+    ser_sources = df_all["QN"] + df_all["QF"] + df_all["QMRain"]
+    ser_sinks = df_all["QH"] + df_all["QE"] + df_all["QS"]
+    ser_sinks += df_all["QM"] + df_all["QMFreeze"]
+    ser_residual = (ser_sources - ser_sinks).abs()
     ser_ratio = ser_residual[mask_valid] / ser_qn[mask_valid].abs()
     ratio_mean = float(ser_ratio.mean())
+    details["ratio_mean"] = ratio_mean
 
+    note_missing = (
+        f" (absent terms treated as zero: {', '.join(details['terms_missing'])})"
+        if details["terms_missing"]
+        else ""
+    )
     if ratio_mean < _ENERGY_BALANCE_THRESHOLD:
         return CheckResult(
             name="energy_balance_closure",
             severity="pass",
             passed=True,
-            message=f"Mean closure residual {ratio_mean:.3f} < {_ENERGY_BALANCE_THRESHOLD:.2f}.",
-            details={"ratio_mean": ratio_mean, "n_rows": int(mask_valid.sum())},
+            message=(
+                f"Mean closure residual {ratio_mean:.3f} < "
+                f"{_ENERGY_BALANCE_THRESHOLD:.2f}{note_missing}."
+            ),
+            details=details,
         )
     return CheckResult(
         name="energy_balance_closure",
@@ -304,9 +414,9 @@ def check_energy_balance_closure(path_run_dir: Path) -> CheckResult:
         passed=False,
         message=(
             f"Mean closure residual {ratio_mean:.3f} exceeds "
-            f"{_ENERGY_BALANCE_THRESHOLD:.2f}."
+            f"{_ENERGY_BALANCE_THRESHOLD:.2f}{note_missing}."
         ),
-        details={"ratio_mean": ratio_mean, "n_rows": int(mask_valid.sum())},
+        details=details,
     )
 
 

--- a/test/cmd/test_diagnose_run.py
+++ b/test/cmd/test_diagnose_run.py
@@ -23,11 +23,11 @@ def _build_minimal_run_dir(tmp_path: Path) -> Path:
     n = 96  # one synthetic day at 15-min steps
     rng = np.random.default_rng(seed=2026)
     qn = rng.normal(loc=200.0, scale=50.0, size=n)
-    # Construct fluxes that close the energy balance to within ~5%.
-    qh = 0.4 * qn + rng.normal(scale=2.0, size=n)
-    qe = 0.3 * qn + rng.normal(scale=2.0, size=n)
-    qs = 0.2 * qn + rng.normal(scale=2.0, size=n)
+    # Construct fluxes that close QN + QF = QH + QE + QS to within ~5%.
     qf = 0.1 * qn + rng.normal(scale=2.0, size=n)
+    qh = 0.5 * qn + rng.normal(scale=2.0, size=n)
+    qe = 0.4 * qn + rng.normal(scale=2.0, size=n)
+    qs = 0.2 * qn + rng.normal(scale=2.0, size=n)
     df = pd.DataFrame({"QN": qn, "QH": qh, "QE": qe, "QS": qs, "QF": qf})
     df.to_csv(run_dir / "df_output.csv", index=False)
 

--- a/test/cmd/test_diagnostics.py
+++ b/test/cmd/test_diagnostics.py
@@ -46,8 +46,8 @@ def _make_run_dir(
     nan_fraction : float
         Inject this fraction of NaNs into QH.
     closure_offset : float
-        Multiply QH/QE/QS/QF sum by ``(1 + closure_offset)`` so the energy
-        balance residual is non-trivial when nonzero.
+        Multiply QH by ``(1 + closure_offset)`` so the energy balance
+        residual is non-trivial when nonzero.
     n : int
         Number of synthetic timesteps.
     """
@@ -56,10 +56,12 @@ def _make_run_dir(
 
     rng = np.random.default_rng(seed=1)
     qn = rng.normal(loc=200.0, scale=10.0, size=n)
-    qh = 0.4 * qn
-    qe = 0.3 * qn
-    qs = 0.2 * qn
+    # SUEWS identity: QN + QF = QH + QE + QS. With QF = 0.1 QN the sinks
+    # must sum to 1.1 QN for the balance to close.
     qf = 0.1 * qn
+    qh = 0.5 * qn
+    qe = 0.4 * qn
+    qs = 0.2 * qn
 
     if closure_offset:
         qh *= 1.0 + closure_offset
@@ -140,6 +142,298 @@ def test_check_energy_balance_closure_warning(tmp_path: Path) -> None:
     assert res.severity == "warning"
 
 
+def _write_csv(path: Path, **columns: object) -> None:
+    pd.DataFrame(columns).to_csv(path, index=False)
+
+
+def _closure_dir(tmp_path: Path, name: str = "run") -> Path:
+    run_dir = tmp_path / name
+    run_dir.mkdir(parents=True)
+    return run_dir
+
+
+def test_closure_passes_when_identity_holds(tmp_path: Path) -> None:
+    """QN + QF = QH + QE + QS must pass (QF is a source, not a sink)."""
+    run_dir = _closure_dir(tmp_path)
+    n = 8
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[100.0] * n,
+        QE=[80.0] * n,
+        QS=[40.0] * n,
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert res.passed, res.message
+    assert res.details["ratio_mean"] == pytest.approx(0.0)
+    assert res.details["n_rows_evaluated"] == n
+    assert res.details["terms_missing"] == ["QM", "QMFreeze", "QMRain"]
+
+
+def test_closure_warns_when_identity_broken(tmp_path: Path) -> None:
+    """Sinks summing to QN alone (220 vs 180) is a 20% residual."""
+    run_dir = _closure_dir(tmp_path)
+    n = 8
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[80.0] * n,
+        QE=[60.0] * n,
+        QS=[40.0] * n,
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert not res.passed
+    assert res.severity == "warning"
+    assert res.details["ratio_mean"] == pytest.approx(0.2)
+
+
+def test_closure_includes_snow_terms(tmp_path: Path) -> None:
+    """QN + QF + QMRain = QH + QE + QS + QM + QMFreeze closes with snow."""
+    run_dir = _closure_dir(tmp_path)
+    n = 6
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QMRain=[5.0] * n,
+        QH=[100.0] * n,
+        QE=[60.0] * n,
+        QS=[40.0] * n,
+        QM=[15.0] * n,
+        QMFreeze=[10.0] * n,
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert res.passed, res.message
+    assert res.details["terms_missing"] == []
+
+    # Dropping the snow sinks leaves 25 W m-2 (12.5%) unaccounted for.
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QMRain=[5.0] * n,
+        QH=[100.0] * n,
+        QE=[60.0] * n,
+        QS=[40.0] * n,
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert not res.passed
+    assert res.details["ratio_mean"] == pytest.approx(0.125)
+    assert res.details["terms_missing"] == ["QM", "QMFreeze"]
+
+
+def test_closure_missing_optional_column_does_not_raise(tmp_path: Path) -> None:
+    run_dir = _closure_dir(tmp_path)
+    n = 4
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QH=[100.0] * n,
+        QE=[60.0] * n,
+        QS=[40.0] * n,
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert res.passed, res.message
+    assert "QF" in res.details["terms_missing"]
+    assert "QF" in res.message
+
+
+def test_closure_missing_required_column_fails(tmp_path: Path) -> None:
+    run_dir = _closure_dir(tmp_path)
+    n = 4
+    _write_csv(
+        run_dir / "df_output.csv", QN=[200.0] * n, QH=[100.0] * n, QE=[100.0] * n
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert res.severity == "fail"
+    assert res.details["missing"] == ["QS"]
+
+
+def test_sentinel_values_are_treated_as_missing(tmp_path: Path) -> None:
+    run_dir = _closure_dir(tmp_path)
+    n = 10
+    qh = [100.0] * n
+    qh[:4] = [-999.0] * 4
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=qh,
+        QE=[80.0] * n,
+        QS=[40.0] * n,
+    )
+    res_nan = check_nan_proportion(run_dir)
+    assert not res_nan.passed
+    assert res_nan.details["fractions"]["df_output.csv"]["QH"] == pytest.approx(0.4)
+
+    res_eb = check_energy_balance_closure(run_dir)
+    assert res_eb.passed, res_eb.message
+    assert res_eb.details["n_rows_evaluated"] == 6
+    assert res_eb.details["n_rows_skipped_nonfinite"] == 4
+
+
+def test_all_rows_nonfinite_gives_warning(tmp_path: Path) -> None:
+    run_dir = _closure_dir(tmp_path)
+    n = 4
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[np.nan] * n,
+        QE=[80.0] * n,
+        QS=[40.0] * n,
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert res.severity == "warning"
+    assert res.details["n_rows_evaluated"] == 0
+
+
+def test_every_csv_partition_is_inspected(tmp_path: Path) -> None:
+    """A second CSV whose fluxes are all NaN must not hide behind the first."""
+    run_dir = _closure_dir(tmp_path)
+    n = 8
+    _write_csv(
+        run_dir / "df_output_a.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[100.0] * n,
+        QE=[80.0] * n,
+        QS=[40.0] * n,
+    )
+    _write_csv(
+        run_dir / "df_output_z.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[np.nan] * n,
+        QE=[np.nan] * n,
+        QS=[40.0] * n,
+    )
+    res_nan = check_nan_proportion(run_dir)
+    assert not res_nan.passed
+    assert res_nan.details["n_partitions"] == 2
+    assert res_nan.details["fractions"]["df_output_z.csv"]["QH"] == pytest.approx(1.0)
+    assert res_nan.details["fractions"]["df_output_a.csv"]["QH"] == pytest.approx(0.0)
+    assert "df_output_z.csv:QH" in res_nan.message
+
+    res_eb = check_energy_balance_closure(run_dir)
+    assert res_eb.details["n_partitions"] == 2
+    assert res_eb.details["n_rows"] == 2 * n
+    assert res_eb.details["n_rows_skipped_nonfinite"] == n
+
+
+def test_every_grid_in_parquet_is_a_partition(tmp_path: Path) -> None:
+    run_dir = _closure_dir(tmp_path)
+    n = 6
+    idx = pd.MultiIndex.from_product(
+        [[1, 2], pd.date_range("2012-01-01", periods=n, freq="h")],
+        names=["grid", "datetime"],
+    )
+    qn = np.full(2 * n, 200.0)
+    qh = np.full(2 * n, 100.0)
+    qh[n:] = np.nan  # grid 2 has no QH
+    df = pd.DataFrame(
+        np.column_stack([qn, qh, 0.4 * qn, 0.2 * qn, 0.1 * qn]),
+        index=idx,
+        columns=_suews_columns(["QN", "QH", "QE", "QS", "QF"]),
+    )
+    df.to_parquet(run_dir / "SUEWS_output.parquet")
+
+    res = check_nan_proportion(run_dir)
+    assert not res.passed
+    assert res.details["n_partitions"] == 2
+    assert res.details["fractions"]["SUEWS_output.parquet[grid=1]"][
+        "QH"
+    ] == pytest.approx(0.0)
+    assert res.details["fractions"]["SUEWS_output.parquet[grid=2]"][
+        "QH"
+    ] == pytest.approx(1.0)
+
+
+def test_multi_group_parquet_uses_core_suews_group(tmp_path: Path) -> None:
+    """A variable repeated in another group (ESTM QS) must not break the check."""
+    run_dir = _closure_dir(tmp_path)
+    n = 6
+    qn = np.full(n, 200.0)
+    columns = pd.MultiIndex.from_tuples(
+        [
+            ("SUEWS", "QN"),
+            ("SUEWS", "QH"),
+            ("SUEWS", "QE"),
+            ("SUEWS", "QS"),
+            ("SUEWS", "QF"),
+            ("ESTM", "QS"),
+        ],
+        names=["group", "var"],
+    )
+    df = pd.DataFrame(
+        np.column_stack([qn, 0.5 * qn, 0.4 * qn, 0.2 * qn, 0.1 * qn, 5.0 * qn]),
+        columns=columns,
+    )
+    df.to_parquet(run_dir / "SUEWS_output.parquet")
+
+    res = check_energy_balance_closure(run_dir)
+    assert res.passed, res.message
+    assert res.details["ratio_mean"] == pytest.approx(0.0)
+
+
+def test_duplicate_output_formats_are_not_double_counted(tmp_path: Path) -> None:
+    """The same run saved as parquet and CSV is read once, from parquet."""
+    run_dir = _closure_dir(tmp_path)
+    n = 8
+    qn = np.full(n, 200.0)
+    df = pd.DataFrame(
+        np.column_stack([qn, 0.5 * qn, 0.4 * qn, 0.2 * qn, 0.1 * qn]),
+        columns=_suews_columns(["QN", "QH", "QE", "QS", "QF"]),
+    )
+    df.to_parquet(run_dir / "SUEWS_output.parquet")
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=qn,
+        QH=[np.nan] * n,
+        QE=0.4 * qn,
+        QS=0.2 * qn,
+        QF=0.1 * qn,
+    )
+    assert check_output_files_present(run_dir).details["files"]
+
+    res_nan = check_nan_proportion(run_dir)
+    assert res_nan.passed, res_nan.message
+    assert list(res_nan.details["fractions"]) == ["SUEWS_output.parquet"]
+
+    res_eb = check_energy_balance_closure(run_dir)
+    assert res_eb.passed, res_eb.message
+    assert res_eb.details["n_partitions"] == 1
+    assert res_eb.details["n_rows"] == n
+
+
+def test_legacy_text_output_partitions(tmp_path: Path) -> None:
+    """Legacy per-grid text files are all read; -999 is missing."""
+    run_dir = _closure_dir(tmp_path)
+    header = "Year DOY Hour Min Dectime QN QF QS QH QE"
+    rows_ok = "\n".join(
+        f"2012 1 {h} 0 1.0 200.0 20.0 40.0 100.0 80.0" for h in range(4)
+    )
+    rows_bad = "\n".join(
+        f"2012 1 {h} 0 1.0 200.0 20.0 40.0 -999.0 -999.0" for h in range(4)
+    )
+    (run_dir / "Site1_2012_SUEWS_60.txt").write_text(f"{header}\n{rows_ok}\n")
+    (run_dir / "Site2_2012_SUEWS_60.txt").write_text(f"{header}\n{rows_bad}\n")
+
+    res_nan = check_nan_proportion(run_dir)
+    assert not res_nan.passed
+    assert res_nan.details["n_partitions"] == 2
+    assert res_nan.details["fractions"]["Site2_2012_SUEWS_60.txt"][
+        "QH"
+    ] == pytest.approx(1.0)
+
+    res_eb = check_energy_balance_closure(run_dir)
+    assert res_eb.passed, res_eb.message
+    assert res_eb.details["n_rows_evaluated"] == 4
+    assert res_eb.details["n_rows_skipped_nonfinite"] == 4
+
+
 def test_check_run_aggregator_returns_all_checks(tmp_path: Path) -> None:
     run_dir = _make_run_dir(tmp_path)
     list_results = check_run(run_dir)
@@ -159,7 +453,7 @@ def test_check_run_reads_real_parquet_output_name_and_columns(tmp_path: Path) ->
 
     qn = np.full(12, 200.0)
     df = pd.DataFrame(
-        np.column_stack([qn, 0.4 * qn, 0.3 * qn, 0.2 * qn, 0.1 * qn]),
+        np.column_stack([qn, 0.5 * qn, 0.4 * qn, 0.2 * qn, 0.1 * qn]),
         columns=_suews_columns(["QN", "QH", "QE", "QS", "QF"]),
     )
     df.to_parquet(run_dir / "SUEWS_output.parquet")

--- a/test/cmd/test_diagnostics.py
+++ b/test/cmd/test_diagnostics.py
@@ -418,8 +418,12 @@ def test_legacy_text_output_partitions(tmp_path: Path) -> None:
     rows_bad = "\n".join(
         f"2012 1 {h} 0 1.0 200.0 20.0 40.0 -999.0 -999.0" for h in range(4)
     )
-    (run_dir / "Site1_2012_SUEWS_60.txt").write_text(f"{header}\n{rows_ok}\n")
-    (run_dir / "Site2_2012_SUEWS_60.txt").write_text(f"{header}\n{rows_bad}\n")
+    (run_dir / "Site1_2012_SUEWS_60.txt").write_text(
+        f"{header}\n{rows_ok}\n", encoding="utf-8"
+    )
+    (run_dir / "Site2_2012_SUEWS_60.txt").write_text(
+        f"{header}\n{rows_bad}\n", encoding="utf-8"
+    )
 
     res_nan = check_nan_proportion(run_dir)
     assert not res_nan.passed

--- a/test/cmd/test_diagnostics.py
+++ b/test/cmd/test_diagnostics.py
@@ -269,9 +269,12 @@ def test_sentinel_values_are_treated_as_missing(tmp_path: Path) -> None:
     assert res_nan.details["fractions"]["df_output.csv"]["QH"] == pytest.approx(0.4)
 
     res_eb = check_energy_balance_closure(run_dir)
-    assert res_eb.passed, res_eb.message
     assert res_eb.details["n_rows_evaluated"] == 6
     assert res_eb.details["n_rows_skipped_nonfinite"] == 4
+    # The evaluable rows close, but 40% of the partition was skipped.
+    assert res_eb.details["ratio_mean"] == pytest.approx(0.0)
+    assert not res_eb.passed
+    assert res_eb.details["partitions"]["df_output.csv"]["status"] == "low_coverage"
 
 
 def test_all_rows_nonfinite_gives_warning(tmp_path: Path) -> None:
@@ -318,9 +321,113 @@ def test_every_csv_partition_is_inspected(tmp_path: Path) -> None:
     assert "df_output_z.csv:QH" in res_nan.message
 
     res_eb = check_energy_balance_closure(run_dir)
+    assert not res_eb.passed
     assert res_eb.details["n_partitions"] == 2
     assert res_eb.details["n_rows"] == 2 * n
     assert res_eb.details["n_rows_skipped_nonfinite"] == n
+    assert res_eb.details["partitions"]["df_output_a.csv"]["status"] == "pass"
+    assert (
+        res_eb.details["partitions"]["df_output_z.csv"]["status"] == "no_evaluable_rows"
+    )
+    assert "df_output_z.csv: no evaluable rows" in res_eb.message
+
+
+def test_single_bad_partition_is_not_averaged_away(tmp_path: Path) -> None:
+    """100 balanced rows in one file plus one 100% residual row in another."""
+    run_dir = _closure_dir(tmp_path)
+    n = 100
+    _write_csv(
+        run_dir / "df_output_a.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[100.0] * n,
+        QE=[80.0] * n,
+        QS=[40.0] * n,
+    )
+    _write_csv(
+        run_dir / "df_output_b.csv",
+        QN=[200.0],
+        QF=[20.0],
+        QH=[300.0],
+        QE=[80.0],
+        QS=[40.0],
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert not res.passed
+    assert res.severity == "warning"
+    partitions = res.details["partitions"]
+    assert partitions["df_output_a.csv"]["status"] == "pass"
+    assert partitions["df_output_b.csv"]["status"] == "residual"
+    assert partitions["df_output_b.csv"]["ratio_mean"] == pytest.approx(1.0)
+    assert "df_output_b.csv: residual 1.000" in res.message
+    # The aggregate is still reported, but it does not decide the verdict.
+    assert res.details["ratio_mean"] == pytest.approx(1.0 / 101.0)
+
+
+def test_partition_with_all_qs_missing_blocks_pass(tmp_path: Path) -> None:
+    """A second partition whose QS is entirely NaN must not be certified."""
+    run_dir = _closure_dir(tmp_path)
+    n = 100
+    _write_csv(
+        run_dir / "df_output_a.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[100.0] * n,
+        QE=[80.0] * n,
+        QS=[40.0] * n,
+    )
+    _write_csv(
+        run_dir / "df_output_b.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[100.0] * n,
+        QE=[80.0] * n,
+        QS=[np.nan] * n,
+    )
+    (run_dir / "provenance.json").write_text("{}", encoding="utf-8")
+
+    by_name = {res.name: res for res in check_run(run_dir)}
+    # QH/QE/QN are finite, so the NaN check cannot see the problem ...
+    assert by_name["nan_proportion"].passed
+    # ... but closure must refuse to certify the unevaluated partition.
+    res = by_name["energy_balance_closure"]
+    assert not res.passed
+    assert res.details["partitions"]["df_output_b.csv"]["status"] == "no_evaluable_rows"
+    assert res.details["partitions"]["df_output_b.csv"]["n_rows_evaluated"] == 0
+
+
+def test_closure_coverage_threshold(tmp_path: Path) -> None:
+    """Up to 5% skipped rows still pass; more than that is low coverage."""
+    run_dir = _closure_dir(tmp_path)
+    n = 100
+    qs_ok = [40.0] * n
+    qs_ok[:4] = [np.nan] * 4
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[100.0] * n,
+        QE=[80.0] * n,
+        QS=qs_ok,
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert res.passed, res.message
+    assert res.details["partitions"]["df_output.csv"]["coverage"] == pytest.approx(0.96)
+
+    qs_bad = [40.0] * n
+    qs_bad[:6] = [np.nan] * 6
+    _write_csv(
+        run_dir / "df_output.csv",
+        QN=[200.0] * n,
+        QF=[20.0] * n,
+        QH=[100.0] * n,
+        QE=[80.0] * n,
+        QS=qs_bad,
+    )
+    res = check_energy_balance_closure(run_dir)
+    assert not res.passed
+    assert res.details["partitions"]["df_output.csv"]["status"] == "low_coverage"
+    assert "94.0% of rows evaluable" in res.message
 
 
 def test_every_grid_in_parquet_is_a_partition(tmp_path: Path) -> None:
@@ -433,9 +540,12 @@ def test_legacy_text_output_partitions(tmp_path: Path) -> None:
     ] == pytest.approx(1.0)
 
     res_eb = check_energy_balance_closure(run_dir)
-    assert res_eb.passed, res_eb.message
+    assert not res_eb.passed
     assert res_eb.details["n_rows_evaluated"] == 4
     assert res_eb.details["n_rows_skipped_nonfinite"] == 4
+    partitions = res_eb.details["partitions"]
+    assert partitions["Site1_2012_SUEWS_60.txt"]["status"] == "pass"
+    assert partitions["Site2_2012_SUEWS_60.txt"]["status"] == "no_evaluable_rows"
 
 
 def test_check_run_aggregator_returns_all_checks(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #1734.

## What changed

`suews diagnose` reported energy-balance closure with QF on the wrong side of the identity, so a run whose output balanced was flagged and an unbalanced one passed. It also crashed when an optional flux column was absent, inspected only the first output file it found, and treated `-999` sentinels as valid data. On real parquet output it raised a `TypeError` because `QS` appears in both the `SUEWS` and `ESTM` groups and flattening left duplicate column labels.

- `src/supy/diagnostics/_checks.py`: the residual is now `(QN + QF + QMRain) - (QH + QE + QS + QM + QMFreeze)`, matching `qh_residual` in the Fortran driver and the identity documented in `workflow.rst`. QN, QH, QE and QS are required; QF and the snow terms default to zero when absent and are named in the result. Rows with any non-finite term, or a `-999` sentinel, are excluded and counted. Closure is evaluated per partition and the run passes only when every partition passes: an excessive residual, fewer than 95 % evaluable rows, or no evaluable rows in any partition blocks the pass, so a healthy partition cannot average away a broken one. The row-weighted aggregate ratio is still reported in `details`. The NaN check reports per-partition fractions and warns when any partition exceeds the threshold.
- `src/supy/_run_output.py`: new `_load_run_output_partitions` returns every file of the highest-priority format present (parquet, then CSV, then legacy text) and every grid within a multi-grid file, restricted to the core `SUEWS` column group. `_load_run_output_dataframe` is unchanged, so `suews summarise` and `suews compare` keep their first-file behaviour.
- `src/supy/cmd/diagnose_run.py`: the closure recommendation now describes an internal-consistency failure rather than sending users to review physics options.
- Tests: both synthetic fixtures previously closed under the wrong identity (sinks summed to QN alone) and are corrected. New regressions cover the balanced/unbalanced counterexamples, snow terms, missing optional and required columns, sentinels, all-NaN rows, a second CSV partition, a second grid in parquet, duplicate output formats, multi-group parquet, legacy text files, one bad row hidden behind 100 good ones in another partition, a partition whose QS is entirely missing, and the 95 % coverage threshold.

## Validation

- `pytest test/cmd/test_diagnostics.py test/cmd/test_diagnose_run.py test/cmd/test_summarise_output.py test/cmd/test_compare_runs.py test/mcp/test_tool_diagnose.py`: 42 passed.
- `make test-smoke`: 15 passed, 1 skipped.
- A 5-day sample run saved as parquet and as legacy text both pass with a mean closure residual of order 1e-16 and 1e-6 respectively. Before this change the parquet case raised and the text case reported a 20 % residual.

## Scope notes

- `suews summarise` and `suews compare` still read one file only; extending them to partitions is a separate change.
- Current writers emit QF and the snow terms in every format; the optional-term handling exists for reduced or older outputs, and the check names any term it treated as zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
