### PR TITLE
Explain a parallel-versus-serial output mismatch by position, not by diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ EXAMPLES:
 
 ## 2026
 
+### 8 Sep 2026
+
+- [maintenance] `test_parallel_output_matches_serial` reports a byte mismatch by position instead of letting pytest diff two multi-megabyte reprs; the expected gh#1741 failure had stalled the Windows API lane for its whole per-test budget (#1762)
+
 ### 7 Sep 2026
 
 - [feature][experimental] Saved runs now carry a `provenance.json` sidecar: `SUEWSSimulation.save()` and `suews run` write the configuration and forcing identities (name, size, SHA-256), SuPy version and git commit, requested and actual simulation period, timestamp conventions, run options and the list of files written (#1746)

--- a/test/core/test_parallel_error_isolation.py
+++ b/test/core/test_parallel_error_isolation.py
@@ -14,6 +14,7 @@ import copy
 from importlib import import_module
 import json
 
+import numpy as np
 import pytest
 
 import supy as sp
@@ -62,6 +63,32 @@ def _run_multi(inputs: dict, failing_flags: list[bool], max_workers: int):
     return inputs["rust"].run_suews_multi(
         configs, inputs["forcing_flat"], inputs["len_sim"], max_workers
     )
+
+
+def _describe_mismatch(label: str, left: bytes, right: bytes) -> str | None:
+    """Constant-size explanation of how two byte blocks differ, or None.
+
+    pytest's default explanation for ``assert left == right`` runs
+    ``difflib.ndiff`` over the reprs of both operands, which is quadratic in
+    the number of differing lines; on the multi-megabyte output blocks
+    compared below it stalled the Windows API lane for the whole per-test
+    budget (#1762). Reporting the first differing byte keeps a failing
+    comparison, expected while gh#1741 is open, cheap to explain.
+    """
+    if left == right:
+        return None
+    if len(left) != len(right):
+        return f"{label} differ in length: {len(left)} vs {len(right)} bytes"
+    diff = np.frombuffer(left, dtype=np.uint8) != np.frombuffer(right, dtype=np.uint8)
+    positions = np.flatnonzero(diff)
+    return (
+        f"{label} differ at byte {int(positions[0])} of {len(left)} "
+        f"({int(positions.size)} bytes differ)"
+    )
+
+
+def _as_bytes(value) -> bytes:
+    return value.encode() if isinstance(value, str) else bytes(value)
 
 
 def _assert_names_grid(exc_info, grid_index: int) -> None:
@@ -128,8 +155,12 @@ def test_parallel_output_matches_serial(bridge_inputs):
         idx_s, out_s, state_s, len_s, _warnings_s = serial_result
         assert idx_p == idx_s
         assert len_p == len_s
-        assert bytes(out_p) == bytes(out_s)
-        assert state_p == state_s
+        mismatch = _describe_mismatch("output blocks", bytes(out_p), bytes(out_s))
+        assert mismatch is None, mismatch
+        mismatch = _describe_mismatch(
+            "state strings", _as_bytes(state_p), _as_bytes(state_s)
+        )
+        assert mismatch is None, mismatch
 
 
 def test_public_multi_grid_run_names_the_failing_grid():


### PR DESCRIPTION
## What

`test_parallel_output_matches_serial` (`xfail` while gh#1741 is open) compared two multi-megabyte output blocks, and the state strings, with a bare `==`. It now reports the first differing byte and the number of differing bytes through a small helper, so a failing comparison costs one vectorised pass and one line of output. The `xfail` contract is unchanged.

## Why

When the comparison fails, as it is expected to, pytest builds its explanation by running `difflib.ndiff` over the reprs of both operands, quadratic in the number of differing lines. On the Windows API lane that never finished: the first Windows run with stack dumps ([run 34213324788](https://github.com/UMEP-dev/SUEWS/actions/runs/34213324788), evidence on #1762) shows the main thread inside `difflib._fancy_replace` under `_pytest.assertion` at both the five-minute faulthandler dump and the ten-minute timeout. The test is `api` and `core`, so every Windows API lane since #1742 merged on 7 September, including the merge queue, has been exposed to it; before #1763 that shows as a 45-minute cancellation with no trace.

## Verification

- Locally on a wheel built from master plus #1766, the file runs in 6 s: 9 passed, 1 xfailed (`test_parallel_output_matches_serial`, gh#1741), with the timeout configuration of #1763 emulated.
- `ruff check` and `ruff format --check` clean.
- The merge-queue run of this PR is the Windows confirmation: its API lane passes through this test in seconds instead of stopping there.

Refs #1762, gh#1741.
