### PR TITLE
Make CLI regression tests fail on command and output errors

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -126,67 +126,16 @@ def _clear_mcp_caches():
 
 
 class CliResultAdapter:
-    """Adapter to make Click's CliRunner results compatible with subprocess.CompletedProcess.
+    """Expose Click's separate captured streams with subprocess-style status.
 
-    This adapter provides a consistent interface for CLI test results, allowing tests
-    to be written in a subprocess-like style while actually running in-process via
-    Click's CliRunner (which avoids the 10-20s ninja rebuild overhead in editable installs).
-
-    Attributes
-    ----------
-    returncode : int
-        Exit code (0 for success, non-zero for failure)
-    stdout : str
-        Standard output content
-    stderr : str
-        Standard error content (heuristically extracted from combined output)
-
-    Notes
-    -----
-    Click's CliRunner combines stdout/stderr by default. This adapter uses keyword
-    matching to heuristically split them, which is a pragmatic workaround. For more
-    precise control, ensure CLI code uses `click.echo(..., err=True)` consistently.
+    Preserve the actual streams, including whitespace and continuation lines.
+    Diagnostic keywords cannot identify which stream a command wrote to.
     """
 
-    # Keywords that typically indicate stderr content
-    STDERR_KEYWORDS = ("DEPRECAT", "ERROR", "WARNING", "=====", "TRACEBACK")
-
     def __init__(self, click_result):
-        """Initialise from a Click Result object.
-
-        Parameters
-        ----------
-        click_result : click.testing.Result
-            Result from CliRunner.invoke()
-        """
-        self._result = click_result
         self.returncode = click_result.exit_code
-        self.stdout = click_result.output or ""
-        self.stderr = self._extract_stderr(click_result.output)
-
-    def _extract_stderr(self, output):
-        """Heuristically extract stderr-like content from combined output.
-
-        Parameters
-        ----------
-        output : str or None
-            Combined output from CliRunner
-
-        Returns
-        -------
-        str
-            Lines that appear to be stderr content
-        """
-        if not output:
-            return ""
-
-        stderr_lines = []
-        for line in output.split("\n"):
-            line_upper = line.upper()
-            if any(kw in line_upper for kw in self.STDERR_KEYWORDS):
-                stderr_lines.append(line)
-
-        return "\n".join(stderr_lines) if stderr_lines else ""
+        self.stdout = click_result.stdout
+        self.stderr = click_result.stderr
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterator
 from importlib.resources import as_file
+from inspect import signature
 from pathlib import Path
 import subprocess
 import sys
@@ -150,6 +151,10 @@ def cli_runner():
     CliRunner
         Click test runner instance
     """
+    # Click <8.2 requires opting out of mixed stderr; newer versions always
+    # capture both streams separately and have removed this argument.
+    if "mix_stderr" in signature(CliRunner).parameters:
+        return CliRunner(mix_stderr=False)
     return CliRunner()
 
 

