### PR TITLE
Report a failed or cancelled scheduled run in a tracking issue

### DIFF
--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -605,6 +605,74 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  # A scheduled run that fails or is cancelled must reach a person. The
+  # nightly full-tier run was cancelled every night from 20 August to
+  # 7 September 2026 (Windows API jobs at the 45-minute cap) and nothing
+  # reported it: ci_observability runs only on pull_request and merge_group,
+  # and a cancelled run never reaches deploy_testpypi. This job runs on every
+  # scheduled run, opens or updates one tracking issue while the nightly is
+  # red, and closes it on the next green run.
+  report_scheduled_run:
+    name: Report scheduled run outcome
+    runs-on: ubuntu-latest
+    needs: [create_nightly_tag, build_wheels, build_mcp, test_api_cross_python, check_test_markers, deploy_testpypi]
+    if: always() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - name: Open, update or close the nightly tracking issue
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          script: |
+            const needs = JSON.parse(process.env.NEEDS_JSON);
+            const bad = Object.entries(needs)
+              .filter(([, v]) => v.result === 'failure' || v.result === 'cancelled')
+              .map(([k, v]) => `${k}: ${v.result}`);
+            const title = 'Nightly scheduled run is failing';
+            const marker = '<!-- nightly-run-tracker -->';
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: '2-infra:ci', per_page: 100,
+            });
+            const tracker = open.find(i => i.title === title && (i.body || '').includes(marker));
+            const today = new Date().toISOString().slice(0, 10);
+            if (bad.length === 0) {
+              if (tracker) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: tracker.number,
+                  body: `Green again on ${today}: ${process.env.RUN_URL}. Closing.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: tracker.number, state: 'closed',
+                });
+              }
+              return;
+            }
+            const line = `${today}: ${process.env.RUN_URL} (${bad.join(', ')})`;
+            if (tracker) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: tracker.number,
+                body: `Still failing. ${line}`,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo,
+              title,
+              labels: ['2-infra:ci'],
+              body: [
+                marker,
+                'Opened automatically by the `report_scheduled_run` job in `build-publish_to_pypi.yml`.',
+                'The scheduled full-tier run did not complete successfully. Each further failing night adds a comment; the first green night closes this issue.',
+                '',
+                `First failure: ${line}`,
+              ].join('\n'),
+            });
+
   deploy_testpypi:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ EXAMPLES:
 
 ## 2026
 
+### 8 Sep 2026
+
+- [maintenance] Scheduled runs now report their outcome: a `report_scheduled_run` job opens or updates one tracking issue when any nightly build, test or publish job fails or is cancelled, and closes it on the next green run (#1764)
+
 ### 7 Sep 2026
 
 - [feature][experimental] Saved runs now carry a `provenance.json` sidecar: `SUEWSSimulation.save()` and `suews run` write the configuration and forcing identities (name, size, SHA-256), SuPy version and git commit, requested and actual simulation period, timestamp conventions, run options and the list of files written (#1746)


### PR DESCRIPTION
## What

Adds a `report_scheduled_run` job to `build-publish_to_pypi.yml`. It runs on every scheduled run after the build, test, marker-lint and TestPyPI jobs, whatever their outcome. If any of them failed or was cancelled it opens one tracking issue (or comments on the open one with the run URL and the failed job names); on the next green scheduled run it closes that issue.

## Why

Nothing reported the nightly outage of 20 August to 7 September (#1762): the `ci_observability` job runs only on `pull_request` and `merge_group`, and a cancelled run never reaches `deploy_testpypi`, so nineteen consecutive cancelled nightlies and nineteen missing TestPyPI dev builds went unnoticed. With this job the second failing night is a comment on an issue, not a silence.

Design notes:

- `if: always() && github.event_name == 'schedule'`, so it never runs on PRs or in the merge queue and never blocks anything.
- One issue, found by title plus a hidden marker under the `2-infra:ci` label, so repeated failures accumulate as comments rather than new issues.
- `issues: write` only on this job; the workflow-level permission stays `contents: read`.
- Uses the same pinned `actions/github-script` SHA as the existing PR summary job.

## Verification

- The workflow parses; the `test/core/test_ci_run_metrics.py`, `test_ci_phase_metrics.py` and `test_pytest_ci_metrics.py` checks that read this workflow pass (22 passed).
- `zizmor@1.30.0` (the version the advisory audit pins) reports no new finding for the added job against the master baseline.
- Live behaviour is exercised by the next scheduled run; while #1762 is open that run is expected to fail and this job is expected to open the tracking issue.

Refs #1762.
