### PR TITLE
Build wheels with the release profile; run the checked profile nightly

### DIFF
--- a/.claude/rules/00-project-essentials.md
+++ b/.claude/rules/00-project-essentials.md
@@ -94,10 +94,11 @@ recipes and the installation docs.
 
 - `FCFLAGS` env var is NOT forwarded through `make dev` -> meson-python pipeline
   - Fortran compiler flags live in `src/suews/Makefile.gfortran`, selected by
-    the build profile: `SUEWS_BUILD_PROFILE=checked` (runtime checks, the
-    current default) or `release` (`-O3`, no checks). `src/supy/run_make.py`
-    and `src/suews_bridge/build.rs` read the same variable
-  - Release build locally: `SUEWS_BUILD_PROFILE=release make dev`
+    the build profile: `SUEWS_BUILD_PROFILE=release` (`-O3`, no checks, the
+    default) or `checked` (runtime checks; the nightly physics tier builds it
+    too). `src/supy/run_make.py` and `src/suews_bridge/build.rs` read the
+    same variable
+  - Checked build locally, for debugging physics: `SUEWS_BUILD_PROFILE=checked make dev`
 - `make clean` removes `build/` but meson-python may cache compiled extensions elsewhere
   - For a truly clean rebuild: `make clean && pip cache purge && make dev`
 

--- a/.github/actions/build-suews/action.yml
+++ b/.github/actions/build-suews/action.yml
@@ -19,9 +19,13 @@ inputs:
     required: false
     default: 'standard'
   build_profile:
-    description: 'Fortran build profile: checked (runtime checks, the current default) or release (optimised, no checks). Read by src/supy/run_make.py and src/suews_bridge/build.rs.'
+    description: 'Fortran build profile: release (optimised, no checks, the default) or checked (runtime checks; the nightly physics tier). Read by src/supy/run_make.py and src/suews_bridge/build.rs.'
     required: false
-    default: 'checked'
+    default: 'release'
+  artifact_prefix:
+    description: 'Prefix for the wheel and metrics artefact names, so a second build of the same platform (the checked nightly build) does not collide with the release wheels that publish.'
+    required: false
+    default: ''
   is_testpypi_build:
     description: 'Whether this is a TestPyPI build (adds notice to README)'
     required: false
