### PR TITLE
Make the Fortran build profile explicit; checked stays the default

### DIFF
--- a/.claude/rules/00-project-essentials.md
+++ b/.claude/rules/00-project-essentials.md
@@ -93,8 +93,11 @@ recipes and the installation docs.
 ## Build System Notes
 
 - `FCFLAGS` env var is NOT forwarded through `make dev` -> meson-python pipeline
-  - Compiler flags are hard-coded in `meson.build` (`fast_build` vs full flag sets)
-  - To add debug flags like `-fcheck=bounds`, modify `meson.build` directly
+  - Fortran compiler flags live in `src/suews/Makefile.gfortran`, selected by
+    the build profile: `SUEWS_BUILD_PROFILE=checked` (runtime checks, the
+    current default) or `release` (`-O3`, no checks). `src/supy/run_make.py`
+    and `src/suews_bridge/build.rs` read the same variable
+  - Release build locally: `SUEWS_BUILD_PROFILE=release make dev`
 - `make clean` removes `build/` but meson-python may cache compiled extensions elsewhere
   - For a truly clean rebuild: `make clean && pip cache purge && make dev`
 

--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Test tier: smoke, core, cfg, standard, physics-full, or all'
     required: false
     default: 'standard'
+  build_profile:
+    description: 'Fortran build profile: checked (runtime checks, the current default) or release (optimised, no checks). Read by src/supy/run_make.py and src/suews_bridge/build.rs.'
+    required: false
+    default: 'checked'
   is_testpypi_build:
     description: 'Whether this is a TestPyPI build (adds notice to README)'
     required: false
@@ -129,6 +133,7 @@ runs:
           PIP_CACHE_DIR=${{ github.workspace }}/.pip-cache
           CARGO_HOME=${{ github.workspace }}/.cargo-cache
           CARGO_TARGET_DIR=${{ github.workspace }}/.rust-target-cache
+          SUEWS_BUILD_PROFILE=${{ inputs.build_profile }}
           SUEWS_KNOWLEDGE_GIT_SHA=${{ github.sha }}
           SUEWS_CI_PHASES='${{ inputs.metrics_host_dir }}/physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-phases.json'
           SUEWS_CI_METRICS_DIR='${{ inputs.metrics_host_dir }}'
@@ -144,6 +149,7 @@ runs:
           PIP_CACHE_DIR=/pip-cache
           CARGO_HOME=/cargo-cache
           CARGO_TARGET_DIR=/rust-target-cache
+          SUEWS_BUILD_PROFILE=${{ inputs.build_profile }}
           SUEWS_KNOWLEDGE_GIT_SHA=${{ github.sha }}
           SUEWS_CI_PHASES=/ci-metrics/physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-phases.json
           SUEWS_CI_METRICS_DIR=/ci-metrics
@@ -188,6 +194,7 @@ runs:
           PIP_CACHE_DIR='${{ github.workspace }}/.pip-cache'
           CARGO_HOME='${{ github.workspace }}/.cargo-cache'
           CARGO_TARGET_DIR='${{ github.workspace }}/.rust-target-cache'
+          SUEWS_BUILD_PROFILE='${{ inputs.build_profile }}'
           SUEWS_KNOWLEDGE_GIT_SHA='${{ github.sha }}'
           SUEWS_CI_PHASES='${{ inputs.metrics_host_dir }}\physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}-phases.json'
           SUEWS_CI_METRICS_DIR='${{ inputs.metrics_host_dir }}'

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -109,6 +109,14 @@ on:
           - core
           - cfg
           - smoke
+      build_profile:
+        description: 'Fortran build profile for this dispatch only (checked = runtime checks, the default; release = optimised, no checks). The default changes only after the release profile is validated on every platform.'
+        required: false
+        default: 'checked'
+        type: choice
+        options:
+          - checked
+          - release
 
 permissions:
   contents: read
