### PR TITLE
Record the zero-tolerance spread of the sample comparison nightly

### DIFF
--- a/.claude/rules/tests/patterns.md
+++ b/.claude/rules/tests/patterns.md
@@ -38,6 +38,19 @@ def test_example():
 
 **Why 0.8% tolerance?** Conservative, well within measurement uncertainty. Eddy covariance has 5-10% uncertainty; energy balance closure rarely better than 70-90%.
 
+**Where the measured spread lives.** The table above is the measurement-uncertainty
+floor. The actual cross-platform and cross-CPython spread of the full-year sample
+comparison is recorded, not assumed: the nightly `tolerance_spread` job in
+`build-publish_to_pypi.yml` runs `scripts/suews/tolerance_spread.py measure` with
+every tolerance set to zero on each built platform for the two CPython bookends and
+uploads one `tolerance-spread-<platform>-<arch>-<cpXY>` artefact per cell (also on
+`workflow_dispatch` with the `tolerance_spread` input). `tolerance_spread.py
+summarise` prints the spread across a set of those artefacts beside the current
+tolerance. Tolerances in `test/core/test_sample_output.py` are to be derived from
+that spread (a documented multiple of it, floored by the table above) and must cite
+the artefacts they came from; a tolerance loosened without a spread artefact behind
+it is a bare number and should be flagged in review.
+
 ---
 
 ## Assertions

--- a/.github/scripts/determine-matrix.sh
+++ b/.github/scripts/determine-matrix.sh
@@ -2,7 +2,7 @@
 # Determine the cibuildwheel build matrix based on trigger type and change detection.
 #
 # Called from build-publish_to_pypi.yml determine_matrix job.
-# Writes buildplat, api_buildplat, python, api_python, test_tier to GITHUB_OUTPUT.
+# Writes buildplat, api_buildplat, python, api_python, bookend_python, test_tier to GITHUB_OUTPUT.
 #
 # "python" is the cibuildwheel build matrix (the abi3 floor derived from
 # pyproject's requires-python — emits one abi3 wheel per platform). Physics
@@ -252,3 +252,9 @@ fi
 # installed into each Python version and exercised with
 # `-m "api and <tier>"` by test-api-cross-python-reusable.yml.
 echo "api_python=$API_PYTHON" >> "$GITHUB_OUTPUT"
+
+# The two CPython bookends (floor and newest after the requires-python clamp),
+# independent of the trigger. The nightly tolerance-spread job runs on exactly
+# these two so its artefacts stay comparable night to night, whereas
+# api_python widens to ALL on schedule.
+echo "bookend_python=$BOOKEND_PYTHON" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-publish_to_pypi.yml
+++ b/.github/workflows/build-publish_to_pypi.yml
@@ -117,6 +117,10 @@ on:
         options:
           - checked
           - release
+      tolerance_spread:
+        description: 'Also record the zero-tolerance spread of the full-year sample comparison on every built platform for the two CPython bookends (what the nightly does; uploads tolerance-spread-* artefacts)'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -286,6 +290,7 @@ jobs:
       api_buildplat: ${{ steps.set-matrix.outputs.api_buildplat }}
       python: ${{ steps.set-matrix.outputs.python }}
       api_python: ${{ steps.set-matrix.outputs.api_python }}
