### PR TITLE
Fail a hung test with its stacks instead of cancelling the lane

### DIFF
--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -228,7 +228,7 @@ runs:
           python "{package}/scripts/suews/ci_phase_metrics.py" start install
         # Pin the scheduler stack so distribution behaviour cannot drift between
         # CI runs. Re-benchmark the fixed-worker candidates before updating.
-        CIBW_TEST_REQUIRES: pytest==9.1.1 pytest-xdist==3.8.0
+        CIBW_TEST_REQUIRES: pytest==9.1.1 pytest-xdist==3.8.0 pytest-timeout==2.4.0
         # Test tiers: choose subset based on path detection and trigger.
         # gh#1300: physics tests are binary-determined, so one run per
         # (OS, arch) on the build Python is sufficient. API tests (Python

--- a/.github/workflows/benchmark-pytest-scheduler.yml
+++ b/.github/workflows/benchmark-pytest-scheduler.yml
@@ -108,7 +108,7 @@ jobs:
           WHEEL_PATH: ${{ steps.wheel.outputs.path }}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0
+          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0 pytest-timeout==2.4.0
           python -m pip install "$WHEEL_PATH"
 
       - name: A1 - loadscope

--- a/.github/workflows/ci-metrics-overhead.yml
+++ b/.github/workflows/ci-metrics-overhead.yml
@@ -74,7 +74,7 @@ jobs:
           CONTROLLED_WHEEL: ${{ steps.wheel.outputs.path }}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0
+          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0 pytest-timeout==2.4.0
           python -m pip install "$CONTROLLED_WHEEL"
 
       - name: Run fixed-worker metrics off/on/on/off trials

--- a/.github/workflows/test-api-cross-python-reusable.yml
+++ b/.github/workflows/test-api-cross-python-reusable.yml
@@ -104,7 +104,7 @@ jobs:
           SUEWS_CI_METRICS: ci-metrics/api-${{ matrix.python_version }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}.json
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0
+          python -m pip install pytest==9.1.1 pytest-xdist==3.8.0 pytest-timeout==2.4.0
           python -m pip install wheelhouse/*.whl mcp-dist/*.whl
           # These imports and the interpreter-local executable are the two
           # conditions that otherwise skip the protocol test at collection or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ EXAMPLES:
 
 ## 2026
 
+### 8 Sep 2026
+
+- [maintenance] Tests carry a per-test wall-clock budget: `pytest-timeout` (thread method, 600 s) and `faulthandler_timeout` (300 s) are configured in `pyproject.toml` and installed in every CI pytest lane, so a hung test fails with the stacks of all threads in the log instead of the lane being cancelled at the job cap (#1763)
+
 ### 7 Sep 2026
 
 - [feature][experimental] Saved runs now carry a `provenance.json` sidecar: `SUEWSSimulation.save()` and `suews run` write the configuration and forcing identities (name, size, SHA-256), SuPy version and git commit, requested and actual simulation period, timestamp conventions, run options and the list of files written (#1746)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
+    "pytest-timeout",
 
     # Code formatting
     "ruff",
@@ -155,6 +156,23 @@ suews-inspect = "supy.cmd.suews_cli:inspect_alias"
 filterwarnings = [
     "ignore::UserWarning:pydantic.main",
 ]
+# Per-test wall-clock budget (pytest-timeout). A hung test must fail with its
+# name and the stacks of every thread in the log, not disappear behind a
+# job-level cancellation: the nightly Windows API lane was cancelled at the
+# 45-minute job cap every night from 20 August to 7 September 2026 because two
+# tests hung after the last reported node, leaving no trace of where.
+# The thread method is the only one that works on every platform (the signal
+# method is Unix-only). On timeout it dumps all thread stacks and ends the
+# pytest process, so a serial lane stops at the culprit and an xdist lane
+# loses only that worker. 600 s is four times the slowest CI test (148 s,
+# the STEBBS reference comparison on Windows); tests that legitimately need
+# more carry an explicit @pytest.mark.timeout.
+# faulthandler_timeout (pytest built-in) dumps the same stacks earlier
+# without ending the test, so a slow-but-alive test is visible in the log
+# before the hard budget hits.
+timeout = 600
+timeout_method = "thread"
+faulthandler_timeout = 300
 # Test markers.
 # Three orthogonal properties (gh#1300, gh#1680):
 #   nature:     physics | api       -- what the test actually exercises


### PR DESCRIPTION
## What

Adds `pytest-timeout` (thread method, 600 s default per test) and pytest's built-in `faulthandler_timeout` (300 s) to `[tool.pytest.ini_options]`, adds the plugin to the `dev` extra, and installs it wherever CI runs pytest: the API cross-CPython lane, the cibuildwheel physics tier (`CIBW_TEST_REQUIRES`), the scheduler ABBA workflow and the metrics-overhead workflow.

## Why

Every scheduled full-tier run since 20 August has been cancelled at the 45-minute job cap because the Windows API lane stops after `test_prompts_advertise_all_three` and produces nothing further (#1762). The log says where the lane stopped, not what it was waiting on. With a per-test budget a hang fails within ten minutes with the stacks of every thread in the log, which is the evidence needed to fix the cause rather than work around it.

Design notes:

- Thread method because the signal method is Unix-only. On timeout it dumps all thread stacks and ends the pytest process, so a serial lane stops at the culprit and an xdist lane loses only that worker.
- 600 s is four times the slowest CI test (148 s, the STEBBS reference comparison on Windows). Tests that legitimately need more can carry `@pytest.mark.timeout`.
- `faulthandler_timeout` dumps the same stacks earlier without ending a slow-but-alive test, so a slow test is visible in the log before the hard budget hits.

## Verification

- A synthetic test that blocks on a thread join produced the `Timeout` stack dump for both the blocked worker and the main thread and ended the process, with the configuration read from `pyproject.toml`.
- Real tests (`test/core/test_supy.py -k "single_step or smd_veg"`, `test/mcp/test_version.py`) run under the new configuration with no `PytestConfigWarning`.
- A Windows-only `workflow_dispatch` of the full tier on this branch is the reproduction run for #1762; its log will carry the stacks at the hang.

Refs #1762. No test behaviour changes; no skips.
