### PR TITLE
Teach canonical suews commands and the Python 3.12 floor in onboarding text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ EXAMPLES:
 
 ## 2026
 
+### 7 Sep 2026
+
+- [doc] Aligned the onboarding text with the canonical `suews run` / `suews validate` / `suews convert` / `suews schema` commands and the Python 3.12+ runtime floor (#1745)
+  - README quick start, `suews run --help` and its namelist deprecation messages no longer recommend the deprecated hyphenated aliases
+  - `make docs-setup`, `docs/README.md` and the developer building/onboarding guides now state the `requires-python` floor from `pyproject.toml` instead of Python 3.9+
+  - Tests in `test/cmd/test_suews_cli.py` check that `suews run --help` and the README teach resolvable canonical commands and that the onboarding files do not understate the runtime floor
+
 ### 1 Sep 2026
 
 - [maintenance] CI: adopted GitHub's self-repository `uses: $/...` syntax for same-repository actions and reusable workflows, and pinned `zizmor` to 1.30.0 so a new release cannot silently move the advisory audit baseline (#1728)

--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,8 @@ docs-setup:
 		echo ""; \
 		exit 1; \
 	fi
-	@$(PYTHON) -c "import sys; sys.exit(sys.version_info < (3, 11))" || { \
-		echo "ERROR: Documentation tooling requires Python 3.11 or newer."; \
-		echo "Runtime support remains Python 3.9+."; \
+	@$(PYTHON) -c "import sys; sys.exit(sys.version_info < (3, 12))" || { \
+		echo "ERROR: SUEWS requires Python 3.12 or newer (requires-python in pyproject.toml)."; \
 		exit 1; \
 	}
 	@TMP_REQ=$$(mktemp "$${TMPDIR:-/tmp}/suews-docs.XXXXXX" 2>/dev/null || mktemp -t suews-docs); \

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ The model represents seven surface types -- paved, buildings, evergreen trees/sh
 * **Storage heat schemes**: OHM, AnOHM, ESTM, EHC (explicit heat conduction)
 * **Building energy**: STEBBS (Simple Thermal Energy Balance for Building Scheme)
 * **Python API**: YAML configuration, pandas DataFrames, programmatic simulations
-* **CLI tools**: `suews-run`, `suews-validate`, `suews-convert`, `suews-schema`
+* **CLI tools**: `suews run`, `suews validate`, `suews convert`, `suews schema`
 
 ## Quick Start
+
+SUEWS requires Python 3.12 or newer.
 
 ```bash
 pip install supy
@@ -47,7 +49,7 @@ pip install supy
 **Run from the command line:**
 
 ```bash
-suews-run /path/to/config.yml
+suews run /path/to/config.yml
 ```
 
 **Or use the Python API:**

--- a/dev-ref/building-locally.md
+++ b/dev-ref/building-locally.md
@@ -4,7 +4,7 @@ If you want to build SUEWS from source for local use, this guide covers prerequi
 
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.12 or newer
 - `gfortran` compiler (≥ 9.3.0)
   - macOS: `brew install gcc`
   - Ubuntu/Debian: `sudo apt-get install gfortran`

--- a/dev-ref/onboarding-guide.md
+++ b/dev-ref/onboarding-guide.md
@@ -12,7 +12,7 @@ Before starting development, ensure you have:
    - Git installed and configured
    - GitHub account with repository access
    - `gfortran` compiler installed (platform-specific installation)
-   - Python 3.9+ installed
+   - Python 3.12 or newer installed
    - Text editor or IDE of choice
 
 2. **Recommended Tools**:

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,9 +140,8 @@ The build system automatically:
 
 ### Dependencies
 Python dependencies specified in `pyproject.toml`.
-Runtime installs support Python 3.9 and newer. Documentation tooling requires
-Python 3.11 or newer because current Sphinx extension versions, including
-`sphinx-design>=0.7.0`, do not support Python 3.9/3.10.
+SUEWS requires Python 3.12 or newer (`requires-python` in `pyproject.toml`);
+the documentation tooling runs on the same interpreter.
 Recommended local setup:
 
 ```bash

--- a/src/supy/cmd/SUEWS.py
+++ b/src/supy/cmd/SUEWS.py
@@ -176,8 +176,8 @@ def _run_with_namelist(path_runcontrol):
         "=" * 60 + "\n"
         "DEPRECATION WARNING: Namelist format is deprecated.\n"
         "Please migrate to YAML configuration:\n\n"
-        f"  1. Convert: suews-convert -i {path_runcontrol.name} -o config.yml\n"
-        "  2. Run:     suews-run config.yml\n\n"
+        f"  1. Convert: suews convert -i {path_runcontrol.name} -o config.yml\n"
+        "  2. Run:     suews run config.yml\n\n"
         "For more information, see: https://docs.suews.io/\n"
         "=" * 60 + "\n",
         err=True,
@@ -282,15 +282,15 @@ Run SUEWS simulation using YAML (recommended) or namelist configuration.
 
 YAML Configuration (Recommended):
 
-    $ suews-run config.yml
+    $ suews run config.yml
 
-    $ suews-run /path/to/config.yml
+    $ suews run /path/to/config.yml
 
 Namelist Configuration (Deprecated):
 
-    $ suews-run -p RunControl.nml
+    $ suews run -p RunControl.nml
 
-    $ suews-run -p /path/to/RunControl.nml
+    $ suews run -p /path/to/RunControl.nml
 
 The format is auto-detected based on file extension:
 - .yml, .yaml: YAML format (modern, recommended)
@@ -298,8 +298,8 @@ The format is auto-detected based on file extension:
 
 To migrate from namelist to YAML:
 
-    $ suews-convert -i RunControl.nml -o config.yml
-    $ suews-run config.yml
+    $ suews convert -i RunControl.nml -o config.yml
+    $ suews run config.yml
 
 For more information, see: https://docs.suews.io/
 """,
@@ -334,7 +334,7 @@ Website: https://suews.io/
         click.echo(
             "\nDEPRECATION: The '-p/--path_runcontrol' option is deprecated. "
             "Use positional argument instead:\n"
-            f"  suews-run {Path(path_runcontrol).name}\n",
+            f"  suews run {Path(path_runcontrol).name}\n",
             err=True,
         )
         config_file = path_runcontrol

--- a/test/cmd/test_suews_cli.py
+++ b/test/cmd/test_suews_cli.py
@@ -11,6 +11,7 @@ Validates:
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import sys
 
 from click.testing import CliRunner
@@ -304,3 +305,84 @@ def test_rust_bridge_main_accepts_explicit_argv(
     # POSIX both pass; ``rust_bridge.main`` stringifies the Path before exec.
     assert captured["cmd"] == [str(fake_binary), "--version"]
     assert captured["check"] is False
+
+
+# ---------------------------------------------------------------------------
+# Onboarding consistency
+#
+# What the README, the ``suews run`` help text and the setup messages teach
+# must match the canonical ``suews <subcmd>`` interface and the Python floor
+# declared in ``pyproject.toml``. These guard the drift that let the README
+# and ``suews run --help`` keep recommending the deprecated hyphenated aliases.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LEGACY_ALIAS_PATTERN = re.compile(r"\bsuews-(run|validate|convert|schema|inspect)\b")
+_PYTHON_FLOOR_CLAIM_PATTERN = re.compile(
+    r"Python (\d+)\.(\d+)\s*(?:\+|or newer|and newer|or later)"
+    r"|version_info < \((\d+), (\d+)\)"
+)
+_ONBOARDING_FILES = (
+    "README.md",
+    "Makefile",
+    "docs/README.md",
+    "dev-ref/building-locally.md",
+    "dev-ref/onboarding-guide.md",
+)
+
+
+def _read_repo_file(relative_path: str) -> str:
+    path = _REPO_ROOT / relative_path
+    if not path.is_file():
+        pytest.skip(f"{relative_path} not present; not running from a source checkout")
+    return path.read_text(encoding="utf-8")
+
+
+def _required_python_floor() -> tuple[int, int]:
+    import tomllib
+
+    project = tomllib.loads(_read_repo_file("pyproject.toml"))["project"]
+    spec = project["requires-python"].strip()
+    match = re.fullmatch(r">=\s*(\d+)\.(\d+)", spec)
+    assert match, f"unexpected requires-python spec: {spec!r}"
+    return int(match.group(1)), int(match.group(2))
+
+
+def test_run_help_teaches_canonical_commands() -> None:
+    from supy.cmd.suews_cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "suews run config.yml" in result.output
+    assert "suews convert -i RunControl.nml" in result.output
+    assert not _LEGACY_ALIAS_PATTERN.search(result.output), result.output
+
+
+def test_readme_teaches_only_resolvable_subcommands() -> None:
+    from supy.cmd.suews_cli import cli
+
+    readme = _read_repo_file("README.md")
+    legacy = sorted(set(_LEGACY_ALIAS_PATTERN.findall(readme)))
+    assert not legacy, f"README still teaches deprecated aliases: {legacy}"
+    taught = set(re.findall(r"\bsuews ([a-z]+)\b", readme))
+    assert taught, "README no longer documents any suews subcommand"
+    missing = sorted(taught - set(cli.commands))
+    assert not missing, f"README teaches unknown subcommands: {missing}"
+
+
+@pytest.mark.parametrize("relative_path", _ONBOARDING_FILES)
+def test_onboarding_files_do_not_understate_python_floor(relative_path: str) -> None:
+    floor = _required_python_floor()
+    text = _read_repo_file(relative_path)
+    claims = [
+        (int(major or check_major), int(minor or check_minor))
+        for major, minor, check_major, check_minor in _PYTHON_FLOOR_CLAIM_PATTERN.findall(
+            text
+        )
+    ]
+    understated = sorted({claim for claim in claims if claim < floor})
+    assert not understated, (
+        f"{relative_path} claims a Python floor below requires-python "
+        f"{floor[0]}.{floor[1]}: {understated}"
+    )

--- a/test/core/test_cli_run.py
+++ b/test/core/test_cli_run.py
@@ -1,4 +1,4 @@
-"""Tests for suews-run CLI command.
+"""Tests for the ``suews run`` CLI command.
 
 Tests YAML and namelist format support, auto-detection,
 backward compatibility, and deprecation warnings.
@@ -23,7 +23,7 @@ from conftest import CliResultAdapter, run_cli_command
 
 
 class TestCLIRun:
-    """Test suews-run CLI command functionality."""
+    """Test ``suews run`` CLI command functionality."""
 
     @pytest.fixture
     def test_data_dir(self):
@@ -141,7 +141,7 @@ sites:
         # Should show namelist deprecation warning (may be in stdout with CliRunner)
         combined = result.stderr + result.stdout
         assert "DEPRECATION WARNING" in combined
-        assert "suews-convert" in combined
+        assert "suews convert -i" in combined
         # Should show SUEWS version banner
         assert "SUEWS version" in result.stdout
 
@@ -248,5 +248,5 @@ sites:
 
         # Should show migration instructions (may be in stdout with CliRunner)
         combined = result.stderr + result.stdout
-        assert "suews-convert" in combined
+        assert "suews convert -i" in combined
         assert "config.yml" in combined


### PR DESCRIPTION
Closes #1745.

## What changed

The onboarding path still taught the pre-#1359 hyphenated commands and a Python 3.9+ runtime floor that `pyproject.toml` (`requires-python = ">=3.12"`) contradicts. This PR reconciles the first-contact surfaces with the canonical `suews <subcmd>` interface and the declared floor, without a wider documentation rewrite.

- `README.md`: CLI tools list and quick start use `suews run` / `suews validate` / `suews convert` / `suews schema`; the quick start states the Python 3.12+ requirement.
- `src/supy/cmd/SUEWS.py`: the `suews run` help text, the namelist deprecation banner and the `-p/--path_runcontrol` deprecation message recommend `suews run` / `suews convert` instead of the deprecated aliases. Message strings only; no run logic changed.
- `Makefile` (`docs-setup`): the interpreter gate moves from `< (3, 11)` to `< (3, 12)` and the message names the `requires-python` floor instead of claiming "Runtime support remains Python 3.9+".
- `docs/README.md`, `dev-ref/building-locally.md`, `dev-ref/onboarding-guide.md`: Python prerequisite corrected to 3.12 or newer.
- `CHANGELOG.md`: `[doc]` entry.

## Tests

Added to `test/cmd/test_suews_cli.py`:

- `suews run --help` teaches `suews run` / `suews convert` and contains no hyphenated alias.
- Every `suews <subcmd>` the README teaches resolves in the dispatcher, and the README contains no deprecated alias.
- Each onboarding file (README, Makefile, docs/README, the two dev-ref guides) claims no Python floor lower than `requires-python`; against the pre-PR Makefile this test fails on the `(3, 11)` gate and the 3.9+ message.

Verification: `pytest test/cmd/test_suews_cli.py` and `make test-smoke` on this branch (results below in the PR conversation once CI runs).

## Deliberately out of scope

Listed on #1745 for follow-up: `docs/source/api/command-line.rst` and `workflow.rst` (a docs pass of their own), the JSON envelope `source: suews-validate` identifier, the Python 3.9 typing rule in `.claude/rules/python/conventions.md`, and `src/suews_bridge/pyproject.toml` (`>=3.9`).

Draft for review; not to be merged by automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
