### PR TITLE
Cap each request in the MCP concurrency tests at 120 s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ EXAMPLES:
 
 ### 9 Sep 2026
 
+- [maintenance] The two MCP concurrency tests cap each client request at 120 s, so a server that never answers fails the test naming the request instead of running the lane into its job timeout (#1768, #1772)
 - [bugfix] Fixed the MCP server hanging on its first `query_knowledge` call on Windows by loading supy's field-rename registry at server start rather than on a worker thread (#1762, #1771).
 - [change][stable] Wheels are built with the `release` Fortran profile (`-O3`, no runtime checks) instead of the checked profile every wheel had carried since 2023; the nightly workflow now also builds the `checked` profile on every platform and runs the full physics tier on it, so runtime checks keep running where they are cheap (#1770)
 - [maintenance] Added targeted SPARTACUS regressions for vegetation above the tree canopy and a short run using explicit changes to the existing sample configuration (#1699).

--- a/test/mcp/test_protocol_handshake.py
+++ b/test/mcp/test_protocol_handshake.py
@@ -27,6 +27,12 @@ pytestmark = [pytest.mark.api, pytest.mark.smoke]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _HANDSHAKE_REQUEST_TIMEOUT = timedelta(seconds=30)
+# Ceiling on any single request in the concurrency tests below. It sits well
+# above the CLI cost on every CI host and well below pytest-timeout's 600 s,
+# so a server that never answers fails here with an ``McpError`` naming the
+# request instead of running the lane into its job timeout, which is how the
+# scheduled Windows lane was lost for 20 nights (gh#1768).
+_CONCURRENT_REQUEST_TIMEOUT = timedelta(seconds=120)
 
 
 _mcp_session = pytest.importorskip(
@@ -295,7 +301,11 @@ async def _run_baseline_then_concurrent(
     )
 
     async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
+        async with ClientSession(
+            read,
+            write,
+            read_timeout_seconds=_CONCURRENT_REQUEST_TIMEOUT,
+        ) as session:
             await session.initialize()
 
             # 1. Warm-up + baseline measurement. This call also primes any


### PR DESCRIPTION
## Summary

The two concurrency tests in `test/mcp/test_protocol_handshake.py` now set a 120 s per-request `read_timeout_seconds` on the MCP client session. A server that never answers a request fails the test with an `McpError` naming that request, instead of running the lane into the 45-minute job timeout, which is how the scheduled Windows lane was lost every night from 20 August to 8 September (#1768).

Diagnostic only. The hang itself was fixed by #1771 (the field-rename registry preload); this is the test-side half that #1769 carried alongside the same fix, ported here after #1769 was closed as superseded.

The ceiling sits well above the CLI cost of these calls on every CI host and well below pytest-timeout's 600 s, so it cannot fire on a healthy run.

## Verification

Locally on Apple silicon, `pytest test/mcp/test_protocol_handshake.py`: the handshake and discovery tests pass with the change. `test_concurrent_query_knowledge_and_search_schema` fails on this machine with or without the change, on the test's own self-calibrated per-task timeout (line 331), not on the new 120 s ceiling; the same test passed on all three platforms in #1771's CI, so that is local timing noise.

Refs #1768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