@@ -432,6 +440,7 @@ jobs:
       python_json: ${{ needs.determine_matrix.outputs.python }}
       test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
       is_testpypi_build: ${{ (github.event_name == 'schedule' || (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev'))) && 'true' || 'false' }}
+      build_profile: ${{ inputs.build_profile || 'checked' }}
 
   build_mcp:
     name: Build MCP package

--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: 'false'
+      build_profile:
+        description: 'Fortran build profile: checked (runtime checks, the current default) or release (optimised, no checks)'
+        required: false
+        type: string
+        default: 'checked'
 
 permissions:
   contents: read
@@ -75,4 +80,5 @@ jobs:
           python: ${{ matrix.python }}
           test_tier: ${{ inputs.test_tier }}
           is_testpypi_build: ${{ inputs.is_testpypi_build }}
+          build_profile: ${{ inputs.build_profile }}
           metrics_host_dir: ${{ runner.temp }}/suews-ci-metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ EXAMPLES:
 
 ## 2026
 
+### 8 Sep 2026
+
+- [maintenance] The Fortran build profile is an explicit option: `SUEWS_BUILD_PROFILE=checked|release` (read by `run_make.py`, the Makefile and `build.rs`, and a `build_profile` input on the wheel workflow); `checked` (`-O0 -fcheck=all`, what every wheel has shipped since 2023) stays the default until the release profile is validated on every platform (#1766)
+
 ### 7 Sep 2026
 
 - [feature][experimental] Saved runs now carry a `provenance.json` sidecar: `SUEWSSimulation.save()` and `suews run` write the configuration and forcing identities (name, size, SHA-256), SuPy version and git commit, requested and actual simulation period, timestamp conventions, run options and the list of files written (#1746)

--- a/dev-ref/building-locally.md
+++ b/dev-ref/building-locally.md
@@ -96,3 +96,30 @@ SUEWS/
 
 For a more comprehensive developer overview (workflow, testing strategy, best practices), see the [Onboarding Guide](onboarding-guide.md).
 
+
+## Build profiles
+
+The Fortran physics library and the Rust bridge's own Fortran sources are
+compiled under one of two profiles, selected by the `SUEWS_BUILD_PROFILE`
+environment variable at build time (`src/supy/run_make.py` passes it to the
+SUEWS Makefile as `DEBUG=1` or `DEBUG=`; `src/suews_bridge/build.rs` reads the
+same variable):
+
+- `checked` (the current default): `-O0 -fcheck=all -finit-real=zero`.
+  Out-of-bounds and uninitialised reads surface as Fortran runtime errors
+  rather than silent numbers. Measured against `release` on the same commit:
+  about 1.7x slower on the sample configuration and 5x on SPARTACUS-heavy
+  configurations.
+- `release`: `-O3 -finit-real=zero`, no runtime checks. Neither profile arms
+  floating-point exception traps; `src/suews/Makefile.gfortran` explains why.
+
+```bash
+SUEWS_BUILD_PROFILE=release make dev     # optimised local build
+SUEWS_BUILD_PROFILE=checked make dev     # the default, spelled out
+```
+
+The variable is read when the Fortran objects are compiled, so change it with
+a clean build (`make clean && make dev`). In CI the profile is an input of the
+`build-suews` action and a `workflow_dispatch` choice on the wheel workflow;
+the default stays `checked` until the release profile has been validated on
+every platform.

--- a/src/suews/Makefile
+++ b/src/suews/Makefile
@@ -37,9 +37,18 @@ else
 	endif
 endif
 
-# Enable debug build: bounds checking and sNaN init protect against
-# uninitialised variables and array-bounds violations.
-DEBUG=1
+# Build profile (Makefile.gfortran reads DEBUG to pick the flag set).
+# run_make.py maps SUEWS_BUILD_PROFILE=checked|release to DEBUG=1|DEBUG= on
+# the make command line; a command-line value overrides the default below.
+#   checked: -O0 -fcheck=all -finit-real=zero. Out-of-bounds and uninitialised
+#            reads surface as Fortran runtime errors instead of silent numbers.
+#            Measured cost against release: about 1.7x on the sample model and
+#            5x on SPARTACUS-heavy configurations.
+#   release: -O3 -finit-real=zero, no runtime checks, no FPE traps.
+# The checked profile stays the default here until the release profile has
+# been validated on every CI platform; a bare `make` therefore builds checked,
+# and `make DEBUG=` builds release.
+DEBUG ?= 1
 
 LIBUTILS = $(addprefix $(DIR_LIB_SUEWS),libsuewsutil.a)
 LIBPHYS = $(addprefix $(DIR_LIB_SUEWS),libsuewsphys.a)

--- a/src/suews/Makefile.gfortran
+++ b/src/suews/Makefile.gfortran
@@ -18,7 +18,7 @@ BASICFLAGS = -J./mod -fconvert=big-endian -ffree-line-length-none -frecursive
 OMPFLAG = -fopenmp
 
 ifndef DEBUG
-# --NORMAL CONFIGURATION--
+# --RELEASE CONFIGURATION-- (SUEWS_BUILD_PROFILE=release, see ../supy/run_make.py)
 
 # Optimization flags
 OPTFLAGS = -O3
@@ -27,12 +27,19 @@ OPTFLAGS = -O3
 WARNFLAGS = -Wall -Wno-unused-label -Wno-unused-dummy-argument -Wno-unused-variable
 # WARNFLAGS = -Wall -Wno-unused-label -Wno-unused-dummy-argument -Wno-unused-variable -Wimplicit-interface
 
-# Debugging flags, such as "-g" to store debugging symbols, and
-# instructions to abort if certain floating-point exceptions occur
-DEBUGFLAGS = -g -ffpe-trap=invalid,zero,overflow
+# -g keeps symbols for backtraces at no run-time cost.
+# -finit-real=zero is kept in both profiles: the library is loaded from Python
+#   through the Rust bridge, and gfortran 14+ segfaults on uninitialised
+#   derived-type descriptors without it (see ../suews_bridge/build.rs).
+# No -ffpe-trap in either profile: on Windows MSYS2 the gfortran runtime arms
+#   hardware FPE traps on library load, and legitimate divisions by zero in
+#   SPARTACUS night-time paths would raise SIGFPE and kill the Python
+#   interpreter, while macOS and Linux leave the traps disabled. IEEE Inf/NaN
+#   propagation is the behaviour every platform shares.
+DEBUGFLAGS = -g -finit-real=zero
 
 else
-# --DEBUGGING CONFIGURATION--
+# --CHECKED CONFIGURATION-- (SUEWS_BUILD_PROFILE=checked, the current default)
 OPTFLAGS = -O0
 WARNFLAGS = -Wall
 # When the physics library is loaded as a shared library from Python/Rust:

--- a/src/suews_bridge/build.rs
+++ b/src/suews_bridge/build.rs
@@ -156,6 +156,19 @@ fn main() {
         println!("cargo:rerun-if-changed={}", src.display());
     }
 
+    // Build profile, shared with src/supy/run_make.py through the same
+    // environment variable: "checked" (the current default) adds gfortran
+    // runtime checks to the bridge's own Fortran sources, "release" omits
+    // them. The physics library follows the same variable through the SUEWS
+    // Makefile, so a wheel is either wholly checked or wholly release.
+    println!("cargo:rerun-if-env-changed=SUEWS_BUILD_PROFILE");
+    let build_profile = env::var("SUEWS_BUILD_PROFILE").unwrap_or_else(|_| "checked".to_string());
+    let runtime_checks = match build_profile.trim().to_ascii_lowercase().as_str() {
+        "" | "checked" => true,
+        "release" => false,
+        other => panic!("SUEWS_BUILD_PROFILE must be \"release\" or \"checked\", got {other:?}"),
+    };
+
     let mut object_files = Vec::new();
     for src in &fortran_sources {
         let stem = src
@@ -180,12 +193,15 @@ fn main() {
             "-finit-real=zero",
             "-finit-integer=0",
             "-finit-logical=false",
-            // Runtime checks: bounds, pointer, memory – catch UB as
-            // Fortran runtime error instead of bare SIGSEGV.
-            "-fcheck=all",
             "-I",
             out_dir.to_string_lossy().as_ref(),
         ]);
+
+        if runtime_checks {
+            // Runtime checks: bounds, pointer, memory – catch UB as
+            // Fortran runtime error instead of bare SIGSEGV.
+            gfortran_cmd.arg("-fcheck=all");
+        }
 
         if physics_enabled {
             let suews_mod_dir = manifest_dir.join("../suews/mod");

--- a/src/supy/run_make.py
+++ b/src/supy/run_make.py
@@ -3,11 +3,51 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import os
+from pathlib import Path
 import platform
 import subprocess
 import sys
-from pathlib import Path
+
+BUILD_PROFILES = ("release", "checked")
+DEFAULT_BUILD_PROFILE = "checked"
+BUILD_PROFILE_ENV = "SUEWS_BUILD_PROFILE"
+
+
+def build_profile_from_env(environ: Mapping[str, str] | None = None) -> str:
+    """Return the Fortran build profile selected by ``SUEWS_BUILD_PROFILE``.
+
+    ``checked`` (the current default) compiles the physics library with
+    ``-O0 -fcheck=all``; ``release`` compiles with ``-O3`` and no runtime
+    checks. Both keep ``-finit-real=zero`` and neither arms FPE traps; the
+    flag sets live in ``src/suews/Makefile.gfortran``. The Rust bridge reads
+    the same variable in ``src/suews_bridge/build.rs``.
+    """
+    source = os.environ if environ is None else environ
+    raw = source.get(BUILD_PROFILE_ENV, "")
+    profile = raw.strip().lower() or DEFAULT_BUILD_PROFILE
+    if profile not in BUILD_PROFILES:
+        raise SystemExit(
+            f"{BUILD_PROFILE_ENV} must be one of {', '.join(BUILD_PROFILES)}; "
+            f"got {raw!r}"
+        )
+    return profile
+
+
+def make_args_for_profile(profile: str) -> list[str]:
+    """Map a build profile to the ``DEBUG`` variable the SUEWS Makefile reads.
+
+    A command-line ``DEBUG=`` (empty) reaches the Makefile's ``ifndef DEBUG``
+    as undefined, because ``ifdef`` tests for a non-empty value, and a
+    command-line variable overrides the ``DEBUG ?= 1`` default inside the
+    Makefile. So the profile is decided here, never by the Makefile default.
+    """
+    if profile == "checked":
+        return ["DEBUG=1"]
+    if profile == "release":
+        return ["DEBUG="]
+    raise ValueError(f"unknown build profile {profile!r}")
 
 
 def _pick_suews_fc() -> str | None:
@@ -58,11 +98,17 @@ def main() -> None:
     stamp_file = Path(sys.argv[2])
 
     fc = _pick_suews_fc()
+    profile = build_profile_from_env()
+    profile_args = make_args_for_profile(profile)
+    sys.stdout.write(
+        f"SUEWS Fortran build profile: {profile} "
+        f"({BUILD_PROFILE_ENV}={os.environ.get(BUILD_PROFILE_ENV, '') or 'unset'})\n"
+    )
 
     # Run make and propagate failures so Meson can fail fast.
     # On macOS it is common for Homebrew to upgrade gfortran, which leaves stale
     # Fortran module files (*.mod) that cannot be read by the new compiler.
-    result = _run_make([], suews_dir, fc)
+    result = _run_make(profile_args, suews_dir, fc)
     if result.returncode != 0:
         output = result.stdout
         stale_mod_patterns = (
@@ -79,7 +125,7 @@ def main() -> None:
                     clean.returncode, clean.args, output=clean.stdout
                 )
 
-            retry = _run_make([], suews_dir, fc)
+            retry = _run_make(profile_args, suews_dir, fc)
             if retry.returncode != 0:
                 raise subprocess.CalledProcessError(
                     retry.returncode, retry.args, output=retry.stdout

--- a/test/core/test_build_profile.py
+++ b/test/core/test_build_profile.py
@@ -1,0 +1,59 @@
+"""Fortran build-profile plumbing in ``src/supy/run_make.py``.
+
+The profile decides whether the physics library and the Rust bridge's own
+Fortran sources are compiled with gfortran runtime checks (``checked``) or
+optimised without them (``release``). The mapping to the Makefile's ``DEBUG``
+variable is what this file pins, because a wrong default silently ships a
+different binary.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.api
+
+
+def _load_run_make():
+    path = Path(__file__).resolve().parents[2] / "src" / "supy" / "run_make.py"
+    spec = importlib.util.spec_from_file_location("suews_run_make", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def run_make():
+    return _load_run_make()
+
+
+def test_default_profile_is_checked(run_make):
+    assert run_make.build_profile_from_env({}) == "checked"
+    assert run_make.build_profile_from_env({"SUEWS_BUILD_PROFILE": ""}) == "checked"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("release", "release"), ("checked", "checked"), (" Release ", "release")],
+)
+def test_profile_is_normalised(run_make, raw, expected):
+    assert run_make.build_profile_from_env({"SUEWS_BUILD_PROFILE": raw}) == expected
+
+
+def test_unknown_profile_is_rejected(run_make):
+    with pytest.raises(SystemExit, match="SUEWS_BUILD_PROFILE must be one of"):
+        run_make.build_profile_from_env({"SUEWS_BUILD_PROFILE": "fast"})
+
+
+def test_checked_profile_forces_debug_on(run_make):
+    assert run_make.make_args_for_profile("checked") == ["DEBUG=1"]
+
+
+def test_release_profile_forces_debug_off(run_make):
+    # An empty command-line DEBUG reaches the Makefile's ``ifndef DEBUG`` as
+    # undefined and overrides its ``DEBUG ?= 1`` default.
+    assert run_make.make_args_for_profile("release") == ["DEBUG="]


### PR DESCRIPTION
## What

Makes the Fortran build profile an explicit, documented option, without changing what is built today.

- `SUEWS_BUILD_PROFILE=checked|release` is read by `src/supy/run_make.py` and passed to make as `DEBUG=1` or `DEBUG=`; the Makefile's hard-coded `DEBUG=1` becomes `DEBUG ?= 1` (an empty command-line `DEBUG` reaches `ifndef DEBUG` as undefined and overrides that default). `src/suews_bridge/build.rs` reads the same variable and adds `-fcheck=all` to the bridge's own Fortran sources only for `checked`.
- `Makefile.gfortran`'s release branch is defined precisely for the first time: `-O3 -g -finit-real=zero`, no `-ffpe-trap`. The trap flag is omitted in both profiles because on Windows MSYS2 the gfortran runtime arms hardware traps on library load and legitimate divisions by zero in SPARTACUS night-time paths would raise SIGFPE inside the Python interpreter; the checked branch's comment already documented this.
- The `build-suews` action, the reusable wheel workflow and the wheel workflow's `workflow_dispatch` gain a `build_profile` input, default `checked`.
- `dev-ref/building-locally.md` documents both profiles; the project-essentials note that pointed at `meson.build` for compiler flags is corrected; `test/core/test_build_profile.py` pins the profile-to-`DEBUG` mapping.

## Why

Every wheel has compiled the physics library and SPARTACUS with `-O0 -fcheck=all` since the 2023 source reorganisation (`src/suews/Makefile` line 42), through a line nothing in the meson, `run_make.py` or CI path could unset. The choice is defensible (runtime checks turn out-of-bounds and uninitialised reads into Fortran runtime errors) but it was invisible, and its cost had never been measured. On the same commit and compiler (gfortran 15.2, Apple silicon), checked against release:

| | checked (shipped) | release | factor |
|---|---|---|---|
| STEBBS fixture, 8 SPARTACUS streams, 288 steps | 46.2 s (160 ms/step) | 8.3 s (29 ms/step) | 5.6x |
| sample configuration, 366 days | 10.4 s | 6.1 s | 1.7x |
| physics standard lane, four workers | 167 s | 94 s | 1.8x |

Both lanes: 166 passed, 1 collection skip; the full-year and STEBBS reference comparisons pass unchanged under `release` on that platform.

This PR only adds the option. The default stays `checked` so the release profile can be validated on Windows first (the platform the trap comment warns about) through a `workflow_dispatch` with `build_profile=release`; moving the default and adding a checked build to the nightly physics tier is a separate PR.

## Verification

- From a clean export of this commit, `run_make.py` standalone with `SUEWS_BUILD_PROFILE=release`: 66 of 66 gfortran compiles (26 of them SPARTACUS) carry `-O3`, none carry `-O0`, `-fcheck=all` or `-ffpe-trap`, all carry `-finit-real=zero`; the make log has no "DEBUG mode is ON". With `checked`: 66 of 66 carry `-O0 -fcheck=all`, "DEBUG mode is ON" printed once.
- `test/core/test_build_profile.py`: 7 passed. `rustfmt --check` clean on `build.rs`; `ruff check` clean.
- All three workflow files parse; `zizmor@1.30.0` reports no new finding.

Refs #1762 (the physics-lane cost is part of the same review).
