### PR TITLE
Load the MCP field-rename registry on the main thread at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ EXAMPLES:
 
 ## 2026
 
+### 9 Sep 2026
+
+- [bugfix] The MCP server now loads supy's field-rename registry on its main thread at startup; importing it lazily inside a `query_knowledge` worker thread deadlocked on Windows in numpy's extension-module load, which hung the scheduled Windows API lane in `test_concurrent_query_knowledge_does_not_block_event_loop` every night from 20 August and left the nightly publish jobs skipped (#1768)
+  - The concurrency tests in `test/mcp/test_protocol_handshake.py` now set a 120 s per-request read timeout, so a server that never answers fails with an `McpError` naming the request instead of running the lane into its job timeout.
+
 ### 8 Sep 2026
 
 - [maintenance] Scheduled runs now report their outcome: a `report_scheduled_run` job opens or updates one tracking issue when any nightly build, test or publish job fails or is cancelled, and closes it on the next green run (#1764)

--- a/mcp/src/suews_mcp/server.py
+++ b/mcp/src/suews_mcp/server.py
@@ -104,6 +104,15 @@ def _build_server() -> Any:
         parameter_importance,
     )
 
+    # Load supy's field-rename registry on this (main) thread before the
+    # event loop starts. `query_knowledge` needs it on every call, and
+    # importing it lazily from an anyio worker thread deadlocks on Windows
+    # inside numpy's extension-module load (gh#1768). Warming it here makes
+    # the worker-side lookup a dictionary access.
+    from .tools.knowledge import load_field_renames
+
+    load_field_renames()
+
     server = FastMCP("suews-mcp", instructions=SERVER_INSTRUCTIONS)
 
     # Plumb the package version into the MCP `initialize` handshake so

--- a/mcp/src/suews_mcp/tools/knowledge.py
+++ b/mcp/src/suews_mcp/tools/knowledge.py
@@ -9,6 +9,7 @@ each piece of evidence comes from.
 
 from __future__ import annotations
 
+import functools
 import re
 from typing import Any, Optional
 
@@ -80,24 +81,55 @@ def _classify_audience(repo_path: Optional[str]) -> str:
     return "developer_doc"
 
 
+@functools.lru_cache(maxsize=1)
+def load_field_renames() -> dict[str, str]:
+    """Return supy's legacy-to-current field rename registry, loaded once.
+
+    ``_legacy_names_in_text`` needs ``ALL_FIELD_RENAMES`` on every
+    ``query_knowledge`` call. The registry lives in ``supy.data_model``,
+    whose first import also loads numpy, pandas and pyarrow. That import
+    must not happen lazily inside a tool call: the tools run on ``anyio``
+    worker threads of the live server, and on Windows the numpy
+    extension-module load from such a thread deadlocks, which hung the
+    scheduled Windows API lane every night from 20 August 2026
+    (gh#1768). ``server._build_server`` therefore calls this on the main
+    thread before the event loop starts, so the worker-side lookup is a
+    dictionary access.
+
+    The warm-up also covers the other tools that import from supy inside
+    their bodies (``examples``, ``validate``, ``readiness``, the docs
+    resource): once ``supy.data_model`` is loaded, those imports add only
+    pure-Python modules, so no worker thread performs an extension load.
+    A caller that imports a tool function directly, without
+    ``_build_server``, still takes the lazy path on first use.
+
+    An older supy without the registry yields an empty mapping; the
+    audience tag alone still annotates the match.
+    """
+    try:
+        from supy.data_model.core.field_renames import ALL_FIELD_RENAMES
+    except Exception:
+        return {}
+    return dict(ALL_FIELD_RENAMES)
+
+
 def _legacy_names_in_text(text: Optional[str]) -> list[dict[str, str]]:
     """Return ``[{legacy: ..., current: ...}]`` for legacy field names
     that appear as whole tokens in ``text`` (gh#1402).
 
-    Backed by ``ALL_FIELD_RENAMES`` in supy's data-model layer. When
-    the function cannot import the rename registry (older supy install)
-    it returns an empty list — the audience tag alone is still
-    actionable.
+    Backed by ``ALL_FIELD_RENAMES`` in supy's data-model layer via
+    :func:`load_field_renames`. When the registry is unavailable (older
+    supy install) it returns an empty list — the audience tag alone is
+    still actionable.
     """
     if not text:
         return []
-    try:
-        from supy.data_model.core.field_renames import ALL_FIELD_RENAMES
-    except Exception:
+    renames = load_field_renames()
+    if not renames:
         return []
     hits: list[dict[str, str]] = []
     seen: set[str] = set()
-    for legacy, current in ALL_FIELD_RENAMES.items():
+    for legacy, current in renames.items():
         if legacy in seen:
             continue
         # Whole-word match so partial substrings (e.g. ``method`` inside

--- a/test/mcp/test_protocol_handshake.py
+++ b/test/mcp/test_protocol_handshake.py
@@ -27,6 +27,12 @@ pytestmark = [pytest.mark.api, pytest.mark.smoke]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _HANDSHAKE_REQUEST_TIMEOUT = timedelta(seconds=30)
+# Ceiling on any single request in the concurrency tests below. It sits well
+# above the CLI cost on every CI host and well below pytest-timeout's 600 s,
+# so a server that never answers fails here with an ``McpError`` naming the
+# request instead of running the lane into its job timeout, which is how the
+# scheduled Windows lane was lost for 20 nights (gh#1768).
+_CONCURRENT_REQUEST_TIMEOUT = timedelta(seconds=120)
 
 
 _mcp_session = pytest.importorskip(
@@ -295,7 +301,11 @@ async def _run_baseline_then_concurrent(
     )
 
     async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
+        async with ClientSession(
+            read,
+            write,
+            read_timeout_seconds=_CONCURRENT_REQUEST_TIMEOUT,
+        ) as session:
             await session.initialize()
 
             # 1. Warm-up + baseline measurement. This call also primes any

--- a/test/mcp/test_server_cli.py
+++ b/test/mcp/test_server_cli.py
@@ -158,3 +158,19 @@ def test_main_without_root_does_not_override_env(
 
     # Env var preserved unchanged.
     assert captured["env_value"] == str(tmp_path)
+
+
+def test_build_server_loads_field_renames_before_serving() -> None:
+    """``_build_server()`` warms supy's field-rename registry on the calling
+    (main) thread so no tool call imports it from a worker thread, where the
+    numpy extension load deadlocks on Windows (gh#1768)."""
+    pytest.importorskip("mcp")
+    from suews_mcp import server as server_mod
+    from suews_mcp.tools import knowledge
+
+    knowledge.load_field_renames.cache_clear()
+    try:
+        server_mod._build_server()
+        assert knowledge.load_field_renames.cache_info().currsize == 1
+    finally:
+        knowledge.load_field_renames.cache_clear()

--- a/test/mcp/test_tool_knowledge.py
+++ b/test/mcp/test_tool_knowledge.py
@@ -450,3 +450,48 @@ def test_query_knowledge_does_not_attach_legacy_for_clean_text(
 
     result = query_knowledge("anything", mode="full")
     assert "legacy_name_for" not in result["data"]["matches"][0]
+
+
+def test_load_field_renames_is_cached_and_backs_legacy_annotations() -> None:
+    """The rename registry is imported once, cached, and drives the
+    ``legacy_name_for`` annotation (gh#1768)."""
+    from suews_mcp.tools import knowledge
+
+    knowledge.load_field_renames.cache_clear()
+    try:
+        first = knowledge.load_field_renames()
+        assert first, "supy in the test environment carries ALL_FIELD_RENAMES"
+        assert knowledge.load_field_renames() is first
+
+        hits = knowledge._legacy_names_in_text("set netradiationmethod to 3")
+        assert {
+            "legacy": "netradiationmethod",
+            "current": first["netradiationmethod"],
+        } in hits
+    finally:
+        knowledge.load_field_renames.cache_clear()
+
+
+def test_load_field_renames_tolerates_missing_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An older supy without the registry degrades to no legacy annotations
+    rather than an import error."""
+    import builtins
+
+    from suews_mcp.tools import knowledge
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("supy.data_model"):
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    knowledge.load_field_renames.cache_clear()
+    try:
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        assert knowledge.load_field_renames() == {}
+        assert knowledge._legacy_names_in_text("netradiationmethod") == []
+    finally:
+        knowledge.load_field_renames.cache_clear()


### PR DESCRIPTION
## Summary

Every scheduled run of `build-publish_to_pypi.yml` from 20 August to 8 September ended `cancelled`: the three Windows cross-Python jobs hung in `test/mcp/test_protocol_handshake.py::test_concurrent_query_knowledge_does_not_block_event_loop` until the 45-minute job timeout, so the publish jobs were skipped without a report. #1763 turned the cancellation into a visible failure and #1764 filed #1768 on 9 September.

The hang is in the MCP server. `query_knowledge` post-processes its envelope through `_legacy_names_in_text`, which imported `supy.data_model.core.field_renames` lazily inside the tool call. That is the server's first import of `supy.data_model` and pulls in numpy, and on Windows the numpy extension-module load from an anyio worker thread of the live server deadlocks: the server logs the `CallToolRequest` and never answers.

## Change

- `load_field_renames()` imports the registry once behind an `lru_cache`; `_build_server()` calls it on the main thread before FastMCP is constructed; `_legacy_names_in_text` reads the cache. An older supy without the registry still yields no annotations.
- The same warm-up covers the other tools that import from supy inside their bodies (`examples`, `validate`, `readiness`, the docs resource): once `supy.data_model` is loaded, those imports add only pure-Python modules, so no worker thread performs an extension load.
- The concurrency tests set a 120 s per-request `read_timeout_seconds` on the session, so a server that never answers fails as an `McpError` naming the request rather than running the lane into its job timeout. Diagnostics, not the fix.
- Unit tests: the registry is cached and drives the `legacy_name_for` annotation; a missing registry degrades to no annotations; `_build_server()` populates the cache. CHANGELOG entry under 9 September.

## Verification

On a Windows 11 machine with the `supy` and `suews-mcp` wheels from run 34301847085, spawning the server through the SDK's `stdio_client` as the test does, with `faulthandler.dump_traceback_later` running inside the server:

- unpatched: `read_knowledge_manifest` returns in 4.7 s; `query_knowledge` never returns, and eight consecutive dumps over four minutes show the worker thread in `importlib` `create_module` loading `numpy._core._multiarray_umath`, reached through `query_knowledge -> _apply_size_policy -> _annotate_match -> _legacy_names_in_text -> supy.data_model -> numpy`;
- controls: `import numpy` completes in 0.1 to 0.2 s in a main thread, a plain thread and `asyncio.to_thread` in the same venv, and giving the server the full environment instead of the SDK whitelist does not help;
- pre-importing either the registry or numpy alone on the server's main thread makes the same call return in 3 to 4 s;
- patched server: `query_knowledge` returns in 3.0 s, and `pytest test/mcp/test_protocol_handshake.py -k concurrent` passes both tests in 20 s.

The machine is Windows on ARM running x64 under emulation; it can confirm the mechanism, and did, but a clean run there would not have refuted it. Locally, `test/mcp` passes against this branch with `test_protocol_handshake.py` deselected (129 passed, 23 skipped); that file spawns the installed `suews-mcp` console script, so it was exercised on the Windows machine instead.

Trade-off: every server spawn now pays the `supy.data_model` import before it can answer `initialize`, about 1.0 s locally and roughly 4 s under emulation, against the five discovery tests' 30 s per-request timeout. The registry was needed on the first `query_knowledge` anyway; the cost has moved to startup, where it is safe.

The 10 September nightly is the first CI run of the concurrency tests on Windows with this change.

Refs #1768. The tracking issue closes itself on the first green nightly, so it stays open until the 10 September run confirms the fix in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1762