+      bookend_python: ${{ steps.set-matrix.outputs.bookend_python }}
       test_tier: ${{ steps.set-matrix.outputs.test_tier }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -523,6 +528,80 @@ jobs:
       api_python_json: >-
         ${{ github.event_name == 'merge_group' && needs.determine_matrix.outputs.python || needs.determine_matrix.outputs.api_python }}
       test_tier: ${{ needs.determine_matrix.outputs.test_tier }}
+
+  # Nightly and on demand: record the zero-tolerance spread of the full-year
+  # sample comparison (scripts/suews/tolerance_spread.py) on every built
+  # platform for the two CPython bookends, one JSON artefact per cell. The
+  # tolerances in test/core/test_sample_output.py are to be derived from a week
+  # of these artefacts, so this job records and never gates: the script exits 0
+  # however large the spread, continue-on-error keeps a runner or install
+  # failure here from turning the nightly red, and the job feeds neither
+  # report_scheduled_run nor pr-gate. It installs the release wheel the run
+  # built (or the profile a dispatch chose), so it measures what ships.
+  tolerance_spread:
+    name: Tolerance spread ${{ matrix.python_version }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
+    needs: [determine_matrix, build_wheels]
+    if: |
+      always() &&
+      needs.build_wheels.result == 'success' &&
+      (
+        github.event_name == 'schedule' ||
+        (github.event_name == 'workflow_dispatch' && inputs.tolerance_spread == true)
+      )
+    runs-on: ${{ matrix.buildplat[0] }}
+    continue-on-error: true
+    # The full-year engine run is under a minute on a laptop; the cap only
+    # bounds a hung install or runner, matching the api lane's guardrail.
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        buildplat: ${{ fromJson(needs.determine_matrix.outputs.buildplat) }}
+        python_version: ${{ fromJson(needs.determine_matrix.outputs.bookend_python) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve Python version (cp312 -> 3.12)
+        id: pyver
+        shell: bash
+        env:
+          PV: ${{ matrix.python_version }}
+        run: |
+          echo "spec=3.${PV#cp3}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ steps.pyver.outputs.spec }}
+
+      - name: Download wheel for this platform
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cp312-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
+          path: wheelhouse/
+
+      - name: Install wheel and measure the spread
+        shell: bash
+        env:
+          SUEWS_BUILD_PROFILE: ${{ inputs.build_profile || 'release' }}
+          OUTPUT: tolerance-spread/tolerance-spread-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}-${{ matrix.python_version }}.json
+        run: |
+          python -m pip install --upgrade pip
+          # The script reuses the sample-output test module, which imports
+          # pytest and the test conftest; the wheel alone does not bring pytest.
+          python -m pip install pytest==9.1.1
+          python -m pip install wheelhouse/*.whl
+          python scripts/suews/tolerance_spread.py measure --output "$OUTPUT"
+
+      - name: Upload tolerance-spread artefact
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: tolerance-spread-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}-${{ matrix.python_version }}
+          path: tolerance-spread/*.json
+          if-no-files-found: error
+          retention-days: 30
 
   # Standalone static lints over the test tree. Both use AST-based scripts
   # that never import supy, so CI can run them without building — that is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ EXAMPLES:
 
 ### 9 Sep 2026
 
+- [maintenance] The nightly wheel workflow records the zero-tolerance spread of the full-year sample comparison on every platform for the two CPython bookends (`scripts/suews/tolerance_spread.py`, one `tolerance-spread-<platform>-<arch>-<cpXY>` artefact per cell, also on `workflow_dispatch`), and a `summarise` mode prints the spread across a set of artefacts beside the current tolerance, so the bare-number tolerances in `test_sample_output.py` can be derived from measured spread; no tolerance changes (#1774)
 - [bugfix] Fixed the MCP server hanging on its first `query_knowledge` call on Windows by loading supy's field-rename registry at server start rather than on a worker thread (#1762, #1771).
 - [change][stable] Wheels are built with the `release` Fortran profile (`-O3`, no runtime checks) instead of the checked profile every wheel had carried since 2023; the nightly workflow now also builds the `checked` profile on every platform and runs the full physics tier on it, so runtime checks keep running where they are cheap (#1770)
 - [maintenance] Added targeted SPARTACUS regressions for vegetation above the tree canopy and a short run using explicit changes to the existing sample configuration (#1699).

--- a/scripts/suews/README.md
+++ b/scripts/suews/README.md
@@ -114,6 +114,52 @@ This manual same-job result is the acceptance evidence. Ordinary PR runs and
 unrelated historical runs cannot establish the overhead bound because GitHub
 host load is uncontrolled.
 
+## Tolerance spread of the sample comparison
+
+**Script**: `tolerance_spread.py`
+
+`test/core/test_sample_output.py` accepts each output variable of the
+full-year sample run within a tolerance, and every tolerance there is a bare
+number: nothing records the cross-platform and cross-CPython spread the numbers
+are meant to absorb. This script records that spread so the tolerances can be
+derived from it.
+
+```bash
+# Run the full-year sample comparison with every tolerance set to zero
+python scripts/suews/tolerance_spread.py measure \
+  --output tolerance-spread/tolerance-spread-manylinux-x86_64-cp312.json
+
+# Print the spread across a set of artefacts beside the current tolerance
+python scripts/suews/tolerance_spread.py summarise artefacts/ [--markdown]
+```
+
+`measure` reuses the test module's loader, variable list, run helpers and
+deviation arithmetic (`deviation_arrays`), so the numbers are exactly what the
+comparator sees. Per variable it records the maximum absolute and maximum
+relative deviation, the timestamp and grid where each occurs, the actual and
+expected values there, the count of exactly equal points, and the tolerance the
+test currently resolves on that platform and CPython. The header carries the
+platform key, CPython version, supy version, git SHA (`--git-sha`, else
+`GITHUB_SHA`, else `git rev-parse HEAD`) and Fortran build profile
+(`--build-profile`, else `SUEWS_BUILD_PROFILE`, else `unknown`; the wheel does
+not expose it). The exit code is 0 however large the spread is. When
+`GITHUB_STEP_SUMMARY` is set, the same table is appended as Markdown.
+
+The `tolerance_spread` job in `build-publish_to_pypi.yml` runs `measure` on
+every scheduled run, on each built platform for the two CPython bookends, and
+uploads one artefact per cell named
+`tolerance-spread-<platform>-<arch>-<cpXY>` (retained 30 days). The same job
+runs on `workflow_dispatch` when the `tolerance_spread` input is set. It never
+fails the nightly: it feeds neither `report_scheduled_run` nor the PR gate.
+
+`summarise` accepts artefact files or directories (the layout `gh run download
+<id> --pattern 'tolerance-spread-*'` produces), lists the artefacts with their
+SHA, supy version and build profile, warns when they span more than one SHA,
+and prints per variable the largest absolute and relative deviation across all
+of them, which artefact and timestamp produced each, and the range of current
+tolerances. Deriving a tolerance from the spread is deliberately left to the
+reader of that table.
+
 ## Hosted pytest scheduler comparison
 
 **Workflow**: `Hosted pytest scheduler ABBA`

--- a/scripts/suews/tolerance_spread.py
+++ b/scripts/suews/tolerance_spread.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Measure the zero-tolerance spread of the full-year sample comparison.
+
+The physics regression in ``test/core/test_sample_output.py`` compares the
+engine's full-year run of the sample configuration against the vendored
+reference and accepts each variable within a tolerance. Every tolerance there
+is a bare number: nothing records the cross-platform and cross-CPython spread
+those numbers are meant to absorb. This script records it.
+
+``measure`` runs the same comparison with every tolerance set to zero and
+writes a JSON artefact with, per output variable, the maximum absolute and
+maximum relative deviation, the timestamp and grid where each occurs, and the
+tolerance the test currently resolves on this platform. The header carries the
+platform, CPython version, supy version, git SHA and Fortran build profile.
+The exit code is 0 however large the spread is: this is a recorder, not a
+gate. The loader, variable list, run helpers and deviation arithmetic are
+imported from the test module rather than re-implemented, so the numbers are
+exactly what the comparator sees.
+
+``summarise`` reads a set of those artefacts (files, or directories as laid
+out by ``gh run download``) and prints, per variable, the spread across all of
+them beside the current tolerance, so tolerances can later be derived from a
+week of nightly runs and cite the runs they came from.
+
+The nightly workflow uploads one artefact per (platform, CPython bookend) named
+``tolerance-spread-<platform>-<arch>-<cpXY>``; the same job can be dispatched
+manually with the ``tolerance_spread`` input.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import UTC, datetime
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+import numpy as np
+
+SCHEMA_VERSION = 1
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TEST_DIR = PROJECT_ROOT / "test"
+TEST_CORE_DIR = TEST_DIR / "core"
+# The full-year test allows the engine this long; the spread run is the same run.
+ENGINE_TIMEOUT_SECONDS = 1800
+BUILD_PROFILE_ENV = "SUEWS_BUILD_PROFILE"
+
+
+def _import_sample_test():
+    """Import the sample-output test module so its helpers are reused, not copied."""
+    for path in (TEST_DIR, TEST_CORE_DIR):
+        if str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+    import test_sample_output as sample  # noqa: PLC0415
+
+    return sample
+
+
+def _git_sha(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit
+    from_env = os.environ.get("GITHUB_SHA")
+    if from_env:
+        return from_env
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(PROJECT_ROOT), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def _runner_identity() -> dict[str, Any]:
+    """GitHub Actions identity when present; explicit nulls otherwise."""
+    keys = (
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_JOB",
+        "GITHUB_REF",
+        "RUNNER_OS",
+        "RUNNER_ARCH",
+    )
+    return {key.lower(): os.environ.get(key) for key in keys}
+
+
+def _point(
+    index_frame, position: int, actual, expected, abs_diff, rel_diff
+) -> dict[str, Any]:
+    """Describe one compared position: where it is and what the two frames hold."""
+    grid, timestamp = index_frame[position]
+    return {
+        "index": int(position),
+        "grid": int(grid),
+        "timestamp": timestamp.isoformat(),
+        "actual": float(actual[position]),
+        "expected": float(expected[position]),
+        "abs_deviation": float(abs_diff[position]),
+        "rel_deviation": float(rel_diff[position]),
+    }
+
+
+def _variable_record(sample, var: str, df_actual, df_expected) -> dict[str, Any]:
+    """Zero-tolerance deviation summary for one variable."""
+    record: dict[str, Any] = {
+        "tolerance_current": sample.get_tolerance_for_variable(var),
+        "tolerance_base": dict(sample.TOLERANCE_CONFIG[var]),
+    }
+    if var not in df_actual.columns:
+        record["status"] = "missing_in_engine_output"
+        return record
+
+    actual = np.asarray(df_actual[var].values, dtype=float)
+    expected = np.asarray(df_expected[var].values, dtype=float)
+    abs_diff, rel_diff, valid_mask, nan_mismatch = sample.deviation_arrays(
+        actual, expected
+    )
+
+    record["status"] = "compared"
+    record["n_points"] = len(actual)
+    record["n_valid"] = int(valid_mask.sum())
+    record["n_nan_mismatch"] = int(nan_mismatch.sum())
+    record["n_exact"] = int(np.count_nonzero((abs_diff == 0) & valid_mask))
+
+    if not valid_mask.any():
+        record["max_abs_deviation"] = None
+        record["max_rel_deviation"] = None
+        return record
+
+    index_frame = df_expected.index
+    masked_abs = np.where(valid_mask, abs_diff, -np.inf)
+    masked_rel = np.where(valid_mask, rel_diff, -np.inf)
+    record["max_abs_deviation"] = _point(
+        index_frame, int(np.argmax(masked_abs)), actual, expected, abs_diff, rel_diff
+    )
+    record["max_rel_deviation"] = _point(
+        index_frame, int(np.argmax(masked_rel)), actual, expected, abs_diff, rel_diff
+    )
+    record["mean_abs_deviation"] = float(np.mean(abs_diff[valid_mask]))
+    return record
+
+
+def measure(args: argparse.Namespace) -> int:
+    """Run the full-year sample comparison at zero tolerance and write the artefact."""
+    sample = _import_sample_test()
+    from sample_output_io import load_sample_output  # noqa: PLC0415
+
+    import supy  # noqa: PLC0415
+
+    engine = sample._locate_engine()
+    sample_dir = sample._sample_data_dir()
+    sample_config = sample_dir / "sample_config.yml"
+    if not sample_config.is_file():
+        raise FileNotFoundError(f"Sample config not found: {sample_config}")
+
+    df_ref = load_sample_output(sample.test_data_dir)
+    steps = len(df_ref)
+    variables = list(sample.TOLERANCE_CONFIG)
+    print(f"Reference: {steps} rows; variables: {', '.join(variables)}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_dir = Path(tmpdir)
+        config_path, forcing_rows = sample._write_run_inputs(
+            sample_dir, sample_config, run_dir, steps, truncated=False
+        )
+        print(f"Running {engine} on {forcing_rows} forcing rows (full year)")
+        started = datetime.now(UTC)
+        arrow_bytes = sample._run_engine(
+            engine, config_path, run_dir, ENGINE_TIMEOUT_SECONDS
+        )
+        engine_seconds = (datetime.now(UTC) - started).total_seconds()
+
+    df_actual = sample._read_engine_output(arrow_bytes, variables)
+    engine_rows = len(df_actual)
+    rows_compared = min(engine_rows, steps)
+    df_actual = df_actual.iloc[:rows_compared]
+    df_expected = df_ref.iloc[:rows_compared]
+
+    records = {
+        var: _variable_record(sample, var, df_actual, df_expected) for var in variables
+    }
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "tolerance_applied": {"rtol": 0.0, "atol": 0.0},
+        "platform": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "release": platform.release(),
+            "platform_key": sample.get_platform_key(),
+        },
+        "python": {
+            "version": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "tag": f"cp{sys.version_info.major}{sys.version_info.minor}",
+        },
+        "supy_version": getattr(supy, "__version__", None),
+        "git_sha": _git_sha(args.git_sha),
+        "build_profile": args.build_profile
+        or os.environ.get(BUILD_PROFILE_ENV)
+        or "unknown",
+        "engine": str(engine),
+        "runner": _runner_identity(),
+        "comparison": {
+            "reference_rows": int(steps),
+            "engine_rows": int(engine_rows),
+            "rows_compared": int(rows_compared),
+            "engine_seconds": round(engine_seconds, 3),
+        },
+        "variables": records,
+    }
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote {output}")
+
+    table = _measure_table(payload)
+    print("\n".join(table))
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        label = _artefact_label(payload)
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(f"### Zero-tolerance spread: {label}\n\n")
+            handle.write("\n".join(_measure_table(payload, markdown=True)) + "\n\n")
+    return 0
+
+
+def _fmt(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.3e}"
+
+
+def _measure_table(payload: dict[str, Any], markdown: bool = False) -> list[str]:
+    header = [
+        "variable",
+        "max abs",
+        "at (timestamp, grid)",
+        "max rel",
+        "at (timestamp, grid)",
+        "exact/points",
+        "rtol",
+        "atol",
+    ]
+    rows = []
+    for var, record in payload["variables"].items():
+        if (
+            record.get("status") != "compared"
+            or record.get("max_abs_deviation") is None
+        ):
+            rows.append([var, "-", record.get("status", "-"), "-", "-", "-", "-", "-"])
+            continue
+        mabs = record["max_abs_deviation"]
+        mrel = record["max_rel_deviation"]
+        tol = record["tolerance_current"]
+        rows.append([
+            var,
+            _fmt(mabs["abs_deviation"]),
+            f"{mabs['timestamp']}, {mabs['grid']}",
+            _fmt(mrel["rel_deviation"]),
+            f"{mrel['timestamp']}, {mrel['grid']}",
+            f"{record['n_exact']}/{record['n_points']}",
+            f"{tol['rtol']:g}",
+            f"{tol['atol']:g}",
+        ])
+    return _render_table(header, rows, markdown)
+
+
+def _render_table(
+    header: list[str], rows: list[list[str]], markdown: bool
+) -> list[str]:
+    if markdown:
+        lines = [
+            "| " + " | ".join(header) + " |",
+            "|" + "|".join("---" for _ in header) + "|",
+        ]
+        lines.extend("| " + " | ".join(row) + " |" for row in rows)
+        return lines
+    widths = [
+        max(len(str(cell)) for cell in column)
+        for column in zip(header, *rows, strict=True)
+    ]
+    fmt = "  ".join(f"{{:<{width}}}" for width in widths)
+    lines = [fmt.format(*header), fmt.format(*("-" * width for width in widths))]
+    lines.extend(fmt.format(*row) for row in rows)
+    return lines
+
+
+def _artefact_label(payload: dict[str, Any]) -> str:
+    return f"{payload['platform']['platform_key']}/{payload['python']['tag']}"
+
+
+def _collect_artefacts(paths: list[str]) -> list[tuple[Path, dict[str, Any]]]:
+    """Load every artefact JSON under the given files or directories."""
+    found: list[tuple[Path, dict[str, Any]]] = []
+    for raw in paths:
+        path = Path(raw)
+        candidates = sorted(path.rglob("*.json")) if path.is_dir() else [path]
+        for candidate in candidates:
+            try:
+                payload = json.loads(candidate.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                print(f"[skip] {candidate}: {exc}", file=sys.stderr)
+                continue
+            if (
+                not isinstance(payload, dict)
+                or payload.get("schema_version") != SCHEMA_VERSION
+            ):
+                print(
+                    f"[skip] {candidate}: not a tolerance-spread artefact (schema {SCHEMA_VERSION})",
+                    file=sys.stderr,
+                )
+                continue
+            found.append((candidate, payload))
+    return found
+
+
+def summarise(args: argparse.Namespace) -> int:
+    """Print the spread across a set of artefacts beside the current tolerance."""
+    artefacts = _collect_artefacts(args.paths)
+    if not artefacts:
+        print("[X] no tolerance-spread artefacts found", file=sys.stderr)
+        return 1
+
+    lines: list[str] = []
+    lines.append(f"Artefacts: {len(artefacts)}")
+    shas = {payload.get("git_sha") for _, payload in artefacts}
+    for path, payload in artefacts:
+        lines.append(
+            f"  {_artefact_label(payload)}  sha={str(payload.get('git_sha'))[:12]}  "
+            f"supy={payload.get('supy_version')}  profile={payload.get('build_profile')}  "
+            f"generated={payload.get('generated_at')}  ({path})"
+        )
+    if len(shas) > 1:
+        lines.append(
+            f"[warn] artefacts span {len(shas)} git SHAs; the spread mixes revisions"
+        )
+    lines.append("")
+
+    variables: list[str] = []
+    for _, payload in artefacts:
+        for var in payload["variables"]:
+            if var not in variables:
+                variables.append(var)
+
+    header = [
+        "variable",
+        "max abs",
+        "from",
+        "max rel",
+        "from",
+        "current rtol",
+        "current atol",
+        "n",
+    ]
+    rows = []
+    for var in variables:
+        best_abs: tuple[float, str, str] | None = None
+        best_rel: tuple[float, str, str] | None = None
+        rtols: set[float] = set()
+        atols: set[float] = set()
+        count = 0
+        for _, payload in artefacts:
+            record = payload["variables"].get(var)
+            if (
+                not record
+                or record.get("status") != "compared"
+                or record.get("max_abs_deviation") is None
+            ):
+                continue
+            count += 1
+            label = _artefact_label(payload)
+            rtols.add(record["tolerance_current"]["rtol"])
+            atols.add(record["tolerance_current"]["atol"])
+            mabs = record["max_abs_deviation"]
+            mrel = record["max_rel_deviation"]
+            if best_abs is None or mabs["abs_deviation"] > best_abs[0]:
+                best_abs = (
+                    mabs["abs_deviation"],
+                    label,
+                    f"{mabs['timestamp']}, grid {mabs['grid']}",
+                )
+            if best_rel is None or mrel["rel_deviation"] > best_rel[0]:
+                best_rel = (
+                    mrel["rel_deviation"],
+                    label,
+                    f"{mrel['timestamp']}, grid {mrel['grid']}",
+                )
+        if best_abs is None or best_rel is None:
+            rows.append([var, "-", "-", "-", "-", "-", "-", "0"])
+            continue
+        rows.append([
+            var,
+            _fmt(best_abs[0]),
+            f"{best_abs[1]} @ {best_abs[2]}",
+            _fmt(best_rel[0]),
+            f"{best_rel[1]} @ {best_rel[2]}",
+            _range(rtols),
+            _range(atols),
+            str(count),
+        ])
+    lines.extend(_render_table(header, rows, args.markdown))
+    print("\n".join(lines))
+    return 0
+
+
+def _range(values: set[float]) -> str:
+    if not values:
+        return "-"
+    low, high = min(values), max(values)
+    return f"{low:g}" if low == high else f"{low:g}..{high:g}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Command-line entry point."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser(
+        "measure",
+        help="run the full-year sample comparison at zero tolerance and write JSON",
+    )
+    run.add_argument("--output", required=True, help="JSON artefact path")
+    run.add_argument(
+        "--build-profile",
+        default=None,
+        help=f"Fortran build profile of the installed supy (else {BUILD_PROFILE_ENV}, else unknown)",
+    )
+    run.add_argument(
+        "--git-sha",
+        default=None,
+        help="source SHA to record (else GITHUB_SHA, else git rev-parse HEAD)",
+    )
+    run.set_defaults(func=measure)
+
+    read = sub.add_parser(
+        "summarise",
+        help="print the spread across a set of artefacts beside the current tolerance",
+    )
+    read.add_argument(
+        "paths", nargs="+", help="artefact JSON files or directories containing them"
+    )
+    read.add_argument(
+        "--markdown", action="store_true", help="emit a GitHub-flavoured Markdown table"
+    )
+    read.set_defaults(func=summarise)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/core/test_sample_output.py
+++ b/test/core/test_sample_output.py
@@ -389,6 +389,34 @@ def get_tolerance_for_variable(
     return tolerance
 
 
+def deviation_arrays(actual, expected):
+    """Return (abs_diff, rel_diff, valid_mask, nan_mismatch) for two equal-shape arrays.
+
+    This is the arithmetic the comparator applies before any tolerance is
+    consulted, factored out so scripts/suews/tolerance_spread.py can record the
+    raw cross-platform deviation with exactly the comparator's definitions: the
+    relative deviation divides by ``|expected| + eps``, and ``valid_mask`` is
+    False only where both arrays are NaN.
+    """
+    actual = np.asarray(actual)
+    expected = np.asarray(expected)
+    if actual.shape != expected.shape:
+        raise ValueError(f"Shape mismatch: {actual.shape} vs {expected.shape}")
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        abs_diff = np.abs(actual - expected)
+        # Use expected value for relative difference calculation
+        # Add small epsilon to avoid division by zero
+        rel_diff = abs_diff / (np.abs(expected) + np.finfo(float).eps)
+
+    actual_nan = np.isnan(actual)
+    expected_nan = np.isnan(expected)
+    nan_mismatch = actual_nan != expected_nan
+    # Ignore positions where both are NaN
+    valid_mask = ~(actual_nan & expected_nan)
+    return abs_diff, rel_diff, valid_mask, nan_mismatch
+
+
 def compare_arrays_with_tolerance(actual, expected, rtol, atol, var_name=""):
     """
     Compare arrays using same logic as numpy.allclose but with detailed reporting.
@@ -430,25 +458,15 @@ def compare_arrays_with_tolerance(actual, expected, rtol, atol, var_name=""):
         )
 
     # Calculate differences
-    with np.errstate(divide="ignore", invalid="ignore"):
-        abs_diff = np.abs(actual - expected)
-        # Use expected value for relative difference calculation
-        # Add small epsilon to avoid division by zero
-        rel_diff = abs_diff / (np.abs(expected) + np.finfo(float).eps)
+    abs_diff, rel_diff, valid_mask, nan_mismatch = deviation_arrays(actual, expected)
 
     # Check tolerance using same logic as numpy.allclose
     within_tol = (abs_diff <= atol) | (rel_diff <= rtol)
 
     # Handle NaN values
-    actual_nan = np.isnan(actual)
-    expected_nan = np.isnan(expected)
-    nan_mismatch = actual_nan != expected_nan
-
     if np.any(nan_mismatch):
         return False, f"NaN mismatch for {var_name}: NaN positions differ"
 
-    # Ignore positions where both are NaN
-    valid_mask = ~(actual_nan & expected_nan)
     within_tol = within_tol | ~valid_mask
 
     # Generate report


### PR DESCRIPTION
## Finding

Only one tolerance in the physics suite is derived (`test_ohm_coefficient_blending.py` computes `atol=1e-6` from the physics band width). Every other one is a bare number. In `test_sample_output.py` that includes the `PLATFORM_ADJUSTMENTS` table, which loosens QS, QE, QH, T2 and U10 on Linux x86_64 ("slightly higher tolerance"), and a 1.5x multiplier for Python 3.13 and later ("may have different numerical behavior"). Nothing records the cross-platform and cross-CPython spread those numbers are meant to absorb, so there is no way to tell whether they are tight, loose, or simply unmotivated. Separately, the comparator's docstring states the `numpy.allclose` sum form while the implementation takes the OR of the two bounds; this PR leaves that alone.

Tolerances are to become a documented multiple of the measured spread, floored by the measurement-uncertainty argument already in `TOLERANCE_CONFIG`. That needs the data first. This PR is the data half only: no tolerance changes.

## Change

- `scripts/suews/tolerance_spread.py measure` runs the full-year sample comparison with every tolerance set to zero and writes a JSON artefact with, per variable, the maximum absolute and maximum relative deviation, the timestamp and grid where each occurs, the actual and expected values there, the count of exactly equal points, and the tolerance the test currently resolves on that platform. The header carries platform key, CPython version, supy version, git SHA and Fortran build profile. Exit code is 0 however large the spread: it records, it does not gate.
- `tolerance_spread.py summarise` takes a set of those artefacts (files or `gh run download` directories) and prints, per variable, the spread across all of them and the current tolerance beside it, so tolerances can be derived from a week of nightly runs and cite the artefacts they came from.
- The script reuses the test module's loader, variable list, run helpers and deviation arithmetic. The comparator's arithmetic is factored into `deviation_arrays()` and the comparator calls it; the numbers and semantics are unchanged (`make test-smoke` passes).
- `build-publish_to_pypi.yml` gains a `tolerance_spread` job on the scheduled path: it installs the release wheel the run built on each platform for the two CPython bookends and uploads one `tolerance-spread-<platform>-<arch>-<cpXY>` artefact per cell (30-day retention). `continue-on-error` and exit-0 mean it can never turn the nightly red; it feeds neither `report_scheduled_run` nor `pr-gate`. A `tolerance_spread` boolean input runs the same job on `workflow_dispatch`. The matrix is `buildplat`, not the trimmed `api_buildplat`, so on the nightly it also runs two short cells on macOS Intel (the api lane skips Intel for runner scarcity; here each cell is one to three minutes, and the platform's spread is part of the data). The dispatch below exercised the `workflow_dispatch` branch with a custom Linux, macOS arm64 and Windows matrix; the schedule branch has not run yet.
- `determine-matrix.sh` emits `bookend_python` so the job stays on the bookends when `api_python` widens to all versions on schedule.
- `scripts/suews/README.md` documents the script; `.claude/rules/tests/patterns.md` says where the spread artefacts come from and that tolerances will cite them.

## First measured spread

Local run, macOS arm64, CPython 3.13, release profile, source ce29700498 (the current tolerance column is what the test resolves on that platform and Python, after the 1.5x multiplier):

| variable | max abs | at | max rel | at | exact/points | current rtol | current atol |
|---|---|---|---|---|---|---|---|
| QN | 1.992e-10 | 2012-08-14T11:35, grid 1 | 1.009e-07 | 2012-10-08T15:25, grid 1 | 19895/105408 | 0.012 | 0.15 |
| QF | 4.027e-10 | 2012-06-09T17:00, grid 1 | 3.680e-12 | 2012-06-09T13:35, grid 1 | 4156/105408 | 0.012 | 0.15 |
| QS | 7.531e-09 | 2012-04-27T13:25, grid 1 | 2.457e-07 | 2012-11-25T08:40, grid 1 | 406/105408 | 0.012 | 0.15 |
| QE | 5.587e-07 | 2012-07-04T12:40, grid 1 | 1.394e-08 | 2012-07-20T11:05, grid 1 | 140/105408 | 0.012 | 0.15 |
| QH | 5.586e-07 | 2012-07-04T12:40, grid 1 | 1.759e-06 | 2012-12-23T03:15, grid 1 | 99/105408 | 0.012 | 0.15 |
| T2 | 3.776e-09 | 2012-06-06T13:30, grid 1 | 8.778e-08 | 2012-02-02T17:55, grid 1 | 1218/105408 | 0.003 | 0.015 |
| RH2 | 4.134e-08 | 2012-05-05T15:25, grid 1 | 8.054e-10 | 2012-05-05T15:25, grid 1 | 3477/105408 | 0.015 | 0.3 |
| U10 | 4.952e-10 | 2012-08-19T14:50, grid 1 | 1.929e-09 | 2012-07-20T11:05, grid 1 | 957/105408 | 0.0075 | 0.015 |
| LAI | 1.684e-11 | 2012-11-10T23:55, grid 1 | 9.746e-12 | 2012-11-11T23:55, grid 1 | 58464/105408 | 0.012 | 0.0015 |

### Dispatched run 34380721789: Linux x86_64, macOS arm64, Windows AMD64; cp312 and cp314; release profile; source 22dcc90352

All six cells ran the same 105408 rows. For eight of the nine variables every cell's maximum absolute and maximum relative deviation agrees to the printed precision, and agrees with the local macOS run above (LAI's maximum relative deviation differs in the last printed digit between macOS arm64 and the other two platforms, 9.746e-12 against 9.747e-12), so the engine-versus-reference deviation is the same on every platform and CPython at the points where it is largest. The platforms do differ from one another below that level: the count of exactly equal points is platform-dependent (for seven of the nine variables Linux and Windows agree with each other and with the reference more often than macOS arm64; QH and RH2 are the exceptions), and it does not depend on the CPython version at all.

Spread across the six cells (`tolerance_spread.py summarise --markdown`; the tolerance columns give the range `get_tolerance_for_variable` resolves across the cells, which spans the base value, the Linux `PLATFORM_ADJUSTMENTS` row and the 1.5x Python >= 3.13 multiplier):

| variable | max abs | from | max rel | from | current rtol | current atol | n |
|---|---|---|---|---|---|---|---|
| QN | 1.992e-10 | darwin-arm64/cp312 @ 2012-08-14T11:35, grid 1 | 1.009e-07 | darwin-arm64/cp312 @ 2012-10-08T15:25, grid 1 | 0.008..0.012 | 0.1..0.15 | 6 |
| QF | 4.027e-10 | darwin-arm64/cp312 @ 2012-06-09T17:00, grid 1 | 3.680e-12 | darwin-arm64/cp312 @ 2012-06-09T13:35, grid 1 | 0.008..0.012 | 0.1..0.15 | 6 |
| QS | 7.531e-09 | darwin-arm64/cp312 @ 2012-04-27T13:25, grid 1 | 2.457e-07 | darwin-arm64/cp312 @ 2012-11-25T08:40, grid 1 | 0.008..0.015 | 0.1..0.3 | 6 |
| QE | 5.587e-07 | linux-x86_64/cp312 @ 2012-07-04T12:40, grid 1 | 1.394e-08 | linux-x86_64/cp312 @ 2012-07-20T11:05, grid 1 | 0.008..0.015 | 0.1..0.3 | 6 |
| QH | 5.586e-07 | linux-x86_64/cp312 @ 2012-07-04T12:40, grid 1 | 1.759e-06 | darwin-arm64/cp312 @ 2012-12-23T03:15, grid 1 | 0.008..0.015 | 0.1..0.3 | 6 |
| T2 | 3.776e-09 | darwin-arm64/cp312 @ 2012-06-06T13:30, grid 1 | 8.778e-08 | linux-x86_64/cp312 @ 2012-02-02T17:55, grid 1 | 0.002..0.0075 | 0.01..0.075 | 6 |
| RH2 | 4.134e-08 | darwin-arm64/cp312 @ 2012-05-05T15:25, grid 1 | 8.054e-10 | darwin-arm64/cp312 @ 2012-05-05T15:25, grid 1 | 0.01..0.015 | 0.3..0.5 | 6 |
| U10 | 4.952e-10 | darwin-arm64/cp312 @ 2012-08-19T14:50, grid 1 | 1.929e-09 | darwin-arm64/cp312 @ 2012-07-20T11:05, grid 1 | 0.005..0.015 | 0.01..0.075 | 6 |
| LAI | 1.684e-11 | linux-x86_64/cp312 @ 2012-11-10T23:55, grid 1 | 9.747e-12 | linux-x86_64/cp312 @ 2012-11-11T23:55, grid 1 | 0.008..0.012 | 0.001..0.0015 | 6 |

The "from" column names the first cell reaching the maximum; the other cells reach the same value except for LAI's last printed digit noted above. Exactly equal points per cell, out of 105408:

| variable | darwin-arm64 cp312 | darwin-arm64 cp314 | linux-x86_64 cp312 | linux-x86_64 cp314 | windows-amd64 cp312 | windows-amd64 cp314 |
|---|---|---|---|---|---|---|
| QN | 19895 | 19895 | 26925 | 26925 | 26899 | 26899 |
| QF | 4156 | 4156 | 4374 | 4374 | 4374 | 4374 |
| QS | 406 | 406 | 430 | 430 | 434 | 434 |
| QE | 140 | 140 | 188 | 188 | 186 | 186 |
| QH | 99 | 99 | 95 | 95 | 96 | 96 |
| T2 | 1218 | 1218 | 1253 | 1253 | 1261 | 1261 |
| RH2 | 3477 | 3477 | 3485 | 3485 | 3472 | 3472 |
| U10 | 957 | 957 | 1224 | 1224 | 1222 | 1222 |
| LAI | 58464 | 58464 | 60768 | 60768 | 60768 | 60768 |

Two observations for the derivation, recorded here and not acted on in this PR: the largest measured deviation in any energy flux is 5.6e-7 W m^-2 against a current absolute tolerance of 0.1 to 0.3 W m^-2, and the Linux `PLATFORM_ADJUSTMENTS` row loosens a platform that is not the worst-matching one on any of the five variables it covers, and is the best-matching on two of them (QE and U10). Whether the deviation is stable night to night, and how it moves when the reference is regenerated, is what the week of nightly artefacts is for.

Engine wall time per cell: Linux 10 s, macOS arm64 20 s, Windows 25 to 29 s; each job took 1 to 2.5 minutes including install.

Refs #1770