--- a/test/core/test_cli_run.py
+++ b/test/core/test_cli_run.py
@@ -8,18 +8,22 @@ This is especially important for editable installs where each subprocess
 triggers a ninja rebuild check (10-20+ seconds).
 """
 
-import tempfile
 from pathlib import Path
+import shutil
 
+from conftest import run_cli_command
+import pandas as pd
 import pytest
+
+from supy.cmd.SUEWS import SUEWS
 
 pytestmark = pytest.mark.api
 
-# Import the CLI command for in-process testing
-from supy.cmd.SUEWS import SUEWS
 
-# Import shared CLI testing utilities from conftest
-from conftest import CliResultAdapter, run_cli_command
+@pytest.fixture(autouse=True)
+def isolated_working_directory(tmp_path, monkeypatch):
+    """Keep default-file searches and simulation outputs local to each test."""
+    monkeypatch.chdir(tmp_path)
 
 
 class TestCLIRun:
@@ -36,11 +40,14 @@ class TestCLIRun:
         return test_data_dir / "benchmark1"
 
     @pytest.fixture
-    def sample_yaml(self, benchmark_dir):
-        """Path to sample YAML configuration."""
-        yaml_file = benchmark_dir / "benchmark1_short.yml"
-        if not yaml_file.exists():
-            pytest.skip(f"Sample YAML not found: {yaml_file}")
+    def sample_yaml(self, benchmark_dir, tmp_path):
+        """Copy the committed short case with its relative forcing dependency."""
+        yaml_file = tmp_path / "benchmark1_short.yml"
+        shutil.copyfile(benchmark_dir / yaml_file.name, yaml_file)
+        forcing_dir = tmp_path / "forcing"
+        forcing_dir.mkdir()
+        forcing_name = "Kc1_2011_data_5_short.txt"
+        shutil.copyfile(benchmark_dir / "forcing" / forcing_name, forcing_dir / forcing_name)
         return yaml_file
 
     @pytest.fixture
@@ -81,25 +88,6 @@ class TestCLIRun:
         assert "DEPRECATED" in result.stdout or "deprecated" in result.stdout.lower()
 
     # ========== YAML FORMAT TESTS ==========
-
-    def test_yaml_positional_argument(self, cli_runner, sample_yaml, tmp_path):
-        """Test running with YAML file as positional argument."""
-        # Run in temp directory to avoid polluting test fixtures
-        result = self.run_suews_run(
-            cli_runner,
-            str(sample_yaml),
-            check=True,
-        )
-        assert result.returncode == 0
-        assert "YAML configuration" in result.stdout
-        assert "successfully done" in result.stdout
-
-    def test_yaml_auto_detection(self, cli_runner, sample_yaml):
-        """Test that .yml extension is auto-detected as YAML format."""
-        result = self.run_suews_run(cli_runner, str(sample_yaml), check=True)
-        assert "YAML configuration" in result.stdout
-        # Should NOT show namelist deprecation warning
-        assert "DEPRECATION WARNING" not in result.stderr
 
     def test_yaml_missing_forcing(self, cli_runner, tmp_path):
         """Test error handling when YAML config lacks forcing data."""
@@ -174,26 +162,21 @@ sites:
     # ========== DEFAULT FILE SEARCH TESTS ==========
 
     def test_default_yaml_search(self, cli_runner, sample_yaml):
-        """Test that config.yml is found by default if it exists."""
-        # Use CliRunner's isolated_filesystem for clean working directory
-        with cli_runner.isolated_filesystem():
-            # Copy sample YAML to config.yml in isolated dir
-            Path("config.yml").write_text(
-                sample_yaml.read_text(encoding="utf-8"), encoding="utf-8"
-            )
+        """A default config must be discovered and complete its simulation."""
+        sample_yaml.rename(sample_yaml.with_name("config.yml"))
 
-            result = self.run_suews_run(cli_runner, check=False)
-            if result.returncode == 0:
-                assert "Using default configuration: config.yml" in result.stdout
+        result = self.run_suews_run(cli_runner)
+
+        assert "Using default configuration: config.yml" in result.stdout
+        assert "successfully done" in result.stdout
 
     def test_no_default_file_error(self, cli_runner):
         """Test error when no default config file exists."""
-        # Use CliRunner's isolated_filesystem for empty working directory
-        with cli_runner.isolated_filesystem():
-            result = self.run_suews_run(cli_runner, check=False)
-            assert result.returncode != 0
-            combined = result.stderr + result.stdout
-            assert "No configuration file found" in combined
+        result = self.run_suews_run(cli_runner, check=False)
+        assert result.returncode != 0
+        assert "No configuration file found" in result.stderr
+        assert "config.yml" in result.stderr
+        assert "No configuration file found" not in result.stdout
 
     # ========== ERROR HANDLING TESTS ==========
 
@@ -213,23 +196,20 @@ sites:
 
     # ========== INTEGRATION TESTS ==========
 
-    @pytest.mark.skipif(
-        not (
-            Path(__file__).parent.parent / "fixtures/benchmark1/benchmark1_short.yml"
-        ).exists(),
-        reason="Benchmark data not available",
-    )
-    def test_yaml_full_simulation(self, cli_runner, benchmark_dir, tmp_path):
-        """End-to-end test: YAML config → run → output files created."""
-        yaml_file = benchmark_dir / "benchmark1_short.yml"
+    def test_yaml_full_simulation(self, cli_runner, sample_yaml, tmp_path):
+        """An explicit YAML path is detected, run successfully, and saved."""
+        result = self.run_suews_run(cli_runner, str(sample_yaml))
 
-        # Use CliRunner for in-process testing
-        result = self.run_suews_run(cli_runner, str(yaml_file), check=False)
-
-        if result.returncode == 0:
-            assert "successfully done" in result.stdout
-            # Just verify successful execution
-            assert "The following files have been written out:" in result.stdout
+        # Cover positional arguments and format detection in this same run.
+        assert "YAML configuration" in result.stdout
+        assert "DEPRECATION WARNING" not in result.stderr
+        assert "successfully done" in result.stdout
+        assert "The following files have been written out:" in result.stdout
+        output_files = list(tmp_path.glob("*_SUEWS_output.parquet"))
+        assert len(output_files) == 1
+        output = pd.read_parquet(output_files[0])
+        assert not output.empty
+        assert output_files[0].name in result.stdout
 
     # ========== DEPRECATION WARNING TESTS ==========
 

--- a/test/core/test_cli_test_helpers.py
+++ b/test/core/test_cli_test_helpers.py
@@ -1,0 +1,35 @@
+"""Contracts relied on by in-process CLI regression tests."""
+
+import subprocess
+
+import click
+from conftest import run_cli_command
+import pytest
+
+pytestmark = pytest.mark.api
+
+
+@pytest.mark.parametrize("check", [False, True])
+@pytest.mark.parametrize("exit_code", [0, 7])
+def test_cli_capture_preserves_streams_and_exit_status(cli_runner, check, exit_code):
+    """Capture streams verbatim, including stderr without diagnostic keywords."""
+    stdout = "WARNING is an ordinary data value here\n"
+    stderr = "Cannot open input\n  Please choose an existing file\n\n"
+
+    @click.command()
+    def command():
+        click.echo(stdout, nl=False)
+        click.echo(stderr, err=True, nl=False)
+        raise SystemExit(exit_code)
+
+    if check and exit_code:
+        with pytest.raises(subprocess.CalledProcessError) as caught:
+            run_cli_command(cli_runner, command, [], check=True)
+        result = caught.value
+        assert result.cmd == ["command"]
+    else:
+        result = run_cli_command(cli_runner, command, [], check=check)
+
+    assert result.returncode == exit_code
+    assert result.stdout == stdout
+    assert result.stderr == stderr


### PR DESCRIPTION
CLI regression tests could pass when a command failed or saved no files, and their shared adapter guessed stderr from keywords in combined output. Preserve Click's actual streams, require successful default and explicit YAML runs, and open the generated Parquet output to verify it is readable and nonempty.

Copy the unchanged short case together with its relative forcing dependency and isolate each test's working directory. Fold the positional-path and format-detection assertions into the output test, avoiding two duplicate simulations while retaining those checks.

Validation:
- Four real Click stream/status witnesses fail against the previous adapter and pass with the correction.
- Requiring success in the previous default-config test exposes its missing-forcing failure; the corrected fixture completes successfully.
- A reversible missing-save mutation passes the old output test and fails the corrected test; source was restored byte-for-byte.
- 57 focused CLI/conversion/dispatcher tests passed; `make test-smoke`: 15 passed, one skipped.
- Marker lint and diff whitespace checks passed.

No production code, physics, reference outputs, scientific tolerances, or CI workflows change. PR1760 also edits `test/conftest.py`, but only `completed_sample_sim`; this change is confined to `CliResultAdapter`. Leave this draft unmerged for commander review.