@@ -279,7 +283,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
-        name: ci-metrics-physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
+        name: ${{ inputs.artifact_prefix }}ci-metrics-physics-${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
         path: ${{ inputs.metrics_host_dir }}/*.json
         if-no-files-found: error
         retention-days: 14
@@ -291,5 +295,5 @@ runs:
     - name: Upload wheels
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
-        name: ${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
+        name: ${{ inputs.artifact_prefix }}${{ inputs.python }}-${{ inputs.buildplat_name }}-${{ inputs.buildplat_arch }}
         path: ./wheelhouse/*.whl

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -110,9 +110,9 @@ on:
           - cfg
           - smoke
       build_profile:
-        description: 'Fortran build profile for this dispatch only (checked = runtime checks, the default; release = optimised, no checks). The default changes only after the release profile is validated on every platform.'
+        description: 'Fortran build profile for this dispatch (release = optimised, no checks, the default; checked = runtime checks, what the nightly physics tier also builds)'
         required: false
-        default: 'checked'
+        default: 'release'
         type: choice
         options:
           - checked
@@ -440,7 +440,30 @@ jobs:
       python_json: ${{ needs.determine_matrix.outputs.python }}
       test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
       is_testpypi_build: ${{ (github.event_name == 'schedule' || (startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'dev'))) && 'true' || 'false' }}
-      build_profile: ${{ inputs.build_profile || 'checked' }}
+      build_profile: ${{ inputs.build_profile || 'release' }}
+
+  # Nightly only: build the checked profile (-O0 -fcheck=all) on every platform
+  # and run the full physics tier on it, so out-of-bounds and uninitialised
+  # reads keep surfacing as Fortran runtime errors now that the published
+  # wheels are release builds. Its artefacts carry the "checked-" prefix, so
+  # the TestPyPI and API-test jobs, which select by the unprefixed names,
+  # never see them.
+  build_wheels_checked:
+    name: Build checked wheels (nightly physics tier)
+    needs: [determine_matrix, create_nightly_tag]
+    if: |
+      always() &&
+      github.event_name == 'schedule' &&
+      needs.determine_matrix.result == 'success' &&
+      needs.create_nightly_tag.result == 'success'
+    uses: $/.github/workflows/build-wheels-reusable.yml
+    with:
+      buildplat_json: ${{ needs.determine_matrix.outputs.buildplat }}
+      python_json: ${{ needs.determine_matrix.outputs.python }}
+      test_tier: all
+      is_testpypi_build: 'false'
+      build_profile: checked
+      artifact_prefix: checked-
 
   build_mcp:
     name: Build MCP package
@@ -624,7 +647,7 @@ jobs:
   report_scheduled_run:
     name: Report scheduled run outcome
     runs-on: ubuntu-latest
-    needs: [create_nightly_tag, build_wheels, build_mcp, test_api_cross_python, check_test_markers, deploy_testpypi]
+    needs: [create_nightly_tag, build_wheels, build_wheels_checked, build_mcp, test_api_cross_python, check_test_markers, deploy_testpypi]
     if: always() && github.event_name == 'schedule'
     permissions:
       issues: write

--- a/.github/workflows/build-wheels-reusable.yml
+++ b/.github/workflows/build-wheels-reusable.yml
@@ -27,10 +27,15 @@ on:
         type: string
         default: 'false'
       build_profile:
-        description: 'Fortran build profile: checked (runtime checks, the current default) or release (optimised, no checks)'
+        description: 'Fortran build profile: release (optimised, no checks, the default) or checked (runtime checks; the nightly physics tier)'
         required: false
         type: string
-        default: 'checked'
+        default: 'release'
+      artifact_prefix:
+        description: 'Prefix for the wheel and metrics artefact names (the checked nightly build uses "checked-" so it never collides with the release wheels)'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -81,4 +86,5 @@ jobs:
           test_tier: ${{ inputs.test_tier }}
           is_testpypi_build: ${{ inputs.is_testpypi_build }}
           build_profile: ${{ inputs.build_profile }}
+          artifact_prefix: ${{ inputs.artifact_prefix }}
           metrics_host_dir: ${{ runner.temp }}/suews-ci-metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ EXAMPLES:
 
 ### 9 Sep 2026
 
+- [change][stable] Wheels are built with the `release` Fortran profile (`-O3`, no runtime checks) instead of the checked profile every wheel had carried since 2023; the nightly workflow now also builds the `checked` profile on every platform and runs the full physics tier on it, so runtime checks keep running where they are cheap (#PR)
 - [maintenance] Added targeted SPARTACUS regressions for vegetation above the tree canopy and a short run using explicit changes to the existing sample configuration (#1699).
 
 ### 8 Sep 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ EXAMPLES:
 
 ### 9 Sep 2026
 
-- [change][stable] Wheels are built with the `release` Fortran profile (`-O3`, no runtime checks) instead of the checked profile every wheel had carried since 2023; the nightly workflow now also builds the `checked` profile on every platform and runs the full physics tier on it, so runtime checks keep running where they are cheap (#PR)
+- [change][stable] Wheels are built with the `release` Fortran profile (`-O3`, no runtime checks) instead of the checked profile every wheel had carried since 2023; the nightly workflow now also builds the `checked` profile on every platform and runs the full physics tier on it, so runtime checks keep running where they are cheap (#1770)
 - [maintenance] Added targeted SPARTACUS regressions for vegetation above the tree canopy and a short run using explicit changes to the existing sample configuration (#1699).
 
 ### 8 Sep 2026

--- a/dev-ref/building-locally.md
+++ b/dev-ref/building-locally.md
@@ -105,21 +105,23 @@ environment variable at build time (`src/supy/run_make.py` passes it to the
 SUEWS Makefile as `DEBUG=1` or `DEBUG=`; `src/suews_bridge/build.rs` reads the
 same variable):
 
-- `checked` (the current default): `-O0 -fcheck=all -finit-real=zero`.
-  Out-of-bounds and uninitialised reads surface as Fortran runtime errors
-  rather than silent numbers. Measured against `release` on the same commit:
-  about 1.7x slower on the sample configuration and 5x on SPARTACUS-heavy
-  configurations.
-- `release`: `-O3 -finit-real=zero`, no runtime checks. Neither profile arms
-  floating-point exception traps; `src/suews/Makefile.gfortran` explains why.
+- `release` (the default): `-O3 -finit-real=zero`, no runtime checks. This
+  is what the published wheels are built with.
+- `checked`: `-O0 -fcheck=all -finit-real=zero`. Out-of-bounds and
+  uninitialised reads surface as Fortran runtime errors rather than silent
+  numbers. Measured against `release` on the same commit: about 1.7x slower
+  on the sample configuration and 5x on SPARTACUS-heavy configurations. The
+  nightly workflow builds this profile on every platform and runs the full
+  physics tier on it, alongside the release wheels it publishes.
+
+Neither profile arms floating-point exception traps; `src/suews/Makefile.gfortran`
+explains why.
 
 ```bash
-SUEWS_BUILD_PROFILE=release make dev     # optimised local build
-SUEWS_BUILD_PROFILE=checked make dev     # the default, spelled out
+make dev                                 # release, the default
+SUEWS_BUILD_PROFILE=checked make dev     # runtime checks, for debugging physics
 ```
 
 The variable is read when the Fortran objects are compiled, so change it with
 a clean build (`make clean && make dev`). In CI the profile is an input of the
-`build-suews` action and a `workflow_dispatch` choice on the wheel workflow;
-the default stays `checked` until the release profile has been validated on
-every platform.
+`build-suews` action and a `workflow_dispatch` choice on the wheel workflow.

--- a/src/suews/Makefile
+++ b/src/suews/Makefile
@@ -45,10 +45,11 @@ endif
 #            Measured cost against release: about 1.7x on the sample model and
 #            5x on SPARTACUS-heavy configurations.
 #   release: -O3 -finit-real=zero, no runtime checks, no FPE traps.
-# The checked profile stays the default here until the release profile has
-# been validated on every CI platform; a bare `make` therefore builds checked,
-# and `make DEBUG=` builds release.
-DEBUG ?= 1
+# Release is the default since the release profile was validated on every CI
+# platform (Windows first, then the nightly): a bare `make` builds release,
+# `make DEBUG=1` builds checked. The nightly physics tier builds the checked
+# profile alongside the release wheels so runtime checks keep running.
+DEBUG ?=
 
 LIBUTILS = $(addprefix $(DIR_LIB_SUEWS),libsuewsutil.a)
 LIBPHYS = $(addprefix $(DIR_LIB_SUEWS),libsuewsphys.a)

--- a/src/suews/Makefile.gfortran
+++ b/src/suews/Makefile.gfortran
@@ -18,7 +18,7 @@ BASICFLAGS = -J./mod -fconvert=big-endian -ffree-line-length-none -frecursive
 OMPFLAG = -fopenmp
 
 ifndef DEBUG
-# --RELEASE CONFIGURATION-- (SUEWS_BUILD_PROFILE=release, see ../supy/run_make.py)
+# --RELEASE CONFIGURATION-- (SUEWS_BUILD_PROFILE=release, the default; see ../supy/run_make.py)
 
 # Optimization flags
 OPTFLAGS = -O3
@@ -39,7 +39,7 @@ WARNFLAGS = -Wall -Wno-unused-label -Wno-unused-dummy-argument -Wno-unused-varia
 DEBUGFLAGS = -g -finit-real=zero
 
 else
-# --CHECKED CONFIGURATION-- (SUEWS_BUILD_PROFILE=checked, the current default)
+# --CHECKED CONFIGURATION-- (SUEWS_BUILD_PROFILE=checked; the nightly physics tier, or `make DEBUG=1`)
 OPTFLAGS = -O0
 WARNFLAGS = -Wall
 # When the physics library is loaded as a shared library from Python/Rust:

--- a/src/suews_bridge/build.rs
+++ b/src/suews_bridge/build.rs
@@ -157,15 +157,15 @@ fn main() {
     }
 
     // Build profile, shared with src/supy/run_make.py through the same
-    // environment variable: "checked" (the current default) adds gfortran
-    // runtime checks to the bridge's own Fortran sources, "release" omits
-    // them. The physics library follows the same variable through the SUEWS
+    // environment variable: "release" (the default) compiles the bridge's
+    // own Fortran sources without runtime checks, "checked" adds
+    // -fcheck=all (the nightly physics tier builds it alongside release). The physics library follows the same variable through the SUEWS
     // Makefile, so a wheel is either wholly checked or wholly release.
     println!("cargo:rerun-if-env-changed=SUEWS_BUILD_PROFILE");
-    let build_profile = env::var("SUEWS_BUILD_PROFILE").unwrap_or_else(|_| "checked".to_string());
+    let build_profile = env::var("SUEWS_BUILD_PROFILE").unwrap_or_else(|_| "release".to_string());
     let runtime_checks = match build_profile.trim().to_ascii_lowercase().as_str() {
-        "" | "checked" => true,
-        "release" => false,
+        "" | "release" => false,
+        "checked" => true,
         other => panic!("SUEWS_BUILD_PROFILE must be \"release\" or \"checked\", got {other:?}"),
     };
 

--- a/src/supy/run_make.py
+++ b/src/supy/run_make.py
@@ -11,16 +11,16 @@ import subprocess
 import sys
 
 BUILD_PROFILES = ("release", "checked")
-DEFAULT_BUILD_PROFILE = "checked"
+DEFAULT_BUILD_PROFILE = "release"
 BUILD_PROFILE_ENV = "SUEWS_BUILD_PROFILE"
 
 
 def build_profile_from_env(environ: Mapping[str, str] | None = None) -> str:
     """Return the Fortran build profile selected by ``SUEWS_BUILD_PROFILE``.
 
-    ``checked`` (the current default) compiles the physics library with
-    ``-O0 -fcheck=all``; ``release`` compiles with ``-O3`` and no runtime
-    checks. Both keep ``-finit-real=zero`` and neither arms FPE traps; the
+    ``release`` (the default) compiles the physics library with ``-O3`` and
+    no runtime checks; ``checked`` compiles with ``-O0 -fcheck=all`` and is
+    what the nightly physics tier runs alongside the release wheels. Both keep ``-finit-real=zero`` and neither arms FPE traps; the
     flag sets live in ``src/suews/Makefile.gfortran``. The Rust bridge reads
     the same variable in ``src/suews_bridge/build.rs``.
     """

--- a/test/core/test_build_profile.py
+++ b/test/core/test_build_profile.py
@@ -31,9 +31,9 @@ def run_make():
     return _load_run_make()
 
 
-def test_default_profile_is_checked(run_make):
-    assert run_make.build_profile_from_env({}) == "checked"
-    assert run_make.build_profile_from_env({"SUEWS_BUILD_PROFILE": ""}) == "checked"
+def test_default_profile_is_release(run_make):
+    assert run_make.build_profile_from_env({}) == "release"
+    assert run_make.build_profile_from_env({"SUEWS_BUILD_PROFILE": ""}) == "release"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

- `release` (`-O3 -finit-real=zero`, no runtime checks, no FPE traps) becomes the default Fortran build profile in `run_make.py`, `build.rs`, the SUEWS Makefile (`DEBUG ?=` empty), the `build-suews` action, the reusable wheel workflow and the `workflow_dispatch` input. `SUEWS_BUILD_PROFILE=checked` still selects `-O0 -fcheck=all`.
- The nightly workflow gains `build_wheels_checked`: the checked profile built on every platform with the full physics tier, under artefact names prefixed `checked-` so the TestPyPI publish and the API-test jobs (which select the unprefixed names) never see them. `report_scheduled_run` watches it.
- Docs (`dev-ref/building-locally.md`, the project-essentials note) and `test_build_profile.py` follow.

## Why

Every wheel carried the checked profile since 2023 through an unconditional `DEBUG=1`; #1766 made the profile explicit without changing it and measured the cost: about 1.7x on the sample configuration and 5x on SPARTACUS-heavy configurations, on the same commit and compiler. The agreed split is: ship the release profile, keep the checks running nightly where they are cheap.

## Verification

- Windows first, the platform whose gfortran runtime arms FPE traps on library load: [run 34348761966](https://github.com/UMEP-dev/SUEWS/actions/runs/34348761966) from master with `build_profile=release`, tier `all`. Build job: 66 of 66 compiles at `-O3`, none with `-O0`, `-fcheck=all` or `-ffpe-trap`. Physics tier: 178 passed, 1 skipped, 332 s (439 s on the checked build in the 7 September queue run); full-year and STEBBS reference comparisons included. No "array temporary" runtime warnings, no floating-point exception, no access violation. API lane: 1933 results, all passing, until the known #1762 hang.
- Locally (Apple silicon, gfortran 15.2, same commit): physics standard lane 167 s checked to 94 s release, both 166 passed; every reference comparison unchanged.
- This PR's own multiplatform build runs the physics tier on the release profile on Linux and macOS as well.
- `zizmor@1.30.0` reports no new finding; the CI-metrics parsing tests pass (23 passed with `test_build_profile.py`).

The first nightly after merge is the live check of the checked build; its result lands in the scheduled-run tracking issue if anything fails.

Refs #1766, #1762.
