### PR TITLE
Run the everyday make test on xdist workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ EXAMPLES:
 
 ## 2026
 
+### 8 Sep 2026
+
+- [maintenance] `make test` runs on up to `TEST_JOBS` (default 4) pytest-xdist workers with work stealing; measured 625 s serial to 124 s on the same selection, same results (#1765)
+
 ### 7 Sep 2026
 
 - [feature][experimental] Saved runs now carry a `provenance.json` sidecar: `SUEWSSimulation.save()` and `suews run` write the configuration and forcing identities (name, size, SHA-256), SuPy version and git commit, requested and actual simulation period, timestamp conventions, run options and the list of files written (#1746)

--- a/Makefile
+++ b/Makefile
@@ -206,13 +206,22 @@ rebuild-meson:
 # one of those, run its directory directly (`pytest test/cmd`) or `make
 # test-all`. CI selects by markers and is unaffected by this default.
 TEST_DEFAULT_PATHS := test/test_api_surface.py test/core test/data_model test/physics test/io_tests
+# Worker cap for the everyday run. pytest-xdist distributes the selection
+# across up to TEST_JOBS processes with work stealing, the same scheduler CI
+# uses; the measured local wall time drops from about 10 minutes serial to
+# about 2 minutes. The cap exists because every worker that draws one of the
+# full-year DailyState tests materialises its own year of output (about 1 GB);
+# raise it on a machine with memory to spare: make test TEST_JOBS=8
+TEST_JOBS ?= 4
 test:
 	@echo "Running everyday development tests (core, data model, physics, I/O)..."
 	@echo "NOTE: slow regressions and peripheral surfaces (cmd, mcp, docs,"
 	@echo "      knowledge, umep) are excluded - run 'make test-all' or the"
 	@echo "      relevant directory (e.g. 'pytest test/cmd') when touched."
+	@echo "      Runs on up to $(TEST_JOBS) workers (make test TEST_JOBS=N);"
+	@echo "      re-run only the last failures with 'pytest --lf'."
 	@echo ""
-	$(PYTHON) -m pytest $(TEST_DEFAULT_PATHS) -m "not slow and not qgis" -v --tb=short --durations=10
+	$(PYTHON) -m pytest $(TEST_DEFAULT_PATHS) -m "not slow and not qgis" -n auto --maxprocesses=$(TEST_JOBS) --dist worksteal -v --tb=short --durations=10
 
 # Smoke tests - fast critical path tests for CI
 test-smoke:

--- a/test/README.md
+++ b/test/README.md
@@ -80,8 +80,13 @@ Test data and resources:
 
 ```bash
 # Everyday development default: core, data_model, physics, io_tests
-# (excludes slow tests and the peripheral surfaces cmd/mcp/docs/knowledge/umep)
+# (excludes slow tests and the peripheral surfaces cmd/mcp/docs/knowledge/umep);
+# runs on up to 4 xdist workers, raise the cap on a machine with memory to spare
 make test
+make test TEST_JOBS=8
+
+# Re-run only what failed last time
+pytest --lf test/core test/data_model test/physics test/io_tests
 
 # Everything, including slow tests and peripheral surfaces
 make test-all
@@ -213,4 +218,4 @@ When adding new tests:
 5. Add docstrings to explain complex test logic
 6. Update this README if adding a new test category
 
-For detailed testing approach, see docstrings in test files or `docs/source/contributing/testing_guide.rst`.
+For detailed testing approach, see docstrings in test files or `dev-ref/testing/TESTING_GUIDELINES.md`.


### PR DESCRIPTION
## What

`make test` now runs on pytest-xdist workers: `-n auto --maxprocesses=$(TEST_JOBS) --dist worksteal`, with `TEST_JOBS` defaulting to 4 and overridable (`make test TEST_JOBS=8`). The recipe's banner says so and points at `pytest --lf` for re-running failures. The test README gets the same note and stops linking a documentation page that does not exist.

## Why

pytest-xdist has been a dev dependency since #1604 and the CI physics tier has used work stealing since then; only the local everyday run was still serial. On the same 1651-test selection, ten-core Apple silicon, CI wheel: 625 s serial against 124 s with workers, same results.

The cap defaults to 4 because each worker that draws one of the full-year DailyState tests materialises its own year of output (about 1 GB), so an unbounded worker count can exhaust a 16 GB laptop; a machine with memory to spare raises it per invocation.

## Verification

- `make -n test` renders the intended pytest command.
- The 124 s figure is the measured `make test` selection with `-n auto` on this machine; the serial figure is the same selection without it.

No test content changes.
